### PR TITLE
SW-2123: Responsive Page Layouts -> Onboarding

### DIFF
--- a/src/components/emptyStatePages/NoOrgLandingPage.tsx
+++ b/src/components/emptyStatePages/NoOrgLandingPage.tsx
@@ -19,8 +19,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'center',
-    minHeight: '100vh',
-    padding: '88px 24px 24px',
+    minHeight: 'calc(100vh - 88px)',
+    padding: (props: StyleProps) => (props.isMobile ? '88px 24px 24px' : '64px 24px 24px'),
     [theme.breakpoints.down('xl')]: {
       background:
         'url(/assets/home-bg-right-layer-z4.svg) no-repeat 753px 100%/auto 285px, ' +
@@ -43,7 +43,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   mainContainer: {
     background: theme.palette.TwClrBg,
     borderRadius: '24px',
-    margin: 'auto',
+    margin: '0 auto',
     maxWidth: '900px',
     padding: (props: StyleProps) => (props.isMobile ? '24px 26px' : '40px 26px'),
   },

--- a/src/components/emptyStatePages/NoOrgLandingPage.tsx
+++ b/src/components/emptyStatePages/NoOrgLandingPage.tsx
@@ -15,12 +15,12 @@ interface StyleProps {
 
 const useStyles = makeStyles((theme: Theme) => ({
   main: {
-    padding: '88px 24px 24px',
-    minHeight: '100vh',
-    display: 'flex',
     alignItems: 'center',
-    justifyContent: 'center',
+    display: 'flex',
     flexDirection: 'column',
+    justifyContent: 'center',
+    minHeight: '100vh',
+    padding: '88px 24px 24px',
     [theme.breakpoints.down('xl')]: {
       background:
         'url(/assets/home-bg-right-layer-z4.svg) no-repeat 753px 100%/auto 285px, ' +

--- a/src/components/emptyStatePages/NoOrgLandingPage.tsx
+++ b/src/components/emptyStatePages/NoOrgLandingPage.tsx
@@ -7,10 +7,15 @@ import dictionary from 'src/strings/dictionary';
 import { Container, Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import PageSnackbar from 'src/components/PageSnackbar';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
+
+interface StyleProps {
+  isMobile?: boolean;
+}
 
 const useStyles = makeStyles((theme: Theme) => ({
   main: {
-    paddingTop: '64px',
+    padding: '88px 24px 24px',
     minHeight: '100vh',
     display: 'flex',
     alignItems: 'center',
@@ -36,9 +41,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   mainContainer: {
-    maxWidth: '1500px',
+    background: theme.palette.TwClrBg,
+    borderRadius: '24px',
     margin: 'auto',
-    marginTop: `max(40px, calc(50% - 1500px/2))`,
+    maxWidth: '900px',
+    padding: (props: StyleProps) => (props.isMobile ? '24px 26px' : '40px 26px'),
   },
 }));
 
@@ -61,7 +68,8 @@ type LandingPageProps = {
 };
 
 export default function NoOrgLandingPage(props: LandingPageProps): JSX.Element {
-  const classes = useStyles();
+  const { isMobile } = useDeviceInfo();
+  const classes = useStyles({ isMobile });
   const [isOrgModalOpen, setIsOrgModalOpen] = useState<boolean>(false);
 
   return (

--- a/src/components/emptyStatePages/NoOrgLandingPage.tsx
+++ b/src/components/emptyStatePages/NoOrgLandingPage.tsx
@@ -16,6 +16,24 @@ const useStyles = makeStyles((theme: Theme) => ({
     alignItems: 'center',
     justifyContent: 'center',
     flexDirection: 'column',
+    [theme.breakpoints.down('xl')]: {
+      background:
+        'url(/assets/home-bg-right-layer-z4.svg) no-repeat 753px 100%/auto 285px, ' +
+        'url(/assets/home-bg-left-layer-z4.svg) no-repeat 0 100%/auto 295px, ' +
+        'url(/assets/home-bg-water-z2.svg) repeat-x 0 100%/auto 180px, ' +
+        'url(/assets/home-bg-left-z4.svg) no-repeat 0 100%/auto 295px, ' +
+        'url(/assets/home-bg-right-z3.svg) no-repeat 911px 100%/auto 400px, ' +
+        'linear-gradient(180deg, #FBF9F9 0%, #EFF5EF 100%) no-repeat 0 0/auto',
+    },
+    [theme.breakpoints.up('xl')]: {
+      background:
+        'url(/assets/home-bg-right-layer-z4.svg) no-repeat 100% 100%/auto 285px, ' +
+        'url(/assets/home-bg-left-layer-z4.svg) no-repeat 0 100%/auto 295px, ' +
+        'url(/assets/home-bg-water-z2.svg) repeat-x 0 100%/auto 180px, ' +
+        'url(/assets/home-bg-left-z4.svg) no-repeat 0 100%/auto 295px, ' +
+        'url(/assets/home-bg-right-z3.svg) no-repeat 100% 100%/auto 400px, ' +
+        'linear-gradient(180deg, #FBF9F9 0%, #EFF5EF 100%) no-repeat 0 0/auto',
+    },
   },
   mainContainer: {
     maxWidth: '1500px',


### PR DESCRIPTION
This PR updates the no organization landing page to align with the new [visual updates](https://www.figma.com/file/aLIG1C6uIMyBWiTopSluxe/Visual-Refresh?node-id=853%3A108782&t=TqgSlECxJ34AklsU-0).

## Screenshots

Desktop:

<img width="2032" alt="Screen Shot 2022-11-21 at 2 22 11 PM" src="https://user-images.githubusercontent.com/1474361/203184650-cf6fc28a-fff5-456b-a7a8-20c4f1a36ff5.png">

Tablet:

![localhost_3000_welcome(iPad Mini)](https://user-images.githubusercontent.com/1474361/203184674-e5f4840c-9ccd-49a3-9784-3ee01c8f9dce.png)

Mobile:

![localhost_3000_welcome(iPhone SE)](https://user-images.githubusercontent.com/1474361/203184693-30ee7b5d-ab70-4190-a7cc-7f443bfa47fa.png)

