### PR TITLE
SW-1876 support deletion of seedlings batches

### DIFF
--- a/src/api/batch/batch.ts
+++ b/src/api/batch/batch.ts
@@ -67,3 +67,29 @@ export const getBatch = async (batchId: number): Promise<GetBatchResponse> => {
 
   return response;
 };
+
+export type DeleteBatchServerResponse =
+  paths[typeof BATCH_ID_ENDPOINT]['delete']['responses'][200]['content']['application/json'];
+
+type DeleteBatchResponse = {
+  requestSucceeded: boolean;
+};
+
+export const deleteBatch = async (batchId: number): Promise<DeleteBatchResponse> => {
+  const response: DeleteBatchResponse = {
+    requestSucceeded: true,
+  };
+
+  try {
+    const serverResponse: DeleteBatchServerResponse = (
+      await axios.delete(BATCH_ID_ENDPOINT.replace('{id}', batchId.toString()))
+    ).data;
+    if (serverResponse.status === 'error') {
+      response.requestSucceeded = false;
+    }
+  } catch {
+    response.requestSucceeded = false;
+  }
+
+  return response;
+};

--- a/src/components/Inventory/view/DeleteBatchesModal.tsx
+++ b/src/components/Inventory/view/DeleteBatchesModal.tsx
@@ -1,0 +1,52 @@
+import { makeStyles } from '@mui/styles';
+import React from 'react';
+import strings from 'src/strings';
+import Button from 'src/components/common/button/Button';
+import DialogBox from 'src/components/common/DialogBox/DialogBox';
+
+const useStyles = makeStyles(() => ({
+  mainContent: {
+    color: '#3A4445',
+    fontSize: '16px',
+  },
+}));
+
+export interface DeleteBatchesModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+}
+
+export default function DeleteBatchesModal(props: DeleteBatchesModalProps): JSX.Element {
+  const classes = useStyles();
+  const { onClose, open, onSubmit } = props;
+
+  return (
+    <DialogBox
+      onClose={onClose}
+      open={open}
+      title={strings.DELETE_SEEDLINGS_BATCHES}
+      size='medium'
+      middleButtons={[
+        <Button
+          label={strings.CANCEL}
+          priority='secondary'
+          type='passive'
+          onClick={onClose}
+          size='medium'
+          key='button-1'
+        />,
+        <Button
+          label={strings.DELETE}
+          icon='iconTrashCan'
+          type='destructive'
+          onClick={onSubmit}
+          size='medium'
+          key='button-2'
+        />,
+      ]}
+    >
+      <p className={classes.mainContent}>{strings.DELETE_SEEDLINGS_BATCHES_MSG}</p>
+    </DialogBox>
+  );
+}

--- a/src/components/Inventory/view/InventorySeedlingsTable.tsx
+++ b/src/components/Inventory/view/InventorySeedlingsTable.tsx
@@ -220,45 +220,6 @@ export default function InventorySeedslingsTable(props: InventorySeedslingsTable
             />
           ))}
         </Grid>
-        {selectedRows.length > 0 && (
-          <Box
-            sx={{
-              backgroundColor: '#F2F4F5',
-              display: 'flex',
-              flexDirection: 'row',
-              padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
-              borderRadius: '4px',
-              alignSelf: 'stretch',
-              flexGrow: 0,
-              marginTop: theme.spacing(2),
-              marginBottom: theme.spacing(2),
-              justifyContent: 'space-between',
-              alignItems: 'center',
-            }}
-          >
-            <Typography
-              sx={{
-                fontSize: '16px',
-                fontWeight: 400,
-                color: '#3A4445',
-              }}
-            >
-              {selectedRows.length === 1
-                ? strings.ROW_SELECTED
-                : strings.formatString(strings.ROWS_SELECTED, selectedRows.length)}
-            </Typography>
-            <Box>
-              <Button
-                id='delete-batch'
-                label={strings.DELETE}
-                onClick={() => setOpenDeleteModal(true)}
-                size='small'
-                type='destructive'
-                priority='secondary'
-              />
-            </Box>
-          </Box>
-        )}
         <Box marginTop={theme.spacing(2)}>
           <Table
             id='batches-table'
@@ -271,6 +232,10 @@ export default function InventorySeedslingsTable(props: InventorySeedslingsTable
             setSelectedRows={setSelectedRows}
             showCheckbox={true}
             isClickable={() => true}
+            showTopBar={true}
+            topBarButtons={[
+              { buttonType: 'destructive', buttonText: strings.DELETE, onButtonClick: () => setOpenDeleteModal(true) },
+            ]}
           />
         </Box>
       </Box>

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -792,6 +792,10 @@ const strings = new LocalizedStrings({
     ADD_BATCH: 'Add Batch',
     SEEDLING_BATCH: 'Seedling Batch',
     EST_READY_DATE: 'Est. Ready Date',
+    ROW_SELECTED: '1 row selected.',
+    ROWS_SELECTED: '{0} rows selected.',
+    DELETE_SEEDLINGS_BATCHES_MSG: 'Are you sure you want to delete the seedlings batches?',
+    DELETE_SEEDLINGS_BATCHES: 'Delete Seedlings Batches',
   },
 });
 

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -792,8 +792,6 @@ const strings = new LocalizedStrings({
     ADD_BATCH: 'Add Batch',
     SEEDLING_BATCH: 'Seedling Batch',
     EST_READY_DATE: 'Est. Ready Date',
-    ROW_SELECTED: '1 row selected.',
-    ROWS_SELECTED: '{0} rows selected.',
     DELETE_SEEDLINGS_BATCHES_MSG: 'Are you sure you want to delete the seedlings batches?',
     DELETE_SEEDLINGS_BATCHES: 'Delete Seedlings Batches',
   },


### PR DESCRIPTION
- added a confirmation modal (which wasn't in the design - but this is an assumption)
- copied confirmation modal from species modal deletion
- we can iterate on the confirmation as needed
- deletion supports batch delete (client side, not BE side)

<img width="772" alt="Terraware App 2022-10-21 10-35-28" src="https://user-images.githubusercontent.com/1865174/197256715-f9cecd12-2ada-4f0f-a9cb-ec1f6647ba85.png">

<img width="481" alt="Terraware App 2022-10-21 10-35-50" src="https://user-images.githubusercontent.com/1865174/197256749-cf0236b4-437a-44e4-ae17-4f0ffe3a8206.png">

<img width="232" alt="Terraware App 2022-10-21 10-35-07" src="https://user-images.githubusercontent.com/1865174/197256784-908c3b5f-312b-4c75-b62b-ff2008cb73a7.png">

<img width="199" alt="Terraware App 2022-10-21 10-36-04" src="https://user-images.githubusercontent.com/1865174/197256827-f97fcb23-5a81-4144-b339-4f57d1a02911.png">

<img width="777" alt="Terraware App 2022-10-21 10-36-39" src="https://user-images.githubusercontent.com/1865174/197256849-5867ef4d-3e30-4b6c-8175-03b62a8e89f0.png">
