### PR TITLE
SW-1718 add edit icon to end-drying reminder

### DIFF
--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -448,18 +448,16 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
             </Box>
           </Box>
         )}
-        <Box
-          sx={{ cursor: 'pointer' }}
-          display='flex'
-          padding={(theme) => theme.spacing(0, 2)}
-          alignItems='center'
-          width={isMobile ? '100%' : 'auto'}
-          onClick={() => setOpenEndDryingReminderModal(true)}
-        >
+        <Box sx={editableParentProps}>
           <Icon name='notification' className={classes.iconStyle} />
-          <Typography paddingLeft={1}>
-            {accession?.dryingEndDate ? strings.END_DRYING_REMINDER_ON : strings.END_DRYING_REMINDER_OFF}
-          </Typography>
+          <Box sx={editableProps}>
+            <Typography paddingLeft={1}>
+              {accession?.dryingEndDate ? strings.END_DRYING_REMINDER_ON : strings.END_DRYING_REMINDER_OFF}
+            </Typography>
+            <IconButton sx={{ marginLeft: 3, height: '24px' }} onClick={() => setOpenEndDryingReminderModal(true)}>
+              <Icon name='iconEdit' className={`${classes.editIcon} edit-icon`} />
+            </IconButton>
+          </Box>
         </Box>
       </Box>
 


### PR DESCRIPTION
- add edit icon to hover-state and mobile view of end-drying reminder label
- this was missed in earlier PR

<img width="584" alt="Terraware App 2022-09-21 13-36-58" src="https://user-images.githubusercontent.com/1865174/191606177-c6c2b483-57d7-4c9a-b93d-ae22a256f1a8.png">

<img width="168" alt="Terraware App 2022-09-21 13-36-03" src="https://user-images.githubusercontent.com/1865174/191606182-d46b8f4e-48db-4b46-ab3d-90c93502090b.png">
