### PR TITLE
SW-2215 Clear subset weight error in calculate on close

### DIFF
--- a/src/components/accession2/edit/CalculatorModal.tsx
+++ b/src/components/accession2/edit/CalculatorModal.tsx
@@ -59,6 +59,7 @@ export default function CalculatorModal(props: CalculatorModalProps): JSX.Elemen
   };
 
   const onCloseHandler = () => {
+    setSubsetError('');
     onClose();
   };
 


### PR DESCRIPTION
- show error only when user clicks 'get total count'
- we don't clear the entered subset weight on close if there is an error, wondering what the behavior should be here