### PR TITLE
SW-2268 Fix double-load of map, fix map height

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -31,11 +31,13 @@ export type MapProps = {
   options: MapOptions;
   onTokenExpired?: () => void;
   enablePopup?: boolean;
+  // changes to mapId will re-create the map, needed for new token refreshes
+  // since mapbox token is not reactive
+  mapId?: string;
 };
 
 export default function Map(props: MapProps): JSX.Element {
-  const { token, onTokenExpired, options, enablePopup } = props;
-  const [mapKey, setMapKey] = useState<number>(Date.now());
+  const { token, onTokenExpired, options, enablePopup, mapId } = props;
   const [geoData, setGeoData] = useState();
   const [layerIds, setLayerIds] = useState<string[]>([]);
   const [popupInfo, setPopupInfo] = useState<PopupInfo | null>(null);
@@ -131,14 +133,10 @@ export default function Map(props: MapProps): JSX.Element {
     }
   }, [options, geoData, setGeoData, token, enablePopup]);
 
-  useEffect(() => {
-    setMapKey(Date.now());
-  }, [token]);
-
   return (
-    <Box sx={{ display: 'flex', flexGrow: 1, height: '100%', minHeight: 100 }}>
+    <Box sx={{ display: 'flex', flexGrow: 1, height: '100%', minHeight: 250 }}>
       <ReactMapGL
-        key={mapKey}
+        key={mapId}
         ref={mapRef}
         mapboxAccessToken={token}
         mapStyle='mapbox://styles/mapbox/satellite-v9'

--- a/src/components/PlantingSites/BoundariesAndPlots.tsx
+++ b/src/components/PlantingSites/BoundariesAndPlots.tsx
@@ -1,4 +1,4 @@
-import { Typography, Grid, Box, CircularProgress } from '@mui/material';
+import { Typography, Box, CircularProgress } from '@mui/material';
 import { Button, theme } from '@terraware/web-components';
 import strings from 'src/strings';
 import { TERRAWARE_SUPPORT_LINK } from 'src/constants';
@@ -13,13 +13,13 @@ export default function BoundariesAndPlots(props: BoundariesAndPlotsProps): JSX.
   const { plantingSite } = props;
 
   return (
-    <>
-      <Grid item xs={12}>
+    <Box display='flex' flexGrow={plantingSite?.boundary ? 1 : 0} flexDirection='column' paddingTop={theme.spacing(3)}>
+      <Box display='flex' flexGrow={0}>
         <Typography fontSize='20px' fontWeight={600} margin={theme.spacing(3, 0)}>
           {strings.BOUNDARIES_AND_PLOTS}
         </Typography>
-      </Grid>
-      <Grid item xs={12} display='flex' flexGrow={1} height='100%' paddingBottom={theme.spacing(10)}>
+      </Box>
+      <Box display='flex' sx={{ flexGrow: 1 }}>
         {plantingSite ? (
           <>
             {plantingSite.boundary ? (
@@ -32,6 +32,7 @@ export default function BoundariesAndPlots(props: BoundariesAndPlotsProps): JSX.
                   margin: '0 auto',
                   textAlign: 'center',
                   paddingX: 5,
+                  marginTop: 3,
                 }}
               >
                 <Typography fontSize='20px' fontWeight={600} margin={theme.spacing(3, 0)}>
@@ -55,7 +56,7 @@ export default function BoundariesAndPlots(props: BoundariesAndPlotsProps): JSX.
             <CircularProgress />
           </Box>
         )}
-      </Grid>
-    </>
+      </Box>
+    </Box>
   );
 }

