### PR TITLE
SW-1215 Show correct unit for seeds remaining in withdrawal modal

### DIFF
--- a/src/components/seeds/withdrawal/index.tsx
+++ b/src/components/seeds/withdrawal/index.tsx
@@ -71,7 +71,7 @@ export default function WithdrawalView({ accession, onSubmit }: Props): JSX.Elem
   } ${accession.totalScheduledWithdrawalQuantity ? strings.SCHEDULED : ''}`;
   const seedsAvailable = accession.remainingQuantity?.quantity || 0;
 
-  const allowWithdrawalInGrams = Boolean(accession.processingMethod === 'Weight');
+  const allowWithdrawalInWeight = Boolean(accession.processingMethod === 'Weight');
 
   const onEdit = (row: AccessionWithdrawal) => {
     setSelectedRecord(row);
@@ -136,8 +136,9 @@ export default function WithdrawalView({ accession, onSubmit }: Props): JSX.Elem
           onClose={onCloseModal}
           onDelete={onDelete}
           seedsAvailable={seedsAvailable}
-          value={selectedRecord}
-          allowWithdrawalInGrams={allowWithdrawalInGrams}
+          withdrawal={selectedRecord}
+          allowWithdrawalInWeight={allowWithdrawalInWeight}
+          accession={accession}
         />
         <InfoModal open={openInfoModal} onClose={onCloseInfoModal} />
         <MainPaper>


### PR DESCRIPTION
Use unit in accession's remaining quantity.
Refactored code a bit, renamed variables.

<img width="357" alt="Terraware App 2022-07-11 16-19-51" src="https://user-images.githubusercontent.com/1865174/178375536-8e2d5bf7-927c-4ad4-baf1-851094c95c1b.png">

<img width="343" alt="Terraware App 2022-07-11 16-19-20" src="https://user-images.githubusercontent.com/1865174/178375537-ae3910bc-fb0a-4d95-86a0-d465d2d6e68a.png">

<img width="345" alt="Terraware App 2022-07-11 16-18-39" src="https://user-images.githubusercontent.com/1865174/178375539-577b869f-cc11-4069-81f2-34c33b406758.png">
