### PR TITLE
SW-2093 Use new table version and remove unnecessaries stopPropagations

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/styled-engine-sc": "^5.8.0",
     "@mui/styles": "^5.8.7",
     "@mui/x-date-pickers": "^5.0.0-alpha.7",
-    "@terraware/web-components": "^1.0.57",
+    "@terraware/web-components": "^1.0.58",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/styled-engine-sc": "^5.8.0",
     "@mui/styles": "^5.8.7",
     "@mui/x-date-pickers": "^5.0.0-alpha.7",
-    "@terraware/web-components": "^1.0.56",
+    "@terraware/web-components": "^1.0.57",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/components/Inventory/view/BatchesCellRenderer.tsx
+++ b/src/components/Inventory/view/BatchesCellRenderer.tsx
@@ -5,7 +5,6 @@ import { Button } from '@terraware/web-components';
 import CellRenderer, { TableRowType } from 'src/components/common/table/TableCellRenderer';
 import { RendererProps } from 'src/components/common/table/types';
 import strings from 'src/strings';
-import stopPropagation from 'src/utils/stopPropagationEvent';
 import ChangeQuantityModal from './ChangeQuantityModal';
 import { Batch } from 'src/api/types/batch';
 import QuantitiesMenu from './QuantitiesMenu';
@@ -31,9 +30,6 @@ export default function BatchesCellRenderer(props: RendererProps<TableRowType>):
 
   const rowClick = (event?: React.SyntheticEvent) => {
     if (onRowClick) {
-      if (event) {
-        stopPropagation(event);
-      }
       onRowClick();
     }
   };

--- a/src/components/Inventory/view/ChangeQuantityModal.tsx
+++ b/src/components/Inventory/view/ChangeQuantityModal.tsx
@@ -9,7 +9,6 @@ import { Batch } from 'src/api/types/batch';
 import { updateBatchQuantities } from 'src/api/batch/batch';
 import useSnackbar from 'src/utils/useSnackbar';
 import useForm from 'src/utils/useForm';
-import stopPropagation from 'src/utils/stopPropagationEvent';
 
 export interface ChangeQuantityModalProps {
   open: boolean;
@@ -67,61 +66,55 @@ export default function ChangeQuantityModal(props: ChangeQuantityModalProps): JS
     onClose();
   };
 
-  const handleClickAway = (event?: any) => {
-    stopPropagation(event);
-  };
-
   return (
-    <div onClick={handleClickAway}>
-      <DialogBox
-        onClose={onCloseHandler}
-        open={open}
-        title={type === 'germinating' ? strings.CHANGE_GERMINATING_STATUS : strings.CHANGE_NOT_READY_STATUS}
-        size='medium'
-        middleButtons={[
-          <Button
-            label={strings.CANCEL}
-            priority='secondary'
-            type='passive'
-            onClick={onCloseHandler}
-            size='medium'
-            key='button-1'
-          />,
-          <Button label={strings.SAVE} type='productive' onClick={onSubmit} size='medium' key='button-2' />,
-        ]}
-      >
-        <Grid>
-          <Grid item xs={11} textAlign='left' display='flex'>
-            <Textfield
-              value={type === 'germinating' ? record.germinatingQuantity : record.notReadyQuantity}
-              display={true}
-              label={type === 'germinating' ? strings.GERMINATING : strings.NOT_READY}
-              id={'previousValue'}
-              type={'number'}
-            />
+    <DialogBox
+      onClose={onCloseHandler}
+      open={open}
+      title={type === 'germinating' ? strings.CHANGE_GERMINATING_STATUS : strings.CHANGE_NOT_READY_STATUS}
+      size='medium'
+      middleButtons={[
+        <Button
+          label={strings.CANCEL}
+          priority='secondary'
+          type='passive'
+          onClick={onCloseHandler}
+          size='medium'
+          key='button-1'
+        />,
+        <Button label={strings.SAVE} type='productive' onClick={onSubmit} size='medium' key='button-2' />,
+      ]}
+    >
+      <Grid>
+        <Grid item xs={11} textAlign='left' display='flex'>
+          <Textfield
+            value={type === 'germinating' ? record.germinatingQuantity : record.notReadyQuantity}
+            display={true}
+            label={type === 'germinating' ? strings.GERMINATING : strings.NOT_READY}
+            id={'previousValue'}
+            type={'number'}
+          />
 
-            <Box maxWidth='70px' marginLeft={2}>
-              <Textfield
-                value={movedValue}
-                label={strings.MOVE}
-                id={'movedValue'}
-                type={'number'}
-                onChange={(id, value) => onChangeMovedValue(value)}
-              />
-            </Box>
-            <Box paddingLeft={1} paddingRight={3} paddingTop={4}>
-              <Icon name='iconArrowRight' />
-            </Box>
+          <Box maxWidth='70px' marginLeft={2}>
             <Textfield
-              value={type === 'germinating' ? record.notReadyQuantity : record.readyQuantity}
-              display={true}
-              label={type === 'germinating' ? strings.NOT_READY : strings.READY}
-              id={'changedValue'}
+              value={movedValue}
+              label={strings.MOVE}
+              id={'movedValue'}
               type={'number'}
+              onChange={(id, value) => onChangeMovedValue(value)}
             />
-          </Grid>
+          </Box>
+          <Box paddingLeft={1} paddingRight={3} paddingTop={4}>
+            <Icon name='iconArrowRight' />
+          </Box>
+          <Textfield
+            value={type === 'germinating' ? record.notReadyQuantity : record.readyQuantity}
+            display={true}
+            label={type === 'germinating' ? strings.NOT_READY : strings.READY}
+            id={'changedValue'}
+            type={'number'}
+          />
         </Grid>
-      </DialogBox>
-    </div>
+      </Grid>
+    </DialogBox>
   );
 }

