### PR TITLE
SW-2218 Update Icon Sizes and Color

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/styled-engine-sc": "^5.8.0",
     "@mui/styles": "^5.8.7",
     "@mui/x-date-pickers": "^5.0.0-alpha.7",
-    "@terraware/web-components": "^2.0.3",
+    "@terraware/web-components": "^2.0.6",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/components/seeds/summary/SummaryPaper.tsx
+++ b/src/components/seeds/summary/SummaryPaper.tsx
@@ -29,7 +29,7 @@ export default function SummaryPaper({ id, title, icon, statistic, loading, erro
   return (
     <>
       <Box sx={{ display: 'flex', alignItems: 'center', marginBottom: theme.spacing(3) }}>
-        <Icon name={icon} className={classes.icon} />
+        <Icon name={icon} className={classes.icon} size='medium' />
         <PanelTitle title={title} gutterBottom={false} tooltipTitle={tooltipTitle} />
       </Box>
       {error && strings.GENERIC_ERROR}

--- a/src/components/seeds/summary/index.tsx
+++ b/src/components/seeds/summary/index.tsx
@@ -47,6 +47,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     top: '50%',
     left: 'calc(50% + 100px)',
   },
+  accessionsByStatusIcon: {
+    fill: theme.palette.TwClrIcnSecondary,
+  },
 }));
 
 Cookies.defaults = {
@@ -224,7 +227,7 @@ export default function SeedSummary(props: SeedSummaryProps): JSX.Element {
                     }}
                   >
                     <Box display='flex' alignContent='center' alignItems='center'>
-                      <Icon name='futures' />
+                      <Icon name='futures' size='medium' className={classes.accessionsByStatusIcon} />
                       <Typography
                         fontSize='20px'
                         fontWeight={600}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2477,10 +2477,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.3.tgz#2c494a74c33488ec775d191b95328884c3eef6ae"
-  integrity sha512-uptjQ81+WfZ08Y8OY58zQFe5slvXAV4GhR/p+u0b0tmsVv0QN+01kmxpE1qV3UMGIzDTcQJJ/ctJBU5QgG0y/g==
+"@terraware/web-components@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.6.tgz#47f7b02c37627b60977cd68ced9e18cbeea3c39a"
+  integrity sha512-m63/VNwHrAyeL1cec/GX5jJve29ObwvxOjlXrx219/Wf6zeYal+uMHxxeVdJt46QB3ZDFfNE1J9Y27zwyJeEXw==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.10.11"


### PR DESCRIPTION
- Seeds dashboard icons should be medium
- Icon colors should be `TwClrIcnSecondary`

<img width="1303" alt="image" src="https://user-images.githubusercontent.com/114949086/201980466-414bf9ac-2244-42ce-ac2f-c1d2e41875d5.png">
