### PR TITLE
SW-1666 Viability testing database - version 1

### DIFF
--- a/cypress/integration/10-database.js
+++ b/cypress/integration/10-database.js
@@ -463,7 +463,7 @@ describe('Database', () => {
       cy.get('#seedCount').should('not.exist');
       cy.get('#subtitle').should('contain', '4 total');
       cy.get('#row1-remainingQuantity').should('contain', '10 Seeds');
-      cy.get('#row2-remainingQuantity').should('contain', '825 Seeds');
+      cy.get('#row2-remainingQuantity').should('contain', '265 Seeds');
       cy.get('#filter-remainingQuantity').should('contain', '(1)');
 
       cy.intercept('POST', '/api/v1/search').as('search');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/styled-engine-sc": "^5.8.0",
     "@mui/styles": "^5.8.7",
     "@mui/x-date-pickers": "^5.0.0-alpha.7",
-    "@terraware/web-components": "^1.0.23",
+    "@terraware/web-components": "^1.0.24",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/api/types/accessions.ts
+++ b/src/api/types/accessions.ts
@@ -23,3 +23,4 @@ export type Accession = AccessionGetResponse['accession'];
 
 export const schemas = 'schemas';
 export type Geolocation = components[typeof schemas]['Geolocation'];
+export type ViabilityTest = components[typeof schemas]['GetViabilityTestPayload'];

--- a/src/components/People/TableCellRenderer.tsx
+++ b/src/components/People/TableCellRenderer.tsx
@@ -26,11 +26,7 @@ export default function Renderer(props: RendererProps<TableRowType>): JSX.Elemen
     );
   };
 
-  if (column.key === 'firstName') {
-    return <CellRenderer index={index} column={column} value={createLinkToPerson(value)} row={row} />;
-  }
-
-  if (column.key === 'lastName') {
+  if (column.key === 'firstName' || column.key === 'lastName') {
     return <CellRenderer index={index} column={column} value={createLinkToPerson(value)} row={row} />;
   }
 

--- a/src/components/accession2/viabilityTesting/NewViabilityTestModal.tsx
+++ b/src/components/accession2/viabilityTesting/NewViabilityTestModal.tsx
@@ -54,7 +54,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
   };
 
   const onChangeUser = (newValue: OrganizationUser) => {
-    onChange('testingStaffUserId', newValue.id);
+    onChange('withdrawnByUserId', newValue.id);
   };
 
   const onChangeDate = (id: string, value?: any) => {
@@ -137,7 +137,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
             isEqual={(a: OrganizationUser, b: OrganizationUser) => a.id === b.id}
             renderOption={(option) => renderUser(option, user, contributor)}
             displayLabel={(option) => renderUser(option, user, contributor)}
-            selectedValue={users?.find((userSel) => userSel.id === record.testingStaffUserId)}
+            selectedValue={users?.find((userSel) => userSel.id === record.withdrawnByUserId)}
             toT={(firstName: string) => ({ firstName } as OrganizationUser)}
             fullWidth={true}
             disabled={contributor}

--- a/src/components/accession2/viabilityTesting/TableCellRenderer.tsx
+++ b/src/components/accession2/viabilityTesting/TableCellRenderer.tsx
@@ -83,7 +83,7 @@ export default function Renderer(props: RendererProps<TableRowType>): JSX.Elemen
       );
     }
 
-    return <CellRenderer {...defaultProps} value={getValue(`${viabilityPercent}%`)} />;
+    return <CellRenderer {...defaultProps} value={getValue(`${viabilityPercent}%`, { fontWeight: 500 })} />;
   }
 
   return <CellRenderer {...props} />;

