### PR TITLE
SW-1919 Right align certain columns in accessions table

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/styled-engine-sc": "^5.8.0",
     "@mui/styles": "^5.8.7",
     "@mui/x-date-pickers": "^5.0.0-alpha.7",
-    "@terraware/web-components": "^1.0.32",
+    "@terraware/web-components": "^1.0.33",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/components/accession2/view/DetailPanel.tsx
+++ b/src/components/accession2/view/DetailPanel.tsx
@@ -178,7 +178,7 @@ export default function DetailPanel(props: DetailPanelProps): JSX.Element {
           </Grid>
           <Grid item xs={12} sx={gridRowStyle}>
             <Grid item xs={gridLeftSide} sx={categoryStyle}>
-              {strings.PLANT_AND_SITE}
+              {strings.PLANT_LABEL}
             </Grid>
             <Grid item xs={gridRightSide}>
               {`${strings.COLLECTED_FROM}${numPlants === undefined ? '' : ' ' + numPlants}${

--- a/src/components/seeds/database/TableCellRenderer.tsx
+++ b/src/components/seeds/database/TableCellRenderer.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { SearchResponseElement } from 'src/api/seeds/search';
 import CellRenderer from 'src/components/common/table/TableCellRenderer';
 import { RendererProps } from 'src/components/common/table/types';
+import { RIGHT_ALIGNED_COLUMNS } from './columns';
 
 const statusStyles = makeStyles((theme: Theme) => ({
   flex: {
@@ -19,14 +20,17 @@ const statusStyles = makeStyles((theme: Theme) => ({
     alignItems: 'center',
     color: theme.palette.neutral[600],
   },
+  rightAligned: {
+    textAlign: 'right',
+  },
 }));
 
 export default function SearchCellRenderer(props: RendererProps<SearchResponseElement>): JSX.Element {
   const { column, value, index, row } = props;
+  const classes = statusStyles();
 
   const id = `row${index}-${column.key}`;
   if (column.key === 'active' && typeof value === 'string' && value) {
-    const classes = statusStyles();
     const active = value === 'Active';
 
     return (
@@ -64,5 +68,7 @@ export default function SearchCellRenderer(props: RendererProps<SearchResponseEl
     return <CellRenderer index={index} column={column} value={`${value === 'true' ? 'Yes' : 'No'}`} row={row} />;
   }
 
-  return <CellRenderer {...props} />;
+  const className = RIGHT_ALIGNED_COLUMNS.indexOf(column.key) !== -1 ? classes.rightAligned : '';
+
+  return <CellRenderer {...props} className={className} />;
 }

--- a/src/components/seeds/database/columns.ts
+++ b/src/components/seeds/database/columns.ts
@@ -464,3 +464,11 @@ export const searchPresets = [
   viabilitySummaryPreset,
   germinationTestingPreset,
 ];
+
+export const RIGHT_ALIGNED_COLUMNS = [
+  'ageMonths',
+  'ageYears',
+  'estimatedWeightGrams',
+  'estimatedCount',
+  'latestViabilityPercent',
+];

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -40,7 +40,7 @@ import emptyMessageStrings from 'src/strings/emptyMessageModal';
 import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
 import { getAllSeedBanks } from 'src/utils/organization';
 import PageHeader from '../PageHeader';
-import { COLUMNS_INDEXED } from './columns';
+import { COLUMNS_INDEXED, RIGHT_ALIGNED_COLUMNS } from './columns';
 import DownloadReportModal from './DownloadReportModal';
 import EditColumns from './EditColumns';
 import Filters from './Filters';
@@ -132,6 +132,9 @@ const useStyles = makeStyles((theme: Theme) => ({
       fontSize: '14px',
     },
   },
+  rightAligned: {
+    textAlign: 'right',
+  },
 }));
 
 type DatabaseProps = {
@@ -169,7 +172,14 @@ export default function Database(props: DatabaseProps): JSX.Element {
     preferences,
   } = props;
   const displayColumnDetails = displayColumnNames.map((name) => {
-    return COLUMNS_INDEXED[name];
+    const detail = { ...COLUMNS_INDEXED[name] };
+
+    // set the classname for right aligned columns
+    if (RIGHT_ALIGNED_COLUMNS.indexOf(name) !== -1) {
+      detail.className = classes.rightAligned;
+    }
+
+    return detail;
   });
   const [editColumnsModalOpen, setEditColumnsModalOpen] = useState(false);
   const [reportModalOpen, setReportModalOpen] = useState(false);

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -190,7 +190,7 @@ const strings = new LocalizedStrings({
     COLLECTION_DATE: 'Collection Date',
     COLLECTOR: 'Collector',
     COLLECTING_LOCATION: 'Collecting Location',
-    PLANT_AND_SITE: 'Plant and Site',
+    PLANT_LABEL: 'Plant',
     COLLECTED_FROM: 'Collected from',
     OWNER: 'Owner',
     PLANT_ID: 'Plant ID',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2459,10 +2459,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^1.0.32":
-  version "1.0.32"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-1.0.32.tgz#099f5944c726a0d13b8e7e96f46d1d0344f46452"
-  integrity sha512-d6oYuTuTRCTNaj+2ElRBBx3tk1mTkOuwwFdNek58lZvm8BryF2erRwf6FWg0Xg7jYvkM3gTlepRZ8G8u+8jOxw==
+"@terraware/web-components@^1.0.33":
+  version "1.0.33"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-1.0.33.tgz#eb565c2a088b63ad2f9b6bc8971ef6fe1bf28ef9"
+  integrity sha512-eeqqbNENHWpyKNg8ekiqFxtbsaYlNnEJGxF32bWqZzFRwmkBpkrKGR8ahm0T2IBjuZaoLP/EZ+5CH+D6+IKvNw==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.10.11"


### PR DESCRIPTION
- based on comments in PR (the headers use up some space for sort icon - which makes the right align a bit iffy)
- snuck in SW-1923 fix (rename Plant and Site => Plant)

<img width="842" alt="Terraware App 2022-10-04 13-35-09" src="https://user-images.githubusercontent.com/1865174/193922768-192023ef-c4df-4e94-a1b2-2eff58a13989.png">
