### PR TITLE
SW-1722 Remove 'Cleaning' from V2 accession states in FE

### DIFF
--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -276,7 +276,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
         const isV2 = featureEnabled('V2 Accessions', preferences);
         if (!isV2 && allValues?.state?.values) {
           allValues.state.values = allValues.state.values.filter(
-            (state) => ['Awaiting Processing', 'Cleaning', 'Used Up'].indexOf(state) === -1
+            (state) => ['Awaiting Processing', 'Used Up'].indexOf(state) === -1
           );
         }
 

--- a/src/types/Accession.ts
+++ b/src/types/Accession.ts
@@ -15,7 +15,7 @@ export const ACCESSION_STATES = [
 export const ACCESSION_2_STATES = [
   'Awaiting Check-In',
   'Awaiting Processing',
-  'Cleaning',
+  'Processing',
   'Drying',
   'In Storage',
   'Used Up',
@@ -24,7 +24,7 @@ export const ACCESSION_2_STATES = [
 export const ACCESSION_2_CREATE_STATES = [
   'Awaiting Check-In',
   'Awaiting Processing',
-  'Cleaning',
+  'Processing',
   'Drying',
   'In Storage',
 ];


### PR DESCRIPTION
- Permit 'Processing' as a V2 accession state