### PR TITLE
SW-2255 Fix accessions to nursery transfer withdrawal when selecting-all

### DIFF
--- a/src/components/Inventory/view/InventorySeedlingsTable.tsx
+++ b/src/components/Inventory/view/InventorySeedlingsTable.tsx
@@ -111,6 +111,7 @@ export default function InventorySeedslingsTable(props: InventorySeedslingsTable
           'version',
           'accession_id',
           'accession_accessionNumber',
+          'notes',
         ],
         sortOrder: [
           {

--- a/src/components/accession2/withdraw/WithdrawModal.tsx
+++ b/src/components/accession2/withdraw/WithdrawModal.tsx
@@ -196,7 +196,7 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
         });
         setNurseryTransferRecord({
           ...nurseryTransferRecord,
-          germinatingQuantity: accession.remainingQuantity?.quantity || 0,
+          germinatingQuantity: accession.estimatedCount ? accession.estimatedCount : 0,
         });
       }
     } else {
@@ -409,7 +409,11 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
               id='withdrawnQuantity'
               onChange={(id, value) => onChangeWithdrawnQuantity(value as number)}
               type='text'
-              value={record.withdrawnQuantity?.quantity.toString()}
+              value={
+                isNurseryTransfer
+                  ? nurseryTransferRecord.germinatingQuantity
+                  : record.withdrawnQuantity?.quantity.toString()
+              }
               errorText={fieldsErrors.withdrawnQuantity}
             />
             <Box paddingLeft={1}>


### PR DESCRIPTION
- use estimatedCount instead of remaining quantity, similar to viability testing purpose
- also fixed notes display on batch details

<img width="417" alt="Terraware App 2022-11-10 16-55-05" src="https://user-images.githubusercontent.com/1865174/201237570-423e988c-16cd-485c-8356-2f6551ca6d93.png">

<img width="300" alt="Terraware App 2022-11-10 16-49-55" src="https://user-images.githubusercontent.com/1865174/201237575-88fb1b38-f4eb-4ca0-a0c8-3b54445859bc.png">

<img width="502" alt="Terraware App 2022-11-10 16-49-22" src="https://user-images.githubusercontent.com/1865174/201237580-c4c0bbed-af1b-4962-88ab-c38f5fbeb835.png">
