### PR TITLE
Create test to select all columns on database

### DIFF
--- a/cypress/integration/10-database.js
+++ b/cypress/integration/10-database.js
@@ -70,48 +70,11 @@ describe('Database', () => {
       cy.get('#more-options').click();
       cy.get('#edit-columns').click();
 
-      cy.get('#active').click();
-      // cy.get('#state').click(); already selected
-      cy.get('#facility_name').click();
-
-      // cy.get('#speciesName').click(); already selected
-      cy.get('#species_commonName').click();
-      cy.get('#species_familyName').click();
-      cy.get('#receivedDate').click();
-      // cy.get('#collectedDate').click(); already selected
-      // cy.get('#collectionSiteName').click(); already selected
-      cy.get('#species_endangered').click();
-      cy.get('#species_rare').click();
-      cy.get('#collectionSource').click();
-      cy.get('#ageYears').click();
-      // cy.get('#ageMonths').click(); already selected
-      // cy.get('#estimatedCount').click(); already selected
-      cy.get('#plantsCollectedFrom').click();
-      cy.get('#bagNumber').click();
-      cy.get('#collectionSiteLandowner').click();
-      cy.get('#collectionNotes').click();
-      // cy.get('#estimatedWeightGrams').click(); already selected
-
-      cy.get('#dryingEndDate').click();
-      cy.get('#remainingQuantity').click();
-      cy.get('#storageCondition').click();
-      cy.get('#storageLocationName').click();
-      cy.get('#withdrawalDate').click();
-      cy.get('#withdrawalQuantity').click();
-      cy.get('#withdrawalPurpose').click();
-      cy.get('#withdrawalNotes').click();
-
-      cy.get('#viabilityTests_type').click();
-      cy.get('#viabilityTests_seedType').click();
-      cy.get('#viabilityTests_treatment').click();
-      cy.get('#viabilityTests_seedsFilled').click();
-      cy.get('#viabilityTests_startDate').click();
-      cy.get('#viabilityTests_seedsSown').click();
-      cy.get('#viabilityTests_viabilityTestResults_seedsGerminated').click();
-      cy.get('#viabilityTests_seedsEmpty').click();
-      cy.get('#viabilityTests_substrate').click();
-      cy.get('#viabilityTests_seedsCompromised').click();
-      cy.get('#viabilityTests_notes').click();
+      cy.get('.MuiCheckbox-root').each((checkbox) => {
+        if (!checkbox.hasClass('Mui-checked')) {
+          checkbox.click();
+        }
+      });
 
       cy.get('#saveColumnsButton').click();
       cy.wait('@search');

--- a/cypress/integration/10-database.js
+++ b/cypress/integration/10-database.js
@@ -62,6 +62,66 @@ describe('Database', () => {
       cy.get('#table-header > :nth-child(9)').contains('SEED BANKS');
     });
 
+    it('should select ALL the columns', () => {
+      cy.visit('/accessions');
+      cy.intercept('POST', '/api/v1/search').as('search');
+      cy.intercept('POST', '/api/v1/seedbank/values').as('values');
+
+      cy.get('#more-options').click();
+      cy.get('#edit-columns').click();
+
+      cy.get('#active').click();
+      // cy.get('#state').click(); already selected
+      cy.get('#facility_name').click();
+
+      // cy.get('#speciesName').click(); already selected
+      cy.get('#species_commonName').click();
+      cy.get('#species_familyName').click();
+      cy.get('#receivedDate').click();
+      // cy.get('#collectedDate').click(); already selected
+      // cy.get('#collectionSiteName').click(); already selected
+      cy.get('#species_endangered').click();
+      cy.get('#species_rare').click();
+      cy.get('#collectionSource').click();
+      cy.get('#ageYears').click();
+      // cy.get('#ageMonths').click(); already selected
+      // cy.get('#estimatedCount').click(); already selected
+      cy.get('#plantsCollectedFrom').click();
+      cy.get('#bagNumber').click();
+      cy.get('#collectionSiteLandowner').click();
+      cy.get('#collectionNotes').click();
+      // cy.get('#estimatedWeightGrams').click(); already selected
+
+      cy.get('#dryingEndDate').click();
+      cy.get('#remainingQuantity').click();
+      cy.get('#storageCondition').click();
+      cy.get('#storageLocationName').click();
+      cy.get('#withdrawalDate').click();
+      cy.get('#withdrawalQuantity').click();
+      cy.get('#withdrawalPurpose').click();
+      cy.get('#withdrawalNotes').click();
+
+      cy.get('#viabilityTests_type').click();
+      cy.get('#viabilityTests_seedType').click();
+      cy.get('#viabilityTests_treatment').click();
+      cy.get('#viabilityTests_seedsFilled').click();
+      cy.get('#viabilityTests_startDate').click();
+      cy.get('#viabilityTests_seedsSown').click();
+      cy.get('#viabilityTests_viabilityTestResults_seedsGerminated').click();
+      cy.get('#viabilityTests_seedsEmpty').click();
+      cy.get('#viabilityTests_substrate').click();
+      cy.get('#viabilityTests_seedsCompromised').click();
+      cy.get('#viabilityTests_notes').click();
+
+      cy.get('#saveColumnsButton').click();
+      cy.wait('@search');
+      cy.wait('@values');
+      cy.get('#editColumnsDialog').should('not.exist');
+
+      cy.get('#table-header').children().should('have.length', 40);
+      cy.get('table tr').should('have.length', 4);
+    });
+
     context('Presets', () => {
       it('General Inventory', () => {
         cy.intercept('POST', '/api/v1/search').as('search');


### PR DESCRIPTION
I don't think we need to add a value for each filter, because search api is including all the fields, so if api doesn't fail (still returns results) then it means that each field added to the search exists. I tested adding a column with a search value that doesn't exist and search fails after selecting it.

Also, we are redoing filters at some point, so if we test adding a value to each filter then we will have to redo all tests