### PR TITLE
Include organization ID in species requests

### DIFF
--- a/scripts/preparedb.sh
+++ b/scripts/preparedb.sh
@@ -28,7 +28,7 @@ speciesId1=$(curl 'http://localhost:8080/api/v1/species' \
   --cookie "${COOKIE}"  \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
-  --data '{"name":"Banana" }' | jq -r '.id')
+  --data '{"name":"Banana","organizationId":1}' | jq -r '.id')
 
 if [ -z "$speciesId1" ]; then
     echo
@@ -42,7 +42,7 @@ speciesId2=$(curl 'http://localhost:8080/api/v1/species' \
   --cookie "${COOKIE}"  \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
-  --data '{"name":"Coconut"}' | jq -r '.id')
+  --data '{"name":"Coconut","organizationId":1}' | jq -r '.id')
 
 layerId=$(curl 'http://localhost:8080/api/v1/gis/layers' \
   --cookie "${COOKIE}"  \

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -173,9 +173,14 @@ function AppContent() {
               <Route exact path='/checkin'>
                 <CheckIn organization={selectedOrganization} />
               </Route>
-              <Route exact path='/accessions/new'>
-                <NewAccession facilityId={selectedOrgInfoDatabase.selectedFacility?.id} />
-              </Route>
+              {selectedOrganization && (
+                <Route exact path='/accessions/new'>
+                  <NewAccession
+                    facilityId={selectedOrgInfoDatabase.selectedFacility?.id}
+                    organization={selectedOrganization}
+                  />
+                </Route>
+              )}
               <Route exact path='/accessions'>
                 <Database
                   organization={selectedOrganization}
@@ -190,7 +195,7 @@ function AppContent() {
                 />
               </Route>
               <Route path='/accessions/:accessionId'>
-                <Accession />
+                <Accession organization={selectedOrganization} />
               </Route>
               <Route exact path='/plants-dashboard'>
                 <PlantDashboard organization={selectedOrganization} />
@@ -202,9 +207,11 @@ function AppContent() {
                   setFilters={setPlantListFilters}
                 />
               </Route>
-              <Route exact path='/species'>
-                <SpeciesList />
-              </Route>
+              {selectedOrganization && (
+                <Route exact path='/species'>
+                  <SpeciesList organization={selectedOrganization} />
+                </Route>
+              )}
               {selectedOrganization && (
                 <Route path='/projects/new'>
                   <NewProject organization={selectedOrganization} reloadOrganizationData={reloadData} />

--- a/src/api/species/species.ts
+++ b/src/api/species/species.ts
@@ -16,14 +16,15 @@ export type GetSpeciesListResponse = {
   requestSucceeded: boolean;
 };
 
-export async function getAllSpecies(): Promise<GetSpeciesListResponse> {
+export async function getAllSpecies(organizationId: number): Promise<GetSpeciesListResponse> {
   const response: GetSpeciesListResponse = {
     speciesById: new Map(),
     requestSucceeded: true,
   };
 
   try {
-    const speciesList: SpeciesList = (await axios.get(SPECIES_ENDPOINT)).data.species;
+    const endpoint = `${SPECIES_ENDPOINT}?organizationId=${organizationId}`;
+    const speciesList: SpeciesList = (await axios.get(endpoint)).data.species;
     speciesList.forEach((species: SpeciesListItem) => {
       response.speciesById.set(species.id, { id: species.id, name: species.name });
     });
@@ -45,14 +46,14 @@ export type CreateSpeciesResponse = {
   error: string | null;
 };
 
-export async function createSpecies(name: string): Promise<CreateSpeciesResponse> {
+export async function createSpecies(name: string, organizationId: number): Promise<CreateSpeciesResponse> {
   const response: CreateSpeciesResponse = {
     species: null,
     error: null,
   };
 
   try {
-    const createSpeciesRequest: PostSpeciesRequest = { name };
+    const createSpeciesRequest: PostSpeciesRequest = { name, organizationId };
     const serverResponse: PostSpeciesResponse = (await axios.post(SPECIES_ENDPOINT, createSpeciesRequest)).data;
     response.species = { id: serverResponse.id, name };
   } catch (error) {
@@ -78,12 +79,12 @@ export type UpdateSpeciesResponse = {
   requestSucceeded: boolean;
 };
 
-export async function updateSpecies(species: Species): Promise<UpdateSpeciesResponse> {
+export async function updateSpecies(species: Species, organizationId: number): Promise<UpdateSpeciesResponse> {
   const response: UpdateSpeciesResponse = { species, requestSucceeded: true };
 
   try {
     const endpoint = PUT_SPECIES_ENDPOINT.replace('{speciesId}', `${species.id}`);
-    const updateSpeciesRequest: PutSpeciesRequest = { name: species.name };
+    const updateSpeciesRequest: PutSpeciesRequest = { name: species.name, organizationId };
     await axios.put(endpoint, updateSpeciesRequest);
   } catch (error) {
     console.error(error);
@@ -96,8 +97,8 @@ export async function updateSpecies(species: Species): Promise<UpdateSpeciesResp
 type SpeciesDeleteResponse =
   paths[typeof PUT_SPECIES_ENDPOINT]['delete']['responses'][200]['content']['application/json'];
 
-export async function deleteSpecies(speciesId: number): Promise<SpeciesDeleteResponse> {
-  const endpoint = PUT_SPECIES_ENDPOINT.replace('{speciesId}', `${speciesId}`);
+export async function deleteSpecies(speciesId: number, organizationId: number): Promise<SpeciesDeleteResponse> {
+  const endpoint = PUT_SPECIES_ENDPOINT.replace('{speciesId}', `${speciesId}`) + `?organizationId=${organizationId}`;
   const response: SpeciesDeleteResponse = (await axios.delete(endpoint)).data;
 
   return response;

--- a/src/components/plants/EditPlantModal.tsx
+++ b/src/components/plants/EditPlantModal.tsx
@@ -11,6 +11,7 @@ import Button from 'src/components/common/button/Button';
 import DialogCloseButton from 'src/components/common/DialogCloseButton';
 import TextField from 'src/components/common/TextField';
 import strings from 'src/strings';
+import { ServerOrganization } from 'src/types/Organization';
 import { Plant } from 'src/types/Plant';
 import { Species, SpeciesById } from 'src/types/Species';
 import DisplayPhoto from './DisplayPhoto';
@@ -58,11 +59,12 @@ export type EditPlantModalProps = {
   speciesById: SpeciesById;
   plant: Plant;
   photoUrl?: string;
+  organization: ServerOrganization;
 };
 
 export default function EditPlantModal(props: EditPlantModalProps): JSX.Element {
   const classes = useStyles();
-  const { onSave, onCancel, canDelete, speciesById, plant, photoUrl } = props;
+  const { onSave, onCancel, canDelete, speciesById, plant, photoUrl, organization } = props;
   const [deleteConfirmationModelOpen, setDeleteConfirmationModelOpen] = useState<boolean>(false);
   // For creating a new species
   const [newSpeciesName, setNewSpeciesName] = useState<string>('');
@@ -99,7 +101,7 @@ export default function EditPlantModal(props: EditPlantModalProps): JSX.Element 
     let speciesId: number | undefined;
     if (inputtedValidNewSpecies()) {
       // create new species
-      const response = await createSpecies(newSpeciesName);
+      const response = await createSpecies(newSpeciesName, organization.id);
       // TODO handle error if cannot save species
       if (response.species) {
         speciesId = response.species.id;

--- a/src/components/plants/PlantDashboard/PlantMap.tsx
+++ b/src/components/plants/PlantDashboard/PlantMap.tsx
@@ -13,6 +13,7 @@ import { cellDateFormatter } from '../../common/table/TableCellRenderer';
 import MapLayers from './MapLayers';
 import EditPlantModal from '../EditPlantModal';
 import DisplayPhoto from '../DisplayPhoto';
+import { ServerOrganization } from 'src/types/Organization';
 import { Plant } from 'src/types/Plant';
 import { SpeciesById } from 'src/types/Species';
 import { getPlantPhoto } from 'src/api/plants/photo';
@@ -69,6 +70,7 @@ export type PlantMapProps = {
   onFullscreen: () => void;
   isFullscreen: boolean;
   plants: Plant[];
+  organization?: ServerOrganization;
   speciesById: SpeciesById;
   colorsBySpeciesId: Record<number, string>;
   reloadData: () => void;
@@ -77,7 +79,7 @@ export type PlantMapProps = {
 function PlantMap(props: PlantMapProps): JSX.Element {
   const classes = useStyles();
 
-  const { onFullscreen, isFullscreen, plants, speciesById, colorsBySpeciesId, reloadData } = props;
+  const { onFullscreen, isFullscreen, plants, organization, speciesById, colorsBySpeciesId, reloadData } = props;
   const [selectedPlant, setSelectedPlant] = useState<Plant>();
   const [selectedPlantPhotoUrl, setSelectedPlantPhotoUrl] = useState<string>();
   const [plantModalOpen, setPlantModalOpen] = React.useState(false);
@@ -178,7 +180,7 @@ function PlantMap(props: PlantMapProps): JSX.Element {
 
   return (
     <>
-      {selectedPlant && plantModalOpen && (
+      {selectedPlant && plantModalOpen && organization && (
         <EditPlantModal
           onSave={onPlantModalSave}
           onCancel={() => setPlantModalOpen(false)}
@@ -186,6 +188,7 @@ function PlantMap(props: PlantMapProps): JSX.Element {
           speciesById={speciesById}
           plant={selectedPlant}
           photoUrl={selectedPlantPhotoUrl}
+          organization={organization}
         />
       )}
       <ReactMapGL

--- a/src/components/plants/PlantDashboard/index.tsx
+++ b/src/components/plants/PlantDashboard/index.tsx
@@ -57,11 +57,13 @@ export default function PlantDashboard(props: PlantDashboardProps): JSX.Element 
 
   const reloadData = useCallback(() => {
     const populateSpecies = async () => {
-      const speciesResponse = await getAllSpecies();
-      if (speciesResponse.requestSucceeded) {
-        setSpeciesById(speciesResponse.speciesById);
-        const speciesIds: number[] = Array.from(speciesResponse.speciesById.keys());
-        setColorsBySpeciesId(getColorsBySpeciesId(speciesIds));
+      if (organization) {
+        const speciesResponse = await getAllSpecies(organization.id);
+        if (speciesResponse.requestSucceeded) {
+          setSpeciesById(speciesResponse.speciesById);
+          const speciesIds: number[] = Array.from(speciesResponse.speciesById.keys());
+          setColorsBySpeciesId(getColorsBySpeciesId(speciesIds));
+        }
       }
     };
 

--- a/src/components/plants/PlantList/index.tsx
+++ b/src/components/plants/PlantList/index.tsx
@@ -58,10 +58,12 @@ export default function PlantList(props: PlantListProps): JSX.Element {
 
   const fetchPlantsAndSpecies = useCallback(() => {
     const populateSpecies = async () => {
-      const speciesResponse = await getAllSpecies();
-      // TODO display errors to client
-      if (speciesResponse.requestSucceeded) {
-        setSpeciesById(speciesResponse.speciesById);
+      if (organization) {
+        const speciesResponse = await getAllSpecies(organization.id);
+        // TODO display errors to client
+        if (speciesResponse.requestSucceeded) {
+          setSpeciesById(speciesResponse.speciesById);
+        }
       }
     };
 
@@ -129,7 +131,7 @@ export default function PlantList(props: PlantListProps): JSX.Element {
 
   return (
     <main>
-      {selectedPlant && (
+      {selectedPlant && organization && (
         <EditPlantModal
           onSave={onPlantEditSaved}
           onCancel={() => setSelectedPlant(undefined)}
@@ -137,6 +139,7 @@ export default function PlantList(props: PlantListProps): JSX.Element {
           speciesById={speciesById}
           plant={selectedPlant}
           photoUrl={selectedPlantPhoto}
+          organization={organization}
         />
       )}
       <Container maxWidth={false} className={classes.mainContainer}>

--- a/src/components/plants/Species/SimpleSpeciesModal.tsx
+++ b/src/components/plants/Species/SimpleSpeciesModal.tsx
@@ -7,6 +7,7 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import React, { useEffect, useState } from 'react';
 import { createSpecies, updateSpecies } from 'src/api/species/species';
 import strings from 'src/strings';
+import { ServerOrganization } from 'src/types/Organization';
 import { Species, SpeciesRequestError } from 'src/types/Species';
 import useForm from 'src/utils/useForm';
 import Button from '../../common/button/Button';
@@ -36,6 +37,7 @@ export type SimpleSpeciesModalProps = {
   open: boolean;
   onClose: (saved: boolean, snackbarMessage?: string) => void;
   initialSpecies?: Species;
+  organization: ServerOrganization;
   onError: (snackbarMessage: string) => void;
 };
 
@@ -49,7 +51,7 @@ function initSpecies(species?: Species): Species {
 }
 export default function SimpleSpeciesModal(props: SimpleSpeciesModalProps): JSX.Element {
   const classes = useStyles();
-  const { open, onClose, initialSpecies, onError } = props;
+  const { open, onClose, initialSpecies, organization, onError } = props;
   const [record, setRecord, onChange] = useForm<Species>(initSpecies(initialSpecies));
   const [nameFormatError, setNameFormatError] = useState('');
 
@@ -70,7 +72,7 @@ export default function SimpleSpeciesModal(props: SimpleSpeciesModalProps): JSX.
     if (record.name.trim()) {
       setNameFormatError('');
       if (record.id === 0) {
-        const newSpecies = await createSpecies(record.name);
+        const newSpecies = await createSpecies(record.name, organization.id);
         if (newSpecies.species?.id) {
           snackbarMessage = strings.SNACKBAR_MSG_NEW_SPECIES_ADDED;
           onClose(true, snackbarMessage);
@@ -84,7 +86,7 @@ export default function SimpleSpeciesModal(props: SimpleSpeciesModalProps): JSX.
         }
       } else {
         try {
-          await updateSpecies(record);
+          await updateSpecies(record, organization.id);
           snackbarMessage = strings.SNACKBAR_MSG_CHANGES_SAVED;
           onClose(true, snackbarMessage);
         } catch {

--- a/src/components/plants/Species/index.tsx
+++ b/src/components/plants/Species/index.tsx
@@ -10,8 +10,13 @@ import Table from 'src/components/common/table';
 import { TableColumnType } from 'src/components/common/table/types';
 import snackbarAtom from 'src/state/snackbar';
 import strings from 'src/strings';
+import { ServerOrganization } from 'src/types/Organization';
 import { Species } from 'src/types/Species';
 import SimpleSpeciesModal from './SimpleSpeciesModal';
+
+type SpeciesListProps = {
+  organization: ServerOrganization;
+};
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -49,7 +54,7 @@ const useStyles = makeStyles((theme) =>
 
 const columns: TableColumnType[] = [{ key: 'name', name: 'Name', type: 'string' }];
 
-export default function SpeciesList(): JSX.Element {
+export default function SpeciesList({ organization }: SpeciesListProps): JSX.Element {
   const classes = useStyles();
   const [species, setSpecies] = useState<Species[]>();
   const [selectedSpecies, setSelectedSpecies] = useState<Species>();
@@ -57,12 +62,12 @@ export default function SpeciesList(): JSX.Element {
   const setSnackbar = useSetRecoilState(snackbarAtom);
 
   const populateSpecies = useCallback(async () => {
-    const response = await getAllSpecies();
+    const response = await getAllSpecies(organization.id);
     // TODO: what if we cannot fetch the species list?
     if (response.requestSucceeded) {
       setSpecies(Array.from(response.speciesById.values()));
     }
-  }, []);
+  }, [organization]);
 
   useEffect(() => {
     populateSpecies();
@@ -102,6 +107,7 @@ export default function SpeciesList(): JSX.Element {
         open={editSpeciesModalOpen}
         onClose={onCloseEditSpeciesModal}
         initialSpecies={selectedSpecies}
+        organization={organization}
         onError={setErrorSnackbar}
       />
       <Container maxWidth={false} className={classes.mainContainer}>

--- a/src/components/seeds/accession/index.tsx
+++ b/src/components/seeds/accession/index.tsx
@@ -8,6 +8,7 @@ import { Accession, AccessionState } from 'src/api/types/accessions';
 import ErrorBoundary from 'src/ErrorBoundary';
 import snackbarAtom from 'src/state/snackbar';
 import strings from 'src/strings';
+import { ServerOrganization } from 'src/types/Organization';
 import Lab from '../lab';
 import { AccessionForm } from '../newAccession';
 import Nursery from '../nursery';
@@ -27,7 +28,11 @@ const useStyles = makeStyles((theme) =>
   })
 );
 
-export default function AccessionPage(): JSX.Element {
+interface AccessionPageProps {
+  organization?: ServerOrganization;
+}
+
+export default function AccessionPage({ organization }: AccessionPageProps): JSX.Element {
   // TODO: consider navigating to the main accessions page if we cannot
   // fetch the current accession.
   const setSnackbar = useSetRecoilState(snackbarAtom);
@@ -41,13 +46,13 @@ export default function AccessionPage(): JSX.Element {
   return (
     <ErrorBoundary handler={errorHandler}>
       <React.Suspense fallback={<div />}>
-        <Content />
+        <Content organization={organization} />
       </React.Suspense>
     </ErrorBoundary>
   );
 }
 
-function Content(): JSX.Element {
+function Content({ organization }: AccessionPageProps): JSX.Element {
   const classes = useStyles();
   const { accessionId } = useParams<{ accessionId: string }>();
   const [accession, setAccession] = useState<Accession>();
@@ -128,6 +133,7 @@ function Content(): JSX.Element {
                   updating={true}
                   photoFilenames={accession.photoFilenames}
                   accession={accession}
+                  organization={organization}
                   onSubmit={onSubmit}
                   onCheckIn={onCheckIn}
                 />

--- a/src/components/seeds/newAccession/SpeciesDropdown.tsx
+++ b/src/components/seeds/newAccession/SpeciesDropdown.tsx
@@ -1,28 +1,32 @@
 import React, { useEffect, useState } from 'react';
 import { getAllSpecies } from 'src/api/species/species';
 import strings from 'src/strings';
+import { ServerOrganization } from 'src/types/Organization';
 import { Species } from 'src/types/Species';
 import Autocomplete from '../../common/Autocomplete';
 
 interface SpeciesDropdownProps {
   selectedSpecies?: string;
+  organization?: ServerOrganization;
   onChange: (id: string, value: unknown, isNew: boolean) => void;
 }
 
 export default function SpeciesDropdown(props: SpeciesDropdownProps): JSX.Element {
-  const { selectedSpecies, onChange } = props;
+  const { selectedSpecies, organization, onChange } = props;
   const [speciesList, setSpeciesList] = useState<Species[]>([]);
 
   useEffect(() => {
     const populateSpecies = async () => {
-      const response = await getAllSpecies();
-      // TODO: what if we cannot fetch the species list?
-      if (response.requestSucceeded) {
-        setSpeciesList(Array.from(response.speciesById.values()));
+      if (organization) {
+        const response = await getAllSpecies(organization.id);
+        // TODO: what if we cannot fetch the species list?
+        if (response.requestSucceeded) {
+          setSpeciesList(Array.from(response.speciesById.values()));
+        }
       }
     };
     populateSpecies();
-  }, []);
+  }, [organization]);
 
   const onChangeHandler = (id: string, selectedName: string) => {
     const found = speciesList.findIndex((item) => item.name === selectedName);

--- a/src/components/seeds/newAccession/index.tsx
+++ b/src/components/seeds/newAccession/index.tsx
@@ -13,6 +13,7 @@ import { updateSpecies } from 'src/api/species/species';
 import { Accession, AccessionPostRequestBody } from 'src/api/types/accessions';
 import snackbarAtom from 'src/state/snackbar';
 import strings from 'src/strings';
+import { ServerOrganization } from 'src/types/Organization';
 import useForm from 'src/utils/useForm';
 import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
 import Divisor from '../../common/Divisor';
@@ -61,10 +62,11 @@ const useStyles = makeStyles((theme) =>
 
 type NewAccessionProps = {
   facilityId?: number;
+  organization: ServerOrganization;
 };
 
 export default function NewAccessionWrapper(props: NewAccessionProps): JSX.Element {
-  const { facilityId } = props;
+  const { facilityId, organization } = props;
   const [accessionId, setAccessionId] = useState<number>();
   const setSnackbar = useSetRecoilState(snackbarAtom);
   const classes = useStyles();
@@ -132,6 +134,7 @@ export default function NewAccessionWrapper(props: NewAccessionProps): JSX.Eleme
                 facilityId,
                 receivedDate: moment().format('YYYY-MM-DD'),
               }}
+              organization={organization}
               onSubmit={onSubmit}
               onCheckIn={onCheckIn}
             />
@@ -147,6 +150,7 @@ interface Props<T extends AccessionPostRequestBody> {
   updating?: boolean;
   photoFilenames?: string[];
   accession: T;
+  organization?: ServerOrganization;
   onSubmit: (record: T) => void;
   onCheckIn: (id: number) => void;
 }
@@ -159,6 +163,7 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
   updating,
   photoFilenames,
   accession,
+  organization,
   onSubmit,
   onCheckIn,
 }: Props<T>): JSX.Element {
@@ -308,8 +313,8 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
 
   const closeModalAndUpdateSpecies = () => {
     const speciesId = (record as unknown as Accession).speciesId;
-    if (speciesId && record.species) {
-      updateSpecies({ id: speciesId, name: record.species });
+    if (speciesId && record.species && organization) {
+      updateSpecies({ id: speciesId, name: record.species }, organization.id);
     }
     onCloseEditSpeciesModal();
   };
@@ -346,7 +351,7 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
               }
             >
               <Grid item xs={4}>
-                <Species selectedSpecies={record.species} onChange={onSpeciesChanged} />
+                <Species selectedSpecies={record.species} organization={organization} onChange={onSpeciesChanged} />
               </Grid>
             </Suspense>
             <Grid item xs={4}>


### PR DESCRIPTION
To support per-organization species, we need clients to specify which organization's species list they want to work with. The server currently accepts organization ID as an optional parameter; update the client code to always include it.