### PR TITLE
SW-2465 Fix map resize issues

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -194,6 +194,7 @@ export default function Map(props: MapProps): JSX.Element {
         onClick={onMapClick}
         style={style}
         attributionControl={false}
+        onRender={(event) => event.target.resize()}
       >
         {mapSources}
         <NavigationControl showCompass={false} style={navControlStyle} position='bottom-right' />

--- a/src/components/Plants/PlantingSiteDashboardMap.tsx
+++ b/src/components/Plants/PlantingSiteDashboardMap.tsx
@@ -69,7 +69,7 @@ export default function PlantingSiteDashboardMap(props: PlantingSiteDashboardMap
           style={MAP_STYLE}
           contextRenderer={contextRenderer}
         />
-      ) : isMobile ? null : (
+      ) : isMobile || !plots ? null : (
         <GenericMap
           style={MAP_STYLE}
           bannerMessage={contributor ? strings.GENERIC_MAP_MESSAGE_CONTRIBUTOR : strings.GENERIC_MAP_MESSAGE_ADMIN}

--- a/src/components/Plants/PlantingSiteDetails.tsx
+++ b/src/components/Plants/PlantingSiteDetails.tsx
@@ -58,6 +58,7 @@ export default function PlantingSiteDetails(props: PlantingSiteDetailsProps): JS
   const mapCardStyle = {
     marginBottom: 3,
     borderRadius: '24px',
+    flexGrow: 1,
   };
 
   useEffect(() => {

--- a/src/components/Plants/index.tsx
+++ b/src/components/Plants/index.tsx
@@ -141,7 +141,7 @@ export default function PlantsDashboard(props: PlantsDashboardProps): JSX.Elemen
       <Grid item xs={12}>
         <PageSnackbar />
       </Grid>
-      <Box ref={contentRef}>
+      <Box ref={contentRef} display='flex' flexGrow={1}>
         <PlantingSiteDetails
           plantingSite={selectedPlantingSite}
           updatePlotPreferences={(plotId) =>


### PR DESCRIPTION
- removed map render while data is loading, so there's no double render of maps
- added flex height since that design want the map to use full height even if charts don't
- added a re-render hook on map to fit map to size (solution online)

<img width="407" alt="Terraware App 2022-12-14 10-47-06" src="https://user-images.githubusercontent.com/1865174/207685701-7cb1bac2-491a-49b2-b9a4-9a9c65b59154.png">

<img width="888" alt="Terraware App 2022-12-14 10-46-28" src="https://user-images.githubusercontent.com/1865174/207685708-b3a76030-e050-44c0-a45d-3b384f05b424.png">
