### PR TITLE
SW-2209 Render Error Page

### DIFF
--- a/src/ErrorContent.tsx
+++ b/src/ErrorContent.tsx
@@ -14,6 +14,8 @@ const useStyles = makeStyles(() => ({
   main: {
     paddingTop: '120px',
     height: (props: StyleProps) => (props.inApp ? '100%' : 'calc(100% - 120px)'),
+    width: '100%',
+    position: 'fixed',
     background:
       'url(/assets/error/wind.png) no-repeat 0% 100%/auto 300px, url(/assets/error/ufo.png) no-repeat 0 100%/auto 600px, url(/assets/error/land1.png) no-repeat bottom left/898px auto, url(/assets/error/land2.png) no-repeat bottom right/898px auto, url(/assets/error/mountains.png) no-repeat 0 100%/100% 400px, url(/assets/error/moon.png) no-repeat 60% 350px/auto 190px, url(/assets/error/stars.png) no-repeat 0 100%/auto 100%, url(/assets/error/background.png) no-repeat 100% 0/100% 100%, linear-gradient(to bottom right, rgb(255, 255, 255) 0%, rgb(199, 226, 234) 100%) no-repeat 0 0/auto',
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,7 +18,9 @@ ReactDOM.render(
         <Router>
           <Switch>
             <Route path={APP_PATHS.ERROR}>
-              <AppError />
+              <ThemeProvider theme={theme}>
+                <AppError />
+              </ThemeProvider>
             </Route>
             <Route path={'*'}>
               <ThemeProvider theme={theme}>


### PR DESCRIPTION
- fix the main element positioning
- wrap error page in ThemeProvider to get text color

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/114949086/201177808-2dff801b-a96f-43f5-a7fd-6953c38fa1ca.png">
<img width="304" alt="image" src="https://user-images.githubusercontent.com/114949086/201182402-b8abc5d8-68e0-49e4-9714-5508f885831c.png">
