### PR TITLE
SW-1953 Fix race condition in accessions database search when coming from dashboard quick-links

### DIFF
--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -252,6 +252,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
   }, [query, location, history, setSearchCriteria, organization, searchCriteria]);
 
   useEffect(() => {
+    let activeRequests = true;
     const getFieldsFromSearchColumns = () => {
       let columnsNamesToSearch = Array<string>();
       if (searchColumns.includes('active')) {
@@ -273,7 +274,9 @@ export default function Database(props: DatabaseProps): JSX.Element {
           count: 1000,
         });
 
-        setUnfilteredResults(apiResponse);
+        if (activeRequests) {
+          setUnfilteredResults(apiResponse);
+        }
       };
 
       const populateSearchResults = async () => {
@@ -284,17 +287,28 @@ export default function Database(props: DatabaseProps): JSX.Element {
           search: convertToSearchNodePayload(searchCriteria, organization.id),
           count: 1000,
         });
-        setSearchResults(apiResponse);
+
+        if (activeRequests) {
+          setSearchResults(apiResponse);
+        }
       };
 
       const populateAvailableFieldOptions = async () => {
         const singleAndMultiChoiceFields = filterSelectFields(searchColumns);
-        setAvailableFieldOptions(await searchFieldValues(singleAndMultiChoiceFields, searchCriteria, organization.id));
+        const data = await searchFieldValues(singleAndMultiChoiceFields, searchCriteria, organization.id);
+
+        if (activeRequests) {
+          setAvailableFieldOptions(data);
+        }
       };
 
       const populatePendingAccessions = async () => {
         if (organization) {
-          setPendingAccessions(await getPendingAccessions(organization.id));
+          const data = await getPendingAccessions(organization.id);
+
+          if (activeRequests) {
+            setPendingAccessions(data);
+          }
         }
       };
 
@@ -309,14 +323,19 @@ export default function Database(props: DatabaseProps): JSX.Element {
           );
         }
 
-        setFieldOptions(allValues);
+        if (activeRequests) {
+          setFieldOptions(allValues);
+        }
       };
 
       const populateSearchSummary = async () => {
         const apiResponse = await searchSummary({
           search: convertToSearchNodePayload(searchCriteria, organization.id),
         });
-        setSearchSummaryResults(apiResponse);
+
+        if (activeRequests) {
+          setSearchSummaryResults(apiResponse);
+        }
       };
       populateUnfilteredResults();
       populateSearchResults();
@@ -325,6 +344,9 @@ export default function Database(props: DatabaseProps): JSX.Element {
       populateFieldOptions();
       populateSearchSummary();
     }
+    return () => {
+      activeRequests = false;
+    };
   }, [searchCriteria, searchSortOrder, searchColumns, organization, preferences]);
 
   const onSelect = (row: SearchResponseElement) => {


### PR DESCRIPTION
- sometimes the slower search (of all accessions) finishes last and it's results get used in the table
- use a state that is reset on unmount, which indicates if a search result is to be used or not