### PR TITLE
SW-2534 Clean up notifications context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,6 @@ import TopBar from 'src/components/TopBar/TopBar';
 import TopBarContent from 'src/components/TopBar/TopBarContent';
 import { APP_PATHS } from 'src/constants';
 import ErrorBoundary from 'src/ErrorBoundary';
-import { Notifications } from 'src/types/Notifications';
 import { ServerOrganization } from 'src/types/Organization';
 import { User } from 'src/types/User';
 import { FacilityType } from 'src/api/types/facilities';
@@ -147,7 +146,6 @@ export default function App() {
   const [selectedOrganization, setSelectedOrganization] = useState<ServerOrganization>();
   const [preferencesOrg, setPreferencesOrg] = useState<{ [key: string]: unknown }>();
   const [orgScopedPreferences, setOrgScopedPreferences] = useState<{ [key: string]: unknown }>();
-  const [notifications, setNotifications] = useState<Notifications>();
   const { isProduction } = useEnvironment();
   const trackingEnabled = isRouteEnabled('Tracking V1');
 
@@ -340,8 +338,6 @@ export default function App() {
         <StyledEngineProvider injectFirst>
           <TopBar fullWidth={true}>
             <TopBarContent
-              notifications={notifications}
-              setNotifications={setNotifications}
               organizations={organizations}
               selectedOrganization={selectedOrganization}
               setSelectedOrganization={setSelectedOrganization}
@@ -429,8 +425,6 @@ export default function App() {
       <ToastSnackbar />
       <TopBar>
         <TopBarContent
-          notifications={notifications}
-          setNotifications={setNotifications}
           organizations={organizations}
           selectedOrganization={selectedOrganization}
           setSelectedOrganization={setSelectedOrganization}

--- a/src/components/NotificationsDropdown.tsx
+++ b/src/components/NotificationsDropdown.tsx
@@ -139,8 +139,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 type NotificationsDropdownProps = {
-  notifications?: Notifications;
-  setNotifications: (notifications?: Notifications) => void;
   organizationId?: number;
   reloadOrganizationData: (selectedOrgId?: number) => void;
 };
@@ -148,10 +146,11 @@ type NotificationsDropdownProps = {
 export default function NotificationsDropdown(props: NotificationsDropdownProps): JSX.Element {
   const classes = useStyles({});
   const history = useHistory();
-  const { notifications, setNotifications, organizationId, reloadOrganizationData } = props;
+  const { organizationId, reloadOrganizationData } = props;
   // notificationsInterval value is only being used when it is set.
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
   const [lastSeen, setLastSeen] = useState<number>(0);
+  const [notifications, setNotifications] = useState<Notifications>();
 
   const populateNotifications = useCallback(async () => {
     const notificationsData = await getNotifications();
@@ -165,7 +164,7 @@ export default function NotificationsDropdown(props: NotificationsDropdownProps)
       return dateB.getTime() - dateA.getTime();
     });
     setNotifications(notificationsData);
-  }, [setNotifications, organizationId]);
+  }, [organizationId]);
 
   useEffect(() => {
     // Update notifications now.

--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -3,7 +3,6 @@ import { makeStyles } from '@mui/styles';
 import { Svg } from '@terraware/web-components';
 import React from 'react';
 
-import { Notifications } from 'src/types/Notifications';
 import { ServerOrganization } from 'src/types/Organization';
 import { User } from 'src/types/User';
 import Icon from '../common/icon/Icon';
@@ -48,8 +47,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 type TopBarProps = {
-  notifications?: Notifications;
-  setNotifications: (notifications?: Notifications) => void;
   organizations?: ServerOrganization[];
   setSelectedOrganization: React.Dispatch<React.SetStateAction<ServerOrganization | undefined>>;
   selectedOrganization?: ServerOrganization;
@@ -62,7 +59,6 @@ type TopBarProps = {
 export default function TopBarContent(props: TopBarProps): JSX.Element | null {
   const classes = useStyles();
   const {
-    setNotifications,
     setSelectedOrganization,
     selectedOrganization,
     organizations,
@@ -97,8 +93,6 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
       </div>
       <div className={classes.right}>
         <NotificationsDropdown
-          notifications={props.notifications}
-          setNotifications={setNotifications}
           organizationId={selectedOrganization?.id}
           reloadOrganizationData={reloadOrganizationData}
         />
@@ -120,8 +114,6 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
 
       <Grid item xs={3} className={classes.right}>
         <NotificationsDropdown
-          notifications={props.notifications}
-          setNotifications={setNotifications}
           organizationId={selectedOrganization?.id}
           reloadOrganizationData={reloadOrganizationData}
         />


### PR DESCRIPTION
- notifications state was being held in the root level App
- probably an artifact of previous notifications design
- every time notifications were fetched (every minute), the app would re-render unnecessarily (due to notifications state change)
- moved notifications state into the notifications dropdown
- removed all the plumbing to App