### PR TITLE
SW-2171: User Reported: Save bar not lined up on mobile app

### DIFF
--- a/src/components/common/FormBottomBar.tsx
+++ b/src/components/common/FormBottomBar.tsx
@@ -41,7 +41,7 @@ export default function FormBottomBar({ onCancel, onSave, cancelButtonText, save
     <AppBar
       position='fixed'
       color='primary'
-      style={{ top: 'auto', bottom: 0, right: 'auto' }}
+      style={{ top: 'auto', bottom: 0, right: 'auto', left: isDesktop ? 'auto' : 0 }}
       className={classes.bottomBar}
     >
       <Button


### PR DESCRIPTION
This PR resolves an issue where changes from a previous PR threw the alignment off for the bottom action bar on mobile in many of the New Entity pages: 

- New Accession
- New Inventory
- New Person
- New Seed Bank
- New Nursery

## Example

### BEFORE

![localhost_3000_people(iPhone SE)](https://user-images.githubusercontent.com/1474361/200459395-8b7bd04d-ad86-4adf-a0ab-2cff2927cda1.png)

![localhost_3000_people(iPhone SE) (1)](https://user-images.githubusercontent.com/1474361/200459373-48fc1a13-73d4-459b-9914-d9258d798fc6.png)

![localhost_3000_people(iPhone SE) (2)](https://user-images.githubusercontent.com/1474361/200459379-bc16c5df-01b3-4dd9-9b44-4c03c47d56ae.png)

![localhost_3000_people(iPhone SE) (3)](https://user-images.githubusercontent.com/1474361/200459380-2a3cdfe5-9474-4145-a014-c0743c5f68eb.png)

### AFTER

![localhost_3000_people(iPhone SE) (4)](https://user-images.githubusercontent.com/1474361/200459381-6b15af60-e2b8-432e-97dd-b02f12bf4e4b.png)

![localhost_3000_people(iPhone SE) (5)](https://user-images.githubusercontent.com/1474361/200459384-051c50a6-9106-443e-85cf-72b203002431.png)

![localhost_3000_people(iPhone SE) (6)](https://user-images.githubusercontent.com/1474361/200459386-8998b122-6200-4458-85e9-3bce24887f20.png)

![localhost_3000_people(iPhone SE) (7)](https://user-images.githubusercontent.com/1474361/200459388-d4f2db28-7de3-4cdf-a75b-3185c83c34ca.png)

![localhost_3000_people(iPhone SE) (8)](https://user-images.githubusercontent.com/1474361/200459391-fd663814-f187-4321-a7c2-7aded9113147.png)

