### PR TITLE
SW-2065 Interactive Header

### DIFF
--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -32,6 +32,7 @@ import { ViabilityTest } from 'src/api/types/accessions';
 import ViewViabilityTestModal from '../viabilityTesting/ViewViabilityTestModal';
 import { getSeedBank, isContributor } from 'src/utils/organization';
 import _ from 'lodash';
+import PageHeaderWrapper from '../../common/PageHeaderWrapper';
 
 const useStyles = makeStyles((theme: Theme) => ({
   iconStyle: {
@@ -81,7 +82,6 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
   const snackbar = useSnackbar();
   const { isMobile } = useDeviceInfo();
   const themeObj = useTheme();
-  const headerRef = useRef(null);
   const contentRef = useRef(null);
 
   const reloadData = useCallback(() => {
@@ -327,7 +327,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
   const isAwaitingCheckin = accession?.state === 'Awaiting Check-In';
 
   return (
-    <TfMain headerElement={headerRef.current} contentElement={contentRef.current} headerHeight={isMobile ? 108 : 124}>
+    <TfMain>
       {accession && (
         <>
           {selectedTest && (
@@ -425,31 +425,33 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
           )}
         </>
       )}
-      <Box ref={headerRef} padding={isMobile ? themeObj.spacing(3, 0) : 3}>
-        <Box display='flex' justifyContent='space-between' alignItems='center'>
-          <Typography>{accession?.accessionNumber}</Typography>
-          {!isMobile && userCanEdit && (
-            <Box display='flex' alignItems='center'>
-              <IconButton
-                sx={{ marginLeft: 3, height: '24px', marginRight: 1 }}
-                onClick={() => setOpenDeleteAccession(true)}
-              >
-                <Icon name='iconTrashCan' />
-              </IconButton>
-              {accession && isAwaitingCheckin ? (
-                <Button onClick={() => checkInAccession()} label={strings.CHECK_IN} size='medium' />
-              ) : (
-                renderWithdrawalButton()
-              )}
-            </Box>
-          )}
+      <PageHeaderWrapper nextElement={contentRef.current}>
+        <Box padding={isMobile ? themeObj.spacing(3, 0) : 3}>
+          <Box display='flex' justifyContent='space-between' alignItems='center'>
+            <Typography>{accession?.accessionNumber}</Typography>
+            {!isMobile && userCanEdit && (
+              <Box display='flex' alignItems='center'>
+                <IconButton
+                  sx={{ marginLeft: 3, height: '24px', marginRight: 1 }}
+                  onClick={() => setOpenDeleteAccession(true)}
+                >
+                  <Icon name='iconTrashCan' />
+                </IconButton>
+                {accession && isAwaitingCheckin ? (
+                  <Button onClick={() => checkInAccession()} label={strings.CHECK_IN} size='medium' />
+                ) : (
+                  renderWithdrawalButton()
+                )}
+              </Box>
+            )}
+          </Box>
+          <Typography color={themeObj.palette.TwClrTxt} fontSize='24px' fontStyle='italic' fontWeight={500}>
+            {accession?.speciesScientificName}
+          </Typography>
+          <Typography color={themeObj.palette.TwClrTxtSecondary}>{accession?.speciesCommonName}</Typography>
+          <PageSnackbar />
         </Box>
-        <Typography color={themeObj.palette.TwClrTxt} fontSize='24px' fontStyle='italic' fontWeight={500}>
-          {accession?.speciesScientificName}
-        </Typography>
-        <Typography color={themeObj.palette.TwClrTxtSecondary}>{accession?.speciesCommonName}</Typography>
-        <PageSnackbar />
-      </Box>
+      </PageHeaderWrapper>
 
       <Box
         ref={contentRef}

--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -3,7 +3,7 @@ import { useTheme, Box, IconButton, Link, Tab, Theme, Typography } from '@mui/ma
 import { makeStyles } from '@mui/styles';
 import { Button, Icon } from '@terraware/web-components';
 import moment from 'moment';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { Accession2, getAccession2 } from 'src/api/accessions2/accession';
 import { checkIn } from 'src/api/seeds/accession';
@@ -81,6 +81,8 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
   const snackbar = useSnackbar();
   const { isMobile } = useDeviceInfo();
   const themeObj = useTheme();
+  const headerRef = useRef(null);
+  const contentRef = useRef(null);
 
   const reloadData = useCallback(() => {
     const populateAccession = async () => {
@@ -325,7 +327,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
   const isAwaitingCheckin = accession?.state === 'Awaiting Check-In';
 
   return (
-    <TfMain>
+    <TfMain headerElement={headerRef.current} contentElement={contentRef.current} headerHeight={isMobile ? 108 : 124}>
       {accession && (
         <>
           {selectedTest && (
@@ -423,7 +425,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
           )}
         </>
       )}
-      <Box padding={isMobile ? themeObj.spacing(3, 0) : 3}>
+      <Box ref={headerRef} padding={isMobile ? themeObj.spacing(3, 0) : 3}>
         <Box display='flex' justifyContent='space-between' alignItems='center'>
           <Typography>{accession?.accessionNumber}</Typography>
           {!isMobile && userCanEdit && (
@@ -450,6 +452,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
       </Box>
 
       <Box
+        ref={contentRef}
         display='flex'
         alignItems={isMobile ? 'flex-start' : 'center'}
         flexDirection={isMobile ? 'column' : 'row'}

--- a/src/components/common/PageHeaderWrapper.tsx
+++ b/src/components/common/PageHeaderWrapper.tsx
@@ -55,20 +55,17 @@ export default function PageHeaderWrapper({ children, nextElement }: Props): JSX
     };
   }, [children, nextElement, height, sticky]);
 
-  const styles = useMemo<Record<string, any>>(
-    () => ({
-      background: sticky ? theme.palette.TwClrBg : undefined,
-      boxShadow: sticky ? `0px 3px 3px -3px ${theme.palette.TwClrBaseGray200}` : undefined,
-      paddingTop: sticky ? theme.spacing(3) : undefined,
-      paddingRight: sticky ? theme.spacing(3) : undefined,
-      position: sticky ? 'fixed' : undefined,
-      top: sticky ? `${TOP_BAR_HEIGHT}px` : undefined,
-      visibility: scrollDown && sticky ? 'hidden' : 'visible',
-      width: sticky ? '-webkit-fill-available' : undefined,
-      zIndex: sticky ? 100 : undefined,
-    }),
-    [theme, sticky, scrollDown]
-  );
+  const styles: Record<string, any> = {
+    background: sticky ? theme.palette.TwClrBg : undefined,
+    boxShadow: sticky ? `0px 3px 3px -3px ${theme.palette.TwClrBaseGray200}` : undefined,
+    paddingTop: sticky ? theme.spacing(3) : undefined,
+    paddingRight: sticky ? theme.spacing(3) : undefined,
+    position: sticky ? 'fixed' : undefined,
+    top: sticky ? `${TOP_BAR_HEIGHT}px` : undefined,
+    visibility: scrollDown && sticky ? 'hidden' : 'visible',
+    width: sticky ? '-webkit-fill-available' : undefined,
+    zIndex: sticky ? 100 : undefined,
+  };
 
   return (
     <Box ref={ref} sx={styles}>

--- a/src/components/common/PageHeaderWrapper.tsx
+++ b/src/components/common/PageHeaderWrapper.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { makeStyles } from '@mui/styles';
+import { Theme } from '@mui/material';
+
+const TOP_BAR_HEIGHT = 64;
+
+const useStyles = makeStyles((theme: Theme) => ({
+  headerFixed: {
+    position: 'fixed',
+    top: `${TOP_BAR_HEIGHT}px`,
+    width: '-webkit-fill-available',
+    background: theme.palette.TwClrBg,
+    boxShadow: `0px 3px 3px -3px ${theme.palette.TwClrBaseGray200}`,
+    zIndex: 100,
+  },
+  hide: {
+    visibility: 'hidden',
+  },
+}));
+
+/**
+ * children The child component which is the page header
+ * nextElement The HTMLElement immediately following the header element
+ */
+interface Props {
+  children?: React.ReactChild;
+  nextElement?: HTMLElement | null;
+}
+
+export default function PageHeaderWrapper({ children, nextElement }: Props): JSX.Element {
+  const classes = useStyles();
+  const ref = useRef<HTMLDivElement>(null);
+  const [sticky, setSticky] = useState(false);
+  const [scrollDown, setScrollDown] = useState(false);
+  const [height, setHeight] = useState<number>();
+
+  useEffect(() => {
+    if (ref.current) {
+      setHeight(ref.current.clientHeight);
+    }
+  }, [children, ref]);
+
+  useEffect(() => {
+    if (!children) {
+      return;
+    }
+
+    let lastScrollY = 0;
+    const handleScroll = (ev: Event) => {
+      const scrolled = window.scrollY > (height ?? 0);
+      const delta = window.scrollY - lastScrollY;
+      setSticky(scrolled);
+      setScrollDown(delta > 0);
+      if (nextElement) {
+        nextElement.style.marginTop = `${scrolled ? height : 0}px`;
+      }
+
+      lastScrollY = window.scrollY;
+    };
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [children, nextElement, height]);
+
+  return (
+    <div ref={ref} className={`${sticky ? classes.headerFixed : ''} ${scrollDown && sticky ? classes.hide : ''}`}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/common/PageHeaderWrapper.tsx
+++ b/src/components/common/PageHeaderWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Box, useTheme } from '@mui/material';
 
 const TOP_BAR_HEIGHT = 64;

--- a/src/components/common/PageHeaderWrapper.tsx
+++ b/src/components/common/PageHeaderWrapper.tsx
@@ -1,22 +1,7 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Box, useTheme } from '@mui/material';
 
 const TOP_BAR_HEIGHT = 64;
-
-const useStyles = makeStyles((theme: Theme) => ({
-  headerFixed: {
-    position: 'fixed',
-    top: `${TOP_BAR_HEIGHT}px`,
-    width: '-webkit-fill-available',
-    background: theme.palette.TwClrBg,
-    boxShadow: `0px 3px 3px -3px ${theme.palette.TwClrBaseGray200}`,
-    zIndex: 100,
-  },
-  hide: {
-    visibility: 'hidden',
-  },
-}));
 
 /**
  * children The child component which is the page header
@@ -28,7 +13,7 @@ interface Props {
 }
 
 export default function PageHeaderWrapper({ children, nextElement }: Props): JSX.Element {
-  const classes = useStyles();
+  const theme = useTheme();
   const ref = useRef<HTMLDivElement>(null);
   const [sticky, setSticky] = useState(false);
   const [scrollDown, setScrollDown] = useState(false);
@@ -64,9 +49,22 @@ export default function PageHeaderWrapper({ children, nextElement }: Props): JSX
     };
   }, [children, nextElement, height]);
 
+  const styles = useMemo<Record<string, any>>(
+    () => ({
+      visibility: scrollDown && sticky ? 'hidden' : 'visible',
+      position: sticky ? 'fixed' : undefined,
+      top: sticky ? `${TOP_BAR_HEIGHT}px` : undefined,
+      width: sticky ? '-webkit-fill-available' : undefined,
+      background: sticky ? theme.palette.TwClrBg : undefined,
+      boxShadow: sticky ? `0px 3px 3px -3px ${theme.palette.TwClrBaseGray200}` : undefined,
+      zIndex: sticky ? 100 : undefined,
+    }),
+    [theme, sticky, scrollDown]
+  );
+
   return (
-    <div ref={ref} className={`${sticky ? classes.headerFixed : ''} ${scrollDown && sticky ? classes.hide : ''}`}>
+    <Box ref={ref} sx={styles}>
       {children}
-    </div>
+    </Box>
   );
 }

--- a/src/components/common/TfMain.tsx
+++ b/src/components/common/TfMain.tsx
@@ -5,7 +5,7 @@ import { Theme } from '@mui/material';
 const useStyles = makeStyles((theme: Theme) => ({
   main: {
     background: theme.palette.TwClrBg,
-    minHeight: `calc(100vh - 64px)`,
+    minHeight: 'calc(100vh - 64px)',
     display: 'flex',
     flexDirection: 'column',
     padding: '24px',

--- a/src/components/common/TfMain.tsx
+++ b/src/components/common/TfMain.tsx
@@ -1,23 +1,72 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material';
+
+const TOP_BAR_HEIGHT = 64;
 
 const useStyles = makeStyles((theme: Theme) => ({
   main: {
     background: theme.palette.TwClrBg,
-    minHeight: 'calc(100vh - 64px)',
+    minHeight: `calc(100vh - ${TOP_BAR_HEIGHT}px)`,
     display: 'flex',
     flexDirection: 'column',
     padding: '24px',
   },
+  headerFloat: {
+    position: 'fixed',
+    top: `${TOP_BAR_HEIGHT}px`,
+    width: '-webkit-fill-available',
+    background: `${theme.palette.TwClrBg} !important`,
+    boxShadow: `0px 3px 3px -3px ${theme.palette.TwClrBaseGray200}`,
+    zIndex: 100,
+  },
+  hide: {
+    visibility: 'hidden',
+  },
 }));
 
+/**
+ * TfMain Component Props
+ * children The child components to be rendered within this element on the page
+ * headerElement The HTMLElement that corresponds to the header of the page
+ * contentElement The HTMLElement immediately following the header element
+ * headerHeight The height of the header in pixels
+ */
 interface Props {
   children?: React.ReactNode;
+  headerElement?: HTMLElement | null;
+  contentElement?: HTMLElement | null;
+  headerHeight?: number;
 }
 
-export default function TfMain({ children }: Props): JSX.Element {
+export default function TfMain({ children, headerElement, contentElement, headerHeight }: Props): JSX.Element {
   const classes = useStyles();
+
+  useEffect(() => {
+    if (!(headerElement && contentElement && headerHeight)) {
+      return;
+    }
+
+    let lastScrollY = 0;
+    const headerClasses = headerElement.className;
+    const handleScroll = (ev: Event) => {
+      if (window.scrollY > headerHeight) {
+        const delta = window.scrollY - lastScrollY;
+        headerElement.className = `${headerClasses} ${classes.headerFloat} ${delta > 0 ? ' ' + classes.hide : ''}`;
+        contentElement.style.marginTop = `${headerHeight}px`;
+      } else {
+        headerElement.className = headerClasses;
+        contentElement.style.marginTop = '0px';
+      }
+
+      lastScrollY = window.scrollY;
+    };
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [headerElement, contentElement, headerHeight, classes.headerFloat, classes.hide]);
 
   return <main className={classes.main}>{children}</main>;
 }

--- a/src/components/common/TfMain.tsx
+++ b/src/components/common/TfMain.tsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexDirection: 'column',
     padding: '24px',
   },
-  headerFloat: {
+  headerFixed: {
     position: 'fixed',
     top: `${TOP_BAR_HEIGHT}px`,
     width: '-webkit-fill-available',
@@ -52,7 +52,7 @@ export default function TfMain({ children, headerElement, contentElement, header
     const handleScroll = (ev: Event) => {
       if (window.scrollY > headerHeight) {
         const delta = window.scrollY - lastScrollY;
-        headerElement.className = `${headerClasses} ${classes.headerFloat} ${delta > 0 ? ' ' + classes.hide : ''}`;
+        headerElement.className = `${headerClasses} ${classes.headerFixed} ${delta > 0 ? ' ' + classes.hide : ''}`;
         contentElement.style.marginTop = `${headerHeight}px`;
       } else {
         headerElement.className = headerClasses;
@@ -66,7 +66,7 @@ export default function TfMain({ children, headerElement, contentElement, header
     return () => {
       window.removeEventListener('scroll', handleScroll);
     };
-  }, [headerElement, contentElement, headerHeight, classes.headerFloat, classes.hide]);
+  }, [headerElement, contentElement, headerHeight, classes.headerFixed, classes.hide]);
 
   return <main className={classes.main}>{children}</main>;
 }

--- a/src/components/common/TfMain.tsx
+++ b/src/components/common/TfMain.tsx
@@ -1,72 +1,23 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material';
-
-const TOP_BAR_HEIGHT = 64;
 
 const useStyles = makeStyles((theme: Theme) => ({
   main: {
     background: theme.palette.TwClrBg,
-    minHeight: `calc(100vh - ${TOP_BAR_HEIGHT}px)`,
+    minHeight: `calc(100vh - 64px)`,
     display: 'flex',
     flexDirection: 'column',
     padding: '24px',
   },
-  headerFixed: {
-    position: 'fixed',
-    top: `${TOP_BAR_HEIGHT}px`,
-    width: '-webkit-fill-available',
-    background: `${theme.palette.TwClrBg} !important`,
-    boxShadow: `0px 3px 3px -3px ${theme.palette.TwClrBaseGray200}`,
-    zIndex: 100,
-  },
-  hide: {
-    visibility: 'hidden',
-  },
 }));
 
-/**
- * TfMain Component Props
- * children The child components to be rendered within this element on the page
- * headerElement The HTMLElement that corresponds to the header of the page
- * contentElement The HTMLElement immediately following the header element
- * headerHeight The height of the header in pixels
- */
 interface Props {
   children?: React.ReactNode;
-  headerElement?: HTMLElement | null;
-  contentElement?: HTMLElement | null;
-  headerHeight?: number;
 }
 
-export default function TfMain({ children, headerElement, contentElement, headerHeight }: Props): JSX.Element {
+export default function TfMain({ children }: Props): JSX.Element {
   const classes = useStyles();
-
-  useEffect(() => {
-    if (!(headerElement && contentElement && headerHeight)) {
-      return;
-    }
-
-    let lastScrollY = 0;
-    const headerClasses = headerElement.className;
-    const handleScroll = (ev: Event) => {
-      if (window.scrollY > headerHeight) {
-        const delta = window.scrollY - lastScrollY;
-        headerElement.className = `${headerClasses} ${classes.headerFixed} ${delta > 0 ? ' ' + classes.hide : ''}`;
-        contentElement.style.marginTop = `${headerHeight}px`;
-      } else {
-        headerElement.className = headerClasses;
-        contentElement.style.marginTop = '0px';
-      }
-
-      lastScrollY = window.scrollY;
-    };
-    window.addEventListener('scroll', handleScroll, { passive: true });
-
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-    };
-  }, [headerElement, contentElement, headerHeight, classes.headerFixed, classes.hide]);
 
   return <main className={classes.main}>{children}</main>;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -9,7 +9,6 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   min-height: 100%;
-  height: 100%;
   background: #ffffff;
   letter-spacing: normal;
 }


### PR DESCRIPTION
- Create wrapper component
- Define class for fixed header
- On scrolling below header fix header to top
- Add padding to immediate sibling below header
- On scroll-down hide the header
- On scroll-up show the header
- Currently only implemented for Accession view

<img width="1047" alt="image" src="https://user-images.githubusercontent.com/114949086/199054800-e3adb6bd-a983-497d-a6ba-bf28528616e8.png">

Desktop:
![Kapture 2022-10-31 at 00 02 24](https://user-images.githubusercontent.com/114949086/198941867-d5e20628-bcca-4d20-8d8a-0c24c1ef926d.gif)

Mobile:
![Kapture 2022-10-31 at 00 03 49](https://user-images.githubusercontent.com/114949086/198941985-b69d5753-aefd-4ca5-a2e5-976834467ca0.gif)
