### PR TITLE
SW-301 Attempt to work around Cypress hang

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -54,6 +54,8 @@ jobs:
         # Skip tests on main because of Cypress hanging bug
         if: github.ref != 'refs/heads/main'
         run: yarn e2e
+        # If Cypress hangs, don't let the job sit there for the default 6-hour timeout.
+        timeout-minutes: 60
         env:
           REACT_APP_TERRAWARE_API: 'http://localhost:8080'
           REACT_APP_SNACKBAR_TIMEOUT: 1000

--- a/cypress/integration/02-processingAndDrying.js
+++ b/cypress/integration/02-processingAndDrying.js
@@ -10,19 +10,34 @@ describe('Processing and Drying', () => {
     cy.get('#menu-processing-drying').click();
   });
 
-  it('should add processing and drying information', () => {
+  // The following sections are split up into small chunks in an effort to work around
+  // a Cypress bug that causes test suites to hang forever.
+
+  it('should set the processing method', () => {
     cy.get('#processingMethod').click();
     cy.get('#Count').click();
+  });
+
+  it('should set the seed count', () => {
     cy.get('#quantity').type(300);
+  });
+
+  it('should add processing and drying information', () => {
     cy.get('#check-Nursery').click();
     cy.get('#dryingStartDate').type('01/01/2021');
     cy.get('#dryingEndDate').type('01/01/2021');
     cy.get('#dryingMoveDate').type('01/01/2021');
     cy.get('#processingNotes').type('A processing note');
     cy.get('#processingStaffResponsible').type('Constanza');
+  });
 
-    cy.get('#saveAccession').click();
+  it('should save the accession', () => {
+    cy.intercept('PUT', '/api/v1/seedbank/accession/*').as('saveAccession');
+    cy.get('#saveAccession', { timeout: 10000 }).click();
+    cy.wait('@saveAccession', { timeout: 10000 });
+  });
 
+  it('should display processing and drying information after saving', () => {
     cy.get('#processingMethod + input').should('have.value', 'Count');
     cy.get('#quantity').should('have.value', '300');
     cy.get('#check-Nursery').should('have.checked', 'true');


### PR DESCRIPTION
The E2E test suite always hangs in roughly the same place: updating or verifying
the seed count in the processing and drying test.

Waiting for the PUT request to finish and splitting the test step up into smaller
pieces appears to make it less likely for Cypress to hang.

But in case this doesn't fix the problem, also set a 1-hour timeout on the E2E
tests so jobs don't sit there for 6 hours chewing through our GitHub Actions
runtime quota.