### PR TITLE
SW-2274 Define a popup renderer prop for Map

### DIFF
--- a/src/components/Map/MapModels.ts
+++ b/src/components/Map/MapModels.ts
@@ -36,11 +36,13 @@ export type MapGeometry = number | number[] | number[][][][];
  * ]
  */
 
+export type MapSourceProperties = { [key: string]: any };
+
 export type MapSource = {
   id: string;
   fillColor: string;
   fillOpacity: number;
-  metadata: { [key: string]: any };
+  properties: MapSourceProperties;
   boundary: MapGeometry;
 };
 
@@ -53,3 +55,8 @@ export type MapOptions = {
   bbox: MapBoundingBox;
   sources: MapSource[];
 };
+
+/**
+ * Render a popup based on properties
+ */
+export type MapPopupRenderer = (properties: MapSourceProperties) => JSX.Element;

--- a/src/components/Map/MapRenderUtils.tsx
+++ b/src/components/Map/MapRenderUtils.tsx
@@ -1,9 +1,13 @@
 import { Box, Typography, useTheme } from '@mui/material';
+import { MapPopupRenderer, MapSourceProperties } from './MapModels';
 
-export function useRenderFeature() {
+/*
+ * Example of a map popup renderer
+ */
+export function useDefaultPopupRenderer(): MapPopupRenderer {
   const theme = useTheme();
 
-  return (data: any): JSX.Element => {
+  return (data: MapSourceProperties): JSX.Element => {
     const { type, id, fullName, name } = data;
 
     return (

--- a/src/components/Map/PlantingSiteMap.tsx
+++ b/src/components/Map/PlantingSiteMap.tsx
@@ -4,9 +4,10 @@ import { getMapboxToken } from 'src/api/tracking/tracking';
 import { Geometry, PlantingSite } from 'src/api/types/tracking';
 import useSnackbar from 'src/utils/useSnackbar';
 import Map from './Map';
-import { MapGeometry, MapOptions, MapSource } from './MapModels';
+import { MapGeometry, MapOptions, MapPopupRenderer, MapSource } from './MapModels';
 import { getBoundingBox } from './MapUtils';
 import _ from 'lodash';
+import { useDefaultPopupRenderer } from './MapRenderUtils';
 
 export type PlantingSiteMapProps = {
   plantingSite: PlantingSite;
@@ -19,6 +20,7 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
   const [token, setToken] = useState<string>();
   const [mapOptions, setMapOptions] = useState<MapOptions>();
   const [mapId, setMapId] = useState<string>();
+  const popupRenderer: MapPopupRenderer = useDefaultPopupRenderer();
 
   const getFillColor = useCallback(() => {
     return theme.palette.TwClrBaseWhite || 'white';
@@ -35,7 +37,7 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
     (site: PlantingSite): MapSource => {
       const { id, name, description, boundary } = site;
       return {
-        metadata: { id, name, description, type: 'site' },
+        properties: { id, name, description, type: 'site' },
         boundary: getPolygons(boundary),
         id: `site-${id}`,
         fillColor: getFillColor(),
@@ -50,7 +52,7 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
       return site.plantingZones?.map((zone) => {
         const { id, name, boundary } = zone;
         return {
-          metadata: { id, name, type: 'zone' },
+          properties: { id, name, type: 'zone' },
           boundary: getPolygons(boundary),
           id: `zone-${id}`,
           fillColor: getFillColor(),
@@ -68,7 +70,7 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
         return plots.map((plot) => {
           const { id, name, fullName, boundary } = plot;
           return {
-            metadata: { id, name, fullName, type: 'plot' },
+            properties: { id, name, fullName, type: 'plot' },
             boundary: getPolygons(boundary),
             id: `plot-${id}`,
             fillColor: getFillColor(),
@@ -134,7 +136,13 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
 
   return (
     <Box sx={{ display: 'flex', flexGrow: 1 }}>
-      <Map token={token} options={mapOptions} onTokenExpired={fetchMapboxToken} mapId={mapId} />
+      <Map
+        token={token}
+        options={mapOptions}
+        onTokenExpired={fetchMapboxToken}
+        mapId={mapId}
+        popupRenderer={popupRenderer}
+      />
     </Box>
   );
 }


### PR DESCRIPTION
- needed so we can have different rendering passed into the Map
- needed for withdrawal log at some point
- for now enabled a default popup renderer (which we will remove once withdrawal log rendering works using default as example)
- NO changes to map, just refactored popup rendering to a prop