### PR TITLE
split grouped routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -361,22 +361,22 @@ export default function App() {
               <Route exact path={APP_PATHS.CONTACT_US}>
                 <ContactUs />
               </Route>
-              {user &&
-                  <Route exact path={APP_PATHS.MY_ACCOUNT_EDIT}>
-                    <MyAccount
-                      user={user}
-                      organizations={organizations}
-                      edit={true}
-                      reloadUser={reloadUser}
-                      reloadData={reloadData}
-                    />
-                  </Route>
-              }
-              {user &&
-                  <Route exact path={APP_PATHS.MY_ACCOUNT}>
-                    <MyAccount user={user} organizations={organizations} edit={false} reloadUser={reloadUser} />
-                  </Route>
-              }
+              {user && (
+                <Route exact path={APP_PATHS.MY_ACCOUNT_EDIT}>
+                  <MyAccount
+                    user={user}
+                    organizations={organizations}
+                    edit={true}
+                    reloadUser={reloadUser}
+                    reloadData={reloadData}
+                  />
+                </Route>
+              )}
+              {user && (
+                <Route exact path={APP_PATHS.MY_ACCOUNT}>
+                  <MyAccount user={user} organizations={organizations} edit={false} reloadUser={reloadUser} />
+                </Route>
+              )}
 
               {/* Redirects. Invalid paths will redirect to the closest valid path. */}
               {/* Only redirect 'major' paths, e.g. handle /projects/* not more granular projects paths */}


### PR DESCRIPTION
noticed that all the routes past the 2 grouped routes were no longer working.
i think the 
```
<>
</>
```
is breaking the routes switch. i could be wrong but this change seems to work.
to test with/without change, go to localhost:3000 and notice redirection to /home