### PR TITLE
SW-2219 More map enhancements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,7 @@
       charset="UTF-8"
       src="//cdn.cookie-script.com/s/12c369c418d1c681aa7a0bfe74c63125.js"
     ></script>
+    <link href="https://api.mapbox.com/mapbox-gl-js/v2.10.0/mapbox-gl.css" rel="stylesheet" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -1,0 +1,107 @@
+import { Box } from '@mui/material';
+import React, { useEffect, useRef } from 'react';
+import mapboxgl from 'mapbox-gl';
+import { MapOptions } from './MapModels';
+import { getLatLng } from './MapUtils';
+
+export type MapProps = {
+  token: string;
+  options: MapOptions;
+};
+
+export default function Map(props: MapProps): JSX.Element {
+  const { token, options } = props;
+
+  const mapContainer = useRef(null);
+  const map = useRef<mapboxgl.Map | null>(null);
+
+  useEffect(() => {
+    const { bbox, sources } = options;
+    if (map.current) {
+      // clean up map if we need to recreate it based on new props
+      map.current.remove();
+    }
+
+    mapboxgl.accessToken = token;
+
+    map.current = new mapboxgl.Map({
+      container: mapContainer.current || '',
+      style: 'mapbox://styles/mapbox/streets-v11',
+    });
+
+    // show +/- zoom options only
+    map.current.addControl(new mapboxgl.NavigationControl({ showCompass: false }), 'bottom-right');
+
+    // initialize sources
+    map.current.on('load', () => {
+      sources.forEach((source) => {
+        if (!source.boundary || !Array.isArray(source.boundary)) {
+          return;
+        }
+        const multiPolygons = (source.boundary as (number | number[][][])[])
+          .map((geom) => {
+            if (!Array.isArray(geom)) {
+              return null;
+            }
+            const g = geom as number[][][];
+            return g.map((gg) => {
+              return gg.map((coord) => getLatLng(coord[0], coord[1]));
+            });
+          })
+          .filter((geom) => !!geom) as number[][][][];
+
+        if (!multiPolygons.length) {
+          return;
+        }
+
+        // add polygons
+        map.current?.addSource(source.name, {
+          type: 'geojson',
+          data: {
+            type: 'FeatureCollection',
+            features: multiPolygons.map((multiPolygon) => {
+              return {
+                type: 'Feature',
+                geometry: {
+                  type: 'Polygon',
+                  coordinates: multiPolygon,
+                },
+                properties: source.metadata,
+              };
+            }),
+          },
+        });
+
+        // add layer
+        map.current?.addLayer({
+          id: source.id,
+          type: 'fill',
+          source: source.name,
+          paint: {
+            'fill-color': source.fillColor,
+            'fill-opacity': source.fillOpacity,
+          },
+          filter: ['==', '$type', 'Polygon'],
+        });
+
+        // add click event handler
+        if (map.current !== null && source.onClick) {
+          const mapInstance = map.current;
+          const onClick = source.onClick;
+          mapInstance.on('click', source.id, (e) => {
+            new mapboxgl.Popup().setLngLat(e.lngLat).setHTML(onClick()).addTo(mapInstance);
+          });
+        }
+      });
+    });
+
+    // fit to bounding box
+    map.current.fitBounds([bbox.lowerLeft, bbox.upperRight], { padding: 20 });
+  }, [token, options]);
+
+  return (
+    <Box>
+      <Box ref={mapContainer} sx={{ height: '400px' }} />
+    </Box>
+  );
+}

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -26,7 +26,7 @@ export default function Map(props: MapProps): JSX.Element {
 
     map.current = new mapboxgl.Map({
       container: mapContainer.current || '',
-      style: 'mapbox://styles/mapbox/streets-v11',
+      style: 'mapbox://styles/mapbox/satellite-v9',
     });
 
     // show +/- zoom options only

--- a/src/components/Map/MapModels.ts
+++ b/src/components/Map/MapModels.ts
@@ -1,0 +1,57 @@
+// flattened info for shapes relating to planting site data
+
+export type MapGeometry = number | number[] | number[][][][];
+
+/**
+ * Example of a boundary:
+ * [
+ *   [
+ *     [
+ *       [-67.13734, 45.13745],
+ *       [-66.96466, 44.8097],
+ *       [-68.03252, 44.3252],
+ *       [-69.06, 43.98],
+ *       [-70.11617, 43.68405],
+ *       [-70.64573, 43.09008],
+ *       [-70.75102, 43.08003],
+ *       [-70.79761, 43.21973],
+ *     ]
+ *   ],
+ *   [
+ *     [
+ *       [-70.98176, 43.36789],
+ *       [-70.94416, 43.46633],
+ *       [-71.08482, 45.30524],
+ *       [-70.66002, 45.46022],
+ *       [-70.30495, 45.91479],
+ *       [-70.00014, 46.69317],
+ *       [-69.23708, 47.44777],
+ *       [-68.90478, 47.18479],
+ *       [-68.2343, 47.35462],
+ *       [-67.79035, 47.06624],
+ *       [-67.79141, 45.70258],
+ *       [-67.13734, 45.13745]
+ *     ]
+ *   ]
+ * ]
+ */
+
+export type MapSource = {
+  id: string;
+  name: string;
+  fillColor: string;
+  fillOpacity: number;
+  metadata: { [key: string]: any };
+  boundary: MapGeometry;
+  onClick?: () => string;
+};
+
+export type MapBoundingBox = {
+  lowerLeft: [number, number];
+  upperRight: [number, number];
+};
+
+export type MapOptions = {
+  bbox: MapBoundingBox;
+  sources: MapSource[];
+};

--- a/src/components/Map/MapUtils.ts
+++ b/src/components/Map/MapUtils.ts
@@ -1,0 +1,69 @@
+import { MapBoundingBox, MapGeometry } from './MapModels';
+import Coordinates from 'coordinate-parser';
+
+export const getLatLng = (x: number, y: number): [number, number] => {
+  const coords = new Coordinates(`${x}, ${y}`);
+  return [coords.getLatitude(), coords.getLongitude()];
+};
+
+export const getBoundingBox = (geometries: MapGeometry[]): MapBoundingBox => {
+  let llx = 0;
+  let lly = 0;
+  let urx = 0;
+  let ury = 0;
+  let first = true;
+
+  const comparePoint = (x: number, y: number) => {
+    if (first) {
+      llx = x;
+      urx = x;
+      lly = y;
+      ury = y;
+      first = false;
+      return;
+    }
+    if (x < llx) {
+      llx = x;
+    }
+    if (x > urx) {
+      urx = x;
+    }
+    if (y < lly) {
+      lly = y;
+    }
+    if (y > ury) {
+      ury = y;
+    }
+  };
+
+  const scanArray = (coord: number[]) => {
+    if (!Array.isArray(coord) || coord.length !== 2) {
+      return;
+    }
+    const [x, y] = coord;
+    if (x !== undefined && y !== undefined) {
+      comparePoint(x, y);
+    }
+  };
+
+  const scanGeometry = (geom: MapGeometry) => {
+    if (!Array.isArray(geom) || !geom.length) {
+      return;
+    }
+    if (!Array.isArray(geom[0])) {
+      scanArray(geom as number[]);
+    }
+    (geom as number[][][][]).forEach((polygonList) => {
+      polygonList.forEach((polygon) => {
+        polygon.forEach(scanArray);
+      });
+    });
+  };
+
+  geometries.forEach(scanGeometry);
+
+  return {
+    lowerLeft: getLatLng(llx, lly),
+    upperRight: getLatLng(urx, ury),
+  };
+};

--- a/src/components/Map/PlantingSiteMap.tsx
+++ b/src/components/Map/PlantingSiteMap.tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { Box, CircularProgress } from '@mui/material';
+import { getMapboxToken, getPlantingSite } from 'src/api/tracking/tracking';
+import { Geometry, PlantingSite } from 'src/api/types/tracking';
+import useSnackbar from 'src/utils/useSnackbar';
+import Map from './Map';
+import { MapGeometry, MapOptions, MapSource } from './MapModels';
+import { getBoundingBox } from './MapUtils';
+
+export type PlantingSiteMapProps = {
+  siteId: number;
+};
+
+export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Element {
+  const { siteId } = props;
+  const [snackbar] = useState(useSnackbar());
+  const [token, setToken] = useState<string>();
+  const [mapOptions, setMapOptions] = useState<MapOptions>();
+
+  const getPolygons = useCallback((boundary?: Geometry): MapGeometry => {
+    if (!boundary) {
+      return [];
+    }
+    return boundary.coordinates;
+  }, []);
+
+  const extractPlantingSite = useCallback(
+    (site: PlantingSite): MapSource => {
+      const { id, name, description, boundary } = site;
+      return {
+        metadata: { id, name, description },
+        boundary: getPolygons(boundary),
+        name: `site-${name}`,
+        id: `site-${id}`,
+        fillColor: 'yellow',
+        fillOpacity: 0.5,
+      };
+    },
+    [getPolygons]
+  );
+
+  const extractPlantingZones = useCallback(
+    (site: PlantingSite): MapSource[] | undefined => {
+      return site.plantingZones?.map((zone) => {
+        const { id, name, boundary } = zone;
+        return {
+          metadata: { id, name },
+          boundary: getPolygons(boundary),
+          name: `zone-${name}`,
+          id: `zone-${id}`,
+          fillColor: 'blue',
+          fillOpacity: 0.5,
+        };
+      });
+    },
+    [getPolygons]
+  );
+
+  const extractPlots = useCallback(
+    (site: PlantingSite): MapSource[] | undefined => {
+      return site.plantingZones?.flatMap((zone) => {
+        const { plots } = zone;
+        return plots.map((plot) => {
+          const { id, name, fullName, boundary } = plot;
+          return {
+            metadata: { id, name, fullName },
+            boundary: getPolygons(boundary),
+            name: `plot-${name}`,
+            id: `plot-${id}`,
+            fillColor: 'green',
+            fillOpacity: 0.5,
+            onClick: () => `
+            ID ${id}
+            Name ${fullName || name}
+          `,
+          };
+        });
+      });
+    },
+    [getPolygons]
+  );
+
+  // fetch token
+  useEffect(() => {
+    // TODO: set timeout to refresh the token
+    const fetchToken = async () => {
+      if (token) {
+        return;
+      }
+      const response = await getMapboxToken();
+      if (response.requestSucceeded) {
+        setToken(response.token);
+      } else {
+        snackbar.toastError(response.error);
+      }
+    };
+
+    fetchToken();
+  });
+
+  // fetch polygons and boundaries
+  useEffect(() => {
+    const fetchPlantingSite = async () => {
+      const response = await getPlantingSite(siteId);
+      if (response.requestSucceeded && response.site) {
+        const site = extractPlantingSite(response.site);
+        const zones = extractPlantingZones(response.site) || [];
+        const plots = extractPlots(response.site) || [];
+
+        const geometries: MapGeometry[] = [
+          site?.boundary,
+          ...zones.map((s) => s.boundary),
+          ...plots.map((s) => s.boundary),
+        ].filter((g) => g) as MapGeometry[];
+
+        setMapOptions({
+          bbox: getBoundingBox(geometries),
+          sources: [site, ...zones, ...plots],
+        });
+      } else {
+        setMapOptions(undefined);
+        snackbar.toastError(response.error);
+      }
+    };
+
+    fetchPlantingSite();
+  }, [siteId, snackbar, extractPlantingSite, extractPlantingZones, extractPlots]);
+
+  if (!token || !mapOptions) {
+    return (
+      <Box sx={{ display: 'flex', flexGrow: 1 }}>
+        <CircularProgress sx={{ margin: 'auto auto' }} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Map token={token} options={mapOptions} />
+    </Box>
+  );
+}

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -1,37 +1,4 @@
-import { Box } from '@mui/material';
-import React, { useEffect, useRef, useState } from 'react';
-import mapboxgl from 'mapbox-gl';
+import Map from './Map';
+import PlantingSiteMap from './PlantingSiteMap';
 
-export type MapProps = {
-  token: string;
-};
-
-export default function MapComponent(props: MapProps): JSX.Element {
-  const { token } = props;
-  mapboxgl.accessToken = token;
-
-  const mapContainer = useRef(null);
-  const map = useRef<mapboxgl.Map | null>(null);
-  const [lng] = useState(-70.9);
-  const [lat] = useState(42.35);
-  const [zoom] = useState(9);
-
-  useEffect(() => {
-    if (map.current) {
-      // initialize map only once
-      return;
-    }
-    map.current = new mapboxgl.Map({
-      container: mapContainer.current || '',
-      style: 'mapbox://styles/mapbox/streets-v11',
-      center: [lng, lat],
-      zoom,
-    });
-  });
-
-  return (
-    <Box>
-      <Box ref={mapContainer} sx={{ height: '400px' }} />
-    </Box>
-  );
-}
+export { Map, PlantingSiteMap };


### PR DESCRIPTION
- add map component for planting site which provides data to the Map component
- introduced some models and utilities
- Map works around these models with no dependency on actual planting site semantics
- this is still an intermediate step, hoping to get this in and we continue to make improvements
- the calculation from polygon coords (EPSG 3857) to lat/long (EPSG 4326) is done in client for now, this will be handled by BE soon and we can remove that code next
- we can make changes to this code over time, just an initial version of the map for planting site
- on click etc we can continue updating
- Example usage 
```
 <PlantingSiteMap siteId={siteId} />
```

image here is based on testing using contactus page and admin ui to upload shapes to a planting site

<img width="836" alt="Terraware App 2022-11-11 15-02-52" src="https://user-images.githubusercontent.com/1865174/201443949-239ba1c5-9048-4d9e-ba3b-28bb7f02dc2d.png">
