### PR TITLE
SW-2278 Show plot labels only after zoomed in

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -49,6 +49,7 @@ export default function Map(props: MapProps): JSX.Element {
     // fit to bounding box
     if (mapRef?.current !== undefined) {
       const mapInstance: any = mapRef.current.getMap();
+      setZoomEnd(false);
       setZoomBegin(true);
       mapInstance.fitBounds([bbox.lowerLeft, bbox.upperRight], { padding: 20 });
     }


### PR DESCRIPTION
- avoid showing during the zoom process to avoid labels dancing around
- to test, view difference with vercel link versus staging