### PR TITLE
SW-1405 Use collectionSiteNotes search field

### DIFF
--- a/src/components/seeds/database/EditColumns.tsx
+++ b/src/components/seeds/database/EditColumns.tsx
@@ -174,7 +174,7 @@ const sections: Section[] = [
         COLUMNS_INDEXED.plantsCollectedFrom,
         COLUMNS_INDEXED.bagNumber,
         COLUMNS_INDEXED.collectionSiteLandowner,
-        COLUMNS_INDEXED.collectionNotes,
+        COLUMNS_INDEXED.collectionSiteNotes,
         COLUMNS_INDEXED.estimatedWeightGrams,
       ],
     ],

--- a/src/components/seeds/database/columns.ts
+++ b/src/components/seeds/database/columns.ts
@@ -114,7 +114,7 @@ const COLUMNS: DatabaseColumn[] = [
     type: 'string',
     filter: { type: 'search' },
   },
-  { key: 'collectionNotes', name: strings.NOTES, type: 'notes' },
+  { key: 'collectionSiteNotes', name: strings.NOTES, type: 'notes' },
   {
     key: 'totalUnits',
     name: strings.SEEDS_UNITS,


### PR DESCRIPTION
The field `collectionNotes` was renamed to `collectionSiteNotes` for consistency.
The code uses the new name in its request payloads, but was still using the old
name for searches. Both names are supported; switch to the new one so we can remove
the old one on the server side.
