### PR TITLE
SW-1527 Add accession, enter plant/site details

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/styled-engine-sc": "^5.8.0",
     "@mui/styles": "^5.8.7",
     "@mui/x-date-pickers": "^5.0.0-alpha.7",
-    "@terraware/web-components": "^1.0.16",
+    "@terraware/web-components": "^1.0.17",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -529,6 +529,7 @@ export interface components {
       collectors?: string[];
       facilityId?: number;
       founderId?: string;
+      notes?: string;
       plantsCollectedFromMax?: number;
       plantsCollectedFromMin?: number;
       receivedDate?: string;
@@ -1001,11 +1002,11 @@ export interface components {
       configuration?: { [key: string]: unknown };
       settings?: { [key: string]: { [key: string]: unknown } };
       type: string;
-      verbosity: number;
       upperThreshold?: number;
-      lowerThreshold?: number;
+      verbosity: number;
       timeseriesName?: string;
       deviceId?: number;
+      lowerThreshold?: number;
     };
     MultiLineString: components["schemas"]["Geometry"] & {
       coordinates?: number[][][];

--- a/src/components/accession2/Accession2Create.tsx
+++ b/src/components/accession2/Accession2Create.tsx
@@ -164,7 +164,7 @@ export default function CreateAccession(props: CreateAccessionProps): JSX.Elemen
           </Grid>
           <Accession2Address record={record} onChange={onChange} />
           <Accession2GPS record={record} onChange={onChange} />
-          <Accession2PlantSiteDetails record={record} onChange={onChange} />
+          <Accession2PlantSiteDetails setRecord={setRecord} record={record} onChange={onChange} />
         </Grid>
         <Grid container>
           <Grid item xs={12} sx={{ marginTop: theme.spacing(4) }}>

--- a/src/components/accession2/Accession2Create.tsx
+++ b/src/components/accession2/Accession2Create.tsx
@@ -17,6 +17,8 @@ import SeedBank2Selector from './SeedBank2Selector';
 import { ACCESSION_2_STATES } from 'src/types/Accession';
 import Accession2Address from './Accession2Address';
 import Accession2GPS from './Accession2GPS';
+import Accession2PlantSiteDetails from './Accession2PlantSiteDetails';
+import getDateDisplayValue from 'src/utils/date';
 
 type CreateAccessionProps = {
   organization: ServerOrganization;
@@ -30,6 +32,7 @@ const SubTitleStyle = {
 const defaultAccession = (): AccessionPostRequestBody =>
   ({
     state: 'Awaiting Check-In',
+    receivedDate: getDateDisplayValue(Date.now()),
   } as AccessionPostRequestBody);
 
 type Dates = {
@@ -125,8 +128,8 @@ export default function CreateAccession(props: CreateAccessionProps): JSX.Elemen
           <Grid item xs={12} sx={datePickerStyle}>
             <DatePicker
               id='collectedDate'
-              label={strings.COLLECTED_DATE_REQUIRED}
-              aria-label={strings.COLLECTED_DATE_REQUIRED}
+              label={strings.COLLECTION_DATE_REQUIRED}
+              aria-label={strings.COLLECTION_DATE_REQUIRED}
               value={dates.collectedDate}
               onChange={changeDate}
             />
@@ -161,6 +164,7 @@ export default function CreateAccession(props: CreateAccessionProps): JSX.Elemen
           </Grid>
           <Accession2Address record={record} onChange={onChange} />
           <Accession2GPS record={record} onChange={onChange} />
+          <Accession2PlantSiteDetails record={record} onChange={onChange} />
         </Grid>
         <Grid container>
           <Grid item xs={12} sx={{ marginTop: theme.spacing(4) }}>
@@ -171,8 +175,8 @@ export default function CreateAccession(props: CreateAccessionProps): JSX.Elemen
           <Grid item xs={12} sx={datePickerStyle}>
             <DatePicker
               id='receivedDate'
-              label={strings.RECEIVED_DATE_REQUIRED}
-              aria-label={strings.RECEIVED_DATE_REQUIRED}
+              label={strings.RECEIVING_DATE_REQUIRED}
+              aria-label={strings.RECEIVING_DATE_REQUIRED}
               value={dates.receivedDate}
               onChange={changeDate}
             />

--- a/src/components/accession2/Accession2PlantSiteDetails.tsx
+++ b/src/components/accession2/Accession2PlantSiteDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, Dispatch, SetStateAction } from 'react';
 import strings from 'src/strings';
 import { Link, Grid, Box, useTheme } from '@mui/material';
 import { AccessionPostRequestBody } from 'src/api/accessions2/accession';
@@ -10,10 +10,11 @@ import { ACCESSION_2_COLLECTION_SOURCES } from 'src/types/Accession';
 type Accession2PlantSiteDetailsProps = {
   record: AccessionPostRequestBody;
   onChange: (id: string, value?: any) => void;
+  setRecord: Dispatch<SetStateAction<AccessionPostRequestBody>>;
 };
 
 export default function Accession2PlantSiteDetails(props: Accession2PlantSiteDetailsProps): JSX.Element {
-  const { record, onChange } = props;
+  const { record, onChange, setRecord } = props;
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [numPlants, setNumPlants] = useState<string>('');
   const { isMobile } = useDeviceInfo();
@@ -24,10 +25,8 @@ export default function Accession2PlantSiteDetails(props: Accession2PlantSiteDet
   const onChangeNumPlants = (value: any) => {
     const numPlantsStr = value as string;
     setNumPlants(numPlantsStr);
-    // tslint:disable-next-line: no-unnecessary-initializer
-    let min = undefined;
-    // tslint:disable-next-line: no-unnecessary-initializer
-    let max = undefined;
+    let min: number | undefined;
+    let max: number | undefined;
     // we support either a number or a range of two numbers, eg. 2 - 5
     const numbers = value.split('-').map((num: string) => num.trim());
     if (numbers.length < 3) {
@@ -52,8 +51,13 @@ export default function Accession2PlantSiteDetails(props: Accession2PlantSiteDet
         max = Math.max(temp, max);
       }
     }
-    onChange('plantsCollectedFromMin', min);
-    onChange('plantsCollectedFromMax', max);
+    setRecord((prev) => {
+      return {
+        ...prev,
+        plantsCollectedFromMin: min,
+        plantsCollectedFromMax: max,
+      };
+    });
   };
 
   if (!isOpen) {
@@ -99,6 +103,7 @@ export default function Accession2PlantSiteDetails(props: Accession2PlantSiteDet
             onChange={onChange}
             type='text'
             label={strings.PLANT_ID + ' ' + strings.IF_APPLICABLE}
+            tooltipText={strings.PLANT_ID_TOOLTIP}
           />
         </Grid>
       </Grid>
@@ -108,7 +113,7 @@ export default function Accession2PlantSiteDetails(props: Accession2PlantSiteDet
           value={record.collectionSiteNotes}
           onChange={onChange}
           type='textarea'
-          label={strings.DESCRIPTION_NOTES}
+          label={strings.PLANT_DESCRIPTION}
         />
       </Grid>
     </Grid>

--- a/src/components/accession2/Accession2PlantSiteDetails.tsx
+++ b/src/components/accession2/Accession2PlantSiteDetails.tsx
@@ -1,0 +1,117 @@
+import React, { useState, useEffect } from 'react';
+import strings from 'src/strings';
+import { Link, Grid, Box, useTheme } from '@mui/material';
+import { AccessionPostRequestBody } from 'src/api/accessions2/accession';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
+import Textfield from 'src/components/common/Textfield/Textfield';
+import Autocomplete from 'src/components/common/Autocomplete';
+import { Select } from '@terraware/web-components';
+import { ACCESSION_2_COLLECTION_SOURCES } from 'src/types/Accession';
+
+type Accession2PlantSiteDetailsProps = {
+  record: AccessionPostRequestBody;
+  onChange: (id: string, value?: any) => void;
+};
+
+export default function Accession2PlantSiteDetails(props: Accession2PlantSiteDetailsProps): JSX.Element {
+  const { record, onChange } = props;
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [numPlants, setNumPlants] = useState<string>('');
+  const { isMobile } = useDeviceInfo();
+  const theme = useTheme();
+
+  const gridSize = () => (isMobile ? 12 : 6);
+
+  const onChangeNumPlants = (value: any) => {
+    const numPlantsStr = value as string;
+    setNumPlants(numPlantsStr);
+    // tslint:disable-next-line: no-unnecessary-initializer
+    let min = undefined;
+    // tslint:disable-next-line: no-unnecessary-initializer
+    let max = undefined;
+    // we support either a number or a range of two numbers, eg. 2 - 5
+    const numbers = value.split('-').map((num: string) => num.trim());
+    if (numbers.length < 3) {
+      // Parse the numbers
+      min = parseInt(numbers[0], 10);
+      max = parseInt(numbers[1], 10);
+      const noMin = isNaN(min) || min === 0;
+      const noMax = isNaN(max) || max === 0;
+      if (noMin) {
+        min = undefined;
+      }
+      if (noMax) {
+        max = min;
+      } else if (noMin) {
+        // if we have " - 3" use 3 as min and max
+        min = max;
+      } else {
+        // if we have "4 - 3" use 3 as min and 4 as max;
+        // if we have "3 - 4" use 3 as min and 4 as max;
+        const temp = min as number;
+        min = Math.min(temp, max);
+        max = Math.max(temp, max);
+      }
+    }
+    onChange('plantsCollectedFromMin', min);
+    onChange('plantsCollectedFromMax', max);
+  };
+
+  if (!isOpen) {
+    return (
+      <Grid item xs={12} marginTop={theme.spacing(2)}>
+        <Box display='flex' justifyContent='flex-start'>
+          <Link sx={{ textDecoration: 'none' }} href='#' id='addPlantSiteDescription' onClick={() => setIsOpen(true)}>
+            {strings.ADD_PLANT_SITE_DESCRIPTION}
+          </Link>
+        </Box>
+      </Grid>
+    );
+  }
+
+  return (
+    <Grid item xs={12} display='flex' flexDirection={'column'} marginTop={theme.spacing(2)}>
+      <Grid item xs={12}>
+        <Select
+          id='collectionSource'
+          label={strings.COLLECTION_SOURCE}
+          placeholder={strings.SELECT}
+          selectedValue={record.collectionSource}
+          options={ACCESSION_2_COLLECTION_SOURCES}
+          onChange={(value) => onChange('collectionSource', value)}
+          fullWidth={true}
+          readonly={true}
+        />
+      </Grid>
+      <Grid item xs={12} display='flex' flexDirection={isMobile ? 'column' : 'row'} marginTop={theme.spacing(2)}>
+        <Grid item xs={gridSize()} sx={{ marginRight: isMobile ? 0 : theme.spacing(2) }}>
+          <Textfield
+            id='numPlants'
+            value={numPlants}
+            onChange={(unused, value) => onChangeNumPlants(value)}
+            type='text'
+            label={strings.NUMBER_PLANTS_COLLECTED_FROM}
+          />
+        </Grid>
+        <Grid item xs={gridSize()} sx={{ marginTop: isMobile ? theme.spacing(2) : 0 }}>
+          <Textfield
+            id='founderId'
+            value={record.founderId}
+            onChange={onChange}
+            type='text'
+            label={strings.PLANT_ID + ' ' + strings.IF_APPLICABLE}
+          />
+        </Grid>
+      </Grid>
+      <Grid item xs={12} sx={{ marginTop: theme.spacing(2) }}>
+        <Textfield
+          id='collectionSiteNotes'
+          value={record.collectionSiteNotes}
+          onChange={onChange}
+          type='textarea'
+          label={strings.DESCRIPTION_NOTES}
+        />
+      </Grid>
+    </Grid>
+  );
+}

--- a/src/components/accession2/Accession2PlantSiteDetails.tsx
+++ b/src/components/accession2/Accession2PlantSiteDetails.tsx
@@ -1,10 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import strings from 'src/strings';
 import { Link, Grid, Box, useTheme } from '@mui/material';
 import { AccessionPostRequestBody } from 'src/api/accessions2/accession';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import Textfield from 'src/components/common/Textfield/Textfield';
-import Autocomplete from 'src/components/common/Autocomplete';
 import { Select } from '@terraware/web-components';
 import { ACCESSION_2_COLLECTION_SOURCES } from 'src/types/Accession';
 

--- a/src/components/accession2/Accession2PlantSiteDetails.tsx
+++ b/src/components/accession2/Accession2PlantSiteDetails.tsx
@@ -109,8 +109,8 @@ export default function Accession2PlantSiteDetails(props: Accession2PlantSiteDet
       </Grid>
       <Grid item xs={12} sx={{ marginTop: theme.spacing(2) }}>
         <Textfield
-          id='collectionSiteNotes'
-          value={record.collectionSiteNotes}
+          id='notes'
+          value={record.notes}
           onChange={onChange}
           type='textarea'
           label={strings.PLANT_DESCRIPTION}

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -566,6 +566,7 @@ const strings = new LocalizedStrings({
     IF_APPLICABLE: '(if applicable)',
     PLANT_ID_TOOLTIP:
       'It’s the ID of a plant for tracking or conservation purpose. Ideally seeds from a tracked plant do not mix with others in a same accession.',
+    PLANT_DESCRIPTION: 'Plant Description',
   },
 });
 

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -548,9 +548,9 @@ const strings = new LocalizedStrings({
     SEED_PROCESSING_DETAIL: 'Seed Processing Detail',
     SEARCH_OR_SELECT: 'Search or Select...',
     SPECIES_REQUIRED: 'Species *',
-    COLLECTED_DATE_REQUIRED: 'Collected Date *',
+    COLLECTION_DATE_REQUIRED: 'Collection Date *',
     COLLECTION_SITE: 'Collection Site',
-    RECEIVED_DATE_REQUIRED: 'Received Date *',
+    RECEIVING_DATE_REQUIRED: 'Receiving Date *',
     PROCESSING_STATUS_REQUIRED: 'Processing Status *',
     LOCATION_REQUIRED: 'Location *',
     SUB_LOCATION_REQUIRED: 'Sub-Location *',
@@ -562,6 +562,10 @@ const strings = new LocalizedStrings({
     DELETE_ACCESSION_MESSAGE: 'You’re about to delete accession {0}.',
     ARE_YOU_SURE: 'Are you sure?',
     LATITUDE_LONGITUDE: 'Latitude, Longitude',
+    NUMBER_PLANTS_COLLECTED_FROM: 'Number of plants collected from',
+    IF_APPLICABLE: '(if applicable)',
+    PLANT_ID_TOOLTIP:
+      'It’s the ID of a plant for tracking or conservation purpose. Ideally seeds from a tracked plant do not mix with others in a same accession.',
   },
 });
 

--- a/src/types/Accession.ts
+++ b/src/types/Accession.ts
@@ -24,3 +24,5 @@ export const ACCESSION_2_STATES = [
   'Used Up',
   'Nursery',
 ];
+
+export const ACCESSION_2_COLLECTION_SOURCES = ['Wild', 'Reintroduced', 'Cultivated', 'Other'];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2459,10 +2459,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^1.0.16":
-  version "1.0.16"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-1.0.16.tgz#e672b92781210c104573db4ee5dc97bfdb8bc529"
-  integrity sha512-ITLV29T/l41Po9LBcx47izSCvLZvxIKdioKuBfm1nGNOuj2ERm3xpLC2W3CfomAVj7Cvm/uGVIZb3oUSrqq4CQ==
+"@terraware/web-components@^1.0.17":
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-1.0.17.tgz#da24559da56db1d43ee7e9a77c3ae1f7d42ec12f"
+  integrity sha512-hGxO2+boloIGQ+1ECSFXseE/I2i4pc4aR1Vnf5eEf7STifRoLY9MdNhHmovpYbEbcIy9zSVgEKnIACB6U/Yy1A==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.10.11"


### PR DESCRIPTION
The icon for tooltip will be followed up, pending this review https://github.com/terraware/web-components/pull/53
Also, the collectionSiteNotes property is being used here and in address view textareas.
The address view property will be supported soon in BE.

<img width="814" alt="Terraware App 2022-09-07 16-51-47" src="https://user-images.githubusercontent.com/1865174/189005363-7832038e-c82f-47cc-9691-172cce811bf6.png">

<img width="221" alt="Terraware App 2022-09-07 16-52-37" src="https://user-images.githubusercontent.com/1865174/189005371-ab5fbbae-0225-40f8-bc37-9dac34b3a261.png">
