### PR TITLE
SW-2433: Update Navigation Items so Items are Correctly Nested

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -219,19 +219,19 @@ export default function NavBar({
                 }}
                 id='nurseries'
               />
+              {trackingEnabled && (
+                <NavItem
+                  label={strings.PLANTING_SITES}
+                  selected={!!isPlantingSitesRoute}
+                  onClick={() => {
+                    closeAndNavigateTo(APP_PATHS.PLANTING_SITES);
+                  }}
+                  id='plantingSites'
+                />
+              )}
             </SubNavbar>
           </NavItem>
         </>
-      )}
-      {trackingEnabled && (
-        <NavItem
-          label={strings.PLANTING_SITES}
-          selected={!!isPlantingSitesRoute}
-          onClick={() => {
-            closeAndNavigateTo(APP_PATHS.PLANTING_SITES);
-          }}
-          id='plantingSites'
-        />
       )}
 
       <NavFooter>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -153,18 +153,25 @@ export default function NavBar({
         </SubNavbar>
       </NavItem>
       {trackingEnabled && (
-        <>
-          <NavSection title={strings.PLANTS.toUpperCase()} />
-          <NavItem
-            label={strings.DASHBOARD}
-            icon='iconRestorationSite'
-            selected={!!isPlantsDashboardRoute}
-            onClick={() => {
-              closeAndNavigateTo(APP_PATHS.PLANTS_DASHBOARD);
-            }}
-            id='plants-dashboard'
-          />
-        </>
+        <NavItem
+          label={strings.PLANTS}
+          icon='iconRestorationSite'
+          id='plants'
+          onClick={() => {
+            closeAndNavigateTo(APP_PATHS.PLANTS_DASHBOARD);
+          }}
+        >
+          <SubNavbar>
+            <NavItem
+              label={strings.DASHBOARD}
+              selected={!!isPlantsDashboardRoute}
+              onClick={() => {
+                closeAndNavigateTo(APP_PATHS.PLANTS_DASHBOARD);
+              }}
+              id='plants-dashboard'
+            />
+          </SubNavbar>
+        </NavItem>
       )}
       {role && ['Admin', 'Owner'].includes(role) && (
         <>

--- a/src/components/accession2/view/DetailPanel.tsx
+++ b/src/components/accession2/view/DetailPanel.tsx
@@ -190,7 +190,7 @@ export default function DetailPanel(props: DetailPanelProps): JSX.Element {
             <Grid item xs={gridRightSide} sx={valueStyle}>
               {`${strings.COLLECTED_FROM}${numPlants === undefined ? '' : ' ' + numPlants}${
                 collectionSource && collectionSource !== 'Other' ? ' ' + collectionSource : ''
-              } ${isNotPlural ? strings.PLANT : strings.PLANTS}`}
+              } ${isNotPlural ? strings.PLANT : strings.PLANTS.toLowerCase()}`}
               {accession.plantId ? <Typography>{`${strings.PLANT_ID}: ${accession.plantId}`}</Typography> : ''}
               {accession.notes ? (
                 <Box marginTop={2} display='flex'>

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -567,7 +567,7 @@ const strings = new LocalizedStrings({
     PLANT_DESCRIPTION: 'Plant Description',
     OPT_IN: 'Opt-In Features',
     PLANT: 'plant',
-    PLANTS: 'plants',
+    PLANTS: 'Plants',
     OR_SEED_WEIGHT: 'or Seed Weight',
     WEIGHT_TO_COUNT_CALCULATOR: 'Weight to Count Calculator',
     SUBSET_COUNT: 'Subset Count',


### PR DESCRIPTION
This PR moves a couple of nav items around to align with the newer nested navigation hierarchy:

- Created nested "Plants" nav item
- Move Plants Dashboard under the new parent "Plants" item
- Move Planting Sites under the parent "Locations" item

## Screenshots

### AFTER

<img width="142" alt="Screen Shot 2022-12-02 at 2 06 43 PM" src="https://user-images.githubusercontent.com/1474361/205411561-626a82cf-7a90-426c-896e-e49491292bad.png">

### BEFORE

<img width="143" alt="Screen Shot 2022-12-02 at 2 06 18 PM" src="https://user-images.githubusercontent.com/1474361/205411563-aed1a3eb-9428-4680-81d3-4b0b87e0dc47.png">
