### PR TITLE
SW-1801 Use same default date for withdraw modal as other modals like create accession

### DIFF
--- a/src/components/accession2/create/Accession2Create.tsx
+++ b/src/components/accession2/create/Accession2Create.tsx
@@ -20,7 +20,7 @@ import Textfield from 'src/components/common/Textfield/Textfield';
 import FormBottomBar from 'src/components/common/FormBottomBar';
 import Select from 'src/components/common/Select/Select';
 import { ACCESSION_2_CREATE_STATES } from 'src/types/Accession';
-import getDateDisplayValue from 'src/utils/date';
+import { getTodaysDateFormatted } from 'src/utils/date';
 import useSnackbar from 'src/utils/useSnackbar';
 
 type CreateAccessionProps = {
@@ -35,7 +35,7 @@ const SubTitleStyle = {
 const defaultAccession = (): AccessionPostRequestBody =>
   ({
     state: 'Awaiting Check-In',
-    receivedDate: getDateDisplayValue(Date.now()),
+    receivedDate: getTodaysDateFormatted(),
   } as AccessionPostRequestBody);
 
 const MANDATORY_FIELDS = ['speciesId', 'collectedDate', 'receivedDate', 'state', 'facilityId'] as const;

--- a/src/utils/date.tsx
+++ b/src/utils/date.tsx
@@ -1,7 +1,6 @@
 import { getDateDisplayValue } from '@terraware/web-components/utils';
-import moment from 'moment';
 export default getDateDisplayValue;
 
 export const getTodaysDateFormatted = () => {
-  return moment().format('YYYY-MM-DD');
+  return getDateDisplayValue(Date.now());
 };


### PR DESCRIPTION
See bug video here https://www.loom.com/share/538d106e11b84e9e9345a03a967ac19e

- update util to use same code that other modals use