### PR TITLE
Remove fragments inside menu to avoid mui error

### DIFF
--- a/src/components/MyAccountNavBar.tsx
+++ b/src/components/MyAccountNavBar.tsx
@@ -188,7 +188,7 @@ export default function MyAccountNavBar({
                   </MenuItem>
                   {hasOrganizations ? (
                     <div>
-                      <Divider />
+                      <Divider sx={{ margin: '16px 0' }} />
                       {organizations?.map((org, index) => {
                         return (
                           <MenuItem


### PR DESCRIPTION
This looks like a lot of changes, but I just removed a fragment <> and replaced another one with a div, to avoid a MUI error that was appearing on console "the Menu component doesn't accept a Fragment as a child"