### PR TITLE
Misc Empty State Pages Updates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -408,6 +408,10 @@ export default function App() {
     if (
       location.pathname.startsWith(APP_PATHS.HOME) ||
       (location.pathname.startsWith(APP_PATHS.SPECIES) && !selectedOrgHasSpecies()) ||
+      (location.pathname.startsWith(APP_PATHS.ACCESSIONS) &&
+        (!selectedOrgHasSeedBanks() || !selectedOrgHasSpecies())) ||
+      (location.pathname.startsWith(APP_PATHS.MONITORING) && !selectedOrgHasSeedBanks()) ||
+      (location.pathname.startsWith(APP_PATHS.INVENTORY) && (!selectedOrgHasNurseries() || !selectedOrgHasSpecies())) ||
       (location.pathname.startsWith(APP_PATHS.SEED_BANKS) && !selectedOrgHasSeedBanks()) ||
       (location.pathname.startsWith(APP_PATHS.NURSERIES) && !selectedOrgHasNurseries()) ||
       (location.pathname.startsWith(APP_PATHS.PLANTING_SITES) && !selectedOrgHasPlantingSites())

--- a/src/components/Monitoring/index.tsx
+++ b/src/components/Monitoring/index.tsx
@@ -32,6 +32,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     margin: '0 auto',
     marginTop: (props: StyleProps) => (props.isMobile ? '32px' : '80px'),
     maxWidth: '800px',
+    padding: '24px 48px 48px',
   },
   titleContainer: {
     display: 'flex',

--- a/src/components/Monitoring/index.tsx
+++ b/src/components/Monitoring/index.tsx
@@ -19,6 +19,10 @@ import useDeviceInfo from 'src/utils/useDeviceInfo';
 import PageSnackbar from 'src/components/PageSnackbar';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 
+interface StyleProps {
+  isMobile: boolean;
+}
+
 const useStyles = makeStyles((theme: Theme) => ({
   mainTitle: {
     display: 'flex',
@@ -26,13 +30,14 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   message: {
     margin: '0 auto',
-    marginTop: '10%',
+    marginTop: (props: StyleProps) => (props.isMobile ? '32px' : '80px'),
     maxWidth: '800px',
   },
   titleContainer: {
     display: 'flex',
     alignItems: 'center',
     paddingBottom: theme.spacing(2),
+    paddingLeft: theme.spacing(3),
   },
   contentContainer: {
     width: '100%',
@@ -58,7 +63,7 @@ type MonitoringProps = {
 
 export default function Monitoring(props: MonitoringProps): JSX.Element {
   const { isMobile } = useDeviceInfo();
-  const classes = useStyles();
+  const classes = useStyles({ isMobile });
   const history = useHistory();
   const { organization, hasSeedBanks, reloadData } = props;
   const [selectedSeedBank, setSelectedSeedBank] = useState<Facility>();
@@ -134,9 +139,9 @@ export default function Monitoring(props: MonitoringProps): JSX.Element {
 
   return (
     <TfMain backgroundImageVisible={!hasSeedBanks}>
-      {hasSeedBanks ? (
-        <>
-          <Grid container>
+      <Grid container>
+        {hasSeedBanks ? (
+          <>
             <PageHeaderWrapper nextElement={contentRef.current}>
               <Grid item xs={12} className={isMobile ? '' : classes.titleContainer}>
                 {isMobile ? (
@@ -194,31 +199,31 @@ export default function Monitoring(props: MonitoringProps): JSX.Element {
                 />
               </div>
             )}
+          </>
+        ) : isAdmin(organization) ? (
+          <Grid item xs={12} className={isMobile ? '' : classes.titleContainer} flexDirection='column'>
+            {getPageHeading()}
+            <PageSnackbar />
+            <EmptyMessage
+              className={classes.message}
+              title={emptyMessageStrings.NO_SEEDBANKS_ADMIN_TITLE}
+              text={emptyMessageStrings.NO_SEEDBANKS_MONITORING_ADMIN_MSG}
+              buttonText={strings.GO_TO_SEED_BANKS}
+              onClick={goToSeedBanks}
+            />
           </Grid>
-        </>
-      ) : isAdmin(organization) ? (
-        <>
-          {getPageHeading()}
-          <PageSnackbar />
-          <EmptyMessage
-            className={classes.message}
-            title={emptyMessageStrings.NO_SEEDBANKS_ADMIN_TITLE}
-            text={emptyMessageStrings.NO_SEEDBANKS_MONITORING_ADMIN_MSG}
-            buttonText={strings.GO_TO_SEED_BANKS}
-            onClick={goToSeedBanks}
-          />
-        </>
-      ) : (
-        <>
-          {getPageHeading()}
-          <PageSnackbar />
-          <EmptyMessage
-            className={classes.message}
-            title={emptyMessageStrings.REACH_OUT_TO_ADMIN_TITLE}
-            text={emptyMessageStrings.NO_SEEDBANKS_MONITORING_NON_ADMIN_MSG}
-          />
-        </>
-      )}
+        ) : (
+          <Grid item xs={12} className={isMobile ? '' : classes.titleContainer} flexDirection='column'>
+            {getPageHeading()}
+            <PageSnackbar />
+            <EmptyMessage
+              className={classes.message}
+              title={emptyMessageStrings.REACH_OUT_TO_ADMIN_TITLE}
+              text={emptyMessageStrings.NO_SEEDBANKS_MONITORING_NON_ADMIN_MSG}
+            />
+          </Grid>
+        )}
+      </Grid>
     </TfMain>
   );
 }

--- a/src/components/common/EmptyMessage.tsx
+++ b/src/components/common/EmptyMessage.tsx
@@ -121,7 +121,11 @@ export default function EmptyMessage(props: EmptyMessageProps): JSX.Element {
                       <Typography fontSize='14px' fontWeight={500} color={theme.palette.TwClrTxt} lineHeight='20px'>
                         {rowItem.altItem.text}
                       </Typography>
-                      <Link onClick={rowItem.altItem.onLinkClick} className={classes.itemLink}>
+                      <Link
+                        color={theme.palette.TwClrTxtBrand}
+                        onClick={rowItem.altItem.onLinkClick}
+                        className={classes.itemLink}
+                      >
                         {rowItem.altItem.linkText}
                       </Link>
                     </div>

--- a/src/components/common/ImportModal.tsx
+++ b/src/components/common/ImportModal.tsx
@@ -357,6 +357,7 @@ export default function ImportSpeciesModal(props: ImportSpeciesModalProps): JSX.
             <p className={classes.description}>{file ? strings.FILE_SELECTED : uploaderDescription}</p>
             {!file && (
               <Link
+                color={theme.palette.TwClrTxtBrand}
                 href='#'
                 onClick={() => {
                   downloadCsvTemplateHandler(templateApi);

--- a/src/components/common/Title.tsx
+++ b/src/components/common/Title.tsx
@@ -6,11 +6,8 @@ const useStyles = makeStyles(() => ({
     display: 'flex',
     alignItems: 'center',
   },
-  title: {
-    color: 'gray',
-  },
+  title: {},
   selectedSection: {
-    color: 'black',
     fontWeight: 600,
     fontSize: 24,
   },
@@ -26,7 +23,9 @@ export default function Title({ page }: TitleProps): JSX.Element {
   return (
     <div className={classes.titleContainer}>
       <div className={classes.title}>
-        <Typography className={classes.selectedSection}>{page}</Typography>
+        <Typography className={classes.selectedSection} variant='h1'>
+          {page}
+        </Typography>
       </div>
     </div>
   );

--- a/src/components/common/Title.tsx
+++ b/src/components/common/Title.tsx
@@ -5,9 +5,9 @@ const useStyles = makeStyles(() => ({
   titleContainer: {
     display: 'flex',
     alignItems: 'center',
+    width: '100%',
   },
-  title: {},
-  selectedSection: {
+  title: {
     fontWeight: 600,
     fontSize: 24,
   },
@@ -22,11 +22,9 @@ export default function Title({ page }: TitleProps): JSX.Element {
 
   return (
     <div className={classes.titleContainer}>
-      <div className={classes.title}>
-        <Typography className={classes.selectedSection} variant='h1'>
-          {page}
-        </Typography>
-      </div>
+      <Typography className={classes.title} variant='h1'>
+        {page}
+      </Typography>
     </div>
   );
 }

--- a/src/components/emptyStatePages/EmptyStateContent.tsx
+++ b/src/components/emptyStatePages/EmptyStateContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Container, Theme, Grid } from '@mui/material';
+import { Container, Theme, Grid, useTheme } from '@mui/material';
 import Button from 'src/components/common/button/Button';
 import Icon from 'src/components/common/icon/Icon';
 import { IconName } from 'src/components/common/icon/icons';
@@ -120,6 +120,7 @@ export default function EmptyStateContent(props: EmptyStateContentProps): JSX.El
   const { title, subtitle, listItems, buttonText, buttonIcon, onClickButton, footnote, styles } = props;
   const { isMobile } = useDeviceInfo();
   const classes = useStyles({ ...styles, isMobile });
+  const theme = useTheme();
 
   const gridSize = () => {
     if (isMobile) {
@@ -143,7 +144,7 @@ export default function EmptyStateContent(props: EmptyStateContentProps): JSX.El
                   {item.description}
                 </p>
                 {item.linkText && item.onLinkClick && (
-                  <Link onClick={item.onLinkClick} className={classes.itemLink}>
+                  <Link onClick={item.onLinkClick} className={classes.itemLink} color={theme.palette.TwClrTxtBrand}>
                     {item.linkText}
                   </Link>
                 )}

--- a/src/components/emptyStatePages/EmptyStateContent.tsx
+++ b/src/components/emptyStatePages/EmptyStateContent.tsx
@@ -134,9 +134,9 @@ export default function EmptyStateContent(props: EmptyStateContentProps): JSX.El
       <h1 className={classes.title}>{title}</h1>
       <p className={classes.subtitle}>{subtitle}</p>
       <div className={classes.listContainer}>
-        {listItems.map((item) => {
+        {listItems.map((item, index) => {
           return (
-            <Grid item xs={gridSize()} key={item.title} className={`${classes.listItem}`}>
+            <Grid item xs={gridSize()} key={`${item.title}-${index}`} className={`${classes.listItem}`}>
               <Icon name={item.icon} className={classes.listItemIcon} />
               {item.title && <p className={classes.listItemTitle}>{item.title}</p>}
               <div>

--- a/src/components/emptyStatePages/EmptyStatePage.tsx
+++ b/src/components/emptyStatePages/EmptyStatePage.tsx
@@ -88,8 +88,6 @@ const NO_NURSERIES_CONTENT: PageContent = {
   listItems: [
     {
       icon: 'blobbyIconNursery',
-      title: strings.INVENTORY_DATA,
-      description: strings.INVENTORY_DATA_DESCRIPTION,
     },
   ],
   buttonText: strings.ADD_NURSERY,

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -752,7 +752,6 @@ const strings = new LocalizedStrings({
     NURSERIES: 'Nurseries',
     ADD_A_NURSERY: 'Add a Nursery',
     INVENTORY_DATA: 'Inventory Data',
-    INVENTORY_DATA_DESCRIPTION: "Monitor your nursery's inventory",
     ADD_NURSERY: 'Add Nursery',
     NURSERY_ADDED: 'Nursery Added',
     GO_TO_NURSERIES: 'Go to Nurseries',


### PR DESCRIPTION
This PR includes a handful of changes to support the visual updates.

Changes include:

- Update link color for import CSV and similar actios in empty state page content
- Update link color in import modal
- Remove title & description from single empty state item in Nurseries empty state
- Update title component to render as `h1` & inherit color from body rather than being incorrectly set to black
- Adjust spacing (margin & padding) of Monitoring page empty state
- Show background image through `NavBar` for empty state pages

## Screenshots

![localhost_3000_monitoring(iPad Mini)](https://user-images.githubusercontent.com/1474361/204931686-cc8db77e-0ae4-413e-91c0-cf0188998c82.png)

![localhost_3000_monitoring(iPhone SE)](https://user-images.githubusercontent.com/1474361/204931687-23d10dd6-30e0-470d-aceb-bc21231e93f6.png)

![localhost_3000_monitoring](https://user-images.githubusercontent.com/1474361/204931680-2205a9a1-e333-4cb1-ac46-5252eb4b4a8c.png)

![localhost_3000_home (1)](https://user-images.githubusercontent.com/1474361/204931836-07b8bb4e-3916-4cb8-80ae-576ee883e9c2.png)

![localhost_3000_home (2)](https://user-images.githubusercontent.com/1474361/204931837-94fb4e99-921e-497a-a6cd-fd363d7efcfd.png)

![localhost_3000_home (3)](https://user-images.githubusercontent.com/1474361/204931839-0bad6b0c-edb0-4589-90d4-726bd20769f2.png)


