### PR TITLE
SW-1978 Skip vercel deploy for gh-pages commits

### DIFF
--- a/.github/scripts/vercel-ignore.sh
+++ b/.github/scripts/vercel-ignore.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ $VERCEL_GIT_COMMIT_REF =~ "gh-pages" ]] ; then
+  echo ">> Skip deploy"
+  exit 0;
+else
+  echo ">> Proceed with deploy"
+  exit 1; 
+fi


### PR DESCRIPTION
This script will be called from Vercel config so that we don't do a bunch of extra deployments for the new gh-pages branch.
<img width="960" alt="Screen Shot 2022-10-27 at 5 11 38 PM" src="https://user-images.githubusercontent.com/104874529/198420315-0fd91d1e-94f0-4831-94f5-8f5ba88a880d.png">
