### PR TITLE
SW-1920 Fix bug on saving accession from edit modal

### DIFF
--- a/src/components/accession2/edit/Accession2EditModal.tsx
+++ b/src/components/accession2/edit/Accession2EditModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Grid, Typography } from '@mui/material';
 import { Button, DialogBox, Textfield } from '@terraware/web-components';
 import { Accession2, updateAccession2 } from 'src/api/accessions2/accession';
@@ -37,6 +37,10 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
     const missingRequiredField = MANDATORY_FIELDS.some((field: MandatoryField) => !record || !record[field]);
     return missingRequiredField;
   };
+
+  useEffect(() => {
+    setRecord(accession);
+  }, [accession, setRecord]);
 
   const saveAccession = async () => {
     if (record) {


### PR DESCRIPTION
If accession was updated outside the Edit Modal, the record used in edit modal was not being updated with last values. So the fix is to update the record used in the edit modal every time the accession changes