### PR TITLE
SW-2432: Fix Contact Us Navigation Item is Difficult to See

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/styled-engine-sc": "^5.8.0",
     "@mui/styles": "^5.8.7",
     "@mui/x-date-pickers": "^5.0.0-alpha.7",
-    "@terraware/web-components": "^2.0.31",
+    "@terraware/web-components": "^2.0.32",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/styled-engine-sc": "^5.8.0",
     "@mui/styles": "^5.8.7",
     "@mui/x-date-pickers": "^5.0.0-alpha.7",
-    "@terraware/web-components": "^2.0.30",
+    "@terraware/web-components": "^2.0.31",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2446,10 +2446,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^2.0.30":
-  version "2.0.30"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.30.tgz#048f29432f81cb1ee0b00be4fecfde13038a1ff3"
-  integrity sha512-bq0FryZRnXFE6mscfxn6G9bmCMohPp+eYHBVfcTVGgeQDZQ8FzsVK2RKo2oDFuZrepkvEHrFdOPOuZzDk9Nc+Q==
+"@terraware/web-components@^2.0.31":
+  version "2.0.31"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.31.tgz#acdcd98d3ce8506972c6d7f34e1eb4dee4c15439"
+  integrity sha512-BIyXlNtBxo5CE7o9k20ApUr/uCWoUWZSoHEdsyP81V8zuxRang0DV6D5OgxmhjbCRqLctcAafhr83dgawdXvSg==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.10.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2446,10 +2446,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^2.0.31":
-  version "2.0.31"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.31.tgz#acdcd98d3ce8506972c6d7f34e1eb4dee4c15439"
-  integrity sha512-BIyXlNtBxo5CE7o9k20ApUr/uCWoUWZSoHEdsyP81V8zuxRang0DV6D5OgxmhjbCRqLctcAafhr83dgawdXvSg==
+"@terraware/web-components@^2.0.32":
+  version "2.0.32"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.32.tgz#baad590754950b7b94793e2185c57e09704dceb5"
+  integrity sha512-OMEjLfbTIhSmnv0YXfos1TAtztnNP9gYAQ7JMtZ+4LJ8YZeJSlG7at8WIG2NVQLdLcKv95vtiUQ+WaTYRGyx+Q==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.10.11"


### PR DESCRIPTION
This PR applies the style `mix-blend-mode: multiply` to the `NavBar` to make it easier for users to see the Contact Us nav item.

## Screenshots

### AFTER
![localhost_3000_home (6)](https://user-images.githubusercontent.com/1474361/206284275-ec2f218b-c007-4490-a7a9-671e15d10af9.png)

### BEFORE

![localhost_3000_home (7)](https://user-images.githubusercontent.com/1474361/206284282-77cb3bd6-c8f3-4022-a753-5726bf256329.png)
