### PR TITLE
TRACK-741 Remove 'up' icon from open nav menus

### DIFF
--- a/src/components/common/Navbar/NavItem.tsx
+++ b/src/components/common/Navbar/NavItem.tsx
@@ -61,7 +61,7 @@ export default function NavItem(props: NavItemProps): JSX.Element {
       <button className='nav-item-content' onClick={onClickHandler} id={id}>
         {icon && <Icon name={icon} className='nav-item--icon' />}
         <span className='nav-item--label'>{label}</span>
-        {children && <Icon name={open ? 'chevronUp' : 'chevronDown'} className='nav-item--arrow' />}
+        {children && !open && <Icon name={'chevronDown'} className='nav-item--arrow' />}
       </button>
       {children && open && children}
     </div>


### PR DESCRIPTION
Since clicking on the 'up' icon does not collapse the menu, remove that icon
so that the user experience is less confusing.