### PR TITLE
Don't disable save button if estimated count change

### DIFF
--- a/src/components/accession2/edit/QuantityModal.tsx
+++ b/src/components/accession2/edit/QuantityModal.tsx
@@ -116,7 +116,8 @@ export default function QuantityModal(props: QuantityModalProps): JSX.Element {
 
   const hasChanged =
     (!statusEdit || accession.state !== record.state) &&
-    !_.isEqual(accession.remainingQuantity, record.remainingQuantity);
+    (!_.isEqual(accession.remainingQuantity, record.remainingQuantity) ||
+      !_.isEqual(accession.estimatedCount, record.estimatedCount));
 
   return (
     <>


### PR DESCRIPTION
When changing the count value in the quantity modal (by using the calculator) when grams value is already set, save button is disabled. Enable it when count value change