### PR TITLE
SW-1595 Change "Finish" to "Done" on sensor kit setup screen

### DIFF
--- a/src/components/Monitoring/sensorKitSetup/SensorLocations.tsx
+++ b/src/components/Monitoring/sensorKitSetup/SensorLocations.tsx
@@ -135,7 +135,7 @@ export default function SensorLocations(props: SensorLocationsProps): JSX.Elemen
       onNext={goToNext}
       title={strings.SENSOR_KIT_SET_UP_SENSOR_LOCATIONS}
       completed={completed}
-      buttonText={strings.FINISH}
+      buttonText={strings.DONE}
     >
       <div>{strings.SENSOR_KIT_SET_UP_SENSOR_LOCATIONS_DESCRIPTION}</div>
       <Grid container xs={12} className={classes.gridContainer}>

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -659,6 +659,7 @@ const strings = new LocalizedStrings({
     DUPLICATED_ACCESSION_NUMBER: 'We found {0} duplicated accession numbers:',
     EXPORT_RECORDS: 'Export records',
     CUSTOMIZE_TABLE_COLUMNS: 'Customize table columns',
+    DONE: 'Done',
   },
 });
 


### PR DESCRIPTION
When assigning sensor locations, change button text from "Finish" to "Done" as a part of sensor kit setup flow.

<img width="634" alt="Screen Shot 2022-09-28 at 9 06 11 PM" src="https://user-images.githubusercontent.com/104874529/192936718-b112358e-64e8-4f80-bf53-fc0c37c3cd28.png">
