### PR TITLE
SW-1904 Fix end-drying reminder date display on accessions view

### DIFF
--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -301,7 +301,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
 
   const editableParentProps = {
     display: 'flex',
-    padding: themeObj.spacing(0, 2, isMobile ? 3 : 0),
+    padding: themeObj.spacing(0, isMobile ? 0 : 2, isMobile ? 3 : 0, isMobile ? 0 : 2),
     alignItems: 'center',
     width: isMobile ? '100%' : 'auto',
   };
@@ -309,7 +309,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
   const editableDynamicValuesProps = {
     display: 'flex',
     flexDirection: isMobile ? 'row' : 'column',
-    padding: isMobile ? 1 : 4,
+    padding: isMobile ? themeObj.spacing(1, 0) : 4,
     width: isMobile ? '100%' : 'auto',
   };
 
@@ -442,7 +442,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
         display='flex'
         alignItems={isMobile ? 'flex-start' : 'center'}
         flexDirection={isMobile ? 'column' : 'row'}
-        padding={(theme) => theme.spacing(0, 1)}
+        padding={(theme) => theme.spacing(0, isMobile ? 0 : 1)}
       >
         {accession?.state && (
           <Box sx={editableParentProps}>
@@ -483,7 +483,12 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
             <Icon name='notification' className={classes.iconStyle} />
             <Box sx={editableProps} onClick={() => setOpenEndDryingReminderModal(true)}>
               <Typography paddingLeft={1}>
-                {accession?.dryingEndDate ? strings.END_DRYING_REMINDER_ON : strings.END_DRYING_REMINDER_OFF}
+                {accession?.dryingEndDate
+                  ? `${strings.END_DRYING_REMINDER} ${moment(accession.dryingEndDate).fromNow()}`
+                  : strings.END_DRYING_REMINDER_OFF}
+                {accession?.dryingEndDate ? (
+                  <Typography display={isMobile ? 'block' : 'inline-block'}>({accession.dryingEndDate})</Typography>
+                ) : null}
               </Typography>
               <IconButton sx={{ marginLeft: 3, height: '24px', width: '24px' }}>
                 <Icon name='iconEdit' className={`${classes.editIcon} edit-icon`} />
@@ -493,7 +498,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
         )}
       </Box>
 
-      <Box display='flex' flexDirection={isMobile ? 'column' : 'row'} padding={isMobile ? 2 : 0}>
+      <Box display='flex' flexDirection={isMobile ? 'column' : 'row'} padding={isMobile ? themeObj.spacing(2, 0) : 0}>
         <Box sx={editableDynamicValuesProps}>
           <Typography minWidth={isMobile ? '100px' : 0}>{strings.QUANTITY} </Typography>
           {accession?.remainingQuantity?.quantity ? (
@@ -572,11 +577,13 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
               <Tab label={strings.VIABILITY_TESTING} value='viabilityTesting' sx={viabilityTestingStyle()} />
             </TabList>
           </Box>
-          <TabPanel value='detail'>
+          <TabPanel value='detail' sx={{ paddingX: isMobile ? 0 : 3 }}>
             <DetailPanel accession={accession} organization={organization} reload={reloadData} />
           </TabPanel>
-          <TabPanel value='history'>{accession && <Accession2History accession={accession} />}</TabPanel>
-          <TabPanel value='viabilityTesting'>
+          <TabPanel value='history' sx={{ paddingX: isMobile ? 0 : 3 }}>
+            {accession && <Accession2History accession={accession} />}
+          </TabPanel>
+          <TabPanel value='viabilityTesting' sx={{ paddingX: isMobile ? 0 : 3 }}>
             {accession && (
               <ViabilityTestingPanel
                 accession={accession}

--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -450,7 +450,14 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
             <Box sx={editableProps} onClick={() => setOpenEditStateModal(true)}>
               <Typography
                 paddingLeft={1}
-                sx={{ ...getStylesForState(), padding: 1, borderRadius: '8px', fontSize: '14px', marginLeft: 1 }}
+                sx={{
+                  ...getStylesForState(),
+                  padding: 1,
+                  borderRadius: '8px',
+                  fontSize: '14px',
+                  marginLeft: 1,
+                  marginTop: isMobile ? -0.5 : 0,
+                }}
               >
                 {accession.state}
               </Typography>

--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -415,7 +415,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
           )}
         </>
       )}
