### PR TITLE
SW-1717 Fetch build-version file with dynamic query param to bust the cache

### DIFF
--- a/src/api/appVersion/index.ts
+++ b/src/api/appVersion/index.ts
@@ -14,7 +14,8 @@ export const getLatestAppVersion = async (): Promise<AppVersionResponse> => {
   };
 
   try {
-    response.version = (await axios.get(APPVERSION_ENDPOINT)).data;
+    const params = { timestamp: Date.now() };
+    response.version = (await axios.get(APPVERSION_ENDPOINT, { params })).data;
   } catch {
     response.requestSucceeded = false;
   }

--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -25,6 +25,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 import useQuery from 'src/utils/useQuery';
 import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
+import PageSnackbar from 'src/components/PageSnackbar';
 import ViabilityModal from '../edit/ViabilityModal';
 import NewViabilityTestModal from '../viabilityTesting/NewViabilityTestModal';
 import { ViabilityTest } from 'src/api/types/accessions';
@@ -411,6 +412,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
           {accession?.speciesScientificName}
         </Typography>
         <Typography color='#708284'>{accession?.speciesCommonName}</Typography>
+        <PageSnackbar />
       </Box>
 
       <Box


### PR DESCRIPTION
- to help fix the cached build-version fetch in production
- also added the page message component to accessions2 view

I didn't test using an nginx setup but can do that.

```
Request URL: http://localhost:3000/build-version.txt?timestamp=1663793133662
Request Method: GET
Status Code: 200 OK
```

<img width="745" alt="Terraware App 2022-09-21 13-48-52" src="https://user-images.githubusercontent.com/1865174/191608116-5228597c-8649-4b12-88f0-0ae5333bc9fe.png">
