### PR TITLE
SW-1818 Allow user to apply viability percent from cut test on the accession.

### DIFF
--- a/src/components/accession2/viabilityTesting/NewViabilityTestModal.tsx
+++ b/src/components/accession2/viabilityTesting/NewViabilityTestModal.tsx
@@ -188,7 +188,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
 
   const hasErrors = () => {
     if (record) {
-      const seedTestedError = !validateSeedsTested(record.seedsTested);
+      const seedTestedError = record.testType !== 'Cut' ? !validateSeedsTested(record.seedsTested) : false;
       const seedsGerminatedError = !validateSeedsGerminated();
       const recordingDateError = !validateRecordingDate();
       let missingRequiredField = MANDATORY_FIELDS.some((field: MandatoryField) => !record[field]);
@@ -221,7 +221,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
       if (response.requestSucceeded) {
         reload();
         onCloseHandler();
-        if (testCompleted && !readOnly) {
+        if ((testCompleted || record.testType === 'Cut') && !readOnly) {
           setSavedRecord({ ...record });
           setOpenViabilityResultModal(true);
         }

--- a/src/components/accession2/viabilityTesting/NewViabilityTestModal.tsx
+++ b/src/components/accession2/viabilityTesting/NewViabilityTestModal.tsx
@@ -221,7 +221,13 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
       if (response.requestSucceeded) {
         reload();
         onCloseHandler();
-        if ((testCompleted || record.testType === 'Cut') && !readOnly) {
+        const cutTestEdited =
+          record.testType === 'Cut' &&
+          (!viabilityTest ||
+            Number(record.seedsFilled) !== Number(viabilityTest.seedsFilled) ||
+            Number(record.seedsCompromised) !== Number(viabilityTest.seedsCompromised) ||
+            Number(record.seedsTested) !== Number(viabilityTest.seedsTested));
+        if ((testCompleted && !readOnly) || cutTestEdited) {
           setSavedRecord({ ...record });
           setOpenViabilityResultModal(true);
         }

--- a/src/components/accession2/viabilityTesting/TableCellRenderer.tsx
+++ b/src/components/accession2/viabilityTesting/TableCellRenderer.tsx
@@ -6,6 +6,7 @@ import { RendererProps } from 'src/components/common/table/types';
 import strings from 'src/strings';
 import { makeStyles } from '@mui/styles';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
+import { getCutTestViabilityPercent } from './utils';
 
 const useStyles = makeStyles(() => ({
   syncIcon: {
@@ -76,13 +77,13 @@ export default function Renderer(props: RendererProps<TableRowType>): JSX.Elemen
   }
 
   if (column.key === 'viabilityPercent') {
-    const { testType, viabilityPercent, seedsFilled, seedsCompromised, seedsTested } = row;
+    const { testType, viabilityPercent } = row;
 
     const getViabilityPercent = () => {
       if (testType !== 'Cut') {
         return viabilityPercent;
       }
-      return Math.floor(((seedsFilled + seedsCompromised) / seedsTested) * 100);
+      return getCutTestViabilityPercent(row);
     };
 
     if (testType !== 'Cut' && (!row.endDate || row.viabilityPercent === undefined)) {

--- a/src/components/accession2/viabilityTesting/ViabilityResultModal.tsx
+++ b/src/components/accession2/viabilityTesting/ViabilityResultModal.tsx
@@ -4,6 +4,7 @@ import { Accession2, updateAccession2 } from 'src/api/accessions2/accession';
 import strings from 'src/strings';
 import useSnackbar from 'src/utils/useSnackbar';
 import { ViabilityTest } from 'src/api/types/accessions';
+import { getCutTestViabilityPercent } from './utils';
 
 export interface ViabilityResultModalProps {
   open: boolean;
@@ -20,7 +21,7 @@ export default function ViabilityResultModal(props: ViabilityResultModalProps): 
 
   const saveResult = async () => {
     if (accession) {
-      const newAccession = { ...accession, viabilityPercent: getViabilityResult() };
+      const newAccession = { ...accession, viabilityPercent: getViabilityPercent() };
       const response = await updateAccession2(newAccession);
 
       if (response.requestSucceeded) {
@@ -32,7 +33,11 @@ export default function ViabilityResultModal(props: ViabilityResultModalProps): 
     }
   };
 
-  const getViabilityResult = () => {
+  const getViabilityPercent = () => {
+    if (viabilityTest?.testType === 'Cut') {
+      return getCutTestViabilityPercent(viabilityTest);
+    }
+
     let sum = 0;
     viabilityTest?.testResults?.forEach((tr) => {
       sum = sum + Number(tr.seedsGerminated);
@@ -56,7 +61,7 @@ export default function ViabilityResultModal(props: ViabilityResultModalProps): 
     >
       <Box padding={3}>
         <Typography color='#859799'>{strings.VIABILITY_RESULT}</Typography>
-        <Typography fontSize='24px'>{getViabilityResult()}%</Typography>
+        <Typography fontSize='24px'>{getViabilityPercent()}%</Typography>
       </Box>
 
       <Typography marginBottom={3}>{strings.APPLY_RESULT_QUESTION}</Typography>

--- a/src/components/accession2/viabilityTesting/utils.ts
+++ b/src/components/accession2/viabilityTesting/utils.ts
@@ -1,0 +1,4 @@
+export const getCutTestViabilityPercent = (cutTest: any) => {
+  const { seedsFilled, seedsCompromised, seedsTested } = cutTest;
+  return Math.floor(((Number(seedsFilled) + Number(seedsCompromised)) / Number(seedsTested)) * 100);
+};


### PR DESCRIPTION
- moved viability percent calculation to a util
- removed cut tests seedsTested validation (since this is implied and not user supplied)