### PR TITLE
SW-2153 Message Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/styled-engine-sc": "^5.8.0",
     "@mui/styles": "^5.8.7",
     "@mui/x-date-pickers": "^5.0.0-alpha.7",
-    "@terraware/web-components": "^2.0.23",
+    "@terraware/web-components": "^2.0.25",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/components/ToastSnackbar.tsx
+++ b/src/components/ToastSnackbar.tsx
@@ -9,10 +9,10 @@ import { Message } from '@terraware/web-components';
 const useStyles = makeStyles((theme: Theme) => ({
   mainSnackbar: {
     '&.MuiSnackbar-anchorOriginTopCenter': {
-      top: '75px',
+      top: '32px',
     },
     '&.MuiSnackbar-anchorOriginBottomCenter': {
-      bottom: '64px',
+      bottom: '32px',
     },
   },
   toastContainer: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2446,10 +2446,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^2.0.23":
-  version "2.0.23"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.23.tgz#366926e35146fcee4c2e233fc06e63df3b4663e1"
-  integrity sha512-BQs/QNqjAqto7GOdImiKGUXjX5dWBrNXHUkqWjsfMUvrcGKEweylZa3iT9+2SaIyYlJCKX1oFLp4O0xLc21I2g==
+"@terraware/web-components@^2.0.25":
+  version "2.0.25"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.25.tgz#e26ac62fa9ce64d65fd484b0e1fef114a2a63229"
+  integrity sha512-+bZ2nfP4u7d3wVkgitMIU4Yf3OptiWgiACDYFyfd6XHTI0qCPGFGK8h4RKD+WESPJ18h9Qgw0jnPURV4zkxqYQ==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.10.11"


### PR DESCRIPTION
- toast position 32px from bottom on mobile
- otherwise 32px from top
- consume style updates from web-components

<img width="1241" alt="image" src="https://user-images.githubusercontent.com/114949086/205103588-d26a9dad-2ce1-49b6-9737-72c86d5a71c5.png">
<img width="519" alt="image" src="https://user-images.githubusercontent.com/114949086/205103859-107164e3-f72c-4a1e-95c4-f62df87f12a8.png">
<img width="1547" alt="image" src="https://user-images.githubusercontent.com/114949086/205103952-a5082850-695e-4938-beb0-751fe0677d03.png">
