### PR TITLE
Fix Monitoring Display

### DIFF
--- a/src/components/Monitoring/index.tsx
+++ b/src/components/Monitoring/index.tsx
@@ -14,7 +14,7 @@ import { getPreferences, updatePreferences } from 'src/api/preferences/preferenc
 import SeedBankMonitoring from './SeedBankMonitoring';
 import Button from '../common/button/Button';
 import Title from '../common/Title';
-import { Box, Container, Grid, Theme } from '@mui/material';
+import { Box, Grid, Theme } from '@mui/material';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import PageSnackbar from 'src/components/PageSnackbar';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
@@ -33,6 +33,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     alignItems: 'center',
     paddingBottom: theme.spacing(2),
+  },
+  contentContainer: {
+    width: '100%',
   },
   divider: {
     margin: '0 1%',
@@ -181,7 +184,7 @@ export default function Monitoring(props: MonitoringProps): JSX.Element {
 
             <PageSnackbar />
             {selectedSeedBank && monitoringPreferences && (
-              <Container ref={contentRef}>
+              <div ref={contentRef} className={classes.contentContainer}>
                 <SeedBankMonitoring
                   monitoringPreferences={monitoringPreferences}
                   updatePreferences={(data) => updateMonitoringPreferences(data)}
@@ -189,7 +192,7 @@ export default function Monitoring(props: MonitoringProps): JSX.Element {
                   organization={organization}
                   reloadData={reloadData}
                 />
-              </Container>
+              </div>
             )}
           </Grid>
         </>


### PR DESCRIPTION
Using a `Container` for the monitoring contents was the wrong choice.
Instead add a class to make it display full width.

with `Container`:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/114949086/200381386-9b73ba77-f9f9-4a45-9397-c8d6b2a31b76.png">
