### PR TITLE
SW-2267 reduce # of fetches to BE for accession, in accession view

### DIFF
--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -94,11 +94,11 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
   const [openViewViabilityTestModal, setOpenViewViabilityTestModal] = useState(false);
   const [selectedTest, setSelectedTest] = useState<ViabilityTest>();
   const [age, setAge] = useState({ value: '', unit: '' });
+  const [snackbar] = useState(useSnackbar());
   const { organization, user } = props;
   const userCanEdit = !isContributor(organization);
   const { isMobile } = useDeviceInfo();
   const classes = useStyles({ isMobile });
-  const snackbar = useSnackbar();
   const themeObj = useTheme();
   const contentRef = useRef(null);
 


### PR DESCRIPTION
- use react state for snackbar - since it was used as a dependency in useEffect, which was being triggered more often than desired
- reduced fetches from 10 to 2