### PR TITLE
SW-2215 Fix different unit error when calculating count

### DIFF
--- a/src/components/accession2/edit/CalculatorModal.tsx
+++ b/src/components/accession2/edit/CalculatorModal.tsx
@@ -50,6 +50,10 @@ export default function CalculatorModal(props: CalculatorModalProps): JSX.Elemen
     if (validateFields()) {
       const response = await updateAccession2(record, true);
       if (response.requestSucceeded && response.accession) {
+        if (response.accession.estimatedCount?.toString() === '0') {
+          setSubsetError(strings.SUBSET_ERROR);
+          return;
+        }
         goToPrev();
         setRecord(response.accession);
       } else {

--- a/src/components/accession2/edit/CalculatorModal.tsx
+++ b/src/components/accession2/edit/CalculatorModal.tsx
@@ -50,7 +50,11 @@ export default function CalculatorModal(props: CalculatorModalProps): JSX.Elemen
     if (validateFields()) {
       const response = await updateAccession2(record, true);
       if (response.requestSucceeded && response.accession) {
-        if (response.accession.estimatedCount?.toString() === '0') {
+        if (
+          response.accession.subsetWeight?.grams &&
+          response.accession.latestObservedQuantity?.grams &&
+          response.accession.subsetWeight?.grams > response.accession.latestObservedQuantity?.grams
+        ) {
           setSubsetError(strings.SUBSET_ERROR);
           return;
         }


### PR DESCRIPTION
If selected units on calculator are different, execute count calculation on backend, and use grams values to see if subset weight is bigger than total weight