### PR TITLE
Set Cursor for Withdrawal Details Photos

### DIFF
--- a/src/components/NurseryWithdrawals/WithdrawalDetails/sections/Photos.tsx
+++ b/src/components/NurseryWithdrawals/WithdrawalDetails/sections/Photos.tsx
@@ -62,6 +62,7 @@ export default function Photos({ withdrawalId }: PhotosSectionProps): JSX.Elemen
             marginTop={theme.spacing(2)}
             maxWidth='500px'
             overflow='hidden'
+            sx={{ cursor: 'pointer' }}
           >
             <img
               src={`${photoUrl}?maxHeight=250`}


### PR DESCRIPTION
- set `cursor: pointer` for the `Box` containing the `img`