### PR TITLE
SW-2251: Update NavBar for nested hierarchy navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/styled-engine-sc": "^5.8.0",
     "@mui/styles": "^5.8.7",
     "@mui/x-date-pickers": "^5.0.0-alpha.7",
-    "@terraware/web-components": "^2.0.6",
+    "@terraware/web-components": "^2.0.7",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,3 +1,4 @@
+import SubNavbar from '@terraware/web-components/components/Navbar/SubNavbar';
 import { useEffect, useState } from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 import Navbar from 'src/components/common/Navbar/Navbar';
@@ -77,47 +78,61 @@ export default function NavBar({ organization, setShowNavBar }: NavBarProps): JS
         }}
         id='speciesNb'
       />
-
-      <NavSection title={strings.SEEDS.toUpperCase()} />
+      <NavSection />
       <NavItem
-        label='Dashboard'
-        icon='dashboard'
-        selected={!!isAccessionDashboardRoute}
+        label='Seeds'
+        icon='seeds'
+        id='seeds'
         onClick={() => {
           closeAndNavigateTo(isAccessionDashboardRoute ? '' : APP_PATHS.SEEDS_DASHBOARD);
         }}
-        id='seeds-dashboard'
-      />
+      >
+        <SubNavbar>
+          <NavItem
+            label='Dashboard'
+            selected={!!isAccessionDashboardRoute}
+            onClick={() => {
+              closeAndNavigateTo(isAccessionDashboardRoute ? '' : APP_PATHS.SEEDS_DASHBOARD);
+            }}
+            id='seeds-dashboard'
+          />
+          <NavItem
+            label='Accessions'
+            selected={isAccessionsRoute || isCheckinRoute ? true : false}
+            onClick={() => {
+              closeAndNavigateTo(APP_PATHS.ACCESSIONS);
+            }}
+            id='accessions'
+          />
+          <NavItem
+            label={strings.MONITORING}
+            selected={!!isMonitoringRoute}
+            onClick={() => {
+              closeAndNavigateTo(APP_PATHS.MONITORING);
+            }}
+            id='monitoring'
+          />
+        </SubNavbar>
+      </NavItem>
       <NavItem
-        label='Accessions'
-        icon='seeds'
-        selected={isAccessionsRoute || isCheckinRoute ? true : false}
+        label='Seedlings'
+        icon='iconSeedling'
+        id='seedlings'
         onClick={() => {
-          closeAndNavigateTo(APP_PATHS.ACCESSIONS);
+          closeAndNavigateTo(APP_PATHS.INVENTORY);
         }}
