### PR TITLE
SW-1080 Show no errors found screen on data check

### DIFF
--- a/src/components/Species/CheckDataModal.tsx
+++ b/src/components/Species/CheckDataModal.tsx
@@ -72,7 +72,7 @@ export type CheckDataModalProps = {
   open: boolean;
   onClose: (saved: boolean, snackbarMessage?: string) => void;
   species: Species[];
-  reviewErrors: () => void;
+  reviewErrors: (hasErrors: boolean) => void;
   reloadData: () => void;
 };
 
@@ -93,7 +93,7 @@ export default function CheckDataModal(props: CheckDataModalProps): JSX.Element 
 
   const reviewErrorsHandler = () => {
     handleCancel();
-    reviewErrors();
+    reviewErrors(speciesWithProblems !== undefined && speciesWithProblems.length > 0);
   };
 
   useEffect(() => {
@@ -131,10 +131,10 @@ export default function CheckDataModal(props: CheckDataModalProps): JSX.Element 
         <Button onClick={startDataCheck} label={error ? strings.TRY_AGAIN : strings.RUN_A_DATABASE_CHECK} key='mb-2' />,
       ];
     }
-    if (completed && !speciesWithProblems) {
+    if (completed && !speciesWithProblems?.length) {
       return [<Button onClick={handleCancel} label={strings.NICE} key='mb-1' />];
     }
-    if (completed && speciesWithProblems) {
+    if (completed && speciesWithProblems?.length) {
       return [<Button onClick={reviewErrorsHandler} label={strings.REVIEW_ERRORS} key='mb-1' />];
     }
   };
@@ -168,7 +168,7 @@ export default function CheckDataModal(props: CheckDataModalProps): JSX.Element 
         {completed && (
           <div className={classes.container}>
             <p className={classes.loadingText}>
-              {speciesWithProblems
+              {speciesWithProblems && speciesWithProblems.length
                 ? strings.formatString(strings.DATA_CHECK_WITH_PROBLEMS, speciesWithProblems.length)
                 : strings.DATA_CHECK_COMPLETED}
             </p>

--- a/src/components/Species/ProblemTooltip.tsx
+++ b/src/components/Species/ProblemTooltip.tsx
@@ -16,6 +16,9 @@ const useStyles = makeStyles((theme: Theme) =>
     spacing: {
       marginRight: theme.spacing(1),
     },
+    verticalSpacing: {
+      marginTop: theme.spacing(1),
+    },
     buttonsContainer: {
       background: '#F2F4F5',
       display: 'flex',
@@ -91,7 +94,7 @@ export default function ProblemTooltip({
         <p>{strings.ISSUE}</p>
         <p className={classes.value}>{problems[0].type}</p>
         {problems[0].suggestedValue ? (
-          <div>
+          <div className={classes.verticalSpacing}>
             <p>{strings.SUGGESTION}</p>
             <p className={classes.value}>{strings.formatString(strings.CHANGE_TO, problems[0].suggestedValue)}</p>
           </div>


### PR DESCRIPTION
1. show errors found vs not found screens
2. align table header icon (introduces a bit of space)
3. clear the error header column if there are no errors remaining

<img width="176" alt="Terraware App 2022-06-22 12-58-01" src="https://user-images.githubusercontent.com/1865174/175125733-9dfcc099-0502-42d7-b075-463bf908bf21.png">

<img width="242" alt="Terraware App 2022-06-22 11-21-00" src="https://user-images.githubusercontent.com/1865174/175125756-576ec932-c303-448b-b087-e70976002b1a.png">

![screencast 2022-06-22 13-02-36](https://user-images.githubusercontent.com/1865174/175126162-da9577ef-9812-4110-a860-1c5e0e1fd5c1.gif)

