### PR TITLE
SW-2080 fix mobile view of empty state inventory

### DIFF
--- a/src/components/Inventory/index.tsx
+++ b/src/components/Inventory/index.tsx
@@ -216,7 +216,7 @@ export default function Inventory(props: InventoryProps): JSX.Element {
         onClose={() => setImportInventoryModalOpen(false)}
         organization={organization}
       />
-      <Grid container spacing={3}>
+      <Grid spacing={3}>
         <Grid item xs={6}>
           <Typography fontSize='24px' fontWeight={600}>
             {strings.INVENTORY}


### PR DESCRIPTION
- removed container from Grid which was introducing a negative margin left
- don't see any impact of this on desktop view or non-empty states

<img width="189" alt="Terraware App 2022-11-01 10-39-38" src="https://user-images.githubusercontent.com/1865174/199302309-ebcddb83-7628-4d97-8f40-e566a6d85925.png">
