### PR TITLE
SW-2022 Remove dependencies on v1 api types in FE codebase

### DIFF
--- a/src/api/seeds/accession.ts
+++ b/src/api/seeds/accession.ts
@@ -1,40 +1,25 @@
 import axios from '..';
-import {
-  Accession,
-  accessionEndpoint,
-  AccessionGetResponse,
-  AccessionPostRequestBody,
-  AccessionPostResponse,
-  AccessionPutRequestBody,
-  checkInEndpoint,
-  photoEndpoint,
-  postAccessionEndpoint,
-} from '../types/accessions';
+import { accessionEndpoint, checkInEndpoint, photoEndpoint } from '../types/accessions';
 import { paths } from '../types/generated-schema';
+import { Accession2 } from 'src/api/accessions2/accession';
 
-export const getAccession = async (accessionId: number): Promise<Accession> => {
-  const endpoint = accessionEndpoint.replace('{id}', `${accessionId}`);
-  const response: AccessionGetResponse = (await axios.get(endpoint)).data;
-
-  return response.accession;
+export const getAccession = async (accessionId: number): Promise<any> => {
+  return null;
 };
 
-export const postAccession = async (accession: AccessionPostRequestBody): Promise<number> => {
-  const response: AccessionPostResponse = (await axios.post(postAccessionEndpoint, accession)).data;
-
-  return response.accession.id;
+export const postAccession = async (accession: any): Promise<number> => {
+  return 0;
 };
 
-export const putAccession = async (accessionId: number, accession: AccessionPutRequestBody): Promise<void> => {
-  const endpoint = accessionEndpoint.replace('{id}', `${accessionId}`);
-  await axios.put(endpoint, accession);
+export const putAccession = async (accessionId: number, accession: unknown): Promise<void> => {
+  return;
 };
 
 export const getPhotoEndpoint = (accessionId: number, photoFilename: string): string => {
   return photoEndpoint.replace('{id}', `${accessionId}`).replace('{photoFilename}', `${photoFilename}`);
 };
 
-export const checkIn = async (id: number): Promise<Accession> => {
+export const checkIn = async (id: number): Promise<Accession2> => {
   const endpoint = checkInEndpoint.replace('{id}', `${id}`);
 
   return (await axios.post(endpoint)).data;

--- a/src/api/types/accessions.ts
+++ b/src/api/types/accessions.ts
@@ -1,27 +1,17 @@
-import { paths, components } from './generated-schema';
+import { components } from './generated-schema';
 
 export const accessionEndpoint = '/api/v1/seedbank/accessions/{id}';
-export type AccessionGetResponse =
-  paths[typeof accessionEndpoint]['get']['responses'][200]['content']['application/json'];
-export type AccessionPutRequestBody =
-  paths[typeof accessionEndpoint]['put']['requestBody']['content']['application/json'];
-export type AccessionActive = AccessionGetResponse['accession']['active'];
-export type AccessionState = AccessionGetResponse['accession']['state'];
-export type AccessionWithdrawal = Required<AccessionGetResponse['accession']>['withdrawals'][0];
-
-export const postAccessionEndpoint = '/api/v1/seedbank/accessions';
-export type AccessionPostRequestBody =
-  paths[typeof postAccessionEndpoint]['post']['requestBody']['content']['application/json'];
-export type AccessionPostResponse =
-  paths[typeof postAccessionEndpoint]['post']['responses'][200]['content']['application/json'];
 
 export const photoEndpoint = '/api/v1/seedbank/accessions/{id}/photos/{photoFilename}';
 
 export const checkInEndpoint = '/api/v1/seedbank/accessions/{id}/checkIn';
 
-export type Accession = AccessionGetResponse['accession'];
-
 export const schemas = 'schemas';
 export type Geolocation = components[typeof schemas]['Geolocation'];
 export type ViabilityTest = components[typeof schemas]['GetViabilityTestPayload'];
 export type TestResult = Required<components[typeof schemas]['GetViabilityTestPayload']>['testResults'][0];
+
+export type Accession = any;
+export type AccessionState = any;
+export type AccessionPostRequestBody = any;
+export type AccessionWithdrawal = any;

--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -105,7 +105,7 @@ export interface paths {
     get: operations["count"];
   };
   "/api/v1/notifications/{id}": {
-    get: operations["read_1"];
+    get: operations["read"];
     put: operations["markRead"];
   };
   "/api/v1/nursery/batches": {
@@ -153,12 +153,7 @@ export interface paths {
   "/api/v1/search": {
     post: operations["search_1"];
   };
-  "/api/v1/seedbank/accessions": {
-    post: operations["create"];
-  };
   "/api/v1/seedbank/accessions/{id}": {
-    get: operations["read"];
-    put: operations["update"];
     delete: operations["delete"];
   };
   "/api/v1/seedbank/accessions/{id}/checkIn": {
@@ -330,102 +325,6 @@ export interface components {
         | "ViabilityTesting"
         | "Withdrawal";
     };
-    AccessionPayload: {
-      /** Server-generated human-readable identifier for the accession. This is unique within a single seed bank, but different seed banks may have accessions with the same number. */
-      accessionNumber: string;
-      /** Server-calculated active indicator. This is based on the accession's state. */
-      active: "Inactive" | "Active";
-      bagNumbers?: string[];
-      checkedInTime?: string;
-      collectedDate?: string;
-      collectionSiteCity?: string;
-      collectionSiteCountryCode?: string;
-      collectionSiteCountrySubdivision?: string;
-      collectionSiteLandowner?: string;
-      collectionSiteName?: string;
-      collectionSiteNotes?: string;
-      collectionSource?: "Wild" | "Reintroduced" | "Cultivated" | "Other";
-      /** Names of the people who collected the seeds. */
-      collectors?: string[];
-      cutTestSeedsCompromised?: number;
-      cutTestSeedsEmpty?: number;
-      cutTestSeedsFilled?: number;
-      dryingEndDate?: string;
-      dryingMoveDate?: string;
-      dryingStartDate?: string;
-      /** @deprecated Backward-compatibility alias for collectionSiteNotes */
-      environmentalNotes?: string;
-      estimatedSeedCount?: number;
-      facilityId: number;
-      fieldNotes?: string;
-      founderId?: string;
-      geolocations?: components["schemas"]["Geolocation"][];
-      /** Server-generated unique identifier for the accession. This is unique across all seed banks, but is not suitable for display to end users. */
-      id: number;
-      /** Initial size of accession. The units of this value must match the measurement type in "processingMethod". */
-      initialQuantity?: components["schemas"]["SeedQuantityPayload"];
-      /** @deprecated Backward-compatibility alias for collectionSiteLandowner */
-      landowner?: string;
-      latestViabilityPercent?: number;
-      latestViabilityTestDate?: string;
-      numberOfTrees?: number;
-      nurseryStartDate?: string;
-      photoFilenames?: string[];
-      processingMethod?: "Count" | "Weight";
-      processingNotes?: string;
-      processingStaffResponsible?: string;
-      processingStartDate?: string;
-      receivedDate?: string;
-      /** Number or weight of seeds remaining for withdrawal and testing. Calculated by the server when the accession's total size is known. */
-      remainingQuantity?: components["schemas"]["SeedQuantityPayload"];
-      /** @deprecated Backward-compatibility alias for collectionSiteName */
-      siteLocation?: string;
-      /** Which application this accession originally came from. This is currently based on the presence of the deviceInfo field. */
-      source?: "Web" | "Seed Collector App" | "File Import";
-      sourcePlantOrigin?: "Wild" | "Outplant";
-      /** Scientific name of the species. */
-      species?: string;
-      /** Common name of the species, if defined. */
-      speciesCommonName?: string;
-      /** Server-generated unique ID of the species. */
-      speciesId?: number;
-      /** Server-calculated accession state. Can change due to modifications to accession data or based on passage of time. */
-      state:
-        | "Awaiting Check-In"
-        | "Pending"
-        | "Awaiting Processing"
-        | "Processing"
-        | "Processed"
-        | "Drying"
-        | "Dried"
-        | "In Storage"
-        | "Withdrawn"
-        | "Used Up"
-        | "Nursery";
-      storageCondition?: "Refrigerator" | "Freezer";
-      storageLocation?: string;
-      storagePackets?: number;
-      storageNotes?: string;
-      storageStaffResponsible?: string;
-      storageStartDate?: string;
-      subsetCount?: number;
-      /** Weight of subset of seeds. Units must be a weight measurement, not "Seeds". */
-      subsetWeight?: components["schemas"]["SeedQuantityPayload"];
-      targetStorageCondition?: "Refrigerator" | "Freezer";
-      /** Total quantity of all past withdrawals, including viability tests. */
-      totalPastWithdrawalQuantity?: components["schemas"]["SeedQuantityPayload"];
-      /** Total quantity of scheduled withdrawals, not counting viability tests. */
-      totalScheduledNonTestQuantity?: components["schemas"]["SeedQuantityPayload"];
-      /** Total quantity of scheduled withdrawals for viability tests. */
-      totalScheduledTestQuantity?: components["schemas"]["SeedQuantityPayload"];
-      /** Total quantity of scheduled withdrawals, including viability tests. */
-      totalScheduledWithdrawalQuantity?: components["schemas"]["SeedQuantityPayload"];
-      totalViabilityPercent?: number;
-      /** Total quantity of all past and scheduled withdrawals, including viability tests. */
-      totalWithdrawalQuantity?: components["schemas"]["SeedQuantityPayload"];
-      viabilityTests?: components["schemas"]["ViabilityTestPayload"][];
-      withdrawals?: components["schemas"]["WithdrawalPayload"][];
-    };
     AccessionPayloadV2: {
       /** Server-generated human-readable identifier for the accession. This is unique within a single seed bank, but different seed banks may have accessions with the same number. */
       accessionNumber: string;
@@ -550,33 +449,6 @@ export interface components {
     ConnectDeviceManagerRequestPayload: {
       facilityId: number;
     };
-    CreateAccessionRequestPayload: {
-      bagNumbers?: string[];
-      collectedDate?: string;
-      collectionSiteCity?: string;
-      collectionSiteCountryCode?: string;
-      collectionSiteCountrySubdivision?: string;
-      collectionSiteLandowner?: string;
-      collectionSiteName?: string;
-      collectionSiteNotes?: string;
-      collectionSource?: "Wild" | "Reintroduced" | "Cultivated" | "Other";
-      collectors?: string[];
-      /** @deprecated Backward-compatibility alias for collectionSiteNotes */
-      environmentalNotes?: string;
-      facilityId?: number;
-      fieldNotes?: string;
-      founderId?: string;
-      geolocations?: components["schemas"]["Geolocation"][];
-      /** @deprecated Backward-compatibility alias for collectionSiteLandowner */
-      landowner?: string;
-      numberOfTrees?: number;
-      receivedDate?: string;
-      /** @deprecated Backward-compatibility alias for collectionSiteName */
-      siteLocation?: string;
-      source?: "Web" | "Seed Collector App" | "File Import";
-      sourcePlantOrigin?: "Wild" | "Outplant";
-      species?: string;
-    };
     CreateAccessionRequestPayloadV2: {
       bagNumbers?: string[];
       collectedDate?: string;
@@ -610,10 +482,6 @@ export interface components {
         | "Used Up"
         | "Nursery";
       storageLocation?: string;
-    };
-    CreateAccessionResponsePayload: {
-      accession: components["schemas"]["AccessionPayload"];
-      status: components["schemas"]["SuccessOrError"];
     };
     CreateAccessionResponsePayloadV2: {
       accession: components["schemas"]["AccessionPayloadV2"];
@@ -885,10 +753,6 @@ export interface components {
     GetAccessionHistoryResponsePayload: {
       /** History of changes in descending time order (newest first.) */
       history: components["schemas"]["AccessionHistoryEntryPayload"][];
-      status: components["schemas"]["SuccessOrError"];
-    };
-    GetAccessionResponsePayload: {
-      accession: components["schemas"]["AccessionPayload"];
       status: components["schemas"]["SuccessOrError"];
     };
     GetAccessionResponsePayloadV2: {
@@ -1451,56 +1315,6 @@ export interface components {
       timeseriesName: string;
       values: components["schemas"]["TimeseriesValuePayload"][];
     };
-    UpdateAccessionRequestPayload: {
-      bagNumbers?: string[];
-      collectedDate?: string;
-      collectionSiteCity?: string;
-      collectionSiteCountryCode?: string;
-      collectionSiteCountrySubdivision?: string;
-      collectionSiteLandowner?: string;
-      collectionSiteName?: string;
-      collectionSiteNotes?: string;
-      collectionSource?: "Wild" | "Reintroduced" | "Cultivated" | "Other";
-      collectors?: string[];
-      cutTestSeedsCompromised?: number;
-      cutTestSeedsEmpty?: number;
-      cutTestSeedsFilled?: number;
-      dryingEndDate?: string;
-      dryingMoveDate?: string;
-      dryingStartDate?: string;
-      /** @deprecated Backward-compatibility alias for collectionSiteNotes */
-      environmentalNotes?: string;
-      facilityId?: number;
-      fieldNotes?: string;
-      founderId?: string;
-      geolocations?: components["schemas"]["Geolocation"][];
-      /** Initial size of accession. The units of this value must match the measurement type in "processingMethod". */
-      initialQuantity?: components["schemas"]["SeedQuantityPayload"];
-      /** @deprecated Backward-compatibility alias for collectionSiteLandowner */
-      landowner?: string;
-      numberOfTrees?: number;
-      nurseryStartDate?: string;
-      processingMethod?: "Count" | "Weight";
-      processingNotes?: string;
-      processingStaffResponsible?: string;
-      processingStartDate?: string;
-      receivedDate?: string;
-      /** @deprecated Backward-compatibility alias for collectionSiteName */
-      siteLocation?: string;
-      sourcePlantOrigin?: "Wild" | "Outplant";
-      species?: string;
-      storageLocation?: string;
-      storageNotes?: string;
-      storagePackets?: number;
-      storageStaffResponsible?: string;
-      storageStartDate?: string;
-      subsetCount?: number;
-      /** Weight of subset of seeds. Units must be a weight measurement, not "Seeds". */
-      subsetWeight?: components["schemas"]["SeedQuantityPayload"];
-      targetStorageCondition?: "Refrigerator" | "Freezer";
-      viabilityTests?: components["schemas"]["ViabilityTestPayload"][];
-      withdrawals?: components["schemas"]["WithdrawalPayload"][];
-    };
     UpdateAccessionRequestPayloadV2: {
       bagNumbers?: string[];
       collectedDate?: string;
@@ -1538,10 +1352,6 @@ export interface components {
       subsetCount?: number;
       subsetWeight?: components["schemas"]["SeedQuantityPayload"];
       viabilityPercent?: number;
-    };
-    UpdateAccessionResponsePayload: {
-      accession: components["schemas"]["AccessionPayload"];
-      status: components["schemas"]["SuccessOrError"];
     };
     UpdateAccessionResponsePayloadV2: {
       accession: components["schemas"]["AccessionPayloadV2"];
@@ -1711,60 +1521,9 @@ export interface components {
       versions: components["schemas"]["VersionsEntryPayload"][];
       status: components["schemas"]["SuccessOrError"];
     };
-    ViabilityTestPayload: {
-      /** Server-assigned unique ID of this viability test. Null when creating a new test. */
-      id?: string;
-      /** Which type of test is described. At most one of each test type is allowed. */
-      testType: "Lab" | "Nursery";
-      startDate?: string;
-      endDate?: string;
-      seedType?: "Fresh" | "Stored";
-      substrate?:
-        | "Agar Petri Dish"
-        | "Nursery Media"
-        | "Paper Petri Dish"
-        | "Other";
-      treatment?: "Soak" | "Scarify" | "GA3" | "Stratification" | "Other";
-      notes?: string;
-      /** Quantity of seeds remaining. For weight-based accessions, this is user input and is required. For count-based accessions, it is calculated by the server and ignored on input. */
-      remainingQuantity?: components["schemas"]["SeedQuantityPayload"];
-      staffResponsible?: string;
-      seedsSown?: number;
-      testResults?: components["schemas"]["ViabilityTestResultPayload"][];
-      totalPercentGerminated?: number;
-      totalSeedsGerminated?: number;
-    };
     ViabilityTestResultPayload: {
       recordingDate: string;
       seedsGerminated: number;
-    };
-    WithdrawalPayload: {
-      /** Server-assigned unique ID of this withdrawal, its ID. Omit when creating a new withdrawal. */
-      id?: number;
-      date: string;
-      purpose?:
-        | "Propagation"
-        | "Outreach or Education"
-        | "Research"
-        | "Broadcast"
-        | "Share with Another Site"
-        | "Other"
-        | "Viability Testing"
-        | "Out-planting"
-        | "Nursery";
-      destination?: string;
-      notes?: string;
-      /** Quantity of seeds remaining. For weight-based accessions, this is user input and is required. For count-based accessions, it is calculated by the server and ignored on input. */
-      remainingQuantity?: components["schemas"]["SeedQuantityPayload"];
-      staffResponsible?: string;
-      /** If this withdrawal is of purpose "Germination Testing", the ID of the test it is associated with. This is always set by the server and cannot be modified. */
-      viabilityTestId?: number;
-      /** For weight-based accessions, the difference between the weight remaining before this withdrawal and the weight remaining after it. This is a server-calculated value and is ignored on input. */
-      weightDifference?: components["schemas"]["SeedQuantityPayload"];
-      /** Quantity of seeds withdrawn. For viability testing withdrawals, this is always the same as the test's "seedsSown" value, if that value is present. Otherwise, it is a user-supplied value. For count-based accessions, the units must always be "Seeds". For weight-based accessions, the units may either be a weight measurement or "Seeds". */
-      withdrawnQuantity?: components["schemas"]["SeedQuantityPayload"];
-      /** The best estimate of the number of seeds withdrawn. This is the same as "withdrawnQuantity" if that is present, or else the same as "weightDifference" if this is a weight-based accession. If this is a count-based accession and "withdrawnQuantity" does not have a value, this field will not be present. This is a server-calculated value and is ignored on input. */
-      estimatedQuantity?: components["schemas"]["SeedQuantityPayload"];
     };
   };
 }
@@ -2574,7 +2333,7 @@ export interface operations {
       };
     };
   };
-  read_1: {
+  read: {
     parameters: {
       path: {
         id: number;
@@ -2981,72 +2740,6 @@ export interface operations {
       };
     };
   };
-  create: {
-    responses: {
-      /** The accession was created successfully. Response includes fields populated by the server, including the accession number and ID. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["CreateAccessionResponsePayload"];
-        };
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateAccessionRequestPayload"];
-      };
-    };
-  };
-  read: {
-    parameters: {
-      path: {
-        id: number;
-      };
-    };
-    responses: {
-      /** OK */
-      200: {
-        content: {
-          "application/json": components["schemas"]["GetAccessionResponsePayload"];
-        };
-      };
-      /** The requested resource was not found. */
-      404: {
-        content: {
-          "application/json": components["schemas"]["SimpleErrorResponsePayload"];
-        };
-      };
-    };
-  };
-  update: {
-    parameters: {
-      path: {
-        id: number;
-      };
-      query: {
-        /** If true, do not actually save the accession; just return the result that would have been returned if it had been saved. */
-        simulate?: string;
-      };
-    };
-    responses: {
-      /** The accession was updated successfully. Response includes fields populated or modified by the server as a result of the update. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["UpdateAccessionResponsePayload"];
-        };
-      };
-      /** The specified accession doesn't exist. */
-      404: {
-        content: {
-          "application/json": components["schemas"]["SimpleErrorResponsePayload"];
-        };
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateAccessionRequestPayload"];
-      };
-    };
-  };
   delete: {
     parameters: {
       path: {
@@ -3078,7 +2771,7 @@ export interface operations {
       /** OK */
       200: {
         content: {
-          "application/json": components["schemas"]["UpdateAccessionResponsePayload"];
+          "application/json": components["schemas"]["UpdateAccessionResponsePayloadV2"];
         };
       };
       /** The requested resource was not found. */

--- a/src/api/types/tests.ts
+++ b/src/api/types/tests.ts
@@ -1,9 +1,2 @@
-import { components } from './generated-schema';
-
-export type ViabilityTests = components['schemas']['AccessionPayload']['viabilityTests'];
-
-export type ViabilityTest = components['schemas']['ViabilityTestPayload'];
-
-export type ViabilityTestResult = components['schemas']['ViabilityTestResultPayload'];
-
-export type ViabilityTestResultKey = keyof ViabilityTestResult;
+export type ViabilityTest = any;
+export type ViabilityTestResult = any;

--- a/src/components/seeds/lab/EnhacedTableDetails.tsx
+++ b/src/components/seeds/lab/EnhacedTableDetails.tsx
@@ -70,7 +70,7 @@ export default function EnhancedTableDetails<T>({
     const selectedTest = row as unknown as ViabilityTest;
 
     if (selectedTest.testResults) {
-      selectedTest.testResults.forEach((testResult) => {
+      selectedTest.testResults.forEach((testResult: any) => {
         total += testResult.seedsGerminated;
       });
     }

--- a/src/components/seeds/lab/index.tsx
+++ b/src/components/seeds/lab/index.tsx
@@ -76,11 +76,11 @@ export default function Nursery({ accession, onSubmit, organization }: Props): J
   }, []);
 
   useEffect(() => {
-    setLabRows(accession.viabilityTests?.filter((viabilityTest) => viabilityTest.testType === 'Lab'));
+    setLabRows(accession.viabilityTests?.filter((viabilityTest: any) => viabilityTest.testType === 'Lab'));
   }, [accession]);
 
   const getTotalScheduled = (): number => {
-    const totalS = accession.viabilityTests?.reduce((acum, viabilityTest) => {
+    const totalS = accession.viabilityTests?.reduce((acum: any, viabilityTest: any) => {
       if (viabilityTest.testType === 'Lab' && moment(viabilityTest.startDate).isAfter(date)) {
         acum += viabilityTest.seedsSown || 0;
       }
@@ -164,7 +164,7 @@ export default function Nursery({ accession, onSubmit, organization }: Props): J
   };
 
   const onDeleteTest = (value: ViabilityTest) => {
-    const newGerminationsTests = accession?.viabilityTests?.filter((germination) => germination !== value) ?? [];
+    const newGerminationsTests = accession?.viabilityTests?.filter((germination: any) => germination !== value) ?? [];
     accession.viabilityTests = newGerminationsTests;
     onSubmit(accession);
     setTestOpen(false);
@@ -172,7 +172,7 @@ export default function Nursery({ accession, onSubmit, organization }: Props): J
 
   const onDeleteTestEntry = (value: ViabilityTestResult) => {
     if (selectedTest && selectedTest.testResults) {
-      const newGerminations = selectedTest.testResults.filter((testResult) => testResult !== value) ?? [];
+      const newGerminations = selectedTest.testResults.filter((testResult: any) => testResult !== value) ?? [];
 
       const newGerminationTest = {
         ...selectedTest,

--- a/src/components/seeds/newAccession/SpeciesDropdown.tsx
+++ b/src/components/seeds/newAccession/SpeciesDropdown.tsx
@@ -19,7 +19,7 @@ interface SpeciesDropdownProps<T extends AccessionPostRequestBody> {
 export default function SpeciesDropdown<T extends AccessionPostRequestBody>(
   props: SpeciesDropdownProps<T>
 ): JSX.Element {
-  const { selectedSpecies, organization, setRecord, disabled } = props;
+  const { selectedSpecies, organization, disabled } = props;
   const [speciesList, setSpeciesList] = useState<Species[]>([]);
 
   const { isMobile } = useDeviceInfo();
@@ -37,12 +37,7 @@ export default function SpeciesDropdown<T extends AccessionPostRequestBody>(
   }, [organization]);
 
   const onChangeHandler = (id: string, value: string) => {
-    setRecord((previousRecord: T): T => {
-      return {
-        ...previousRecord,
-        [id]: value,
-      };
-    });
+    return;
   };
 
   return (

--- a/src/components/seeds/newAccession/index.tsx
+++ b/src/components/seeds/newAccession/index.tsx
@@ -246,23 +246,11 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
   };
 
   const onSubmitHandler = () => {
-    setIsEditing(false);
-    setIsSaving(true);
-    const filteredCollectors = record.collectors?.filter((iValue) => iValue !== '');
-    const newRecord = {
-      ...record,
-      collectors: filteredCollectors,
-    };
-    setTimeout(() => onSubmit(newRecord), 1000);
+    return;
   };
 
   const onSendToNurseryHandler = () => {
-    const newRecord = {
-      ...record,
-      nurseryStartDate: getTodaysDateFormatted(),
-    };
-    setIsSendingToNursery(true);
-    setTimeout(() => onSubmit(newRecord), 1000);
+    return;
   };
 
   const onCheckInHandler = () => {
@@ -271,11 +259,7 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
   };
 
   const onUndoSendToNursery = () => {
-    const newRecord = {
-      ...record,
-      nurseryStartDate: undefined,
-    };
-    onSubmit(newRecord);
+    return;
   };
 
   const OnNumberOfTreesChange = (id: string, value: unknown) => {
@@ -338,7 +322,6 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
             }
           >
             <Species
-              selectedSpecies={record.species}
               organization={organization}
               disabled={isPendingCheckIn || isContributor}
               record={record}
@@ -347,8 +330,8 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
           </Suspense>
           <Grid item xs={gridSize()}>
             <TextField
+              value={''}
               id='numberOfTrees'
-              value={record.numberOfTrees}
               onChange={OnNumberOfTreesChange}
               type='number'
               label={strings.NUMBER_OF_TREES}
@@ -362,7 +345,7 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
           <Grid item xs={gridSize()}>
             <TextField
               id='founderId'
-              value={record.founderId}
+              value={''}
               onChange={onChange}
               label={strings.FOUNDER_ID}
               disabled={isPendingCheckIn || isContributor}
@@ -371,8 +354,8 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
           <Grid item xs={gridSize()}>
             <Dropdown
               id='collectionSource'
+              selected={''}
               label={strings.COLLECTION_SOURCE}
-              selected={record.collectionSource}
               values={[
                 { label: strings.WILD, value: 'Wild' },
                 { label: strings.REINTRODUCED, value: 'Reintroduced' },
@@ -386,7 +369,7 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
           <Grid item xs={12}>
             <TextArea
               id='fieldNotes'
-              value={record.fieldNotes}
+              value={''}
               onChange={onChange}
               label={strings.FIELD_NOTES}
               placeholder={strings.FIELD_NOTES_PLACEHOLDER}
@@ -403,8 +386,8 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
           }
         >
           <AccessionDates
-            collectedDate={record.collectedDate}
-            receivedDate={record.receivedDate}
+            collectedDate={''}
+            receivedDate={''}
             refreshErrors={refreshErrors}
             onChange={onChange}
             disabled={isPendingCheckIn || isContributor}
@@ -424,7 +407,7 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
                 <Collectors
                   organizationId={organization.id!}
                   id='collectors'
-                  collectors={record.collectors}
+                  collectors={[]}
                   onChange={onChange}
                   disabled={isPendingCheckIn || isContributor}
                 />
@@ -437,7 +420,7 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
           <Grid item xs={gridSize()}>
             <TextField
               id='collectionSiteName'
-              value={record.collectionSiteName}
+              value={''}
               onChange={onChange}
               label={strings.SITE}
               disabled={isPendingCheckIn || isContributor}
@@ -446,7 +429,7 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
           <Grid item xs={gridSize()}>
             <TextField
               id='collectionSiteLandowner'
-              value={record.collectionSiteLandowner}
+              value={''}
               onChange={onChange}
               label={strings.LANDOWNER}
               disabled={isPendingCheckIn || isContributor}
@@ -456,7 +439,7 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
           <Grid item xs={12}>
             <TextArea
               id='collectionSiteNotes'
-              value={record.collectionSiteNotes}
+              value={''}
               onChange={onChange}
               label={strings.ENVIRONMENTAL_NOTES}
               placeholder={strings.ENVIRONMENTAL_NOTES_PLACEHOLDER}
@@ -470,7 +453,7 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
             <Dropdown
               id='facilityId'
               label={strings.SEED_BANK}
-              selected={record.facilityId?.toString()}
+              selected={''}
               values={seedBanks.map((seedBank) => ({ label: seedBank!.name, value: seedBank!.id.toString() }))}
               onChange={onChange}
               disabled={isPendingCheckIn || isContributor}
@@ -485,7 +468,7 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
               <Typography component='p' variant='body2' className={classes.listItem}>
                 {strings.BAG_IDS}
               </Typography>
-              {record.bagNumbers?.map((bag, index) => (
+              {[].map((bag, index) => (
                 <Typography id={`bag${index}`} key={index} component='p' variant='body1' className={classes.listItem}>
                   {bag}
                 </Typography>
@@ -512,16 +495,14 @@ export function AccessionForm<T extends AccessionPostRequestBody>({
               <Typography component='p' variant='body2' className={classes.listItem}>
                 {strings.GEOLOCATIONS}
               </Typography>
-              {record.geolocations?.map((geolocation, index) => (
+              {[].map((geolocation, index) => (
                 <Typography
                   id={`location${index}`}
                   key={index}
                   component='p'
                   variant='body1'
                   className={classes.listItem}
-                >
-                  {`${geolocation.latitude}, ${geolocation.longitude}`}
-                </Typography>
+                />
               ))}
             </Grid>
           </Grid>

--- a/src/components/seeds/nursery/index.tsx
+++ b/src/components/seeds/nursery/index.tsx
@@ -70,7 +70,7 @@ export default function Nursery({ accession, onSubmit, organization }: Props): J
   }, []);
 
   useEffect(() => {
-    setNurseryRows(accession.viabilityTests?.filter((germinationTest) => germinationTest.testType === 'Nursery'));
+    setNurseryRows(accession.viabilityTests?.filter((germinationTest: any) => germinationTest.testType === 'Nursery'));
   }, [accession]);
 
   const onEdit = (row: TableRowType) => {
@@ -101,14 +101,14 @@ export default function Nursery({ accession, onSubmit, organization }: Props): J
   };
 
   const onDelete = (value: ViabilityTest) => {
-    const newGerminationsTests = accession?.viabilityTests?.filter((germination) => germination !== value) ?? [];
+    const newGerminationsTests = accession?.viabilityTests?.filter((germination: any) => germination !== value) ?? [];
     accession.viabilityTests = newGerminationsTests;
     onSubmit(accession);
     setOpen(false);
   };
 
   const getTotalScheduled = (): number => {
-    const totali = accession.viabilityTests?.reduce((acum, germinationTest) => {
+    const totali = accession.viabilityTests?.reduce((acum: any, germinationTest: any) => {
       if (germinationTest.testType === 'Nursery' && moment(germinationTest.startDate).isAfter(date)) {
         acum += germinationTest.seedsSown || 0;
       }

--- a/src/components/seeds/withdrawal/index.tsx
+++ b/src/components/seeds/withdrawal/index.tsx
@@ -125,7 +125,7 @@ export default function WithdrawalView({ accession, onSubmit, organization }: Pr
   };
 
   const onDelete = (value: AccessionWithdrawal) => {
-    const newWithdrawals = accession?.withdrawals?.filter((withdrawal) => withdrawal !== value) ?? [];
+    const newWithdrawals = accession?.withdrawals?.filter((withdrawal: any) => withdrawal !== value) ?? [];
     accession.withdrawals = newWithdrawals;
     onSubmit(accession);
 
@@ -133,8 +133,8 @@ export default function WithdrawalView({ accession, onSubmit, organization }: Pr
   };
 
   const hasBothWithdrawals =
-    accession.withdrawals?.some((withdrawal) => withdrawal.withdrawnQuantity?.units !== 'Seeds') &&
-    accession.withdrawals?.some((withdrawal) => withdrawal.withdrawnQuantity?.units === 'Seeds');
+    accession.withdrawals?.some((withdrawal: any) => withdrawal.withdrawnQuantity?.units !== 'Seeds') &&
+    accession.withdrawals?.some((withdrawal: any) => withdrawal.withdrawnQuantity?.units === 'Seeds');
 
   const gridSize = () => {
     if (isMobile) {


### PR DESCRIPTION
- this is so BE can remove API and FE will still build/work
- FE code removal of v1 can happen ad hoc after this
- changes here are mostly to trick the type checker, codepaths are not functional today
- this PR blocks https://github.com/terraware/terraware-server/pull/716#issuecomment-1282959590