### PR TITLE
Fix temporary rendering of a generic map in plants dashboard

### DIFF
--- a/src/components/Plants/index.tsx
+++ b/src/components/Plants/index.tsx
@@ -84,7 +84,7 @@ export default function PlantsDashboard(props: PlantsDashboardProps): JSX.Elemen
     }
   };
 
-  if (!plantingSites) {
+  if (!plantingSites || (plantingSites.length && !selectedPlantingSite)) {
     return (
       <TfMain>
         <CircularProgress sx={{ margin: 'auto' }} />


### PR DESCRIPTION
- don't render until we have a selection