### PR TITLE
SW-1837 / SW-1965 Misc UI fixes

### DIFF
--- a/src/components/accession2/viabilityTesting/NewViabilityTestModal.tsx
+++ b/src/components/accession2/viabilityTesting/NewViabilityTestModal.tsx
@@ -70,6 +70,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
       withdrawnByUserId: user.id,
       testType: 'Lab',
       seedsTested: 0,
+      startDate: getTodaysDateFormatted(),
     };
 
     const initViabilityTest = () => {
@@ -292,7 +293,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
   const onAddResult = () => {
     if (record) {
       const updatedResults = [...(record.testResults || [])];
-      updatedResults.push({ recordingDate: '', seedsGerminated: 0 });
+      updatedResults.push({ recordingDate: getTodaysDateFormatted(), seedsGerminated: 0 });
 
       onChange('testResults', updatedResults);
     }

--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -456,7 +456,10 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
         {accession?.state && (
           <Box sx={editableParentProps}>
             <Icon name='seedbankNav' className={classes.iconStyle} />
-            <Box sx={editableProps} onClick={() => !isAwaitingCheckin && setOpenEditStateModal(true)}>
+            <Box
+              sx={isAwaitingCheckin ? readOnlyProps : editableProps}
+              onClick={() => !isAwaitingCheckin && setOpenEditStateModal(true)}
+            >
               <Typography
                 paddingLeft={1}
                 sx={{

--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -321,6 +321,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
 
   const quantityEditable = accession?.state === 'Drying' || accession?.state === 'In Storage';
   const viabilityEditable = accession?.state !== 'Used Up';
+  const isAwaitingCheckin = accession?.state === 'Awaiting Check-In';
 
   return (
     <TfMain>
@@ -431,7 +432,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
               >
                 <Icon name='iconTrashCan' />
               </IconButton>
-              {accession && accession.state === 'Awaiting Check-In' ? (
+              {accession && isAwaitingCheckin ? (
                 <Button onClick={() => checkInAccession()} label={strings.CHECK_IN} size='medium' />
               ) : (
                 renderWithdrawalButton()
@@ -455,7 +456,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
         {accession?.state && (
           <Box sx={editableParentProps}>
             <Icon name='seedbankNav' className={classes.iconStyle} />
-            <Box sx={editableProps} onClick={() => setOpenEditStateModal(true)}>
+            <Box sx={editableProps} onClick={() => !isAwaitingCheckin && setOpenEditStateModal(true)}>
               <Typography
                 paddingLeft={1}
                 sx={{
@@ -469,7 +470,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
               >
                 {accession.state}
               </Typography>
-              {accession.state !== 'Awaiting Check-In' ? (
+              {!isAwaitingCheckin ? (
                 <IconButton sx={{ marginLeft: 1, height: '24px', width: '24px' }}>
                   <Icon name='iconEdit' className={`${classes.editIcon} edit-icon`} />
                 </IconButton>
@@ -612,7 +613,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
             <Icon name='iconTrashCan' />
           </IconButton>
           <Box paddingLeft={2} width='100%'>
-            {accession && accession.state === 'Awaiting Check-In' ? (
+            {accession && isAwaitingCheckin ? (
               <Button
                 onClick={() => checkInAccession()}
                 label={strings.CHECK_IN}


### PR DESCRIPTION
- disallow editing status of accession that is awaiting check in (the edit icon was hidden but status badge was clickable)
- default viability start and recording dates to today