### PR TITLE
add expandable component

### DIFF
--- a/src/components/common/Expandable.tsx
+++ b/src/components/common/Expandable.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles((theme) =>
     },
     icon: {
       fill: '#3A4445',
-    }
+    },
   })
 );
 
@@ -42,7 +42,7 @@ export default function Expandable(props: ExpandableProps): JSX.Element {
       <div className={classes.titleExpandable}>
         <span>{title}</span>
         <IconButton onClick={() => setOpen(!open)} disabled={disabled}>
-          <Icon name={open ? 'chevronUp' : 'chevronDown'} className={classes.icon}/>
+          <Icon name={open ? 'chevronUp' : 'chevronDown'} className={classes.icon} />
         </IconButton>
       </div>
       {open && <div>{children}</div>}


### PR DESCRIPTION
for seed bank onboarding flow
also fixed chevron up svg as it was not displaying, downloaded it from zeroheight

example:
<img width="325" alt="Terraware App 2022-05-31 17-09-40" src="https://user-images.githubusercontent.com/1865174/171303726-89e70dea-d501-42f0-a352-d08929301f98.png">

