### PR TITLE
SW-2538 Reassignments table column changes

### DIFF
--- a/src/components/NurseryWithdrawals/NurseryReassignment.tsx
+++ b/src/components/NurseryWithdrawals/NurseryReassignment.tsx
@@ -27,7 +27,6 @@ const columns: TableColumnType[] = [
   { key: 'zoneName', name: strings.ZONE, type: 'string' },
   { key: 'originalPlot', name: strings.ORIGINAL_PLOT, type: 'string' },
   { key: 'newPlot', name: strings.NEW_PLOT, type: 'string' },
-  { key: 'numPlants', name: strings.QUANTITY, type: 'number' },
   { key: 'reassign', name: strings.REASSIGN, type: 'string' },
   { key: 'notes', name: strings.NOTES, type: 'string' },
 ];

--- a/src/components/NurseryWithdrawals/ReassignmentRenderer.tsx
+++ b/src/components/NurseryWithdrawals/ReassignmentRenderer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material';
+import { Box, Typography, Theme } from '@mui/material';
 import CellRenderer, { TableRowType } from 'src/components/common/table/TableCellRenderer';
 import { RendererProps } from 'src/components/common/table/types';
 import { Autocomplete, Textfield } from '@terraware/web-components';
@@ -91,15 +91,20 @@ export default function ReassignmentRenderer({ plots, setReassignment }: Reassig
 
     if (column.key === 'reassign') {
       const value = (
-        <Textfield
-          id={`quantity_${plantingId}`}
-          type='text'
-          onChange={onUpdateQuantity}
-          value={quantity}
-          label={''}
-          errorText={error.quantity}
-          className={classes.input}
-        />
+        <Box display='flex' alignItems={error.quantity ? 'start' : 'center'}>
+          <Textfield
+            id={`quantity_${plantingId}`}
+            type='text'
+            onChange={onUpdateQuantity}
+            value={quantity}
+            label={''}
+            errorText={error.quantity}
+            className={classes.input}
+          />
+          <Typography paddingLeft={1} paddingTop={error.quantity ? '10px' : 0}>
+            / {numPlants}
+          </Typography>
+        </Box>
       );
 
       return <CellRenderer {...props} value={value} />;


### PR DESCRIPTION
- show numplants in same column as quantity edit
- no longer a column on its own
- this is consistent with batch withdrawals design

<img width="744" alt="Terraware App 2022-12-14 11-31-59" src="https://user-images.githubusercontent.com/1865174/207697014-351ff54b-34a0-48d7-9be9-c992028710b4.png">

<img width="753" alt="Terraware App 2022-12-14 11-29-07" src="https://user-images.githubusercontent.com/1865174/207697023-0d379b9a-a278-4891-bbe9-2d3e8b3e2b32.png">
