### PR TITLE
SW-2441 Fix Error focus active input field on withdrawal form batches cut off on left

### DIFF
--- a/src/components/Inventory/withdraw/flow/WithdrawalBatchesCellRenderer.tsx
+++ b/src/components/Inventory/withdraw/flow/WithdrawalBatchesCellRenderer.tsx
@@ -11,6 +11,7 @@ const useStyles = makeStyles(() => ({
     fontSize: '14px',
     '& > p': {
       fontSize: '14px',
+      overflow: 'visible',
     },
   },
   input: {


### PR DESCRIPTION
When focusing on input field, the border increases to 2px and takes more space, so the fix was remove overflow: hidden to avoid cutting off the border

<img width="201" alt="Screenshot 2022-12-19 at 13 30 26" src="https://user-images.githubusercontent.com/5919083/208473762-3f981215-25a0-476c-9ffc-16947de1e6dc.png">
