### PR TITLE
SW-1931 Show notes icon inside the notes div

### DIFF
--- a/src/components/accession2/view/DetailPanel.tsx
+++ b/src/components/accession2/view/DetailPanel.tsx
@@ -158,8 +158,10 @@ export default function DetailPanel(props: DetailPanelProps): JSX.Element {
 
               {accession.collectionSiteNotes && (
                 <Box marginTop={2} display='flex'>
-                  <Icon name='iconFile' className={classes.folderIcon} />
-                  <Typography>{accession.collectionSiteNotes}</Typography>
+                  <Typography>
+                    <Icon name='iconFile' className={classes.folderIcon} />
+                    {accession.collectionSiteNotes}
+                  </Typography>
                 </Box>
               )}
 


### PR DESCRIPTION
Put the notes icon inside the div so text can go under the icon.

<img width="1393" alt="Screen Shot 2022-10-05 at 10 46 56" src="https://user-images.githubusercontent.com/5919083/194076300-49bac71f-43ed-40d5-a9e0-613c7e9059f3.png">