-        id='accessions'
-      />
-      <NavItem
-        label={strings.MONITORING}
-        icon='monitoringNav'
-        selected={!!isMonitoringRoute}
-        onClick={() => {
-          closeAndNavigateTo(APP_PATHS.MONITORING);
-        }}
-        id='monitoring'
-      />
-      <>
-        <NavSection title={strings.SEEDLINGS.toUpperCase()} />
-        <NavItem
-          label={strings.INVENTORY}
-          icon='iconSeedling'
-          selected={!!isInventoryRoute}
-          onClick={() => {
-            closeAndNavigateTo(APP_PATHS.INVENTORY);
-          }}
-          id='inventory'
-        />
-      </>
+      >
+        <SubNavbar>
+          <NavItem
+            label={strings.INVENTORY}
+            selected={!!isInventoryRoute}
+            onClick={() => {
+              closeAndNavigateTo(APP_PATHS.INVENTORY);
+            }}
+            id='inventory'
+          />
+        </SubNavbar>
+      </NavItem>
       {role && ['Admin', 'Owner'].includes(role) && (
         <>
           <NavSection title={strings.SETTINGS.toUpperCase()} />
@@ -140,23 +155,34 @@ export default function NavBar({ organization, setShowNavBar }: NavBarProps): JS
             id='people'
           />
           <NavItem
-            label={strings.SEED_BANKS}
+            label='Locations'
             icon='seedbankNav'
-            selected={!!isSeedbanksRoute}
+            id='locations'
             onClick={() => {
               closeAndNavigateTo(APP_PATHS.SEED_BANKS);
             }}
-            id='seedbanks'
-          />
-          <NavItem
-            label={strings.NURSERIES}
-            icon='iconNursery'
-            selected={!!isNurseriesRoute}
-            onClick={() => {
-              closeAndNavigateTo(APP_PATHS.NURSERIES);
-            }}
-            id='nurseries'
-          />
+          >
+            <SubNavbar>
+              <NavItem
+                label={strings.SEED_BANKS}
+                icon='seedbankNav'
+                selected={!!isSeedbanksRoute}
+                onClick={() => {
+                  closeAndNavigateTo(APP_PATHS.SEED_BANKS);
+                }}
+                id='seedbanks'
+              />
+              <NavItem
+                label={strings.NURSERIES}
+                icon='iconNursery'
+                selected={!!isNurseriesRoute}
+                onClick={() => {
+                  closeAndNavigateTo(APP_PATHS.NURSERIES);
+                }}
+                id='nurseries'
+              />
+            </SubNavbar>
+          </NavItem>
         </>
       )}
       {isEnabled('Tracking V1') && (

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -165,7 +165,6 @@ export default function NavBar({ organization, setShowNavBar }: NavBarProps): JS
             <SubNavbar>
               <NavItem
                 label={strings.SEED_BANKS}
-                icon='seedbankNav'
                 selected={!!isSeedbanksRoute}
                 onClick={() => {
                   closeAndNavigateTo(APP_PATHS.SEED_BANKS);
@@ -174,7 +173,6 @@ export default function NavBar({ organization, setShowNavBar }: NavBarProps): JS
               />
               <NavItem
                 label={strings.NURSERIES}
-                icon='iconNursery'
                 selected={!!isNurseriesRoute}
                 onClick={() => {
                   closeAndNavigateTo(APP_PATHS.NURSERIES);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2477,10 +2477,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.6.tgz#47f7b02c37627b60977cd68ced9e18cbeea3c39a"
-  integrity sha512-m63/VNwHrAyeL1cec/GX5jJve29ObwvxOjlXrx219/Wf6zeYal+uMHxxeVdJt46QB3ZDFfNE1J9Y27zwyJeEXw==
+"@terraware/web-components@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.7.tgz#7c5e21cbdee230ef14c68505fc1232ef707b9433"
+  integrity sha512-NpR75m+8nRJ1+gomT5e5NSv1OvOfiPsEhSQGJPSe561vAPmlzbGzHw5JgmOqpnshIiynxZ9rm5PPa1TMaEU6tQ==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.10.11"


### PR DESCRIPTION
This PR updates the navigation to use a nested hierarchy, viewable [here in the designs](https://www.figma.com/file/DftqOeGx8irCdRf7IZ4lbc/Navigation?node-id=5005%3A199381&viewport=-688%2C-4385%2C0.64).

## Screenshots

### AFTER

#### Mobile

![tree-location-gy2aw7plr-terraformation vercel app_inventory(iPhone SE)](https://user-images.githubusercontent.com/1474361/202038716-f7a02a53-f103-4247-9bd6-13c0dd21c206.png)

![tree-location-gy2aw7plr-terraformation vercel app_inventory(iPhone SE) (1)](https://user-images.githubusercontent.com/1474361/202038707-6c2a3921-785a-4559-bea3-6fcfe65afa80.png)

![tree-location-gy2aw7plr-terraformation vercel app_inventory(iPhone SE) (3)](https://user-images.githubusercontent.com/1474361/202038714-af099134-190f-4114-b02f-b3fc5c4b5080.png)


#### Desktop

<img width="2012" alt="Screen Shot 2022-11-15 at 12 11 55 PM" src="https://user-images.githubusercontent.com/1474361/202037361-75aaadb1-dadc-40d1-b74c-c89cf86a73af.png">

<img width="2012" alt="Screen Shot 2022-11-15 at 12 11 59 PM" src="https://user-images.githubusercontent.com/1474361/202037357-0eb40b67-7990-4ebc-bd69-58bcc7efae6c.png">

<img width="2012" alt="Screen Shot 2022-11-15 at 12 12 02 PM" src="https://user-images.githubusercontent.com/1474361/202037352-de5458e9-17da-45c4-8a35-2a83dbfb31a2.png">

### BEFORE

<img width="2012" alt="Screen Shot 2022-11-15 at 12 11 47 PM" src="https://user-images.githubusercontent.com/1474361/202037366-7302315a-4ae7-4f0b-b5ec-9544e4481637.png">
