### PR TITLE
Cancel in-progress builds of previous commits on branches that aren't main

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,6 +19,11 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  # Cancel in-progress builds on PRs, but not on staging deploys.
+  cancel-in-progress: ${{ github.ref != 'main' }}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Helps save on resources.