### PR TITLE
SW-1616 / SW-1650 Withdrawal modal updates for withdrawn-user

### DIFF
--- a/src/components/accession2/Accession2EditModal.tsx
+++ b/src/components/accession2/Accession2EditModal.tsx
@@ -69,7 +69,7 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
       ]}
       scrolled={true}
     >
-      <Grid container xs={12} spacing={2} textAlign='left'>
+      <Grid container item xs={12} spacing={2} textAlign='left'>
         <Grid item xs={12}>
           <Textfield
             id='accessionNumber'

--- a/src/components/accession2/WithdrawModal.tsx
+++ b/src/components/accession2/WithdrawModal.tsx
@@ -18,6 +18,7 @@ import { getTodaysDateFormatted } from 'src/utils/date';
 import { WITHDRAWAL_SUBSTRATES, WITHDRAWAL_TREATMENTS, WITHDRAWAL_TYPES } from 'src/types/Accession';
 import useSnackbar from 'src/utils/useSnackbar';
 import { Dropdown } from '@terraware/web-components';
+import { isContributor } from 'src/utils/organization';
 
 export interface WithdrawDialogProps {
   open: boolean;
@@ -53,6 +54,7 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
   const [isNotesOpened, setIsNotesOpened] = useState(false);
   const theme = useTheme();
   const snackbar = useSnackbar();
+  const contributor = isContributor(organization);
 
   useEffect(() => {
     const getOrgUsers = async () => {
@@ -164,7 +166,19 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
     onClose();
   };
 
-  const renderUser = (userSel: User) => `${userSel?.firstName} ${userSel?.lastName}`;
+  const renderUser = (userSel: User): string => {
+    const firstName = contributor ? user.firstName : userSel?.firstName;
+    const lastName = contributor ? user.lastName : userSel?.lastName;
+    const email = contributor ? user.email : userSel?.email;
+
+    if (!firstName && !lastName) {
+      return email as string;
+    } else if (firstName && lastName) {
+      return `${firstName} ${lastName}`;
+    } else {
+      return (firstName || lastName) as string;
+    }
+  };
 
   return (
     <DialogBox
@@ -266,6 +280,7 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
             selectedValue={users?.find((userSel) => userSel.id === record.withdrawnByUserId)}
             toT={(firstName: string) => ({ firstName } as OrganizationUser)}
             fullWidth={true}
+            disabled={contributor}
           />
         </Grid>
         <Grid item xs={12}>

--- a/src/utils/organization.tsx
+++ b/src/utils/organization.tsx
@@ -1,5 +1,6 @@
 import { Facility } from 'src/api/types/facilities';
 import { HighOrganizationRolesValues, ServerOrganization } from 'src/types/Organization';
+import { OrganizationUser } from 'src/types/User';
 
 export const getAllSeedBanks = (organization: ServerOrganization): (Facility | undefined)[] => {
   let seedBanks: (Facility | undefined)[] = [];
@@ -11,4 +12,8 @@ export const getAllSeedBanks = (organization: ServerOrganization): (Facility | u
 
 export const isAdmin = (organization: ServerOrganization | undefined) => {
   return HighOrganizationRolesValues.includes(organization?.role || '');
+};
+
+export const isContributor = (roleHolder: ServerOrganization | OrganizationUser | undefined) => {
+  return roleHolder?.role === 'Contributor';
 };


### PR DESCRIPTION
- Contributors cannot set withdrawn user (defaults to self)
- If name is not available, use email (this we can iterate on, I think BE returns empty string if we don't have a name - for history, but over here we need to show something to identify user)

<img width="275" alt="Terraware App 2022-09-14 10-24-22" src="https://user-images.githubusercontent.com/1865174/190223667-fda4aca0-3895-49ba-bcfd-14ad9df4dbd0.png">

<img width="291" alt="Terraware App 2022-09-14 10-26-39" src="https://user-images.githubusercontent.com/1865174/190223671-b2769567-1a18-4ac1-861f-c60949377e7d.png">
