### PR TITLE
SW-1605 Show in-situ/ex-situ suffixes for collection source

### DIFF
--- a/src/components/accession2/Accession2PlantSiteDetails.tsx
+++ b/src/components/accession2/Accession2PlantSiteDetails.tsx
@@ -4,8 +4,7 @@ import { Link, Grid, Box, useTheme } from '@mui/material';
 import { AccessionPostRequestBody } from 'src/api/accessions2/accession';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import Textfield from 'src/components/common/Textfield/Textfield';
-import { Select } from '@terraware/web-components';
-import { ACCESSION_2_COLLECTION_SOURCES } from 'src/types/Accession';
+import CollectionSource from './CollectionSource';
 
 type Accession2PlantSiteDetailsProps = {
   record: AccessionPostRequestBody;
@@ -35,15 +34,12 @@ export default function Accession2PlantSiteDetails(props: Accession2PlantSiteDet
   return (
     <Grid item xs={12} display='flex' flexDirection={'column'} marginTop={theme.spacing(2)}>
       <Grid item xs={12}>
-        <Select
+        <CollectionSource
           id='collectionSource'
           label={strings.COLLECTION_SOURCE}
           placeholder={strings.SELECT}
           selectedValue={record.collectionSource}
-          options={ACCESSION_2_COLLECTION_SOURCES}
           onChange={(value) => onChange('collectionSource', value)}
-          fullWidth={true}
-          readonly={true}
         />
       </Grid>
       <Grid item xs={12} display='flex' flexDirection={isMobile ? 'column' : 'row'} marginTop={theme.spacing(2)}>

--- a/src/components/accession2/CollectionSource.tsx
+++ b/src/components/accession2/CollectionSource.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import strings from 'src/strings';
+import { SelectValue } from 'src/components/common/Select/Select';
+
+interface Props {
+  placeholder: string;
+  id: string;
+  label: string;
+  onChange: (value: string) => void;
+  selectedValue?: string;
+}
+
+export default function CollectionSource(props: Props): JSX.Element {
+  return (
+    <SelectValue
+      {...props}
+      fullWidth={true}
+      readonly={true}
+      options={[
+        {
+          label: strings.WILD_IN_SITU,
+          value: 'Wild',
+        },
+        {
+          label: strings.REINTRODUCED,
+          value: 'Reintroduced',
+        },
+        {
+          label: strings.CULTIVATED_EX_SITU,
+          value: 'Cultivated',
+        },
+        {
+          label: strings.OTHER,
+          value: 'Other',
+        },
+      ]}
+    />
+  );
+}

--- a/src/components/accession2/DetailPanel.tsx
+++ b/src/components/accession2/DetailPanel.tsx
@@ -55,7 +55,25 @@ export default function DetailPanel(props: DetailPanelProps): JSX.Element {
     }
   };
 
-  const collectionSource = accession?.collectionSource;
+  const getCollectionSource = () => {
+    const source = accession?.collectionSource;
+
+    if (source === 'Wild') {
+      return strings.WILD_IN_SITU;
+    }
+
+    if (source === 'Reintroduced') {
+      return strings.REINTRODUCED;
+    }
+
+    if (source === 'Cultivated') {
+      return strings.CULTIVATED_EX_SITU;
+    }
+
+    return strings.OTHER;
+  };
+
+  const collectionSource = getCollectionSource();
   const numPlants = accession?.plantsCollectedFrom;
   const isNotPlural = numPlants === 1;
 

--- a/src/components/common/Select/Select.tsx
+++ b/src/components/common/Select/Select.tsx
@@ -1,2 +1,58 @@
-import { Select } from '@terraware/web-components';
+import { Select, SelectT } from '@terraware/web-components';
 export default Select;
+
+export type SelectItem = {
+  label: string;
+  value: string;
+};
+
+export interface SelectValueProps {
+  onChange: (newValue: string) => void;
+  label?: string;
+  disabled?: boolean;
+  id?: string;
+  className?: string;
+  helperText?: string | string[];
+  placeholder?: string;
+  errorText?: string | string[];
+  warningText?: string | string[];
+  selectedValue?: string;
+  readonly?: boolean;
+  options?: SelectItem[];
+  fullWidth?: boolean;
+  hideArrow?: boolean;
+  onBlur?: () => void;
+  onFocus?: () => void;
+  fixedMenu?: boolean;
+}
+
+/**
+ * This is a simple component that takes in a tuple { label, value }
+ * for list of options.
+ * The label is used for display, the value is passed back in onChange, and used to set selectedValue.
+ * This is a very common use-case for a Select component, extracting it out
+ * here. Not a candidate for web-components at this point.
+ *
+ * Example:
+ * <SelectValue
+ *   options=[{ label: 'label', value: 'value'}, { label: 'label1': value: 'value1'} ]
+ *   onChange={(value: string) => setSomeValue(value)}
+ *   selectedValue={'value1'}
+ * />
+ */
+export function SelectValue(props: SelectValueProps): JSX.Element {
+  const { selectedValue, onChange, ...remainingProps } = props;
+  const selectedItem = props.options?.find((option) => option.value === selectedValue);
+
+  return (
+    <SelectT<SelectItem>
+      {...remainingProps}
+      selectedValue={selectedItem}
+      isEqual={(A: SelectItem, B: SelectItem) => A.value === B.value}
+      renderOption={(option: SelectItem) => option.label}
+      toT={(str: string) => ({ label: str, value: str } as SelectItem)}
+      displayLabel={(option: SelectItem) => option?.label || ''}
+      onChange={(option: SelectItem) => onChange(option.value)}
+    />
+  );
+}

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -580,6 +580,9 @@ const strings = new LocalizedStrings({
     OPT_IN: 'Opt-In Features',
     PLANT: 'plant',
     PLANTS: 'plants',
+    WILD_IN_SITU: 'Wild (In Situ)',
+    REINTRODUCED: 'Reintroduced',
+    CULTIVATED_EX_SITU: 'Cultivated (Ex Situ)',
   },
 });
 


### PR DESCRIPTION
- added a new Select utility that has a { label, value } type for options but string for selectedValue and onChange
- we could maybe move this into web-components as a new Dropdown component? the Current one is outdated

<img width="815" alt="Terraware App 2022-09-12 12-48-17" src="https://user-images.githubusercontent.com/1865174/189745408-84b89cd8-b30c-4f15-996d-fdb3d44c32d9.png">

<img width="818" alt="Terraware App 2022-09-12 12-47-59" src="https://user-images.githubusercontent.com/1865174/189745412-9bf07d3c-8f7d-40fc-b21f-9a8c4946c32e.png">

<img width="807" alt="Terraware App 2022-09-12 12-47-36" src="https://user-images.githubusercontent.com/1865174/189745414-61474ebf-1789-4a31-ac8c-8e1293097287.png">
