### PR TITLE
Increase time to debounce search

### DIFF
--- a/src/components/Species/AddSpeciesModal.tsx
+++ b/src/components/Species/AddSpeciesModal.tsx
@@ -54,7 +54,7 @@ export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Elemen
   const [optionsForCommonName, setOptionsForCommonName] = useState<string[]>();
   const [newScientificName, setNewScientificName] = useState(false);
   // Debounce search term so that it only gives us latest value if searchTerm has not been updated within last 500ms.
-  const debouncedSearchTerm = useDebounce(record.scientificName, 500);
+  const debouncedSearchTerm = useDebounce(record.scientificName, 700);
   const [showWarning, setShowWarning] = useState(false);
 
   React.useEffect(() => {


### PR DESCRIPTION
After analizing the logs of response time of search api, I'm seeing that for example when I type "Orna", if I type it normally (slow, but not to slow) we execute 3 api calls: one for "or", one for "orn" and one for "orna", and the "or" response is the one that responds at the end (it has much more results), and that is why options are changing inconsistently.
Increasing the debounce time results in calling the api only one time, just for "orna", and results are correct.

Staging:
<img width="408" alt="Screen Shot 2022-06-23 at 10 08 45" src="https://user-images.githubusercontent.com/5919083/175306182-7d2d4342-9f86-4342-acda-94152af863ac.png">

Vercel (with increased time):
<img width="353" alt="Screen Shot 2022-06-23 at 10 10 02" src="https://user-images.githubusercontent.com/5919083/175306440-310058e1-2d1e-4936-bb58-f1f4967d271e.png">
