### PR TITLE
SW-1807 create button accession v2 should saw 'create' instead of 'add'

### DIFF
--- a/src/components/accession2/create/Accession2Create.tsx
+++ b/src/components/accession2/create/Accession2Create.tsx
@@ -182,7 +182,7 @@ export default function CreateAccession(props: CreateAccessionProps): JSX.Elemen
           />
         </Grid>
       </Container>
-      <FormBottomBar onCancel={goToAccessions} onSave={saveAccession} saveButtonText={strings.ADD} />
+      <FormBottomBar onCancel={goToAccessions} onSave={saveAccession} saveButtonText={strings.CREATE} />
     </Box>
   );
 }

--- a/src/components/accession2/history/Accession2History.tsx
+++ b/src/components/accession2/history/Accession2History.tsx
@@ -57,7 +57,7 @@ export default function Accession2History(props: Accession2HistoryProps): JSX.El
           <Typography whiteSpace='pre' marginRight={theme.spacing(3)}>
             {item.date}
           </Typography>
-          <Typography sx={{ wordBreak: 'break-all' }}>
+          <Typography>
             {item.fullName || strings.NAME_UNKNOWN}&nbsp;{item.description}
           </Typography>
         </Box>


### PR DESCRIPTION
- also plugged in fix for SW-1813 history content breaking all of word