### PR TITLE
SW-2447 Fix Extra Header Spacing

### DIFF
--- a/src/components/emptyStatePages/EmptyStatePage.tsx
+++ b/src/components/emptyStatePages/EmptyStatePage.tsx
@@ -45,6 +45,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     maxWidth: '800px',
     width: (props: StyleProps) => (props.isMobile ? 'auto' : '800px'),
   },
+  spacer: {
+    padding: theme.spacing(3),
+  },
 }));
 
 export const EMPTY_STATE_CONTENT_STYLES = {
@@ -274,6 +277,10 @@ export default function EmptyStatePage({
     }
   };
 
+  const spacer = () => {
+    return <div className={classes.spacer} />;
+  };
+
   return (
     <TfMain backgroundImageVisible={backgroundImageVisible}>
       {organization && (
@@ -291,7 +298,12 @@ export default function EmptyStatePage({
           />
         </>
       )}
-      {content.title1 && <PageHeader title={content.title1} subtitle='' />}
+      {content.title1 && (
+        <>
+          <PageHeader title={content.title1} subtitle='' />
+          {!isMobile && spacer()}
+        </>
+      )}
       {content.listItems.length === 0 && content.linkLocation === undefined ? (
         <EmptyMessage className={classes.message} title={content.title2} text={content.subtitle} />
       ) : (

--- a/src/components/seeds/PageHeader.tsx
+++ b/src/components/seeds/PageHeader.tsx
@@ -5,7 +5,6 @@ import { SelectedOrgInfo, ServerOrganization } from 'src/types/Organization';
 import PageSnackbar from 'src/components/PageSnackbar';
 import { Container, Grid, Box, Typography, Theme, useTheme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import useDeviceInfo from 'src/utils/useDeviceInfo';
 import { Icon } from '@terraware/web-components';
 import strings from '../../strings';
 
@@ -59,7 +58,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface Props {
   title?: string | string[];
   subtitle?: string | React.ReactNode;
-  children?: React.ReactNode;
+  children?: React.ReactNode[];
   rightComponent?: React.ReactNode;
   page?: string;
   parentPage?: string;
@@ -116,7 +115,7 @@ export default function PageHeader({
         )}
         <Grid item xs={12} className={classes.flex}>
           <div className={classes.mainContent}>
-            <Box padding={theme.spacing(0, 3, children ? 3 : 0, 3)}>
+            <Box padding={theme.spacing(0, 3, children?.some((el) => el) ? 3 : 0, 3)}>
               <Box display='flex' justifyContent='space-between' alignItems='center'>
                 <Typography
                   id='title'

--- a/src/components/seeds/PageHeader.tsx
+++ b/src/components/seeds/PageHeader.tsx
@@ -9,16 +9,12 @@ import useDeviceInfo from 'src/utils/useDeviceInfo';
 import { Icon } from '@terraware/web-components';
 import strings from '../../strings';
 
-interface StyleProps {
-  isMobile: boolean;
-}
-
 const useStyles = makeStyles((theme: Theme) => ({
   mainContainer: {
     '&.MuiContainer-root': {
       paddingLeft: 0,
       paddingRight: 0,
-      paddingBottom: (props: StyleProps) => (props.isMobile ? theme.spacing(4) : theme.spacing(10)),
+      paddingBottom: theme.spacing(4),
     },
   },
   container: {
@@ -93,8 +89,7 @@ export default function PageHeader({
   showFacility,
   titleClassName,
 }: Props): JSX.Element {
-  const { isMobile } = useDeviceInfo();
-  const classes = useStyles({ isMobile });
+  const classes = useStyles();
   const theme = useTheme();
 
   const getPageHeading = () => {

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -546,6 +546,10 @@ export default function Database(props: DatabaseProps): JSX.Element {
     </>
   );
 
+  const emptyStateSpacer = () => {
+    return <Grid item xs={12} padding={theme.spacing(3)} />;
+  };
+
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
       {selectedOrgInfo.selectedFacility && (
@@ -669,17 +673,23 @@ export default function Database(props: DatabaseProps): JSX.Element {
                   </Grid>
                 </>
               ) : isAdmin(organization) ? (
-                <EmptyMessage
-                  className={classes.message}
-                  title={emptyMessageStrings.ONBOARDING_ADMIN_TITLE}
-                  rowItems={getEmptyState()}
-                />
+                <>
+                  {!isMobile && emptyStateSpacer()}
+                  <EmptyMessage
+                    className={classes.message}
+                    title={emptyMessageStrings.ONBOARDING_ADMIN_TITLE}
+                    rowItems={getEmptyState()}
+                  />
+                </>
               ) : (
-                <EmptyMessage
-                  className={classes.message}
-                  title={emptyMessageStrings.REACH_OUT_TO_ADMIN_TITLE}
-                  text={emptyMessageStrings.NO_SEEDBANKS_NON_ADMIN_MSG}
-                />
+                <>
+                  {!isMobile && emptyStateSpacer()}
+                  <EmptyMessage
+                    className={classes.message}
+                    title={emptyMessageStrings.REACH_OUT_TO_ADMIN_TITLE}
+                    text={emptyMessageStrings.NO_SEEDBANKS_NON_ADMIN_MSG}
+                  />
+                </>
               )}
             </Grid>
           ) : (

--- a/src/components/seeds/summary/index.tsx
+++ b/src/components/seeds/summary/index.tsx
@@ -131,7 +131,7 @@ export default function SeedSummary(props: SeedSummaryProps): JSX.Element {
         {organization && summary ? (
           <Grid container spacing={3}>
             {isEmptyState === true && (
-              <Grid item xs={12}>
+              <Grid item xs={12} paddingBottom={theme.spacing(1)}>
                 <Box
                   sx={{
                     background: theme.palette.TwClrBgInfoTertiary,


### PR DESCRIPTION
- extra spacing was added to PageHeader for some empty states
- remove it from PageHeader
- add spacing to appropriate empty state components
- fix PageHeader child spacing

example extra spacing:
before:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/114949086/205317525-96f0eafa-4f8d-4fa7-89c2-77c34ac58bee.png">

after:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/114949086/205327161-f64b1b1c-0cc2-468e-a3b8-67298baca956.png">
