### PR TITLE
Allow access to admin UI without trailing slash

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -42,7 +42,7 @@ server {
     # /swagger-ui/ = Interactive API browser
     # /v3/ = OpenAPI user interface
 
-    location ~ ^/(actuator/health|admin/|api/|sso/|swagger-ui|v3/) {
+    location ~ ^/(actuator/health|admin([/?]|$)|api/|sso/|swagger-ui|v3/) {
         proxy_pass ${SERVER_URL};
         proxy_set_header Host $http_host;
     }


### PR DESCRIPTION
Currently, Nginx is configured to pass requests whose URL paths start with
`/admin/` through to terraware-server. But people sometimes forget the trailing
slash, and `/admin` doesn't match the passthrough rule so they get redirected to
the web app's home page.

Update the rule so that it matches URL paths that start with `/admin` if there
are no more characters in the path or if the next character is `/` or `?`. That
way if we add, say, `/administration` as a path, it won't match the rule.
