### PR TITLE
Fix alignment Page heading on Empty state

### DIFF
--- a/src/components/emptyStatePages/EmptyStatePage.tsx
+++ b/src/components/emptyStatePages/EmptyStatePage.tsx
@@ -211,8 +211,8 @@ export default function EmptyStatePage({ pageName, organization, reloadData }: E
           />
         </>
       )}
+      <PageHeader title={content.title1} subtitle='' />
       <Container className={classes.mainContainer}>
-        <PageHeader title={content.title1} subtitle='' />
         <div className={classes.content}>
           <EmptyStateContent
             title={content.title2}


### PR DESCRIPTION
Before:
<img width="1789" alt="Screen Shot 2022-06-23 at 16 34 17" src="https://user-images.githubusercontent.com/5919083/175382644-2dd6654b-87c7-4056-a8bd-2c46250f964c.png">

After:
<img width="1792" alt="Screen Shot 2022-06-23 at 16 33 31" src="https://user-images.githubusercontent.com/5919083/175382721-434db1f9-e3a8-4ed7-9f62-81e2caa4f581.png">
