### PR TITLE
SW-2203: Web-App page content lacks left and top padding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,13 +72,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: '100%',
     overflow: 'auto',
     '& > div, & > main': {
-      paddingBottom: '160px',
+      paddingBottom: theme.spacing(25),
       paddingTop: '96px',
     },
   },
   contentWithNavBar: {
     '& > div, & > main': {
-      paddingBottom: '96px',
       paddingLeft: '200px',
     },
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,11 +72,13 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: '100%',
     overflow: 'auto',
     '& > div, & > main': {
+      paddingBottom: '160px',
       paddingTop: '96px',
     },
   },
   contentWithNavBar: {
     '& > div, & > main': {
+      paddingBottom: '96px',
       paddingLeft: '200px',
     },
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   container: {
     '& .navbar': {
       backgroundColor: 'transparent',
-      paddingTop: (props: StyleProps) => (props.isDesktop ? '64px' : '8px'),
+      paddingTop: (props: StyleProps) => (props.isDesktop ? '88px' : '8px'),
       overflowY: 'auto',
       zIndex: 1000,
     },
@@ -72,7 +72,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: '100%',
     overflow: 'auto',
     '& > div, & > main': {
-      paddingTop: '64px',
+      paddingTop: '96px',
     },
   },
   contentWithNavBar: {


### PR DESCRIPTION
This PR adjusts content padding.

## Example

### AFTER

<img width="2032" alt="Screen Shot 2022-11-09 at 10 17 19 AM" src="https://user-images.githubusercontent.com/1474361/200933819-2eed36ff-c9d1-4b78-a08e-c30f6b9d38c7.png">

<img width="2032" alt="Screen Shot 2022-11-09 at 10 17 25 AM" src="https://user-images.githubusercontent.com/1474361/200933794-d6bdf42e-e61f-4eea-8d0b-14ef0bac9961.png">

![localhost_3000_home(iPhone SE)](https://user-images.githubusercontent.com/1474361/200933956-8277a378-79cf-464a-9067-a4d9a7e006cf.png)

![localhost_3000_home(iPhone SE) (1)](https://user-images.githubusercontent.com/1474361/200933955-583c580f-8665-4983-bd7b-46abe3399ea5.png)

### BEFORE

![screencast 2022-11-09 09-56-59](https://user-images.githubusercontent.com/1474361/200934113-16ca758d-3557-4934-8e97-5a1dc62b4731.gif)


