### PR TITLE
SW-1081 misc UI fixes (part 2 of 4)

### DIFF
--- a/src/components/MyAccount/index.tsx
+++ b/src/components/MyAccount/index.tsx
@@ -33,14 +33,17 @@ const useStyles = makeStyles((theme) =>
       marginTop: 0,
       fontSize: '24px',
     },
-    mainContent: {
-      paddingTop: theme.spacing(4),
-    },
     centered: {
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'center',
       alignItems: 'flex-end',
+    },
+    organizationsHeading: {
+      marginBottom: 0,
+    },
+    editContainer: {
+      marginBottom: `${theme.spacing(8)}px`,
     },
   })
 );
@@ -264,12 +267,12 @@ export default function MyAccount({ user, organizations, edit, reloadUser, reloa
         </>
       )}
       <TfMain>
-        <Grid container spacing={3}>
-          <Grid item xs={2}>
+        <Grid container spacing={3} className={edit ? classes.editContainer : ''}>
+          <Grid item xs={4}>
             <h1 className={classes.title}>{strings.MY_ACCOUNT}</h1>
             <p>{strings.MY_ACCOUNT_DESC}</p>
           </Grid>
-          <Grid item xs={8} />
+          <Grid item xs={6} />
           <Grid item xs={2} className={classes.centered}>
             <Button
               id='edit-account'
@@ -333,10 +336,10 @@ export default function MyAccount({ user, organizations, edit, reloadUser, reloa
             <TfDivisor />
           </Grid>
           <Grid item xs={12}>
-            <h2>{dictionary.ORGANIZATIONS}</h2>
+            <h2 className={classes.organizationsHeading}>{dictionary.ORGANIZATIONS}</h2>
           </Grid>
           <Grid item xs={12}>
-            <div className={classes.mainContent}>
+            <div>
               <Grid container spacing={4}>
                 <Grid item xs={12}>
                   {organizations && (

--- a/src/components/People/TableCellRenderer.tsx
+++ b/src/components/People/TableCellRenderer.tsx
@@ -1,11 +1,22 @@
 import React from 'react';
+import { createStyles, makeStyles } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
 import { APP_PATHS } from 'src/constants';
 import CellRenderer, { TableRowType } from '../common/table/TableCellRenderer';
 import { RendererProps } from '../common/table/types';
 
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    link: {
+      color: '#0067C8',
+    },
+  })
+);
+
 export default function ProjectsCellRenderer(props: RendererProps<TableRowType>): JSX.Element {
+  const classes = useStyles();
   const { column, row, value, index } = props;
+
   if (column.key === 'projectNames' && Array.isArray(value)) {
     return <CellRenderer index={index} column={column} value={value.join(', ')} row={row} />;
   }
@@ -14,7 +25,11 @@ export default function ProjectsCellRenderer(props: RendererProps<TableRowType>)
     const personLocation = {
       pathname: APP_PATHS.PEOPLE_VIEW.replace(':personId', row.id.toString()),
     };
-    return <Link to={personLocation.pathname}>{iValue}</Link>;
+    return (
+      <Link to={personLocation.pathname} className={classes.link}>
+        {iValue}
+      </Link>
+    );
   };
 
   if (column.key === 'firstName') {

--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -280,11 +280,11 @@ export default function PeopleList({ organization, reloadData, user }: PeopleLis
         </>
       )}
       <Grid container spacing={3}>
-        <Grid item xs={2}>
+        <Grid item xs={4}>
           <h1 className={classes.title}>{strings.PEOPLE}</h1>
           <p>{strings.PEOPLE_DESCRIPTION}</p>
         </Grid>
-        <Grid item xs={8} />
+        <Grid item xs={6} />
         <Grid item xs={2} className={classes.centered}>
           <Button id='new-person' label={strings.ADD_PERSON} onClick={goToNewPerson} size='medium' />
         </Grid>

--- a/src/components/SeedBanks/TableCellRenderer.tsx
+++ b/src/components/SeedBanks/TableCellRenderer.tsx
@@ -1,17 +1,31 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { createStyles, makeStyles } from '@material-ui/core/styles';
 import { APP_PATHS } from 'src/constants';
 import CellRenderer, { TableRowType } from '../common/table/TableCellRenderer';
 import { RendererProps } from '../common/table/types';
 
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    link: {
+      color: '#0067C8',
+    },
+  })
+);
+
 export default function SeedBanksCellRenderer(props: RendererProps<TableRowType>): JSX.Element {
+  const classes = useStyles();
   const { column, row, value, index } = props;
 
   const createLinkToSeedBank = (iValue: React.ReactNode | unknown[]) => {
     const seedBankLocation = {
       pathname: APP_PATHS.SEED_BANKS_VIEW.replace(':seedBankId', row.id.toString()),
     };
-    return <Link to={seedBankLocation.pathname}>{iValue}</Link>;
+    return (
+      <Link to={seedBankLocation.pathname} className={classes.link}>
+        {iValue}
+      </Link>
+    );
   };
 
   if (column.key === 'name') {

--- a/src/components/SeedBanks/index.tsx
+++ b/src/components/SeedBanks/index.tsx
@@ -24,9 +24,6 @@ const useStyles = makeStyles((theme) =>
       marginTop: 0,
       fontSize: '24px',
     },
-    mainContent: {
-      paddingTop: theme.spacing(4),
-    },
     centered: {
       display: 'flex',
       flexDirection: 'column',
@@ -162,7 +159,7 @@ export default function SeedBanksList({ organization }: SeedBanksListProps): JSX
           />
         </Grid>
         <Grid item xs={12}>
-          <div className={classes.mainContent}>
+          <div>
             <Grid container spacing={4}>
               <Grid item xs={12}>
                 {seedBanks && (


### PR DESCRIPTION
This PR covers:
    
    [People] Description under title is scrunched up.
    
    [People] Table styling of links is not the right color.
    
    [Account] Description under title is scrunched up.
    
    [Account] Spacing between Organization title and table is too big.
    
    [Account] Not enough bottom padding to display paging for Organization table.
    
    [Seed Banks] Spacing between search bar and table is too big.
    
    [Seed Banks] Table styling of links is not the right color.

<img width="727" alt="Terraware App 2022-06-29 16-13-06" src="https://user-images.githubusercontent.com/1865174/176562614-7c9a7f69-2edf-41cc-9630-0f33cb75b785.png">

<img width="720" alt="Terraware App 2022-06-29 16-04-22" src="https://user-images.githubusercontent.com/1865174/176562616-a006528f-e5fb-4c98-b0b4-b181c7e58ca3.png">

<img width="717" alt="Terraware App 2022-06-29 15-55-42" src="https://user-images.githubusercontent.com/1865174/176562619-755b88a8-6c48-48dc-83c8-c76fad856651.png">

<img width="735" alt="Terraware App 2022-06-29 16-18-12" src="https://user-images.githubusercontent.com/1865174/176562610-2b7b5cd7-a332-4719-9611-70c669c6fa66.png">

