### PR TITLE
SW-2008 Allow summary sub-section to wrap with count and type info

### DIFF
--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -642,29 +642,33 @@ export default function Database(props: DatabaseProps): JSX.Element {
                         sx={{ background: '#F2F4F5', display: 'flex', color: '#000000', padding: 2, flexWrap: 'wrap' }}
                       >
                         <Typography>{strings.TOTAL}</Typography>
-                        <Typography sx={{ paddingLeft: '4px', fontWeight: 500 }}>
-                          {searchSummaryResults.accessions}
-                        </Typography>
-                        <Typography sx={{ paddingLeft: '4px', paddingRight: '12px' }}>
-                          {searchSummaryResults.accessions === 1
-                            ? strings.ACCESSION.toLowerCase()
-                            : strings.ACCESSIONS.toLowerCase()}
-                        </Typography>
-                        <Typography sx={{ fontWeight: 500 }}>{searchSummaryResults.species}</Typography>
-                        <Typography sx={{ paddingLeft: '4px', paddingRight: '12px' }}>
-                          {strings.SPECIES.toLowerCase()}
-                        </Typography>
-                        <Typography sx={{ fontWeight: 500 }}>{`${searchSummaryResults.seedsRemaining.total}${
-                          searchSummaryResults.seedsRemaining &&
-                          searchSummaryResults.seedsRemaining.unknownQuantityAccessions > 0
-                            ? '+'
-                            : ''
-                        }`}</Typography>
-                        <Typography sx={{ paddingLeft: '4px' }}>
-                          {searchSummaryResults.seedsRemaining.total === 1
-                            ? strings.SEED.toLowerCase()
-                            : strings.SEEDS.toLowerCase()}
-                        </Typography>
+                        <Box sx={{ paddingRight: '12px', display: 'flex' }}>
+                          <Typography sx={{ paddingLeft: '4px', fontWeight: 500 }}>
+                            {searchSummaryResults.accessions}
+                          </Typography>
+                          <Typography sx={{ paddingLeft: '4px' }}>
+                            {searchSummaryResults.accessions === 1
+                              ? strings.ACCESSION.toLowerCase()
+                              : strings.ACCESSIONS.toLowerCase()}
+                          </Typography>
+                        </Box>
+                        <Box sx={{ paddingRight: '12px', display: 'flex' }}>
+                          <Typography sx={{ fontWeight: 500 }}>{searchSummaryResults.species}</Typography>
+                          <Typography sx={{ paddingLeft: '4px' }}>{strings.SPECIES.toLowerCase()}</Typography>
+                        </Box>
+                        <Box sx={{ paddingRight: '12px', display: 'flex' }}>
+                          <Typography sx={{ fontWeight: 500 }}>{`${searchSummaryResults.seedsRemaining.total}${
+                            searchSummaryResults.seedsRemaining &&
+                            searchSummaryResults.seedsRemaining.unknownQuantityAccessions > 0
+                              ? '+'
+                              : ''
+                          }`}</Typography>
+                          <Typography sx={{ paddingLeft: '4px' }}>
+                            {searchSummaryResults.seedsRemaining.total === 1
+                              ? strings.SEED.toLowerCase()
+                              : strings.SEEDS.toLowerCase()}
+                          </Typography>
+                        </Box>
                       </Box>
                     </Grid>
                   )}


### PR DESCRIPTION
- was previously wrapping by the single word
- make the wrapping units a pair of count/type

<img width="947" alt="Terraware App 2022-10-17 16-13-04" src="https://user-images.githubusercontent.com/1865174/196300971-3a15ad37-1144-496b-a52a-a6efbb92e5a8.png">

<img width="225" alt="Terraware App 2022-10-17 16-13-59" src="https://user-images.githubusercontent.com/1865174/196300966-aeed1e8f-fc22-416c-8907-a4156d4c495d.png">

<img width="192" alt="Terraware App 2022-10-17 16-13-32" src="https://user-images.githubusercontent.com/1865174/196300970-8029ab8f-79ae-4cf3-ab15-ee478ef40bd6.png">
