### PR TITLE
fix padding on edit status warning

### DIFF
--- a/src/components/accession2/edit/EditState.tsx
+++ b/src/components/accession2/edit/EditState.tsx
@@ -72,7 +72,7 @@ export default function EditState(props: EditStateProps): JSX.Element {
         {stateChanged && (
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
             <Icon name='warning' className={classes.messageIcon} size='large' />
-            <Typography sx={{ color: '#000000', fontSize: '14px', paddingLeft: 1 }}>
+            <Typography sx={{ color: '#000000', fontSize: '14px', paddingLeft: 0.5 }}>
               {strings.UPDATE_STATUS_WARNING}
             </Typography>
           </Box>


### PR DESCRIPTION
- don't wrap the text on next line (Ming's request)

<img width="177" alt="Terraware App 2022-10-05 11-50-26" src="https://user-images.githubusercontent.com/1865174/194139160-569d0b39-108f-4f2d-bb08-061be7f94eef.png">