-      <Box padding={3}>
+      <Box padding={isMobile ? themeObj.spacing(3, 0) : 3}>
         <Box display='flex' justifyContent='space-between' alignItems='center'>
           <Typography>{accession?.accessionNumber}</Typography>
           {!isMobile && (
@@ -487,7 +487,9 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
                   ? `${strings.END_DRYING_REMINDER} ${moment(accession.dryingEndDate).fromNow()}`
                   : strings.END_DRYING_REMINDER_OFF}
                 {accession?.dryingEndDate ? (
-                  <Typography display={isMobile ? 'block' : 'inline-block'}>({accession.dryingEndDate})</Typography>
+                  <Typography display={isMobile ? 'block' : 'inline-block'}>
+                    {isMobile ? '' : ' '}({accession.dryingEndDate})
+                  </Typography>
                 ) : null}
               </Typography>
               <IconButton sx={{ marginLeft: 3, height: '24px', width: '24px' }}>

--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -289,7 +289,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
       display: isMobile ? 'block' : 'none',
       ...iconProps,
     },
-    alignItems: 'center',
+    alignItems: isMobile ? 'flex-start' : 'center',
     justifyContent: isMobile ? 'space-between' : 'normal',
     width: isMobile ? '100%' : 'auto',
   };
@@ -302,7 +302,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
   const editableParentProps = {
     display: 'flex',
     padding: themeObj.spacing(0, isMobile ? 0 : 2, isMobile ? 3 : 0, isMobile ? 0 : 2),
-    alignItems: 'center',
+    alignItems: isMobile ? 'flex-start' : 'center',
     width: isMobile ? '100%' : 'auto',
   };
 
@@ -468,7 +468,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
           <Box sx={editableParentProps}>
             <Icon name='iconMyLocation' className={classes.iconStyle} />
             <Box sx={editableProps} onClick={() => setOpenEditLocationModal(true)}>
-              <Typography paddingLeft={1}>
+              <Typography paddingLeft={1} lineHeight={isMobile ? 1.2 : 1.5}>
                 {getSeedBank(organization, accession.facilityId)?.name}
                 {accession.storageLocation ? ` / ${accession.storageLocation}` : ''}
               </Typography>
@@ -482,12 +482,16 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
           <Box sx={editableParentProps}>
             <Icon name='notification' className={classes.iconStyle} />
             <Box sx={editableProps} onClick={() => setOpenEndDryingReminderModal(true)}>
-              <Typography paddingLeft={1}>
+              <Typography paddingLeft={1} lineHeight={isMobile ? 1.2 : 1.5}>
                 {accession?.dryingEndDate
                   ? `${strings.END_DRYING_REMINDER} ${moment(accession.dryingEndDate).fromNow()}`
                   : strings.END_DRYING_REMINDER_OFF}
                 {accession?.dryingEndDate ? (
-                  <Typography display={isMobile ? 'block' : 'inline-block'}>
+                  <Typography
+                    display={isMobile ? 'block' : 'inline-block'}
+                    lineHeight={isMobile ? 1.2 : 1.5}
+                    marginTop={isMobile ? 1 : 0}
+                  >
                     {isMobile ? '' : ' '}({accession.dryingEndDate})
                   </Typography>
                 ) : null}

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -624,7 +624,6 @@ const strings = new LocalizedStrings({
     MARK_AS_COMPLETE: 'Mark as Complete',
     END_DRYING_REMINDER: 'End-Drying Reminder',
     END_DRYING_REMINDER_OFF: 'End-drying Reminder Off',
-    END_DRYING_REMINDER_ON: 'End-drying Reminder On',
     TURN_ON_END_DRYING_REMINDER: 'Turn on End-drying Reminder',
     REMINDER_DATE: 'Reminder Date',
     VIABILITY_RATE: 'Viability Rate',


### PR DESCRIPTION
- show relative time left/passed for end-drying reminder
- update padding on mobile view as per spec, current horizontal padding was too big
- update alignment to be `flex-start` on mobile, `center` on desktop - to match the spec

<img width="835" alt="Terraware App 2022-10-03 14-35-26" src="https://user-images.githubusercontent.com/1865174/193689294-2ed38abf-6280-4fc6-aa25-45ef504de47f.png">

<img width="228" alt="Terraware App 2022-10-03 16-01-08" src="https://user-images.githubusercontent.com/1865174/193700979-74c1a115-3b2d-44c2-a4f7-d4448cc6efdd.png">

