### PR TITLE
SW-2027 updates: Iteration on onboarding for accessions/inventory

### DIFF
--- a/src/components/Inventory/index.tsx
+++ b/src/components/Inventory/index.tsx
@@ -75,30 +75,30 @@ export default function Inventory(props: InventoryProps): JSX.Element {
   const getEmptyState = () => {
     const emptyState = [];
 
+    if (!hasNurseries) {
+      emptyState.push({
+        title: strings.ADD_NURSERIES_ONBOARDING_TITLE,
+        text: emptyMessageStrings.INVENTORY_ONBOARDING_NURSERIES_MSG,
+        buttonText: strings.GO_TO_NURSERIES,
+        onClick: () => goTo(APP_PATHS.NURSERIES),
+      });
+    }
+
     if (!hasSpecies) {
       emptyState.push({
         title: strings.CREATE_SPECIES_LIST,
         text: emptyMessageStrings.INVENTORY_ONBOARDING_SPECIES_MSG,
         buttonText: strings.GO_TO_SPECIES,
         onClick: () => goTo(APP_PATHS.SPECIES),
-        altItem: hasNurseries
-          ? {
-              title: strings.IMPORT_INVENTORY_ALT_TITLE,
-              linkText: strings.IMPORT_INVENTORY_WITH_TEMPLATE,
-              onLinkClick: () => downloadCsvTemplateHandler(downloadInventoryTemplate),
-              buttonText: strings.IMPORT_INVENTORY,
-              onClick: () => importInventory(),
-            }
-          : undefined,
-      });
-    }
-
-    if (!hasNurseries) {
-      emptyState.push({
-        title: strings.NURSERIES,
-        text: emptyMessageStrings.INVENTORY_ONBOARDING_NURSERIES_MSG,
-        buttonText: strings.GO_TO_NURSERIES,
-        onClick: () => goTo(APP_PATHS.NURSERIES),
+        disabled: !hasNurseries,
+        altItem: {
+          title: strings.IMPORT_INVENTORY_ALT_TITLE,
+          text: strings.IMPORT_INVENTORY_WITH_TEMPLATE,
+          linkText: strings.DOWNLOAD_THE_CSV_TEMPLATE,
+          onLinkClick: () => downloadCsvTemplateHandler(downloadInventoryTemplate),
+          buttonText: strings.IMPORT_INVENTORY,
+          onClick: () => importInventory(),
+        },
       });
     }
 

--- a/src/components/common/EmptyMessage.tsx
+++ b/src/components/common/EmptyMessage.tsx
@@ -50,7 +50,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   itemLink: {
-    fontSize: '16px',
+    fontSize: '14px',
     cursor: 'pointer',
   },
   or: {
@@ -61,6 +61,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 type RowAltItem = {
   title: string;
+  text: string;
   linkText: string;
   onLinkClick: () => void;
   buttonText: string;
@@ -72,6 +73,7 @@ type RowItem = {
   text: string;
   buttonText: string;
   onClick: () => void;
+  disabled?: boolean;
   altItem?: RowAltItem;
 };
 
@@ -107,7 +109,7 @@ export default function EmptyMessage(props: EmptyMessageProps): JSX.Element {
                     {rowItem.text}
                   </Typography>
                 </div>
-                <Button label={rowItem.buttonText} onClick={rowItem.onClick} />
+                <Button label={rowItem.buttonText} onClick={rowItem.onClick} disabled={rowItem.disabled} />
               </div>
               {rowItem.altItem !== undefined ? (
                 <>
@@ -117,11 +119,19 @@ export default function EmptyMessage(props: EmptyMessageProps): JSX.Element {
                       <Typography fontSize='16px' fontWeight={600} color={theme.palette.TwClrTxt} lineHeight='20px'>
                         {rowItem.altItem.title}
                       </Typography>
+                      <Typography fontSize='14px' fontWeight={500} color={theme.palette.TwClrTxt} lineHeight='20px'>
+                        {rowItem.altItem.text}
+                      </Typography>
                       <Link onClick={rowItem.altItem.onLinkClick} className={classes.itemLink}>
                         {rowItem.altItem.linkText}
                       </Link>
                     </div>
-                    <Button label={rowItem.altItem.buttonText} onClick={rowItem.altItem.onClick} priority='secondary' />
+                    <Button
+                      label={rowItem.altItem.buttonText}
+                      onClick={rowItem.altItem.onClick}
+                      priority='secondary'
+                      disabled={rowItem.disabled}
+                    />
                   </div>
                 </>
               ) : null}

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -457,11 +457,10 @@ export default function Database(props: DatabaseProps): JSX.Element {
 
   const getEmptyState = () => {
     const emptyState = [];
-    const seedBanks = organization ? getAllSeedBanks(organization) : null;
 
     if (!hasSeedBanks) {
       emptyState.push({
-        title: strings.ADD_SEED_BANKS,
+        title: strings.ADD_SEED_BANKS_ONBOARDING_TITLE,
         text: emptyMessageStrings.ACCESSIONS_ONBOARDING_SEEDBANKS_MSG,
         buttonText: strings.GO_TO_SEED_BANKS,
         onClick: () => goTo(APP_PATHS.SEED_BANKS),
@@ -474,16 +473,15 @@ export default function Database(props: DatabaseProps): JSX.Element {
         text: emptyMessageStrings.ACCESSIONS_ONBOARDING_SPECIES_MSG,
         buttonText: strings.GO_TO_SPECIES,
         onClick: () => goTo(APP_PATHS.SPECIES),
-        altItem:
-          seedBanks && seedBanks.length > 0
-            ? {
-                title: strings.IMPORT_ACCESSIONS_ALT_TITLE,
-                linkText: strings.IMPORT_ACCESSIONS_WITH_TEMPLATE,
-                onLinkClick: () => downloadCsvTemplateHandler(downloadAccessionsTemplate),
-                buttonText: strings.IMPORT_ACCESSIONS,
-                onClick: () => importAccessions(),
-              }
-            : undefined,
+        disabled: !hasSeedBanks,
+        altItem: {
+          title: strings.IMPORT_ACCESSIONS_ALT_TITLE,
+          text: strings.IMPORT_ACCESSIONS_WITH_TEMPLATE,
+          linkText: strings.DOWNLOAD_THE_CSV_TEMPLATE,
+          onLinkClick: () => downloadCsvTemplateHandler(downloadAccessionsTemplate),
+          buttonText: strings.IMPORT_ACCESSIONS,
+          onClick: () => importAccessions(),
+        },
       });
     }
 

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -758,6 +758,7 @@ const strings = new LocalizedStrings({
     ADD_NURSERY: 'Add Nursery',
     NURSERY_ADDED: 'Nursery Added',
     GO_TO_NURSERIES: 'Go to Nurseries',
+    ADD_NURSERIES_ONBOARDING_TITLE: 'First, Add Nurseries',
     FRESH: 'Fresh',
     STORED: 'Stored',
     SAND_PETRI_DISH: 'Sand Petri Dish',
@@ -809,11 +810,12 @@ const strings = new LocalizedStrings({
     IMPORTING_INVENTORY: 'Importing inventory...this may take a few minutes.',
     DUPLICATED_INVENTORY: 'We found {0} duplicated inventory:',
     CREATE_SPECIES_LIST: 'Create Species List',
-    ADD_SEED_BANKS: 'Add Seed Banks',
+    ADD_SEED_BANKS_ONBOARDING_TITLE: 'First, Add Seed Banks',
+    DOWNLOAD_THE_CSV_TEMPLATE: 'Download the CSV template.',
     IMPORT_ACCESSIONS_ALT_TITLE: 'Already have a seed accession database?',
-    IMPORT_ACCESSIONS_WITH_TEMPLATE: 'Import accessions using our CSV template',
+    IMPORT_ACCESSIONS_WITH_TEMPLATE: 'Import accessions using our CSV template.',
     IMPORT_INVENTORY_ALT_TITLE: 'Already have an inventory database?',
-    IMPORT_INVENTORY_WITH_TEMPLATE: 'Import inventory using our CSV template',
+    IMPORT_INVENTORY_WITH_TEMPLATE: 'Import inventory using our CSV template.',
   },
 });
 


### PR DESCRIPTION
- show import options disabled if seedbanks/nurseries are not available
- change text as per Ming's suggestion
- disabled button state is weird, captured in bug [SW-2079](https://terraformation.atlassian.net/browse/SW-2079)

<img width="749" alt="Terraware App 2022-10-31 16-10-10" src="https://user-images.githubusercontent.com/1865174/199127379-889055b8-cfbe-428d-9b97-8e15bc8d91ff.png">

<img width="889" alt="Terraware App 2022-10-31 16-09-24" src="https://user-images.githubusercontent.com/1865174/199127385-bb1800ce-c8bd-4f65-b8a8-c0f76688b166.png">


<img width="764" alt="Terraware App 2022-10-31 16-06-09" src="https://user-images.githubusercontent.com/1865174/199127422-7e8584ea-2d46-4bc7-8048-3f1f4a60a799.png">

<img width="889" alt="Terraware App 2022-10-31 16-05-02" src="https://user-images.githubusercontent.com/1865174/199127423-c3575d10-085f-4500-a473-9d386ae401da.png">
