### PR TITLE
Default viability date to today

### DIFF
--- a/src/components/accession2/viabilityTesting/NewViabilityTestModal.tsx
+++ b/src/components/accession2/viabilityTesting/NewViabilityTestModal.tsx
@@ -70,6 +70,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
       withdrawnByUserId: user.id,
       testType: 'Lab',
       seedsTested: 0,
+      startDate: getTodaysDateFormatted(),
     };
 
     const initViabilityTest = () => {


### PR DESCRIPTION
We need to set a default date for the viability test, so setting it to today's date