--- a/src/components/accession2/viabilityTesting/TableCellRenderer.tsx
+++ b/src/components/accession2/viabilityTesting/TableCellRenderer.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { Icon } from '@terraware/web-components';
+import CellRenderer, { TableRowType } from 'src/components/common/table/TableCellRenderer';
+import { RendererProps } from 'src/components/common/table/types';
+import strings from 'src/strings';
+import { makeStyles } from '@mui/styles';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
+
+const useStyles = makeStyles(() => ({
+  syncIcon: {
+    '& path': {
+      fill: '#BD6931',
+    },
+  },
+}));
+
+export default function Renderer(props: RendererProps<TableRowType>): JSX.Element {
+  const classes = useStyles();
+  const { column, row, index } = props;
+  const defaultProps = { column, row, index };
+  const { isMobile } = useDeviceInfo();
+
+  const getValue = (iValue: React.ReactNode | unknown[], style?: object) => {
+    const styleProps = style || {};
+    return <Typography sx={{ ...styleProps, cursor: 'pointer' }}>{iValue}</Typography>;
+  };
+
+  const renderId = () => getValue(row.id, { color: '#0067C8' });
+
+  const renderDate = () => {
+    const { startDate, endDate } = row;
+    const date = `${startDate} ${strings.TO.toLowerCase()} ${endDate || '--'}`;
+    return getValue(date);
+  };
+
+  const renderTestType = () => {
+    const { testType } = row;
+    const label = () => {
+      if (testType === 'Lab') {
+        return strings.LAB_GERMINATION;
+      } else if (testType === 'Nursery') {
+        return strings.NURSERY_GERMINATION;
+      } else {
+        return strings.CUT_TEST;
+      }
+    };
+
+    return getValue(label(), { color: '#708284' });
+  };
+
+  const renderMobileId = () => {
+    return (
+      <Box>
+        {renderId()}
+        {renderDate()}
+        {renderTestType()}
+      </Box>
+    );
+  };
+
+  if (column.key === 'id') {
+    if (isMobile) {
+      return <CellRenderer {...defaultProps} value={renderMobileId()} />;
+    } else {
+      return <CellRenderer {...defaultProps} value={renderId()} />;
+    }
+  }
+
+  if (column.key === 'startDate') {
+    return <CellRenderer {...defaultProps} value={renderDate()} />;
+  }
+
+  if (column.key === 'testType') {
+    return <CellRenderer {...defaultProps} value={renderTestType()} />;
+  }
+
+  if (column.key === 'viabilityPercent') {
+    const { viabilityPercent } = row;
+    if (!row.endDate || row.viabilityPercent === undefined) {
+      return (
+        <CellRenderer {...defaultProps} value={getValue(<Icon name='iconSynced' className={classes.syncIcon} />)} />
+      );
+    }
+
+    return <CellRenderer {...defaultProps} value={getValue(`${viabilityPercent}%`)} />;
+  }
+
+  return <CellRenderer {...props} />;
+}

