### PR TITLE
Accession 2 misc tiny UI fixes

### DIFF
--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -279,7 +279,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
     right: isMobile ? 0 : `-${themeObj.spacing(1)}`,
   };
 
-  const editableProps = {
+  const readOnlyProps = {
     display: 'flex',
     whiteSpace: 'pre',
     '&:hover .edit-icon': {
@@ -293,6 +293,10 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
     alignItems: 'center',
     justifyContent: isMobile ? 'space-between' : 'normal',
     width: isMobile ? '100%' : 'auto',
+  };
+
+  const editableProps = {
+    ...readOnlyProps,
     cursor: 'pointer',
   };
 
@@ -494,7 +498,10 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
         <Box sx={editableDynamicValuesProps}>
           <Typography minWidth={isMobile ? '100px' : 0}>{strings.QUANTITY} </Typography>
           {accession?.remainingQuantity?.quantity ? (
-            <Box sx={editableProps} onClick={() => quantityEditable && setOpenQuantityModal(true)}>
+            <Box
+              sx={quantityEditable ? editableProps : readOnlyProps}
+              onClick={() => quantityEditable && setOpenQuantityModal(true)}
+            >
               <Box display='flex'>
                 {getAbsoluteQuantity()} {getEstimatedQuantity()}
               </Box>

--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -293,6 +293,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
     alignItems: 'center',
     justifyContent: isMobile ? 'space-between' : 'normal',
     width: isMobile ? '100%' : 'auto',
+    cursor: 'pointer',
   };
 
   const editableParentProps = {
@@ -443,7 +444,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
         {accession?.state && (
           <Box sx={editableParentProps}>
             <Icon name='seedbankNav' className={classes.iconStyle} />
-            <Box sx={editableProps}>
+            <Box sx={editableProps} onClick={() => setOpenEditStateModal(true)}>
               <Typography
                 paddingLeft={1}
                 sx={{ ...getStylesForState(), padding: 1, borderRadius: '8px', fontSize: '14px', marginLeft: 1 }}
@@ -451,7 +452,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
                 {accession.state}
               </Typography>
               {accession.state !== 'Awaiting Check-In' ? (
-                <IconButton sx={{ marginLeft: 3, height: '24px' }} onClick={() => setOpenEditStateModal(true)}>
+                <IconButton sx={{ marginLeft: 3, height: '24px' }}>
                   <Icon name='iconEdit' className={`${classes.editIcon} edit-icon`} />
                 </IconButton>
               ) : (
@@ -463,40 +464,42 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
         {accession?.facilityId !== undefined && (
           <Box sx={editableParentProps}>
             <Icon name='iconMyLocation' className={classes.iconStyle} />
-            <Box sx={editableProps}>
+            <Box sx={editableProps} onClick={() => setOpenEditLocationModal(true)}>
               <Typography paddingLeft={1}>
                 {getSeedBank(organization, accession.facilityId)?.name}
                 {accession.storageLocation ? ` / ${accession.storageLocation}` : ''}
               </Typography>
-              <IconButton sx={{ marginLeft: 3, height: '24px' }} onClick={() => setOpenEditLocationModal(true)}>
+              <IconButton sx={{ marginLeft: 3, height: '24px' }}>
                 <Icon name='iconEdit' className={`${classes.editIcon} edit-icon`} />
               </IconButton>
             </Box>
           </Box>
         )}
-        <Box sx={editableParentProps}>
-          <Icon name='notification' className={classes.iconStyle} />
-          <Box sx={editableProps}>
-            <Typography paddingLeft={1}>
-              {accession?.dryingEndDate ? strings.END_DRYING_REMINDER_ON : strings.END_DRYING_REMINDER_OFF}
-            </Typography>
-            <IconButton sx={{ marginLeft: 3, height: '24px' }} onClick={() => setOpenEndDryingReminderModal(true)}>
-              <Icon name='iconEdit' className={`${classes.editIcon} edit-icon`} />
-            </IconButton>
+        {accession?.state === 'Drying' && (
+          <Box sx={editableParentProps}>
+            <Icon name='notification' className={classes.iconStyle} />
+            <Box sx={editableProps} onClick={() => setOpenEndDryingReminderModal(true)}>
+              <Typography paddingLeft={1}>
+                {accession?.dryingEndDate ? strings.END_DRYING_REMINDER_ON : strings.END_DRYING_REMINDER_OFF}
+              </Typography>
+              <IconButton sx={{ marginLeft: 3, height: '24px' }}>
+                <Icon name='iconEdit' className={`${classes.editIcon} edit-icon`} />
+              </IconButton>
+            </Box>
           </Box>
-        </Box>
+        )}
       </Box>
 
       <Box display='flex' flexDirection={isMobile ? 'column' : 'row'} padding={isMobile ? 2 : 0}>
         <Box sx={editableDynamicValuesProps}>
           <Typography minWidth={isMobile ? '100px' : 0}>{strings.QUANTITY} </Typography>
           {accession?.remainingQuantity?.quantity ? (
-            <Box sx={editableProps}>
+            <Box sx={editableProps} onClick={() => quantityEditable && setOpenQuantityModal(true)}>
               <Box display='flex'>
                 {getAbsoluteQuantity()} {getEstimatedQuantity()}
               </Box>
               {quantityEditable ? (
-                <IconButton sx={{ marginLeft: 3, height: '24px' }} onClick={() => setOpenQuantityModal(true)}>
+                <IconButton sx={{ marginLeft: 3, height: '24px' }}>
                   <Icon name='iconEdit' className={`${classes.editIcon} edit-icon`} />
                 </IconButton>
               ) : (
@@ -518,11 +521,11 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
         <Box sx={editableDynamicValuesProps}>
           <Typography minWidth={isMobile ? '100px' : 0}>{strings.VIABILITY}</Typography>
           {accession?.viabilityPercent ? (
-            <Box sx={editableProps}>
+            <Box sx={editableProps} onClick={() => setOpenViabilityModal(true)}>
               <Box display='flex'>
                 <Typography fontWeight={500}>{accession?.viabilityPercent}</Typography>%
               </Box>
-              <IconButton sx={{ marginLeft: 3, height: '24px' }} onClick={() => setOpenViabilityModal(true)}>
+              <IconButton sx={{ marginLeft: 3, height: '24px' }}>
                 <Icon name='iconEdit' className={`${classes.editIcon} edit-icon`} />
               </IconButton>
             </Box>

--- a/src/components/seeds/summary/index.tsx
+++ b/src/components/seeds/summary/index.tsx
@@ -61,6 +61,7 @@ export default function SeedSummary(props: SeedSummaryProps): JSX.Element {
   // populateSummaryInterval value is only being used when it is set.
   const [, setPopulateSummaryInterval] = useState<ReturnType<typeof setInterval>>();
   const [summary, setSummary] = useState<GetSummaryResponse>();
+  const [isEmptyState, setIsEmptyState] = useState<boolean>(false);
   const errorOccurred = summary ? summary.errorOccurred : false;
   const [, setSelectedOrgInfo] = useRecoilState(seedsSummarySelectedOrgInfo);
   const { isMobile } = useDeviceInfo();
@@ -72,7 +73,11 @@ export default function SeedSummary(props: SeedSummaryProps): JSX.Element {
         organization && organization.facilities?.find((facility) => facility.name === 'Seed Bank');
 
       const populateSummary = async () => {
-        setSummary(await getSummary(organization.id));
+        const response = await getSummary(organization.id);
+        if (!response.value?.activeAccessions) {
+          setIsEmptyState(true);
+        }
+        setSummary(response);
       };
 
       // Update summary information
@@ -118,26 +123,28 @@ export default function SeedSummary(props: SeedSummaryProps): JSX.Element {
       <Container maxWidth={false} className={classes.mainContainer}>
         {organization && summary ? (
           <Grid container spacing={3}>
-            <Grid item xs={12}>
-              <Box
-                sx={{
-                  background: '#F2F4F5',
-                  borderRadius: '14px',
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  padding: (theme) => theme.spacing(3, 4),
-                }}
-              >
-                <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                  <Icon name='seedbankNav' className={classes.messageIcon} size='large' />
-                  <Typography sx={{ color: '#000000', size: '20px', paddingLeft: 1 }}>
-                    {strings.DASHBOARD_MESSAGE}
-                  </Typography>
+            {isEmptyState === true && (
+              <Grid item xs={12}>
+                <Box
+                  sx={{
+                    background: '#F2F4F5',
+                    borderRadius: '14px',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    padding: (theme) => theme.spacing(3, 4),
+                  }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    <Icon name='seedbankNav' className={classes.messageIcon} size='large' />
+                    <Typography sx={{ color: '#000000', size: '20px', paddingLeft: 1 }}>
+                      {strings.DASHBOARD_MESSAGE}
+                    </Typography>
+                  </Box>
+                  <Button label={strings.GET_STARTED} onClick={() => history.push(APP_PATHS.ACCESSIONS)} />
                 </Box>
-                <Button label={strings.GET_STARTED} onClick={() => history.push(APP_PATHS.ACCESSIONS)} />
-              </Box>
-            </Grid>
+              </Grid>
+            )}
             <Grid item xs={12}>
               <Grid container spacing={3}>
                 <Grid item xs={cardGridSize()}>


### PR DESCRIPTION
- SW-1830 - end-drying reminder to be shown only when accession is in status 'Drying'
- SW-1829 - expand clickable area for accession info (status, location, etc.)
- SW-1826 - Get Started banner to be shown in empty state only
- 
<img width="848" alt="Terraware App 2022-09-30 10-07-56" src="https://user-images.githubusercontent.com/1865174/193323687-30e6d45a-1710-4415-8429-85649ad1124b.png">

<img width="845" alt="Terraware App 2022-09-30 10-07-30" src="https://user-images.githubusercontent.com/1865174/193323692-51ea963a-0d18-4722-8c35-6d807cf0badc.png">
