### PR TITLE
SW-1726 show edit state only if accession is checked-in

### DIFF
--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -431,9 +431,13 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
               >
                 {accession.state}
               </Typography>
-              <IconButton sx={{ marginLeft: 3, height: '24px' }} onClick={() => setOpenEditStateModal(true)}>
-                <Icon name='iconEdit' className={`${classes.editIcon} edit-icon`} />
-              </IconButton>
+              {accession.state !== 'Awaiting Check-In' ? (
+                <IconButton sx={{ marginLeft: 3, height: '24px' }} onClick={() => setOpenEditStateModal(true)}>
+                  <Icon name='iconEdit' className={`${classes.editIcon} edit-icon`} />
+                </IconButton>
+              ) : (
+                <Box sx={{ marginLeft: 3, height: '24px', width: 2 }} />
+              )}
             </Box>
           </Box>
         )}


### PR DESCRIPTION
- show edit state only if accession is checked-in
- noticed that some accessions are already checked in but status is still awaiting check-in, these are mostly v1 accessions
- added a box to fill up space when we are not showing the edit icon so the spacing looks even

<img width="182" alt="Terraware App 2022-09-22 08-32-01" src="https://user-images.githubusercontent.com/1865174/191790830-5697f108-a89c-468a-bd3d-387b6e65f9bd.png">

<img width="650" alt="Terraware App 2022-09-22 08-31-35" src="https://user-images.githubusercontent.com/1865174/191790834-0d9dd103-f124-4ccc-afd6-2779861ef002.png">

<img width="647" alt="Terraware App 2022-09-22 08-30-23" src="https://user-images.githubusercontent.com/1865174/191790837-7da471fa-7842-452b-baf2-f23d1d3fccff.png">
