### PR TITLE
Add Padding to Match Main Padding

### DIFF
--- a/src/components/common/PageHeaderWrapper.tsx
+++ b/src/components/common/PageHeaderWrapper.tsx
@@ -100,6 +100,7 @@ export default function PageHeaderWrapper({ children, nextElement }: Props): JSX
     background: debouncedSticky ? theme.palette.TwClrBg : undefined,
     boxShadow: debouncedSticky ? `0px 3px 3px -3px ${theme.palette.TwClrBaseGray200}` : undefined,
     paddingRight: debouncedSticky ? theme.spacing(3) : undefined,
+    paddingTop: debouncedSticky ? theme.spacing(4) : undefined,
     position: debouncedSticky ? 'fixed' : undefined,
     top: debouncedSticky ? (debouncedScrollDown ? `${TOP_BAR_HEIGHT - height}px` : `${TOP_BAR_HEIGHT}px`) : undefined,
     visibility: debouncedSticky && debouncedScrollDown ? 'hidden' : 'visible',


### PR DESCRIPTION
The change in the padding in the main window to 96px caused the
header to no longer line up when transitioning between sticky and
fixed. Add some padding to cause it to line up again.

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/114949086/202314018-bb87de27-f512-4a0c-a748-ea401efa910f.png">
