### PR TITLE
SW-954 support for user added to project notification

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -792,7 +792,8 @@ export interface components {
       notificationType:
         | "User Added to Organization"
         | "Facility Idle"
-        | "Facility Alert Requested";
+        | "Facility Alert Requested"
+        | "User Added to Project";
       notificationCriticality: "Info" | "Warning" | "Error" | "Success";
       organizationId?: number;
       title: string;

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,7 +1,6 @@
 import { Container, Grid } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import React, { useEffect, useState } from 'react';
-import { useHistory } from 'react-router';
 import { getUser } from 'src/api/user/user';
 import PageCard from 'src/components/common/PageCard';
 import PageHeader from 'src/components/seeds/PageHeader';
@@ -11,7 +10,6 @@ import strings from 'src/strings';
 import homePageStrings from 'src/strings/homePage';
 import { HighOrganizationRolesValues, ServerOrganization } from 'src/types/Organization';
 import { User } from 'src/types/User';
-import useQuery from 'src/utils/useQuery';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -45,8 +43,6 @@ export type HomeProps = {
 
 export default function Home({ organizations, selectedOrganization, setSelectedOrganization }: HomeProps): JSX.Element {
   const classes = useStyles();
-  const query = useQuery();
-  const history = useHistory();
   const [user, setUser] = useState<User>();
 
   useEffect(() => {
@@ -58,17 +54,6 @@ export default function Home({ organizations, selectedOrganization, setSelectedO
     };
     populateUser();
   }, []);
-
-  useEffect(() => {
-    const organizationId = query.get('organizationId');
-    if (organizationId) {
-      const newlySelectedOrg = organizations?.find((org) => org.id === parseInt(organizationId, 10));
-      if (newlySelectedOrg) {
-        setSelectedOrganization(newlySelectedOrg);
-        history.push({ pathname: APP_PATHS.HOME });
-      }
-    }
-  }, [organizations, query, setSelectedOrganization, history]);
 
   return (
     <main className={classes.main}>

--- a/src/components/NotificationsDropdown.tsx
+++ b/src/components/NotificationsDropdown.tsx
@@ -56,6 +56,7 @@ const useStyles = makeStyles((theme) =>
       },
     },
     unreadNotificationIndicator: {
+      marginLeft: '8px',
       width: '8px',
       height: '8px',
       borderRadius: '4px',
@@ -74,6 +75,9 @@ const useStyles = makeStyles((theme) =>
       },
     },
     notificationContent: {
+      display: 'flex',
+      flexDirection: 'column',
+      minWidth: '375px',
       fontSize: '14px',
       fontWeight: 400,
       margin: '0px',
@@ -88,7 +92,7 @@ const useStyles = makeStyles((theme) =>
     notificationBody: {
       display: 'block',
       color: '#3A4445',
-      margin: '8px',
+      margin: '0px 8px',
     },
     notificationTimestamp: {
       display: 'block',
@@ -125,10 +129,10 @@ const useStyles = makeStyles((theme) =>
     },
     notificationMenuWrapper: {
       maxWidth: '40px',
-      margin: 'auto auto',
-      marginLeft: '4px',
+      margin: 'auto 0',
       display: 'flex',
-      justifyContent: 'center',
+      justifyContent: 'left',
+      padding: '0px 8px',
     },
   })
 );
@@ -137,14 +141,14 @@ type NotificationsDropdownProps = {
   notifications?: Notifications;
   setNotifications: (notifications?: Notifications) => void;
   organizationId?: number;
+  reloadOrganizationData: () => void;
 };
 
 export default function NotificationsDropdown(props: NotificationsDropdownProps): JSX.Element {
   const classes = useStyles();
   const history = useHistory();
-  const { notifications, setNotifications, organizationId } = props;
+  const { notifications, setNotifications, organizationId, reloadOrganizationData } = props;
   // notificationsInterval value is only being used when it is set.
-  const [, setNotificationsInterval] = useState<ReturnType<typeof setInterval>>();
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
   const [lastSeen, setLastSeen] = useState<number>(0);
 
@@ -167,23 +171,14 @@ export default function NotificationsDropdown(props: NotificationsDropdownProps)
     populateNotifications();
 
     // Create interval to fetch future notifications.
+    let interval: ReturnType<typeof setInterval>;
     if (!process.env.REACT_APP_DISABLE_RECURRENT_REQUESTS) {
-      setNotificationsInterval((currInterval) => {
-        if (currInterval) {
-          clearInterval(currInterval);
-        }
-        return setInterval(populateNotifications, API_PULL_INTERVAL);
-      });
+      interval = setInterval(populateNotifications, API_PULL_INTERVAL);
     }
 
     // Clean up existing interval.
     return () => {
-      setNotificationsInterval((currInterval) => {
-        if (currInterval) {
-          clearInterval(currInterval);
-        }
-        return undefined;
-      });
+      clearInterval(interval);
     };
   }, [populateNotifications, organizationId]);
 
@@ -262,7 +257,12 @@ export default function NotificationsDropdown(props: NotificationsDropdownProps)
           )}
           {notifications &&
             notifications.items.map((notification) => (
-              <NotificationItem key={notification.id} notification={notification} markAsRead={markAsRead} />
+              <NotificationItem
+                key={notification.id}
+                notification={notification}
+                markAsRead={markAsRead}
+                reloadOrganizationData={reloadOrganizationData}
+              />
             ))}
           {notifications?.errorOccurred && (
             <ListItem>
@@ -282,16 +282,20 @@ export default function NotificationsDropdown(props: NotificationsDropdownProps)
 type NotificationItemProps = {
   notification: Notification;
   markAsRead: (read: boolean, id: number, close?: boolean) => void;
+  reloadOrganizationData: () => void;
 };
 
 function NotificationItem(props: NotificationItemProps): JSX.Element {
   const [inFocus, setInFocus] = useState<boolean>(false);
   const classes = useStyles();
-  const { notification, markAsRead } = props;
-  const { id, title, body, localUrl, createdTime, isRead, notificationCriticality } = notification;
+  const { notification, markAsRead, reloadOrganizationData } = props;
+  const { id, title, body, localUrl, createdTime, isRead, notificationCriticality, notificationType } = notification;
   const criticality = notificationCriticality.toLowerCase();
 
-  const onNotificationClick = (read: boolean, close?: boolean) => {
+  const onNotificationClick = async (read: boolean, close?: boolean) => {
+    if (close && (notificationType === 'User Added to Organization' || notificationType === 'User Added to Project')) {
+      await reloadOrganizationData();
+    }
     markAsRead(read, id, close);
   };
 

--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -48,6 +48,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
         notifications={props.notifications}
         setNotifications={setNotifications}
         organizationId={selectedOrganization?.id}
+        reloadOrganizationData={reloadOrganizationData}
       />
       <div className={classes.separator} />
       <OrganizationsDropdown

--- a/src/types/Notifications.ts
+++ b/src/types/Notifications.ts
@@ -12,7 +12,11 @@ export type MarkNotificationsRead = {
   organizationId?: number;
 };
 
-export type NotificationType = 'User Added to Organization' | 'Facility Idle' | 'Facility Alert Requested';
+export type NotificationType =
+  | 'User Added to Organization'
+  | 'Facility Idle'
+  | 'Facility Alert Requested'
+  | 'User Added to Project';
 
 export type NotificationCriticality = 'Info' | 'Warning' | 'Error' | 'Success';
 


### PR DESCRIPTION
Add support for User Added to Project notification.
The email to user will have a link <host>/projects/{projectId}?organizationId={organizationId}
Moved query param org id parsing from Home to App (which will now support auto switching of orgs using URL for any of our views now).
Fixed interval canceling for notifications, the previous code was not canceling the interval when switch orgs because of incorrect usage.
Fixed some styling (when there's a scroll bar in notifications list)