--- a/src/components/accession2/viabilityTesting/ViabilityTestingDatabase.tsx
+++ b/src/components/accession2/viabilityTesting/ViabilityTestingDatabase.tsx
@@ -1,0 +1,61 @@
+import { useTheme, Box, Typography } from '@mui/material';
+import { Button } from '@terraware/web-components';
+import Table from 'src/components/common/table';
+import { TableColumnType } from 'src/components/common/table/types';
+import { Accession2 } from 'src/api/accessions2/accession';
+import strings from 'src/strings';
+import TableCellRenderer from './TableCellRenderer';
+import { ViabilityTest } from 'src/api/types/accessions';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
+
+interface ViabilityTestingDatabaseProps {
+  accession: Accession2;
+  onNewViabilityTest: () => void;
+  onSelectViabilityTest: (test: ViabilityTest) => void;
+}
+
+const columns: TableColumnType[] = [
+  { key: 'id', name: '', type: 'number' },
+  { key: 'startDate', name: '', type: 'string' },
+  { key: 'testType', name: '', type: 'string' },
+  { key: 'viabilityPercent', name: '', type: 'number' },
+];
+
+const mobileColumns: TableColumnType[] = [
+  { key: 'id', name: '', type: 'number' },
+  { key: 'viabilityPercent', name: '', type: 'number' },
+];
+
+export default function ViabilityTestingDatabase(props: ViabilityTestingDatabaseProps): JSX.Element {
+  const { accession, onNewViabilityTest, onSelectViabilityTest } = props;
+  const { viabilityTests } = accession;
+  const { isMobile } = useDeviceInfo();
+  const theme = useTheme();
+
+  return (
+    <Box display='flex' flexDirection='column'>
+      <Box
+        display='flex'
+        flexDirection='row'
+        justifyContent='space-between'
+        alignItems='center'
+        marginBottom={theme.spacing(3)}
+      >
+        <Typography fontSize='16px' fontWeight={500}>
+          {strings.VIABILITY_TESTING}
+        </Typography>
+        <Button priority='secondary' label={strings.ADD_TEST} onClick={onNewViabilityTest} />
+      </Box>
+      <Box>
+        <Table
+          id='viability-testing-database'
+          columns={isMobile ? mobileColumns : columns}
+          rows={viabilityTests || []}
+          orderBy='id'
+          Renderer={TableCellRenderer}
+          onSelect={(test: ViabilityTest) => onSelectViabilityTest(test)}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/accession2/viabilityTesting/ViabilityTestingPanel.tsx
+++ b/src/components/accession2/viabilityTesting/ViabilityTestingPanel.tsx
@@ -7,6 +7,7 @@ import strings from 'src/strings';
 import { ServerOrganization } from 'src/types/Organization';
 import { User } from 'src/types/User';
 import NewViabilityTestModal from './NewViabilityTestModal';
+import ViabilityTestingDatabase from './ViabilityTestingDatabase';
 
 type ViabilityTestingPanelProps = {
   accession: Accession2;
@@ -31,7 +32,13 @@ export default function ViabilityTestingPanel(props: ViabilityTestingPanelProps)
         user={user}
       />
       {accession?.viabilityTests ? (
-        <Box>Viability Testing</Box>
+        <Box>
+          <ViabilityTestingDatabase
+            accession={accession}
+            onNewViabilityTest={() => setNewViabilityTestOpened(true)}
+            onSelectViabilityTest={(test) => window.alert(`Selected viability test ${test.id}`)}
+          />
+        </Box>
       ) : (
         <Box width={isMobile ? '100%' : '420px'} textAlign='center' sx={{ margin: '0 auto', paddingTop: 4 }}>
           <Typography>{strings.VIABILITY_TESTING_EMPTY_MESSAGE}</Typography>

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -612,6 +612,7 @@ const strings = new LocalizedStrings({
     TESTING_STAFF: 'Testing Staff',
     START_DATE_REQUIRED: 'Start Date *',
     NUMBER_OF_SEEDS_TESTED_REQUIRED: '# Seeds Tested *',
+    ADD_TEST: 'Add Test',
   },
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2459,10 +2459,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^1.0.23":
-  version "1.0.23"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-1.0.23.tgz#e538810601d7304d3116f512b6ea25a5780511d1"
-  integrity sha512-mIA+lXssoKSSdN19LDbNShAlQejro1FZNiNu9bvs5VgusEwk/HoNCDkDYbmpVWnBjSXMuUbibB6R9oSDZ35YNQ==
+"@terraware/web-components@^1.0.24":
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-1.0.24.tgz#a35a563f259c47c9761a0a26ad0756fa169061c1"
+  integrity sha512-lsN+pNNUSlgACC6Gl03jG5vrrB0eL/IVD1ypQHHCdH/q3Y0H4UcRuYC+/t4fryyiqn/c1EjlyBcnHqbTSZlWFA==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.10.11"


### PR DESCRIPTION
- this version shows data as required/specified in designs
- ability to create a new test from database, triggers the new test modal in the parent component
- added new hook to view existing tests
- version 2 will be iterations on top of this if any are needed

<img width="765" alt="viability-testing-database-desktop" src="https://user-images.githubusercontent.com/1865174/190734968-d66eb328-37b3-4c65-8a07-ed74894235f2.png">

<img width="301" alt="viability-testing-database-tablet" src="https://user-images.githubusercontent.com/1865174/190734980-11f389be-5dc6-482a-b3cb-396f096715ae.png">

<img width="208" alt="viability-testing-database-mobile" src="https://user-images.githubusercontent.com/1865174/190734984-338ca815-3258-40cb-9fd2-89628faa3b65.png">