--- a/src/components/Inventory/view/InventorySeedlingsTable.tsx
+++ b/src/components/Inventory/view/InventorySeedlingsTable.tsx
@@ -252,7 +252,7 @@ export default function InventorySeedslingsTable(props: InventorySeedslingsTable
             selectedRows={selectedRows}
             setSelectedRows={setSelectedRows}
             showCheckbox={true}
-            isClickable={() => true}
+            isClickable={() => false}
             showTopBar={true}
             topBarButtons={[
               {

--- a/src/components/Inventory/view/QuantitiesMenu.tsx
+++ b/src/components/Inventory/view/QuantitiesMenu.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { IconButton, MenuItem, MenuList, Popover, Typography, useTheme } from '@mui/material';
 import { Icon } from '@terraware/web-components';
 import strings from 'src/strings';
-import stopPropagation from 'src/utils/stopPropagationEvent';
 import { ModalValuesType } from './BatchesCellRenderer';
 
 export type QuantitiesMenuProps = {
@@ -16,7 +15,6 @@ export default function QuantitiesMenu(props: QuantitiesMenuProps): JSX.Element 
   const openMenu = Boolean(menuAnchorEl);
 
   const openMenuHandler = (event: React.MouseEvent<HTMLButtonElement>) => {
-    stopPropagation(event);
     setMenuAnchorEl(event.currentTarget);
   };
 
@@ -25,7 +23,6 @@ export default function QuantitiesMenu(props: QuantitiesMenuProps): JSX.Element 
   };
 
   const openChangeQuantityHandler = (event: any, type: string) => {
-    stopPropagation(event);
     closeMenuHandler();
     setModalValues({
       openChangeQuantityModal: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2459,7 +2459,7 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^1.0.57":
+"@terraware/web-components@^1.0.58":
   version "1.0.58"
   resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-1.0.58.tgz#94ebeef8e5ea62956e3dea03a4c91f955dc641ee"
   integrity sha512-sVsjh9ExC4120yBXxXQ14LbIGmkrRQcmfFPCLMDux9/IVkhsYJulZy4qUoc0ham7MezphCKbhfY0MYDddo55RQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2459,10 +2459,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^1.0.56":
-  version "1.0.56"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-1.0.56.tgz#9f6bbf50b84cf951094790ef07426b88cc11a41e"
-  integrity sha512-CEWLre+53gFfps3+YmGlV3N5KO24riuOQ6T0NAADnrUh9So3j6x7Pd7e1cVGASYPtWHnYiaavCwDFomG9SSpbQ==
+"@terraware/web-components@^1.0.57":
+  version "1.0.58"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-1.0.58.tgz#94ebeef8e5ea62956e3dea03a4c91f955dc641ee"
+  integrity sha512-sVsjh9ExC4120yBXxXQ14LbIGmkrRQcmfFPCLMDux9/IVkhsYJulZy4qUoc0ham7MezphCKbhfY0MYDddo55RQ==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.10.11"


### PR DESCRIPTION
New version of web-components, when rows are not clickable, only clicking on the checkbox is allowed. This is why we are removing all the stopPropagations that are not necessary anymore