### PR TITLE
Add a way to reload data in seedlings view

### DIFF
--- a/src/components/Inventory/InventoryView.tsx
+++ b/src/components/Inventory/InventoryView.tsx
@@ -34,6 +34,7 @@ export default function InventoryView(props: InventoryViewProps): JSX.Element {
   const { species, organization } = props;
   const { speciesId } = useParams<{ speciesId: string }>();
   const [inventorySpecies, setInventorySpecies] = useState<Species>();
+  const [modified, setModified] = useState<number>(Date.now());
 
   const classes = useStyles();
   const theme = useTheme();
@@ -76,8 +77,13 @@ export default function InventoryView(props: InventoryViewProps): JSX.Element {
         </Grid>
         {speciesId && (
           <Grid item xs={12} sx={{ display: 'flex', flexDirection: 'column' }}>
-            <InventorySummary speciesId={Number(speciesId)} />
-            <InventorySeedlingsTable speciesId={Number(speciesId)} organization={organization} />
+            <InventorySummary speciesId={Number(speciesId)} modified={modified} />
+            <InventorySeedlingsTable
+              speciesId={Number(speciesId)}
+              organization={organization}
+              modified={modified}
+              setModified={setModified}
+            />
           </Grid>
         )}
       </Grid>

--- a/src/components/Inventory/view/InventorySeedlingsTable.tsx
+++ b/src/components/Inventory/view/InventorySeedlingsTable.tsx
@@ -36,10 +36,12 @@ const columns = (editable: boolean): TableColumnType[] => {
 interface InventorySeedslingsTableProps {
   speciesId: number;
   organization: ServerOrganization;
+  modified: number;
+  setModified: (val: number) => void;
 }
 
 export default function InventorySeedslingsTable(props: InventorySeedslingsTableProps): JSX.Element {
-  const { speciesId, organization } = props;
+  const { speciesId, organization, modified, setModified } = props;
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
   const [temporalSearchValue, setTemporalSearchValue] = useState<string>('');
@@ -121,7 +123,7 @@ export default function InventorySeedslingsTable(props: InventorySeedslingsTable
     return () => {
       activeRequests = false;
     };
-  }, [debouncedSearchTerm, organization.id, speciesId, filters.facilityIds]);
+  }, [debouncedSearchTerm, organization.id, speciesId, filters.facilityIds, modified]);
 
   const clearSearch = () => {
     setTemporalSearchValue('');
@@ -133,11 +135,12 @@ export default function InventorySeedslingsTable(props: InventorySeedslingsTable
 
   const addBatch = () => {
     // TODO
+    reloadData();
     return;
   };
 
   const reloadData = () => {
-    // TODO
+    setModified(Date.now());
     return;
   };
 

--- a/src/components/Inventory/view/InventorySummary.tsx
+++ b/src/components/Inventory/view/InventorySummary.tsx
@@ -9,10 +9,11 @@ import _ from 'lodash';
 
 interface InventorySummaryProps {
   speciesId: number;
+  modified: number;
 }
 
 export default function InventorySummary(props: InventorySummaryProps): JSX.Element {
-  const { speciesId } = props;
+  const { speciesId, modified } = props;
   const [summary, setSummary] = useState<SpeciesInventorySummary>();
 
   const theme = useTheme();
@@ -38,7 +39,7 @@ export default function InventorySummary(props: InventorySummaryProps): JSX.Elem
 
   useEffect(() => {
     reloadData();
-  }, [speciesId, reloadData]);
+  }, [speciesId, reloadData, modified]);
 
   const getData = () => {
     if (!summary) {


### PR DESCRIPTION
- seedlings view does not lift state of summary and table into parent component
- need a way to reload data from parent view across child components
- mocked message passing using a modified timestamp