### PR TITLE
SW-1863 add multiple-select nursery filters for inventory

### DIFF
--- a/src/components/Inventory/InventoryFiltersPopover.tsx
+++ b/src/components/Inventory/InventoryFiltersPopover.tsx
@@ -1,4 +1,4 @@
-import { Grid, IconButton, Popover } from '@mui/material';
+import { Grid, IconButton, Popover, Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import React, { useEffect, useState } from 'react';
 import Icon from 'src/components/common/icon/Icon';
@@ -6,10 +6,19 @@ import strings from 'src/strings';
 import { ServerOrganization } from 'src/types/Organization';
 import useForm from 'src/utils/useForm';
 import Button from '../common/button/Button';
-import { InventoryFiltersType } from './InventoryTable';
-import NurseryDropdown from './NurseryDropdown';
+import { Checkbox } from '@terraware/web-components';
+import { getAllNurseries } from 'src/utils/organization';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
 
-const useStyles = makeStyles(() => ({
+export type InventoryFiltersType = {
+  facilityIds?: number[];
+};
+
+interface StyleProps {
+  isMobile: boolean;
+}
+
+const useStyles = makeStyles((theme: Theme) => ({
   iconContainer: {
     borderRadius: 0,
     fontSize: '16px',
@@ -28,7 +37,7 @@ const useStyles = makeStyles(() => ({
     },
   },
   popover: {
-    width: '478px',
+    width: (props: StyleProps) => (props.isMobile ? '350px' : '478px'),
     paddingTop: 0,
     borderRadius: '8px',
   },
@@ -47,9 +56,11 @@ const useStyles = makeStyles(() => ({
     padding: '16px 24px',
     display: 'flex',
     justifyContent: 'end',
+    flexDirection: (props: StyleProps) => (props.isMobile ? 'column-reverse' : 'row'),
 
     '& button+button': {
-      marginLeft: '8px',
+      marginLeft: (props: StyleProps) => (props.isMobile ? 0 : theme.spacing(1)),
+      marginBottom: (props: StyleProps) => (props.isMobile ? theme.spacing(1) : 0),
     },
   },
 }));
@@ -65,7 +76,8 @@ export default function InventoryFiltersPopover({
   setFilters,
   organization,
 }: InventoryFiltersPopoverProps): JSX.Element {
-  const classes = useStyles();
+  const { isMobile } = useDeviceInfo();
+  const classes = useStyles({ isMobile });
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [temporalRecord, setTemporalRecord] = useForm<InventoryFiltersType>({});
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -81,7 +93,7 @@ export default function InventoryFiltersPopover({
 
   const onReset = () => {
     setFilters({
-      facilityId: undefined,
+      facilityIds: undefined,
     });
     handleClose();
   };
@@ -89,6 +101,35 @@ export default function InventoryFiltersPopover({
   const onDone = () => {
     setFilters(temporalRecord);
     handleClose();
+  };
+
+  const addFacility = (id: number) => {
+    setTemporalRecord((prev) => {
+      return {
+        facilityIds: [...(prev.facilityIds || []), id],
+      };
+    });
+  };
+
+  const removeFacility = (id: number) => {
+    setTemporalRecord((prev) => {
+      const { facilityIds } = prev;
+      return {
+        facilityIds: facilityIds?.filter((val) => val.toString() !== id.toString()) || [],
+      };
+    });
+  };
+
+  const onChange = (id: string, value: any) => {
+    if (value) {
+      addFacility(Number(id));
+    } else {
+      removeFacility(Number(id));
+    }
+  };
+
+  const hasFilter = (id: number) => {
+    return temporalRecord.facilityIds?.some((n) => n.toString() === id.toString()) === true;
   };
 
   return (
@@ -114,14 +155,17 @@ export default function InventoryFiltersPopover({
         <div className={classes.popover}>
           <div className={classes.title}>{strings.FILTERS}</div>
           <Grid container spacing={2} className={classes.container}>
-            <Grid item xs={12}>
-              <NurseryDropdown
-                organization={organization}
-                record={temporalRecord}
-                setRecord={setTemporalRecord}
-                label={strings.NURSERY}
-              />
-            </Grid>
+            {getAllNurseries(organization).map((n) => (
+              <Grid item xs={12} key={n.id}>
+                <Checkbox
+                  id={n.id.toString()}
+                  name={n.name}
+                  label={n.name}
+                  value={hasFilter(n.id)}
+                  onChange={onChange}
+                />
+              </Grid>
+            ))}
           </Grid>
           <div className={classes.footer}>
             <Button label='Reset' onClick={onReset} size='medium' priority='secondary' type='passive' />

--- a/src/components/Inventory/InventoryFiltersPopover.tsx
+++ b/src/components/Inventory/InventoryFiltersPopover.tsx
@@ -1,4 +1,4 @@
-import { Grid, IconButton, Popover, Theme } from '@mui/material';
+import { Grid, IconButton, Popover, Theme, Typography, useTheme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import React, { useEffect, useState } from 'react';
 import Icon from 'src/components/common/icon/Icon';
@@ -76,6 +76,7 @@ export default function InventoryFiltersPopover({
   setFilters,
   organization,
 }: InventoryFiltersPopoverProps): JSX.Element {
+  const theme = useTheme();
   const { isMobile } = useDeviceInfo();
   const classes = useStyles({ isMobile });
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -155,6 +156,9 @@ export default function InventoryFiltersPopover({
         <div className={classes.popover}>
           <div className={classes.title}>{strings.FILTERS}</div>
           <Grid container spacing={2} className={classes.container}>
+            <Typography fontSize='16px' paddingLeft={theme.spacing(2)} color='#708284'>
+              {strings.NURSERIES}
+            </Typography>
             {getAllNurseries(organization).map((n) => (
               <Grid item xs={12} key={n.id}>
                 <Checkbox

--- a/src/components/Inventory/InventoryTable.tsx
+++ b/src/components/Inventory/InventoryTable.tsx
@@ -54,7 +54,7 @@ export default function InventoryTable(props: InventoryTableProps): JSX.Element 
   };
 
   const getFilteredNurseryName = (facilityId: number) => {
-    const found = getAllNurseries(organization).find((n) => n.toString() === facilityId.toString());
+    const found = getAllNurseries(organization).find((n) => n.id.toString() === facilityId.toString());
     if (found) {
       return found.name;
     }

--- a/src/components/Inventory/InventoryTable.tsx
+++ b/src/components/Inventory/InventoryTable.tsx
@@ -9,8 +9,9 @@ import { useDeviceInfo } from '@terraware/web-components/utils';
 import { APP_PATHS } from 'src/constants';
 import TextField from '@terraware/web-components/components/Textfield/Textfield';
 import InventoryCellRenderer from './InventoryCellRenderer';
-import InventoryFilters from './InventoryFiltersPopover';
+import InventoryFilters, { InventoryFiltersType } from './InventoryFiltersPopover';
 import Pill from '../Species/Pill';
+import PageSnackbar from 'src/components/PageSnackbar';
 import { getAllNurseries } from 'src/utils/organization';
 
 const columns: TableColumnType[] = [
@@ -28,16 +29,12 @@ interface InventoryTableProps {
   results: SearchResponseElement[];
   temporalSearchValue: string;
   setTemporalSearchValue: React.Dispatch<React.SetStateAction<string>>;
-  record: InventoryFiltersType;
-  setRecord: React.Dispatch<React.SetStateAction<InventoryFiltersType>>;
+  filters: InventoryFiltersType;
+  setFilters: React.Dispatch<React.SetStateAction<InventoryFiltersType>>;
 }
 
-export type InventoryFiltersType = {
-  facilityId?: number;
-};
-
 export default function InventoryTable(props: InventoryTableProps): JSX.Element {
-  const { organization, results, setTemporalSearchValue, temporalSearchValue, record, setRecord } = props;
+  const { organization, results, setTemporalSearchValue, temporalSearchValue, filters, setFilters } = props;
   const { isMobile } = useDeviceInfo();
   const history = useHistory();
 
@@ -56,12 +53,21 @@ export default function InventoryTable(props: InventoryTableProps): JSX.Element 
     setTemporalSearchValue(value as string);
   };
 
-  const getFilteredNurseryName = () => {
-    const found = getAllNurseries(organization).find((n) => n.id.toString() === record.facilityId?.toString());
+  const getFilteredNurseryName = (facilityId: number) => {
+    const found = getAllNurseries(organization).find((n) => n.toString() === facilityId.toString());
     if (found) {
       return found.name;
     }
     return '';
+  };
+
+  const removeFilter = (id: number) => {
+    setFilters((prev) => {
+      const { facilityIds } = prev;
+      return {
+        facilityIds: facilityIds?.filter((val) => val !== id) || [],
+      };
+    });
   };
 
   return (
@@ -80,6 +86,9 @@ export default function InventoryTable(props: InventoryTableProps): JSX.Element 
             />
           ))}
       </Grid>
+      <Grid item xs={12}>
+        <PageSnackbar />
+      </Grid>
       <Grid item xs={12} marginTop={3} display='flex'>
         <Box width='300px'>
           <TextField
@@ -94,13 +103,18 @@ export default function InventoryTable(props: InventoryTableProps): JSX.Element 
             onClickRightIcon={clearSearch}
           />
         </Box>
-        <InventoryFilters filters={record} setFilters={setRecord} organization={organization} />
+        <InventoryFilters filters={filters} setFilters={setFilters} organization={organization} />
       </Grid>
 
       <Grid xs={12} display='flex' paddingLeft={3} paddingTop={1}>
-        {record.facilityId && (
-          <Pill filter={strings.NURSERY} value={getFilteredNurseryName()} onRemoveFilter={() => setRecord({})} />
-        )}
+        {filters.facilityIds?.map((id) => (
+          <Pill
+            key={id}
+            filter={strings.NURSERY}
+            value={getFilteredNurseryName(id)}
+            onRemoveFilter={() => removeFilter(id)}
+          />
+        ))}
       </Grid>
       <Grid item xs={12}>
         <div>


### PR DESCRIPTION
- centered spinner
- adjusted position of page snackbar
- updated filters to be multiple-select
- filters will next be used in the seedlings table (follow up)
- 
<img width="208" alt="Terraware App 2022-10-20 10-03-29" src="https://user-images.githubusercontent.com/1865174/197013527-c1399e8b-62a0-4466-b4cb-f8faeef598bd.png">

<img width="570" alt="Terraware App 2022-10-20 10-03-11" src="https://user-images.githubusercontent.com/1865174/197013531-83efacef-00b3-41a0-aa7b-5696a711c7cb.png">

<img width="261" alt="Terraware App 2022-10-20 09-57-48" src="https://user-images.githubusercontent.com/1865174/197012088-20a79348-6358-44a5-b984-e6f797b22a5f.png">
