### PR TITLE
SW-2066: Update Navigation & TopBar

### DIFF
--- a/src/components/SmallDeviceUserMenu.tsx
+++ b/src/components/SmallDeviceUserMenu.tsx
@@ -21,16 +21,22 @@ import strings from 'src/strings';
 import { ServerOrganization } from 'src/types/Organization';
 import { User } from 'src/types/User';
 import AddNewOrganizationModal from './AddNewOrganizationModal';
-import { ReactComponent as AvatarIcon } from './avatar-default.svg';
 import Icon from './common/icon/Icon';
 import useEnvironment from 'src/utils/useEnvironment';
 
 const useStyles = makeStyles((theme: Theme) => ({
   icon: {
-    width: '32px',
+    alignItems: 'center',
+    backgroundColor: '#F1F0EC',
+    borderRadius: '50%',
+    color: theme.palette.TwClrTxt,
+    display: 'flex',
+    fontWeight: 500,
     height: '32px',
+    justifyContent: 'center',
+    width: '32px',
   },
-  internalIcon: {
+  largeIcon: {
     width: '48px',
     height: '48px',
   },
@@ -109,6 +115,7 @@ export default function SmallDeviceUserMenu({
   const [open, setOpen] = React.useState(false);
   const anchorRef = React.useRef<HTMLButtonElement>(null);
   const { isProduction } = useEnvironment();
+  const iconLetter = user?.firstName?.charAt(0) || user?.lastName?.charAt(0);
 
   const navigate = (url: string) => {
     history.push(url);
@@ -157,7 +164,7 @@ export default function SmallDeviceUserMenu({
         reloadOrganizationData={reloadOrganizationData}
       />
       <Button ref={anchorRef} id='composition-button' onClick={handleToggle} className={classes.avatarButton}>
-        <AvatarIcon className={classes.icon} />
+        <div className={classes.icon}>{iconLetter}</div>
       </Button>
       <div className='blurred'>
         <Popper
@@ -179,7 +186,7 @@ export default function SmallDeviceUserMenu({
                 >
                   <Box sx={{ display: 'flex' }}>
                     <Box sx={{ display: 'flex' }}>
-                      <AvatarIcon className={classes.internalIcon} />
+                      <div className={`${classes.icon} ${classes.largeIcon}`}>{iconLetter}</div>
                       <Typography sx={{ paddingLeft: '8px', color: theme.palette.TwClrTxt }}>
                         {user?.firstName} {user?.lastName}
                       </Typography>

--- a/src/components/SmallDeviceUserMenu.tsx
+++ b/src/components/SmallDeviceUserMenu.tsx
@@ -115,7 +115,7 @@ export default function SmallDeviceUserMenu({
   const [open, setOpen] = React.useState(false);
   const anchorRef = React.useRef<HTMLButtonElement>(null);
   const { isProduction } = useEnvironment();
-  const iconLetter = user?.firstName?.charAt(0) || user?.lastName?.charAt(0);
+  const iconLetter = user?.firstName?.charAt(0) || user?.lastName?.charAt(0) || user?.email?.charAt(0);
 
   const navigate = (url: string) => {
     history.push(url);

--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -17,6 +17,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   logo: {
     width: 137,
   },
+  backgroundLogo: {
+    background: 'url(/assets/logo.svg) no-repeat center/37px',
+  },
   separator: {
     width: '1px',
     height: '32px',
@@ -104,7 +107,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
       </div>
     </>
   ) : (
-    <Grid container className={classes.flex}>
+    <Grid container className={`${classes.flex}  ${classes.backgroundLogo}`}>
       <Grid item xs={3} className={classes.left}>
         {selectedOrganization && (
           <IconButton onClick={() => setShowNavBar(true)} size='small'>
@@ -113,9 +116,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
         )}
       </Grid>
 
-      <Grid item xs={6} className={`${classes.center} logo`}>
-        <Svg.Logo className={classes.logo} />
-      </Grid>
+      <Grid item xs={6} className={`${classes.center} logo`}></Grid>
 
       <Grid item xs={3} className={classes.right}>
         <NotificationsDropdown

--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -116,7 +116,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
         )}
       </Grid>
 
-      <Grid item xs={6} className={`${classes.center} logo`}></Grid>
+      <Grid item xs={6} className={`${classes.center} logo`} />
 
       <Grid item xs={3} className={classes.right}>
         <NotificationsDropdown


### PR DESCRIPTION
This PR updates a couple of elements of the `TopBar` on mobile devices:

- use icon-only Terraformation logo
- update user menu icon: smiley face --> first letter of name

## Example

### AFTER

![localhost_3000_home(iPhone SE) (2)](https://user-images.githubusercontent.com/1474361/201454393-032aab82-e4ee-4643-851c-1bb348988814.png)

![localhost_3000_home(iPhone SE) (3)](https://user-images.githubusercontent.com/1474361/201454394-70b10a15-7c03-4fb6-a0c6-55b8a252149c.png)

### BEFORE

![localhost_3000_home(iPhone SE) (4)](https://user-images.githubusercontent.com/1474361/201454395-8b3fa99e-c394-4fc1-8987-56b7fa5f70cb.png)

![localhost_3000_home(iPhone SE) (5)](https://user-images.githubusercontent.com/1474361/201454396-6738d078-f1df-46de-a36c-6a7191573d62.png)
