### PR TITLE
Add oauth2-proxy Docker service

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,16 @@
 ### Step 1: Configure the `.env` file
 
 ```
+OAUTH2_PROXY_CLIENT_SECRET=(client secret for the localhost-oauth2-proxy user)
+OAUTH2_PROXY_COOKIE_SECRET=(see below)
+OAUTH2_PROXY_OIDC_ISSUER_URL=(URL of Keycloak server)
 REACT_APP_TERRAWARE_API=http://localhost:8008
+```
+
+For the OAuth2 Proxy settings, get the client secret and OIDC issuer URL from an existing member of the team. Generate a cookie secret like this:
+
+```
+python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(16)).decode())'
 ```
 
 ### Step 2: Login to Docker hub
@@ -35,7 +44,11 @@ yarn docker:start
 yarn start
 ```
 
-### Step 5: Stopping the app
+### Step 5: Logging into the app
+
+You need to access the app via the authentication proxy, which will be listening on port 4000, so point your browser at [http://localhost:4000/](http://localhost:4000/).
+
+### Step 6: Stopping the app
 
 Execute the following commands:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - 8008:8000
     environment:
       - SQLALCHEMY_DATABASE_URL=postgresql://postgres:localdev1234@db:5432/gis-server
+      - ENABLE_AUTH=false
       - ACCESS_TOKEN_SECRET_KEY=test1234
       - ACCESS_TOKEN_EXPIRE_MINUTES=10080
       - PHOTO_PATH=/photos
@@ -32,6 +33,24 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=localdev1234
       - POSTGRES_DB=gis-server
+
+  proxy:
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.3
+    ports:
+      - 4000:4000
+    environment:
+      - OAUTH2_PROXY_CLIENT_SECRET
+      - OAUTH2_PROXY_COOKIE_SECRET
+      - OAUTH2_PROXY_OIDC_ISSUER_URL
+      - OAUTH2_PROXY_HTTP_ADDRESS=:4000
+      - OAUTH2_PROXY_CLIENT_ID=localhost-oauth2-proxy
+      - OAUTH2_PROXY_COOKIE_SECURE=false
+      - OAUTH2_PROXY_EMAIL_DOMAINS=*
+      - OAUTH2_PROXY_PASS_ACCESS_TOKEN=true
+      - OAUTH2_PROXY_PROVIDER=oidc
+      - OAUTH2_PROXY_SKIP_PROVIDER_BUTTON=true
+      - OAUTH2_PROXY_UPSTREAMS=http://host.docker.internal:3000/,http://web:8000/api/
+      - OAUTH2_PROXY_WHITELIST_DOMAINS=localhost:*
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Allow authenticating to a local instance of oauth2-proxy for local development.
