### PR TITLE
SW-2437 Fix wrapping of zone and plot selectors

### DIFF
--- a/src/components/PlotSelector/index.tsx
+++ b/src/components/PlotSelector/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid, Typography, useTheme } from '@mui/material';
+import { Box, Typography, useTheme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { Autocomplete } from '@terraware/web-components';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
@@ -57,8 +57,6 @@ export default function PlotSelector(props: PlotSelectorProps): JSX.Element {
     onPlotSelected(foundPlot);
   };
 
-  const gridSize = () => (isMobile ? 12 : 6);
-
   const isEqual = (optionA: any, optionB: any) => {
     if (optionA?.value && optionB?.value) {
       return optionA.value === optionB.value;
@@ -72,7 +70,7 @@ export default function PlotSelector(props: PlotSelectorProps): JSX.Element {
       fontWeight={500}
       color={theme.palette.ClrTextFill}
       marginRight={theme.spacing(1)}
-      minWidth={isMobile ? '40px' : 'auto'}
+      minWidth='40px'
       textAlign='right'
     >
       {text}
@@ -86,15 +84,17 @@ export default function PlotSelector(props: PlotSelectorProps): JSX.Element {
   };
 
   return (
-    <Grid
+    <Box
       display='flex'
-      margin={theme.spacing(1, 0, 2)}
+      flexWrap='wrap'
       flexDirection={isMobile ? 'column' : 'row'}
+      flexGrow={1}
+      margin={theme.spacing(1, 0, 2)}
       className={horizontalLayout ? `${classes.horizontal}` : ''}
     >
-      <Grid
-        xs={gridSize()}
-        margin={theme.spacing(2, isMobile ? 0 : 2, 0, 0)}
+      <Box
+        flexGrow={1}
+        margin={theme.spacing(2, isMobile || horizontalLayout ? 0 : 2, 0, 0)}
         sx={horizontalLayout ? horizontalStyle : {}}
       >
         {horizontalLayout && horizontalLabel(strings.ZONE)}
@@ -111,8 +111,8 @@ export default function PlotSelector(props: PlotSelectorProps): JSX.Element {
           freeSolo={false}
           hideClearIcon={true}
         />
-      </Grid>
-      <Grid xs={gridSize()} margin={theme.spacing(2, 0, 0)} sx={horizontalLayout ? horizontalStyle : {}}>
+      </Box>
+      <Box flexGrow={1} margin={theme.spacing(2, 0, 0)} sx={horizontalLayout ? horizontalStyle : {}}>
         {horizontalLayout && horizontalLabel(strings.PLOT)}
         <Autocomplete
           id='plot'
@@ -127,7 +127,7 @@ export default function PlotSelector(props: PlotSelectorProps): JSX.Element {
           freeSolo={false}
           hideClearIcon={true}
         />
-      </Grid>
-    </Grid>
+      </Box>
+    </Box>
   );
 }


### PR DESCRIPTION
- switched to Box instead of Grid which did not work well for wrapping
- finer control with Box gives us better wrapping for all breakpoints in all use-cases of the selectors
- screenshots attached

<img width="220" alt="Terraware App 2022-12-19 10-32-14" src="https://user-images.githubusercontent.com/1865174/208496006-6e5fa504-a276-40f5-a307-2b9cdc087dbd.png">

<img width="301" alt="Terraware App 2022-12-19 10-31-53" src="https://user-images.githubusercontent.com/1865174/208496009-2c2fd894-bdde-4fc6-80b6-8e152aa0fa4e.png">

<img width="773" alt="Terraware App 2022-12-19 10-31-25" src="https://user-images.githubusercontent.com/1865174/208496012-d453eb9e-46cd-498f-8574-9718efa31fb3.png">

<img width="228" alt="Terraware App 2022-12-19 10-30-59" src="https://user-images.githubusercontent.com/1865174/208496020-10390806-e00e-41d3-a3d5-d07d79b581de.png">

<img width="480" alt="Terraware App 2022-12-19 10-30-36" src="https://user-images.githubusercontent.com/1865174/208496023-eb5577f2-c8b2-4d80-951f-244f13506fb6.png">

<img width="827" alt="Terraware App 2022-12-19 10-30-17" src="https://user-images.githubusercontent.com/1865174/208496028-a58a2097-3ffa-41b5-bfc2-aa24f9c0e878.png">
