### PR TITLE
SW-2481: Page header styling fixes

### DIFF
--- a/src/components/common/PageHeaderWrapper.tsx
+++ b/src/components/common/PageHeaderWrapper.tsx
@@ -99,7 +99,6 @@ export default function PageHeaderWrapper({ children, nextElement, nextElementIn
 
   const styles: Record<string, any> = {
     background: debouncedSticky ? theme.palette.TwClrBaseGray025 : undefined,
-    boxShadow: debouncedSticky ? `0px 3px 3px -3px ${theme.palette.TwClrBaseGray200}` : undefined,
     paddingRight: debouncedSticky ? theme.spacing(4) : undefined,
     paddingTop: debouncedSticky ? theme.spacing(4) : undefined,
     position: debouncedSticky ? 'fixed' : undefined,
@@ -108,6 +107,9 @@ export default function PageHeaderWrapper({ children, nextElement, nextElementIn
     animation: anim,
     width: '-webkit-fill-available',
     zIndex: debouncedSticky ? 100 : undefined,
+    '& > div': {
+      boxShadow: debouncedSticky ? `0px 3px 3px -3px ${theme.palette.TwClrBaseGray200}` : undefined,
+    },
   };
 
   return (

--- a/src/components/common/PageHeaderWrapper.tsx
+++ b/src/components/common/PageHeaderWrapper.tsx
@@ -99,6 +99,13 @@ export default function PageHeaderWrapper({ children, nextElement, nextElementIn
 
   const styles: Record<string, any> = {
     background: debouncedSticky ? theme.palette.TwClrBaseGray025 : undefined,
+    borderBottom: debouncedSticky ? '1px solid' : '1px transparent',
+    borderImage: debouncedSticky
+      ? `linear-gradient(to right, ${theme.palette.TwClrBaseGray300}00,` +
+        `${theme.palette.TwClrBaseGray300}FF, ${theme.palette.TwClrBaseGray300}FF,` +
+        `${theme.palette.TwClrBaseGray300}FF, ${theme.palette.TwClrBaseGray300}00) 1`
+      : undefined,
+    boxShadow: 'none',
     paddingRight: debouncedSticky ? theme.spacing(4) : undefined,
     paddingTop: debouncedSticky ? theme.spacing(4) : undefined,
     position: debouncedSticky ? 'fixed' : undefined,
@@ -107,14 +114,6 @@ export default function PageHeaderWrapper({ children, nextElement, nextElementIn
     animation: anim,
     width: '-webkit-fill-available',
     zIndex: debouncedSticky ? 100 : undefined,
-    '& > div': {
-      borderBottom: '1px solid',
-      borderImage:
-        `linear-gradient(to right, ${theme.palette.TwClrBaseGray300}00,` +
-        `${theme.palette.TwClrBaseGray300}FF, ${theme.palette.TwClrBaseGray300}FF,` +
-        `${theme.palette.TwClrBaseGray300}FF, ${theme.palette.TwClrBaseGray300}00) 1`,
-      boxShadow: 'none',
-    },
   };
 
   return (

--- a/src/components/common/PageHeaderWrapper.tsx
+++ b/src/components/common/PageHeaderWrapper.tsx
@@ -108,7 +108,12 @@ export default function PageHeaderWrapper({ children, nextElement, nextElementIn
     width: '-webkit-fill-available',
     zIndex: debouncedSticky ? 100 : undefined,
     '& > div': {
-      boxShadow: debouncedSticky ? `0px 3px 3px -3px ${theme.palette.TwClrBaseGray200}` : undefined,
+      borderBottom: '1px solid',
+      borderImage:
+        `linear-gradient(to right, ${theme.palette.TwClrBaseGray300}00,` +
+        `${theme.palette.TwClrBaseGray300}FF, ${theme.palette.TwClrBaseGray300}FF,` +
+        `${theme.palette.TwClrBaseGray300}FF, ${theme.palette.TwClrBaseGray300}00) 1`,
+      boxShadow: 'none',
     },
   };
 


### PR DESCRIPTION
This PR fixes some styles in the page header:

- Page header box shadow should stop 32px from the right edge of the screen
- Page header box shadow & stroke should match cancel/save action bar

## Screenshots

### AFTER

![localhost_3000_accessions (2)](https://user-images.githubusercontent.com/1474361/206330217-a916eed3-3eda-47b0-98a9-36a1902d840c.png)

### BEFORE

![localhost_3000_accessions (1)](https://user-images.githubusercontent.com/1474361/206317653-89011547-654a-4ec9-900d-4ae5eaea3d95.png)