### PR TITLE
SW-1932 / SW-1929 change accession state UX updates 

### DIFF
--- a/src/components/accession2/edit/CalculatorModal.tsx
+++ b/src/components/accession2/edit/CalculatorModal.tsx
@@ -2,13 +2,20 @@ import React from 'react';
 import strings from 'src/strings';
 import Button from 'src/components/common/button/Button';
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
-import { Box, Grid } from '@mui/material';
+import { Box, Grid, Theme } from '@mui/material';
 import { Textfield } from '@terraware/web-components';
 import { Accession2, updateAccession2 } from 'src/api/accessions2/accession';
 import { ServerOrganization } from 'src/types/Organization';
 import { Unit, WEIGHT_UNITS_V2 } from 'src/components/seeds/nursery/NewTest';
 import useSnackbar from 'src/utils/useSnackbar';
 import { Dropdown } from '@terraware/web-components';
+import { makeStyles } from '@mui/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  units: {
+    marginLeft: theme.spacing(0.5),
+  },
+}));
 
 export interface CalculatorModalProps {
   open: boolean;
@@ -24,6 +31,7 @@ export interface CalculatorModalProps {
 export default function CalculatorModal(props: CalculatorModalProps): JSX.Element {
   const { onClose, open, record, onChange, setRecord, onPrevious } = props;
 
+  const classes = useStyles();
   const snackbar = useSnackbar();
 
   const getTotalCount = async () => {
@@ -103,6 +111,7 @@ export default function CalculatorModal(props: CalculatorModalProps): JSX.Elemen
                 onChange={onChangeSubsetUnit}
                 selectedValue={record.subsetWeight?.units}
                 fullWidth={true}
+                className={classes.units}
               />
             </Box>
           </Grid>
@@ -130,6 +139,7 @@ export default function CalculatorModal(props: CalculatorModalProps): JSX.Elemen
                 onChange={onChangeRemainingQuantityUnit}
                 selectedValue={record.remainingQuantity?.units}
                 fullWidth={true}
+                className={classes.units}
               />
             </Box>
           </Grid>

--- a/src/components/accession2/edit/EditState.tsx
+++ b/src/components/accession2/edit/EditState.tsx
@@ -69,7 +69,7 @@ export default function EditState(props: EditStateProps): JSX.Element {
           height: '74px',
         }}
       >
-        {accession.state !== record.state && (
+        {stateChanged && (
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
             <Icon name='warning' className={classes.messageIcon} size='large' />
             <Typography sx={{ color: '#000000', fontSize: '14px', paddingLeft: 1 }}>

--- a/src/components/accession2/edit/EditState.tsx
+++ b/src/components/accession2/edit/EditState.tsx
@@ -39,6 +39,8 @@ export default function EditState(props: EditStateProps): JSX.Element {
     }
   };
 
+  const stateChanged = accession.state !== record.state;
+
   return (
     <>
       <Grid item xs={12} textAlign='left'>
@@ -57,21 +59,24 @@ export default function EditState(props: EditStateProps): JSX.Element {
       </Grid>
       <Box
         sx={{
-          background: '#FDE7C3',
+          background: stateChanged ? '#FDE7C3' : 'initial',
           borderRadius: '14px',
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
           padding: (theme) => theme.spacing(2, 1),
           marginTop: (theme) => theme.spacing(4),
+          height: '74px',
         }}
       >
-        <Box sx={{ display: 'flex', alignItems: 'center' }}>
-          <Icon name='warning' className={classes.messageIcon} size='large' />
-          <Typography sx={{ color: '#000000', fontSize: '14px', paddingLeft: 1 }}>
-            {strings.UPDATE_STATUS_WARNING}
-          </Typography>
-        </Box>
+        {accession.state !== record.state && (
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <Icon name='warning' className={classes.messageIcon} size='large' />
+            <Typography sx={{ color: '#000000', fontSize: '14px', paddingLeft: 1 }}>
+              {strings.UPDATE_STATUS_WARNING}
+            </Typography>
+          </Box>
+        )}
       </Box>
     </>
   );

--- a/src/components/accession2/edit/EditStateModal.tsx
+++ b/src/components/accession2/edit/EditStateModal.tsx
@@ -57,7 +57,7 @@ export default function EditStateModal(props: EditStateModalProps): JSX.Element 
       size='small'
       middleButtons={[
         <Button label={strings.CANCEL} type='passive' onClick={onClose} priority='secondary' key='button-1' />,
-        <Button onClick={saveState} label={strings.UPDATE} key='button-2' />,
+        <Button onClick={saveState} label={strings.SAVE} key='button-2' disabled={accession.state === record.state} />,
       ]}
     >
       <EditState accession={accession} record={record} onChange={onChange} />

--- a/src/components/accession2/edit/QuantityModal.tsx
+++ b/src/components/accession2/edit/QuantityModal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import strings from 'src/strings';
 import Button from 'src/components/common/button/Button';
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
-import { Box, Grid, Link, useTheme } from '@mui/material';
+import { Box, Grid, Link, Theme, useTheme } from '@mui/material';
 import { Textfield } from '@terraware/web-components';
 import { Accession2, updateAccession2 } from 'src/api/accessions2/accession';
 import useForm from 'src/utils/useForm';
@@ -13,6 +13,13 @@ import CalculatorModal from './CalculatorModal';
 import { Dropdown } from '@terraware/web-components';
 import EditState from './EditState';
 import _ from 'lodash';
+import { makeStyles } from '@mui/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  units: {
+    marginLeft: theme.spacing(0.5),
+  },
+}));
 
 export interface QuantityModalProps {
   open: boolean;
@@ -26,6 +33,7 @@ export interface QuantityModalProps {
 export default function QuantityModal(props: QuantityModalProps): JSX.Element {
   const { onClose, open, accession, reload, organization, statusEdit } = props;
 
+  const classes = useStyles();
   const [record, setRecord, onChange] = useForm(accession);
   const [isCalculatorOpened, setIsCalculatorOpened] = useState(false);
   const [quantityError, setQuantityError] = useState(false);
@@ -171,6 +179,7 @@ export default function QuantityModal(props: QuantityModalProps): JSX.Element {
                 onChange={onChangeUnit}
                 selectedValue={record.remainingQuantity?.units}
                 fullWidth={true}
+                className={classes.units}
               />
             </Box>
           </Grid>

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -4,7 +4,6 @@ const strings = new LocalizedStrings({
   en: {
     CANCEL: 'Cancel',
     SAVE: 'Save',
-    UPDATE: 'Update',
     SAVE_CHANGES: 'Save Changes',
     GENERIC_ERROR: 'An error occurred',
     PREEXISTING_SPECIES: 'This species already exists',
@@ -288,7 +287,6 @@ const strings = new LocalizedStrings({
     POUNDS: 'Pounds',
     UNITS: 'Units',
     REQUIRED_FIELD: 'Required field.',
-    REQUIRED_CHANGE: 'Required change.',
     SCHEDULED_FOR_TESTING: 'Scheduled for Testing',
     SCHEDULED_SEEDS: '{0} Seeds',
     SEND_TO_NURSERY: 'Send to Nursery',


### PR DESCRIPTION
- show warning only when status changes
- disable button if save is not relevant
- change button text to Save
- also update quantity update ux (involved with used-up state changes)
- add margin left to units dropdowns

<img width="209" alt="Terraware App 2022-10-04 17-01-19" src="https://user-images.githubusercontent.com/1865174/193953584-a8287378-cfe3-4059-81a8-e22c773b883a.png">

<img width="174" alt="Terraware App 2022-10-04 17-00-53" src="https://user-images.githubusercontent.com/1865174/193953585-5954c6fb-c001-4b24-bea2-4cac41d2495a.png">

<img width="188" alt="Terraware App 2022-10-04 17-00-36" src="https://user-images.githubusercontent.com/1865174/193953587-5801e9be-bbd3-4658-90f3-4a598d57bfbe.png">

<img width="194" alt="Terraware App 2022-10-04 17-10-22" src="https://user-images.githubusercontent.com/1865174/193953575-5f53de62-9bd0-4c7b-bc95-73501808e3f0.png">

<img width="174" alt="Terraware App 2022-10-04 17-10-04" src="https://user-images.githubusercontent.com/1865174/193953577-1aae21a2-6a23-4264-b270-0fb4e52db5fa.png">

<img width="213" alt="Terraware App 2022-10-04 17-01-44" src="https://user-images.githubusercontent.com/1865174/193953579-9c3099d2-ea17-48d0-af33-da9505ac547f.png">

<img width="199" alt="Terraware App 2022-10-04 17-27-19" src="https://user-images.githubusercontent.com/1865174/193954318-8767db2f-3a98-491e-bf67-3c8cc27f1ec0.png">


