### PR TITLE
SW-2215 Convert string values to number before comparing

### DIFF
--- a/src/components/accession2/edit/CalculatorModal.tsx
+++ b/src/components/accession2/edit/CalculatorModal.tsx
@@ -37,7 +37,7 @@ export default function CalculatorModal(props: CalculatorModalProps): JSX.Elemen
 
   const validateFields = () => {
     if (record.subsetWeight?.units === record.remainingQuantity?.units) {
-      if ((record.subsetWeight?.quantity || 0) > (record.remainingQuantity?.quantity || 0)) {
+      if (+(record.subsetWeight?.quantity || 0) > +(record.remainingQuantity?.quantity || 0)) {
         setSubsetError(strings.SUBSET_ERROR);
         return false;
       }


### PR DESCRIPTION
When values have decimals the comparison using ( > ) was incorrect because values were not numbers. Adding (+) in front of values to ensure comparison is correct

