### PR TITLE
SW-1997 enable a way to test production view in staging

### DIFF
--- a/src/components/OptInFeatures/index.tsx
+++ b/src/components/OptInFeatures/index.tsx
@@ -27,6 +27,12 @@ export default function OptInFeatures({ refresh }: OptInFeaturesProps): JSX.Elem
             data[key] = prefs[key] || false;
           }
         });
+
+        OPT_IN_FEATURES.forEach((f) => {
+          if (f.get) {
+            data[f.preferenceName] = f.get();
+          }
+        });
       }
       setTimeout(() => {
         setPreferences(data);
@@ -39,7 +45,16 @@ export default function OptInFeatures({ refresh }: OptInFeaturesProps): JSX.Elem
   });
 
   const savePreference = async (feature: Feature, value: boolean) => {
-    const response = await updatePreferences(feature.preferenceName, value);
+    let response = {
+      requestSucceeded: true,
+    };
+
+    if (feature.set) {
+      feature.set(value);
+    } else {
+      response = await updatePreferences(feature.preferenceName, value);
+    }
+
     if (response.requestSucceeded) {
       setPreferences((prev) => ({
         ...prev,

--- a/src/utils/useEnvironment.ts
+++ b/src/utils/useEnvironment.ts
@@ -1,13 +1,28 @@
-// Check if web app environment
+import { APP_PATHS } from 'src/constants';
+
+const isForcedProductionView = () => {
+  return sessionStorage !== undefined && Boolean(sessionStorage.getItem('productionView'));
+};
+
+const forceProductionView = (val: boolean) => {
+  if (sessionStorage) {
+    sessionStorage.setItem('productionView', val.toString());
+    window.location.pathname = APP_PATHS.HOME;
+  }
+};
+
+// Get web app environment
 const useEnvironment = () => {
-  const isProduction = !!window.location.origin.match(/^https:\/\/(www.)?terraware.io/);
-  const isStaging = !!window.location.origin.match(/^https:\/\/(www.)?staging.terraware.io/);
+  const isProduction = isForcedProductionView() || !!window.location.origin.match(/^https:\/\/(www.)?terraware.io/);
+  const isStaging = !isProduction && !!window.location.origin.match(/^https:\/\/(www.)?staging.terraware.io/);
   const isDev = !(isProduction || isStaging);
 
   return {
     isProduction,
     isStaging,
     isDev,
+    isForcedProductionView,
+    forceProductionView,
   };
 };
 


### PR DESCRIPTION
- added a set/get property pair in opt-in-feature config
- set/get can be defined in specific context
- introduced a new feature 'show production view'
- useEnvironment provides set/get semantics for 'show production view'
- uses session storage for property persistence
- not using BE preferences here since we have no way of clearing it if production view is enabled, we don't show opt-in features in production view
- clearing "productionView" from session storage will restore default view
- this is only for testing and not production end-user facing