--- a/src/components/PlantingSites/PlantingSiteCreate.tsx
+++ b/src/components/PlantingSites/PlantingSiteCreate.tsx
@@ -130,51 +130,53 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
 
   return (
     <TfMain>
-      <Container maxWidth={false} sx={{ display: 'flex', flexDirection: record?.boundary ? 'row' : 'column' }}>
+      <Container maxWidth={false} sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
         {loaded && (
-          <Grid container spacing={3}>
-            <Grid item xs={12}>
-              <Link id='back' to={APP_PATHS.PLANTING_SITES} className={classes.back}>
-                <Icon name='caretLeft' className={classes.backIcon} />
-                {strings.PLANTING_SITES}
-              </Link>
-            </Grid>
-            <Grid item xs={12}>
-              <Typography
-                fontSize={selectedPlantingSite ? '20px' : '24px'}
-                fontWeight={600}
-                margin={theme.spacing(1, 0)}
-              >
-                {record.id !== -1 && selectedPlantingSite ? selectedPlantingSite.name : strings.ADD_PLANTING_SITE}
-              </Typography>
-              {record.id === -1 && (
-                <Typography fontSize='14px' fontWeight={400} margin={theme.spacing(0, 0, 3, 0)}>
-                  {strings.ADD_PLANTING_SITE_DESCRIPTION}
+          <>
+            <Grid container spacing={3} flexGrow={0}>
+              <Grid item xs={12}>
+                <Link id='back' to={APP_PATHS.PLANTING_SITES} className={classes.back}>
+                  <Icon name='caretLeft' className={classes.backIcon} />
+                  {strings.PLANTING_SITES}
+                </Link>
+              </Grid>
+              <Grid item xs={12}>
+                <Typography
+                  fontSize={selectedPlantingSite ? '20px' : '24px'}
+                  fontWeight={600}
+                  margin={theme.spacing(1, 0)}
+                >
+                  {record.id !== -1 && selectedPlantingSite ? selectedPlantingSite.name : strings.ADD_PLANTING_SITE}
                 </Typography>
-              )}
-            </Grid>
-            <PageSnackbar />
-            <Grid item xs={gridSize()}>
-              <TextField
-                id='name'
-                label={strings.NAME_REQUIRED}
-                type='text'
-                onChange={onChange}
-                value={record.name}
-                errorText={record.name ? '' : nameError}
-              />
-            </Grid>
-            <Grid item xs={gridSize()}>
-              <TextField
-                id='description'
-                label={strings.DESCRIPTION}
-                type='textarea'
-                onChange={onChange}
-                value={record.description}
-              />
+                {record.id === -1 && (
+                  <Typography fontSize='14px' fontWeight={400} margin={theme.spacing(0, 0, 3, 0)}>
+                    {strings.ADD_PLANTING_SITE_DESCRIPTION}
+                  </Typography>
+                )}
+              </Grid>
+              <PageSnackbar />
+              <Grid item xs={gridSize()}>
+                <TextField
+                  id='name'
+                  label={strings.NAME_REQUIRED}
+                  type='text'
+                  onChange={onChange}
+                  value={record.name}
+                  errorText={record.name ? '' : nameError}
+                />
+              </Grid>
+              <Grid item xs={gridSize()}>
+                <TextField
+                  id='description'
+                  label={strings.DESCRIPTION}
+                  type='textarea'
+                  onChange={onChange}
+                  value={record.description}
+                />
+              </Grid>
             </Grid>
             <BoundariesAndPlots plantingSite={record} />
-          </Grid>
+          </>
         )}
       </Container>
       <FormBottomBar onCancel={goToPlantingSites} onSave={savePlantingSite} />

--- a/src/components/PlantingSites/PlantingSiteView.tsx
+++ b/src/components/PlantingSites/PlantingSiteView.tsx
@@ -62,8 +62,8 @@ export default function PlantingSiteView(): JSX.Element {
 
   return (
     <TfMain>
-      <Container maxWidth={false} sx={{ display: 'flex', flexDirection: plantingSite?.boundary ? 'row' : 'column' }}>
-        <Grid container spacing={3}>
+      <Container maxWidth={false} sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
+        <Grid container spacing={3} flexGrow={0}>
           <Grid item xs={12}>
             <Link id='back' to={APP_PATHS.PLANTING_SITES} className={classes.back}>
               <Icon name='caretLeft' className={classes.backIcon} />
@@ -93,8 +93,8 @@ export default function PlantingSiteView(): JSX.Element {
               display={true}
             />
           </Grid>
-          {plantingSite && <BoundariesAndPlots plantingSite={plantingSite} />}
         </Grid>
+        {plantingSite && <BoundariesAndPlots plantingSite={plantingSite} />}
       </Container>
     </TfMain>
   );


### PR DESCRIPTION
- the way we were setting the map's key (needed for recreating the map) was generating the map twice
- the mapboxAccessToken is not reactive, meaning, changes to the token will not recreate the map, hence the map key property (assigned to mapId)
- moved mapId assignment to the parent since we have more control there
- fixed layout of map in planting site view and create - now the map uses up remaining height and changes as you resize the browser

![screencast 2022-11-15 15-23-13](https://user-images.githubusercontent.com/1865174/202045843-90a2ed00-2ec3-4b00-b817-012c18a00b41.gif)
