### PR TITLE
SW-1416 Remove mapping from old withdrawal purpose to new

### DIFF
--- a/src/utils/withdrawalPurposes.tsx
+++ b/src/utils/withdrawalPurposes.tsx
@@ -1,14 +1,1 @@
 export const WITHDRAWAL_PURPOSES = ['Nursery', 'Out-planting', 'Viability Testing', 'Other'];
-
-export const getSelectedPurpose = (value: string | undefined) => {
-  if (value && WITHDRAWAL_PURPOSES.indexOf(value) > -1) {
-    return value;
-  } else {
-    switch (value) {
-      case 'Propagation':
-        return 'Out-planting';
-      default:
-        return 'Other';
-    }
-  }
-};


### PR DESCRIPTION
- mapping usage was removed as part of v1 accessions code deletion
- the mapping function was left around, removing that now