### PR TITLE
SW-1669 Add support to delete a viability test

### DIFF
--- a/src/api/accessions2/viabilityTest.ts
+++ b/src/api/accessions2/viabilityTest.ts
@@ -75,3 +75,37 @@ export const putViabilityTest = async (
 
   return response;
 };
+
+export type ViabilityTestDeleteResponse =
+  paths[typeof VIABILITY_TEST_ENDPOINT]['delete']['responses'][200]['content']['application/json'];
+
+type DeleteViabilityTestResponse = {
+  requestSucceeded: boolean;
+};
+
+export const deleteViabilityTest = async (
+  accessionId: number,
+  viabilityTestId: number
+): Promise<DeleteViabilityTestResponse> => {
+  const response: DeleteViabilityTestResponse = {
+    requestSucceeded: true,
+  };
+
+  try {
+    const serverResponse: ViabilityTestDeleteResponse = (
+      await axios.delete(
+        VIABILITY_TEST_ENDPOINT.replace('{accessionId}', accessionId.toString()).replace(
+          '{viabilityTestId}',
+          viabilityTestId.toString()
+        )
+      )
+    ).data;
+    if (serverResponse.status === 'error') {
+      response.requestSucceeded = false;
+    }
+  } catch {
+    response.requestSucceeded = false;
+  }
+
+  return response;
+};

--- a/src/components/accession2/viabilityTesting/DeleteViabilityTestModal.tsx
+++ b/src/components/accession2/viabilityTesting/DeleteViabilityTestModal.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import strings from 'src/strings';
+import Button from 'src/components/common/button/Button';
+import DialogBox from 'src/components/common/DialogBox/DialogBox';
+import { Typography } from '@mui/material';
+import { Accession2 } from 'src/api/accessions2/accession';
+import { ViabilityTest } from 'src/api/types/accessions';
+import { deleteViabilityTest } from 'src/api/accessions2/viabilityTest';
+import useSnackbar from 'src/utils/useSnackbar';
+
+export interface DeleteViabilityTestModalProps {
+  open: boolean;
+  accession: Accession2;
+  viabilityTest: ViabilityTest;
+  onCancel: () => void;
+  onDone: () => void;
+}
+
+export default function DeleteViabilityTestModal(props: DeleteViabilityTestModalProps): JSX.Element {
+  const { onCancel, open, accession, viabilityTest, onDone } = props;
+  const snackbar = useSnackbar();
+
+  const deleteHandler = async () => {
+    const response = await deleteViabilityTest(accession.id, viabilityTest.id);
+    if (response.requestSucceeded) {
+      onDone();
+    } else {
+      snackbar.toastError();
+    }
+  };
+
+  return (
+    <DialogBox
+      onClose={onCancel}
+      open={open}
+      title={strings.DELETE_VIABILITY_TEST}
+      size='medium'
+      middleButtons={[
+        <Button label={strings.CANCEL} type='passive' onClick={onCancel} priority='secondary' key='button-1' />,
+        <Button onClick={deleteHandler} type='destructive' label={strings.DELETE} key='button-2' />,
+      ]}
+      message={strings.formatString(strings.DELETE_VIABILITY_TEST_MESSAGE, viabilityTest.id.toString())}
+    >
+      <Typography sx={{ paddingTop: 3 }}>{strings.ARE_YOU_SURE}</Typography>
+    </DialogBox>
+  );
+}

--- a/src/components/accession2/viabilityTesting/ViewViabilityTestModal.tsx
+++ b/src/components/accession2/viabilityTesting/ViewViabilityTestModal.tsx
@@ -1,4 +1,5 @@
-import { Grid, Typography } from '@mui/material';
+import { useState } from 'react';
+import { Box, Grid, Typography } from '@mui/material';
 import { Button, DialogBox } from '@terraware/web-components';
 import { Accession2 } from 'src/api/accessions2/accession';
 import strings from 'src/strings';
@@ -6,6 +7,7 @@ import { ViabilityTest } from 'src/api/types/accessions';
 import { getFullTestType } from 'src/utils/viabilityTest';
 import ObservationsChart from './ObservationsChart';
 import { useDeviceInfo } from '@terraware/web-components/utils';
+import DeleteViabilityTestModal from './DeleteViabilityTestModal';
 
 export interface ViewViabilityTestModalProps {
   open: boolean;
@@ -13,10 +15,12 @@ export interface ViewViabilityTestModalProps {
   onClose: () => void;
   viabilityTest: ViabilityTest;
   onEdit: () => void;
+  reload: () => void;
 }
 
 export default function ViewViabilityTestModal(props: ViewViabilityTestModalProps): JSX.Element {
-  const { onClose, open, viabilityTest, onEdit } = props;
+  const { onClose, open, accession, viabilityTest, onEdit, reload } = props;
+  const [openDeleteModal, setOpenDeleteModal] = useState<boolean>(false);
   const { isMobile } = useDeviceInfo();
 
   const onCloseHandler = () => {
@@ -32,6 +36,22 @@ export default function ViewViabilityTestModal(props: ViewViabilityTestModalProp
   };
 
   const smallColumn = isMobile ? 6 : 4;
+
+  if (openDeleteModal) {
+    return (
+      <DeleteViabilityTestModal
+        open={openDeleteModal}
+        accession={accession}
+        viabilityTest={viabilityTest}
+        onCancel={() => setOpenDeleteModal(false)}
+        onDone={() => {
+          reload();
+          onCloseHandler();
+        }}
+      />
+    );
+  }
+
   return (
     <DialogBox
       onClose={onCloseHandler}
@@ -51,6 +71,14 @@ export default function ViewViabilityTestModal(props: ViewViabilityTestModalProp
             </Typography>
           </Grid>
           <Grid xs={6} textAlign='right'>
+            <Box marginRight={1} display='inline-block'>
+              <Button
+                type='passive'
+                priority='secondary'
+                label={strings.DELETE}
+                onClick={() => setOpenDeleteModal(true)}
+              />
+            </Box>
             <Button label={strings.EDIT} onClick={() => openEdit()} />
           </Grid>
         </Grid>

--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -311,6 +311,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
                 setSelectedTest(undefined);
               }}
               onEdit={() => setOpenNewViabilityTest(true)}
+              reload={reloadData}
             />
           )}
 

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -646,6 +646,8 @@ const strings = new LocalizedStrings({
     TOTAL_SEEDS_TESTED: 'Total Seeds Tested',
     APPLY_RESULT_QUESTION: 'Do you want to apply this result to the accession?',
     APPLY_RESULT: 'Apply Result',
+    DELETE_VIABILITY_TEST: 'Delete Viability Test',
+    DELETE_VIABILITY_TEST_MESSAGE: 'You’re about to delete viability test {0}.',
   },
 });
 


### PR DESCRIPTION
- i reused the accessions delete modal code
- the text message for deleting viability test may need to be iterated on later

<img width="332" alt="Terraware App 2022-09-22 14-26-16" src="https://user-images.githubusercontent.com/1865174/191854617-de0da777-d51b-4288-904d-cbc0834882c1.png">

<img width="254" alt="Terraware App 2022-09-22 14-26-38" src="https://user-images.githubusercontent.com/1865174/191854639-0be91a11-f240-4dd0-9ad3-9f853d286650.png">

<img width="183" alt="Terraware App 2022-09-22 14-27-04" src="https://user-images.githubusercontent.com/1865174/191854673-13b85097-fbe0-40ca-958d-97244ec4e600.png">

