### PR TITLE
SW-2351 Fix rendering performance issues on planting site maps

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -90,7 +90,7 @@ export default function Map(props: MapProps): JSX.Element {
      */
     const geo = sources
       .map((source) => {
-        const features = source.objectData
+        const features = source.entities
           .map((data) => {
             if (!data.boundary || !Array.isArray(data.boundary)) {
               return null;

--- a/src/components/Map/MapModels.ts
+++ b/src/components/Map/MapModels.ts
@@ -44,13 +44,17 @@ export type MapAnnotation = {
   textColor: string;
 };
 
+export type MapObjectData = {
+  properties: MapSourceProperties;
+  boundary: MapGeometry;
+};
+
 export type MapSource = {
   id: string;
   fillColor: string;
   lineColor: string;
   lineWidth: number;
-  properties: MapSourceProperties;
-  boundary: MapGeometry;
+  objectData: MapObjectData[];
   isInteractive?: boolean;
   // property name to render as a polygon annotation
   annotation?: MapAnnotation;

--- a/src/components/Map/MapModels.ts
+++ b/src/components/Map/MapModels.ts
@@ -44,7 +44,11 @@ export type MapAnnotation = {
   textColor: string;
 };
 
-export type MapObjectData = {
+/**
+ * A renderable map entity
+ * eg. site, zone, plot
+ */
+export type MapEntity = {
   properties: MapSourceProperties;
   boundary: MapGeometry;
 };
@@ -54,7 +58,7 @@ export type MapSource = {
   fillColor: string;
   lineColor: string;
   lineWidth: number;
-  objectData: MapObjectData[];
+  entities: MapEntity[];
   isInteractive?: boolean;
   // property name to render as a polygon annotation
   annotation?: MapAnnotation;

--- a/src/components/Map/PlantingSiteMap.tsx
+++ b/src/components/Map/PlantingSiteMap.tsx
@@ -75,7 +75,7 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
       const renderAttributes = getRenderAttributes('site');
 
       return {
-        objectData: [
+        entities: [
           {
             properties: { id, name, description, type: 'site' },
             boundary: getPolygons(boundary),
@@ -102,7 +102,7 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
         }) || [];
 
       return {
-        objectData: zonesData,
+        entities: zonesData,
         id: 'zones',
         ...renderAttributes,
       };
@@ -127,7 +127,7 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
         }) || [];
 
       return {
-        objectData: allPlotsData.flatMap((f) => f),
+        entities: allPlotsData.flatMap((f) => f),
         id: 'plots',
         isInteractive: true,
         annotation: {
@@ -167,9 +167,9 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
       const plots = extractPlots(plantingSite);
 
       const geometries: MapGeometry[] = [
-        site.objectData[0]?.boundary,
-        ...(zones?.objectData.map((s) => s.boundary) || []),
-        ...(plots?.objectData.map((s) => s.boundary) || []),
+        site.entities[0]?.boundary,
+        ...(zones?.entities.map((s) => s.boundary) || []),
+        ...(plots?.entities.map((s) => s.boundary) || []),
       ].filter((g) => g) as MapGeometry[];
 
       const newMapOptions = {

--- a/src/components/Map/PlantingSiteMap.tsx
+++ b/src/components/Map/PlantingSiteMap.tsx
@@ -131,9 +131,9 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
         id: 'plots',
         isInteractive: true,
         annotation: {
-          textField: 'fullName',
+          textField: 'name',
           textColor: theme.palette.TwClrBaseWhite as string,
-          textSize: 10,
+          textSize: 16,
         },
         ...renderAttributes,
       };
@@ -187,8 +187,8 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
 
   if (!token || !mapOptions) {
     return (
-      <Box sx={{ display: 'flex', flexGrow: 1, height: '100%' }}>
-        <CircularProgress sx={{ margin: 'auto auto' }} />
+      <Box sx={{ display: 'flex', flexGrow: 1, height: '100%', margin: 'auto' }}>
+        <CircularProgress sx={{ margin: 'auto' }} />
       </Box>
     );
   }

--- a/src/components/Map/PlantingSiteMap.tsx
+++ b/src/components/Map/PlantingSiteMap.tsx
@@ -75,9 +75,13 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
       const renderAttributes = getRenderAttributes('site');
 
       return {
-        properties: { id, name, description, type: 'site' },
-        boundary: getPolygons(boundary),
-        id: `site-${id}`,
+        objectData: [
+          {
+            properties: { id, name, description, type: 'site' },
+            boundary: getPolygons(boundary),
+          },
+        ],
+        id: 'sites',
         ...renderAttributes,
       };
     },
@@ -85,44 +89,54 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
   );
 
   const extractPlantingZones = useCallback(
-    (site: PlantingSite): MapSource[] | undefined => {
+    (site: PlantingSite): MapSource => {
       const renderAttributes = getRenderAttributes('zone');
 
-      return site.plantingZones?.map((zone) => {
-        const { id, name, boundary } = zone;
-        return {
-          properties: { id, name, type: 'zone' },
-          boundary: getPolygons(boundary),
-          id: `zone-${id}`,
-          ...renderAttributes,
-        };
-      });
+      const zonesData =
+        site.plantingZones?.map((zone) => {
+          const { id, name, boundary } = zone;
+          return {
+            properties: { id, name, type: 'zone' },
+            boundary: getPolygons(boundary),
+          };
+        }) || [];
+
+      return {
+        objectData: zonesData,
+        id: 'zones',
+        ...renderAttributes,
+      };
     },
     [getPolygons, getRenderAttributes]
   );
 
   const extractPlots = useCallback(
-    (site: PlantingSite): MapSource[] | undefined => {
+    (site: PlantingSite): MapSource => {
       const renderAttributes = getRenderAttributes('plot');
 
-      return site.plantingZones?.flatMap((zone) => {
-        const { plots } = zone;
-        return plots.map((plot) => {
-          const { id, name, fullName, boundary } = plot;
-          return {
-            properties: { id, name, fullName, type: 'plot' },
-            boundary: getPolygons(boundary),
-            id: `plot-${id}`,
-            ...renderAttributes,
-            isInteractive: true,
-            annotation: {
-              textField: 'fullName',
-              textColor: theme.palette.TwClrBaseWhite as string,
-              textSize: 10,
-            },
-          };
-        });
-      });
+      const allPlotsData =
+        site.plantingZones?.flatMap((zone) => {
+          const { plots } = zone;
+          return plots.map((plot) => {
+            const { id, name, fullName, boundary } = plot;
+            return {
+              properties: { id, name, fullName, type: 'plot' },
+              boundary: getPolygons(boundary),
+            };
+          });
+        }) || [];
+
+      return {
+        objectData: allPlotsData.flatMap((f) => f),
+        id: 'plots',
+        isInteractive: true,
+        annotation: {
+          textField: 'fullName',
+          textColor: theme.palette.TwClrBaseWhite as string,
+          textSize: 10,
+        },
+        ...renderAttributes,
+      };
     },
     [getPolygons, getRenderAttributes, theme.palette.TwClrBaseWhite]
   );
@@ -149,18 +163,18 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
   useEffect(() => {
     const fetchPlantingSite = () => {
       const site = extractPlantingSite(plantingSite);
-      const zones = extractPlantingZones(plantingSite) || [];
-      const plots = extractPlots(plantingSite) || [];
+      const zones = extractPlantingZones(plantingSite);
+      const plots = extractPlots(plantingSite);
 
       const geometries: MapGeometry[] = [
-        site?.boundary,
-        ...zones.map((s) => s.boundary),
-        ...plots.map((s) => s.boundary),
+        site.objectData[0]?.boundary,
+        ...(zones?.objectData.map((s) => s.boundary) || []),
+        ...(plots?.objectData.map((s) => s.boundary) || []),
       ].filter((g) => g) as MapGeometry[];
 
       const newMapOptions = {
         bbox: getBoundingBox(geometries),
-        sources: [site, ...plots, ...zones],
+        sources: [site, plots, zones],
       };
 
       if (!_.isEqual(newMapOptions, mapOptions)) {


### PR DESCRIPTION
- Code was overzealous creating Mapbox Layers
- One layer per plot was being created.. this was not necessary
- One layer encompassing all plots should be the correct approach
- One layer per rendering style is the purpose of a Layer
- With large number of layers, mapbox was slow in rendering and creating tileset data on the fly