### PR TITLE
SW-1928 Fix attempting to remove the last person in an org generates error on first attempt

### DIFF
--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -155,6 +155,8 @@ export default function PeopleList({ organization, reloadData, user }: PeopleLis
       });
 
       if (allRemoved) {
+        setRemovePeopleModalOpened(false);
+        setSelectedPeopleRows([]);
         if (reloadData) {
           reloadData();
         }


### PR DESCRIPTION
This error was because the removed row was still "selected" after removing, and modal was still open.
Fix is to clean selectedRows after deleting and close the modal.