### PR TITLE
SW-2482 Fix ghost area where page card was not clickable

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/styled-engine-sc": "^5.8.0",
     "@mui/styles": "^5.8.7",
     "@mui/x-date-pickers": "^5.0.0-alpha.7",
-    "@terraware/web-components": "^2.0.28",
+    "@terraware/web-components": "^2.0.29",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/styled-engine-sc": "^5.8.0",
     "@mui/styles": "^5.8.7",
     "@mui/x-date-pickers": "^5.0.0-alpha.7",
-    "@terraware/web-components": "^2.0.29",
+    "@terraware/web-components": "^2.0.30",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/components/common/PageCard.tsx
+++ b/src/components/common/PageCard.tsx
@@ -51,7 +51,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontWeight: 400,
   },
   link: {
-    marginTop: '28px',
     display: 'block',
     fontSize: '16px',
     fontWeight: 500,
@@ -118,7 +117,7 @@ export default function PageCard(props: PageCardProps): JSX.Element {
         {description}
       </Typography>
       {linkStyle === 'plain' && (
-        <Box onClick={stopBubblingEvent}>
+        <Box onClick={stopBubblingEvent} marginTop='28px'>
           <Link className={classes.link} component={RouterLink} to={link}>
             {linkText}
           </Link>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2446,10 +2446,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^2.0.29":
-  version "2.0.29"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.29.tgz#3e0bb1eef64969b908a3d50477472c94648ae045"
-  integrity sha512-O4lAJrrig3edjKxmro49kQfVO0JBSA468BwwWUPlI7tY1jnZGpul2CscCc4C/3GvAAxzvAWH8Y6aSaXhOuDThQ==
+"@terraware/web-components@^2.0.30":
+  version "2.0.30"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.30.tgz#048f29432f81cb1ee0b00be4fecfde13038a1ff3"
+  integrity sha512-bq0FryZRnXFE6mscfxn6G9bmCMohPp+eYHBVfcTVGgeQDZQ8FzsVK2RKo2oDFuZrepkvEHrFdOPOuZzDk9Nc+Q==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.10.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2446,10 +2446,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^2.0.28":
-  version "2.0.28"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.28.tgz#4ed1b5c11607493a7ac27b68487ceb519641a1a0"
-  integrity sha512-Au5dLEBBGB1NwSr4y9yw4YPOFMMQEGZxmjHwJKUSfoPx/bG5qy/xiGqrK9gvtfmcHW/V0UZF/WlXKxL7w1tBLg==
+"@terraware/web-components@^2.0.29":
+  version "2.0.29"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.29.tgz#3e0bb1eef64969b908a3d50477472c94648ae045"
+  integrity sha512-O4lAJrrig3edjKxmro49kQfVO0JBSA468BwwWUPlI7tY1jnZGpul2CscCc4C/3GvAAxzvAWH8Y6aSaXhOuDThQ==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.10.11"


### PR DESCRIPTION
- moved margin to the wrapper around link
- otherwise the margin was within wrapper which does not allow clicks to escape
- also update npm version for web-components