### PR TITLE
SW-2467 Use consistent spacing between page and bottom cancel/save bar

### DIFF
--- a/src/components/EditOrganization/index.tsx
+++ b/src/components/EditOrganization/index.tsx
@@ -7,7 +7,7 @@ import { ServerOrganization } from 'src/types/Organization';
 import TextField from '../common/Textfield/Textfield';
 import useForm from 'src/utils/useForm';
 import Select from '../common/Select/Select';
-import FormBottomBar from '../common/FormBottomBar';
+import PageForm from '../common/PageForm';
 import { Country, Subdivision } from 'src/types/Country';
 import { searchCountries } from 'src/api/country/country';
 import { updateOrganization } from 'src/api/organization/organization';
@@ -117,66 +117,67 @@ export default function OrganizationView({ organization, reloadOrganizationData 
 
   return (
     <TfMain>
-      <Box margin={theme.spacing(0, 3, 4, 3)}>
-        <Box display='flex' flexDirection='column' justifyContent='space-between' marginBottom={theme.spacing(1)}>
-          <Typography margin={0} fontSize='24px' fontWeight={600}>
-            {strings.ORGANIZATION}
-          </Typography>
-          <PageSnackbar />
+      <PageForm onCancel={goToOrganization} onSave={saveOrganization}>
+        <Box margin={theme.spacing(0, 3, 4, 3)}>
+          <Box display='flex' flexDirection='column' justifyContent='space-between' marginBottom={theme.spacing(1)}>
+            <Typography margin={0} fontSize='24px' fontWeight={600}>
+              {strings.ORGANIZATION}
+            </Typography>
+            <PageSnackbar />
+          </Box>
         </Box>
-      </Box>
-      <Grid
-        container
-        sx={{
-          backgroundColor: theme.palette.TwClrBg,
-          borderRadius: '32px',
-          padding: theme.spacing(3),
-          marginBottom: isMobile ? theme.spacing(40) : theme.spacing(6),
-        }}
-      >
-        <Grid item xs={gridSize()} paddingBottom={theme.spacing(4)}>
-          <TextField
-            id='name'
-            label={strings.ORGANIZATION_NAME_REQUIRED}
-            type='text'
-            onChange={onChange}
-            value={organizationRecord.name}
-            errorText={organizationRecord.name ? '' : nameError}
-          />
-        </Grid>
-        <Grid item xs={gridSize()} paddingLeft={isMobile ? 0 : theme.spacing(2)} paddingBottom={theme.spacing(4)}>
-          <TextField
-            id='description'
-            label={strings.DESCRIPTION}
-            type='textarea'
-            onChange={onChange}
-            value={organizationRecord.description}
-          />
-        </Grid>
-        <Grid item xs={gridSize()} paddingBottom={isMobile ? theme.spacing(4) : 0}>
-          <Select
-            label={strings.COUNTRY}
-            id='countyCode'
-            onChange={onChangeCountry}
-            options={countries?.map((country) => country.name)}
-            selectedValue={getSelectedCountry()?.name}
-            fullWidth
-          />
-        </Grid>
-        {getSelectedCountry()?.subdivisions && (
-          <Grid item xs={gridSize()} paddingLeft={isMobile ? 0 : theme.spacing(2)}>
+        <Grid
+          container
+          sx={{
+            backgroundColor: theme.palette.TwClrBg,
+            borderRadius: '32px',
+            padding: theme.spacing(3),
+            marginBottom: theme.spacing(10),
+          }}
+        >
+          <Grid item xs={gridSize()} paddingBottom={theme.spacing(4)}>
+            <TextField
+              id='name'
+              label={strings.ORGANIZATION_NAME_REQUIRED}
+              type='text'
+              onChange={onChange}
+              value={organizationRecord.name}
+              errorText={organizationRecord.name ? '' : nameError}
+            />
+          </Grid>
+          <Grid item xs={gridSize()} paddingLeft={isMobile ? 0 : theme.spacing(2)} paddingBottom={theme.spacing(4)}>
+            <TextField
+              id='description'
+              label={strings.DESCRIPTION}
+              type='textarea'
+              onChange={onChange}
+              value={organizationRecord.description}
+            />
+          </Grid>
+          <Grid item xs={gridSize()} paddingBottom={isMobile ? theme.spacing(4) : 0}>
             <Select
-              label={strings.STATE}
-              id='countySubdivisionCode'
-              onChange={onChangeSubdivision}
-              options={getSelectedCountry()?.subdivisions.map((subdivision) => subdivision.name)}
-              selectedValue={getSelectedSubdivision()?.name}
+              label={strings.COUNTRY}
+              id='countyCode'
+              onChange={onChangeCountry}
+              options={countries?.map((country) => country.name)}
+              selectedValue={getSelectedCountry()?.name}
               fullWidth
             />
           </Grid>
-        )}
-      </Grid>
-      <FormBottomBar onCancel={goToOrganization} onSave={saveOrganization} />
+          {getSelectedCountry()?.subdivisions && (
+            <Grid item xs={gridSize()} paddingLeft={isMobile ? 0 : theme.spacing(2)}>
+              <Select
+                label={strings.STATE}
+                id='countySubdivisionCode'
+                onChange={onChangeSubdivision}
+                options={getSelectedCountry()?.subdivisions.map((subdivision) => subdivision.name)}
+                selectedValue={getSelectedSubdivision()?.name}
+                fullWidth
+              />
+            </Grid>
+          )}
+        </Grid>
+      </PageForm>
     </TfMain>
   );
 }

--- a/src/components/Inventory/InventoryCreate.tsx
+++ b/src/components/Inventory/InventoryCreate.tsx
@@ -7,7 +7,7 @@ import useForm from 'src/utils/useForm';
 import { Box, Container, Divider, Grid, Typography, useTheme } from '@mui/material';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import Textfield from 'src/components/common/Textfield/Textfield';
-import FormBottomBar from 'src/components/common/FormBottomBar';
+import PageForm from 'src/components/common/PageForm';
 import { getTodaysDateFormatted } from '@terraware/web-components/utils';
 import useSnackbar from 'src/utils/useSnackbar';
 import { DatePicker } from '@terraware/web-components';
@@ -101,135 +101,137 @@ export default function CreateInventory(props: CreateInventoryProps): JSX.Elemen
 
   return (
     <TfMain>
-      <Typography sx={{ paddingLeft: theme.spacing(3), fontWeight: 600, fontSize: '24px' }}>
-        {strings.ADD_INVENTORY}
-      </Typography>
-      <Box
-        display='flex'
-        flexDirection='column'
-        margin='0 auto'
-        maxWidth='584px'
-        marginTop={5}
-        marginBottom={5}
-        padding={theme.spacing(0, 3)}
-      >
-        <Typography variant='h2' sx={{ fontSize: '20px', fontWeight: 'bold', paddingBottom: 1 }}>
+      <PageForm onCancel={goToInventory} onSave={saveInventory} saveButtonText={strings.SAVE}>
+        <Typography sx={{ paddingLeft: theme.spacing(3), fontWeight: 600, fontSize: '24px' }}>
           {strings.ADD_INVENTORY}
         </Typography>
-        <Typography sx={{ fontSize: '14px' }}>{strings.ADD_INVENTORY_DESCRIPTION}</Typography>
-        <Container
-          maxWidth={false}
-          sx={{
-            width: isMobile ? '100%' : '640px',
-            marginTop: theme.spacing(3),
-            border: `1px solid ${theme.palette.TwClrBrdrTertiary}`,
-            borderRadius: '16px',
-            paddingBottom: 3,
-            marginBottom: 5,
-          }}
+        <Box
+          display='flex'
+          flexDirection='column'
+          margin='0 auto'
+          maxWidth='584px'
+          marginTop={5}
+          marginBottom={5}
+          padding={theme.spacing(0, 3)}
         >
-          <Grid container padding={0}>
-            <Grid item xs={12} sx={marginTop}>
-              <Species2Dropdown
-                record={record}
-                organization={organization}
-                setRecord={setRecord}
-                validate={validateFields}
-              />
-            </Grid>
-            <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>
-              <NurseryDropdown
-                organization={organization}
-                record={record}
-                setRecord={setRecord}
-                validate={validateFields}
-                isSelectionValid={(r) => !!r?.facilityId}
-                label={strings.RECEIVING_NURSERY_REQUIRED}
-              />
-            </Grid>
-            <Grid item xs={gridSize()} sx={marginTop} paddingLeft={paddingSeparator}>
-              <DatePicker
-                id='dateAdded'
-                label={strings.DATE_ADDED_REQUIRED}
-                aria-label={strings.DATE_ADDED_REQUIRED}
-                value={record.addedDate}
-                onChange={changeDate}
-                errorText={validateFields && !record.addedDate ? strings.REQUIRED_FIELD : ''}
-              />
-            </Grid>
+          <Typography variant='h2' sx={{ fontSize: '20px', fontWeight: 'bold', paddingBottom: 1 }}>
+            {strings.ADD_INVENTORY}
+          </Typography>
+          <Typography sx={{ fontSize: '14px' }}>{strings.ADD_INVENTORY_DESCRIPTION}</Typography>
+          <Container
+            maxWidth={false}
+            sx={{
+              width: isMobile ? '100%' : '640px',
+              marginTop: theme.spacing(3),
+              border: `1px solid ${theme.palette.TwClrBrdrTertiary}`,
+              borderRadius: '16px',
+              paddingBottom: 3,
+              marginBottom: 5,
+              backgroundColor: theme.palette.TwClrBg,
+            }}
+          >
+            <Grid container padding={0}>
+              <Grid item xs={12} sx={marginTop}>
+                <Species2Dropdown
+                  record={record}
+                  organization={organization}
+                  setRecord={setRecord}
+                  validate={validateFields}
+                />
+              </Grid>
+              <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>
+                <NurseryDropdown
+                  organization={organization}
+                  record={record}
+                  setRecord={setRecord}
+                  validate={validateFields}
+                  isSelectionValid={(r) => !!r?.facilityId}
+                  label={strings.RECEIVING_NURSERY_REQUIRED}
+                />
+              </Grid>
+              <Grid item xs={gridSize()} sx={marginTop} paddingLeft={paddingSeparator}>
+                <DatePicker
+                  id='dateAdded'
+                  label={strings.DATE_ADDED_REQUIRED}
+                  aria-label={strings.DATE_ADDED_REQUIRED}
+                  value={record.addedDate}
+                  onChange={changeDate}
+                  errorText={validateFields && !record.addedDate ? strings.REQUIRED_FIELD : ''}
+                />
+              </Grid>
 
-            <Grid item xs={12} sx={marginTop}>
-              <Divider />
-            </Grid>
+              <Grid item xs={12} sx={marginTop}>
+                <Divider />
+              </Grid>
 
-            <Grid
-              item
-              xs={gridSize()}
-              paddingRight={paddingSeparator}
-              sx={{ ...marginTop, marginRight: isMobile ? 0 : theme.spacing(2) }}
-            >
-              <Textfield
-                id='germinatingQuantity'
-                value={record.germinatingQuantity}
-                onChange={onChange}
-                type='text'
-                label={strings.GERMINATING_QUANTITY_REQUIRED}
-                tooltipTitle={strings.TOOLTIP_GERMINATING_QUANTITY}
-                errorText={validateFields && !record.germinatingQuantity ? strings.REQUIRED_FIELD : ''}
-              />
+              <Grid
+                item
+                xs={gridSize()}
+                paddingRight={paddingSeparator}
+                sx={{ ...marginTop, marginRight: isMobile ? 0 : theme.spacing(2) }}
+              >
+                <Textfield
+                  id='germinatingQuantity'
+                  value={record.germinatingQuantity}
+                  onChange={onChange}
+                  type='text'
+                  label={strings.GERMINATING_QUANTITY_REQUIRED}
+                  tooltipTitle={strings.TOOLTIP_GERMINATING_QUANTITY}
+                  errorText={validateFields && !record.germinatingQuantity ? strings.REQUIRED_FIELD : ''}
+                />
+              </Grid>
+              <Grid item xs={12} sx={marginTop}>
+                <Divider />
+              </Grid>
+              <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>
+                <Textfield
+                  id='notReadyQuantity'
+                  value={record.notReadyQuantity}
+                  onChange={onChange}
+                  type='text'
+                  label={strings.NOT_READY_QUANTITY_REQUIRED}
+                  tooltipTitle={strings.TOOLTIP_NOT_READY_QUANTITY}
+                  errorText={validateFields && !record.notReadyQuantity ? strings.REQUIRED_FIELD : ''}
+                />
+              </Grid>
+              <Grid item xs={gridSize()} sx={marginTop} paddingLeft={paddingSeparator}>
+                <DatePicker
+                  id='readyByDate'
+                  label={strings.ESTIMATED_READY_DATE}
+                  aria-label={strings.ESTIMATED_READY_DATE}
+                  value={record.readyByDate}
+                  onChange={changeDate}
+                />
+              </Grid>
+              <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>
+                <Textfield
+                  id='readyQuantity'
+                  value={record.readyQuantity}
+                  onChange={onChange}
+                  type='text'
+                  label={strings.READY_QUANTITY_REQUIRED}
+                  tooltipTitle={strings.TOOLTIP_READY_QUANTITY}
+                  errorText={validateFields && !record.readyQuantity ? strings.REQUIRED_FIELD : ''}
+                />
+              </Grid>
+              <Grid item xs={12} sx={{ marginTop: theme.spacing(4) }}>
+                <Textfield
+                  id='totalQuantity'
+                  value={totalQuantity}
+                  onChange={onChange}
+                  type='text'
+                  label={strings.TOTAL_QUANTITY}
+                  display={true}
+                  tooltipTitle={strings.TOOLTIP_TOTAL_QUANTITY}
+                />
+              </Grid>
+              <Grid item xs={12} sx={{ marginTop: theme.spacing(4) }}>
+                <Textfield id='notes' value={record.notes} onChange={onChange} type='textarea' label={strings.NOTES} />
+              </Grid>
             </Grid>
-            <Grid item xs={12} sx={marginTop}>
-              <Divider />
-            </Grid>
-            <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>
-              <Textfield
-                id='notReadyQuantity'
-                value={record.notReadyQuantity}
-                onChange={onChange}
-                type='text'
-                label={strings.NOT_READY_QUANTITY_REQUIRED}
-                tooltipTitle={strings.TOOLTIP_NOT_READY_QUANTITY}
-                errorText={validateFields && !record.notReadyQuantity ? strings.REQUIRED_FIELD : ''}
-              />
-            </Grid>
-            <Grid item xs={gridSize()} sx={marginTop} paddingLeft={paddingSeparator}>
-              <DatePicker
-                id='readyByDate'
-                label={strings.ESTIMATED_READY_DATE}
-                aria-label={strings.ESTIMATED_READY_DATE}
-                value={record.readyByDate}
-                onChange={changeDate}
-              />
-            </Grid>
-            <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>
-              <Textfield
-                id='readyQuantity'
-                value={record.readyQuantity}
-                onChange={onChange}
-                type='text'
-                label={strings.READY_QUANTITY_REQUIRED}
-                tooltipTitle={strings.TOOLTIP_READY_QUANTITY}
-                errorText={validateFields && !record.readyQuantity ? strings.REQUIRED_FIELD : ''}
-              />
-            </Grid>
-            <Grid item xs={12} sx={{ marginTop: theme.spacing(4) }}>
-              <Textfield
-                id='totalQuantity'
-                value={totalQuantity}
-                onChange={onChange}
-                type='text'
-                label={strings.TOTAL_QUANTITY}
-                display={true}
-                tooltipTitle={strings.TOOLTIP_TOTAL_QUANTITY}
-              />
-            </Grid>
-            <Grid item xs={12} sx={{ marginTop: theme.spacing(4) }}>
-              <Textfield id='notes' value={record.notes} onChange={onChange} type='textarea' label={strings.NOTES} />
-            </Grid>
-          </Grid>
-        </Container>
-      </Box>
-      <FormBottomBar onCancel={goToInventory} onSave={saveInventory} saveButtonText={strings.SAVE} />
+          </Container>
+        </Box>
+      </PageForm>
     </TfMain>
   );
 }

--- a/src/components/Inventory/withdraw/flow/AddPhotos.tsx
+++ b/src/components/Inventory/withdraw/flow/AddPhotos.tsx
@@ -3,7 +3,7 @@ import { Container, useTheme } from '@mui/material';
 import strings from 'src/strings';
 import SelectPhotos, { ErrorType } from 'src/components/common/SelectPhotos';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
-import FormBottomBar from 'src/components/common/FormBottomBar';
+import PageForm from 'src/components/common/PageForm';
 import { NurseryWithdrawalPurposes } from 'src/api/types/batch';
 
 type AddPhotosProps = {
@@ -34,7 +34,7 @@ export default function AddPhotos(props: AddPhotosProps): JSX.Element {
   };
 
   return (
-    <>
+    <PageForm onCancel={onCancel} onSave={onNextHandler} saveButtonText={saveText}>
       <Container
         maxWidth={false}
         sx={{
@@ -44,7 +44,6 @@ export default function AddPhotos(props: AddPhotosProps): JSX.Element {
           paddingLeft: theme.spacing(isMobile ? 1 : 4),
           paddingRight: theme.spacing(isMobile ? 1 : 4),
           paddingTop: theme.spacing(5),
-          paddingBottom: isMobile ? '185px' : '105px',
         }}
       >
         <SelectPhotos
@@ -59,7 +58,6 @@ export default function AddPhotos(props: AddPhotosProps): JSX.Element {
           error={error}
         />
       </Container>
-      <FormBottomBar onCancel={onCancel} onSave={onNextHandler} saveButtonText={saveText} />
-    </>
+    </PageForm>
   );
 }

--- a/src/components/Inventory/withdraw/flow/SelectBatchesWithdrawnQuantity.tsx
+++ b/src/components/Inventory/withdraw/flow/SelectBatchesWithdrawnQuantity.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Container, Grid, Typography, useTheme } from '@mui/material';
 import { ServerOrganization } from 'src/types/Organization';
-import FormBottomBar from 'src/components/common/FormBottomBar';
+import PageForm from 'src/components/common/PageForm';
 import { useDeviceInfo } from '@terraware/web-components/utils';
 import strings from 'src/strings';
 import { NurseryWithdrawalRequest, NurseryWithdrawalPurposes } from 'src/api/types/batch';
@@ -254,7 +254,7 @@ export default function SelectBatches(props: SelectBatchesWithdrawnQuantityProps
   };
 
   return (
-    <>
+    <PageForm onCancel={onCancel} onSave={onNextHandler} saveButtonText={saveText}>
       {errorPageMessage && (
         <Box sx={{ marginTop: 5, marginBottom: 3 }}>
           <ErrorBox text={errorPageMessage} className={classes.error} />
@@ -314,7 +314,6 @@ export default function SelectBatches(props: SelectBatchesWithdrawnQuantityProps
             })}
         </Grid>
       </Container>
-      <FormBottomBar onCancel={onCancel} onSave={onNextHandler} saveButtonText={saveText} />
-    </>
+    </PageForm>
   );
 }

--- a/src/components/Inventory/withdraw/flow/SelectPurposeForm.tsx
+++ b/src/components/Inventory/withdraw/flow/SelectPurposeForm.tsx
@@ -25,7 +25,7 @@ import { listPlantingSites } from 'src/api/tracking/tracking';
 import { getAllSpecies } from 'src/api/species/species';
 import { PlantingSite } from 'src/api/types/tracking';
 import useSnackbar from 'src/utils/useSnackbar';
-import FormBottomBar from 'src/components/common/FormBottomBar';
+import PageForm from 'src/components/common/PageForm';
 import ErrorMessage from 'src/components/common/ErrorMessage';
 import PlotSelector, { PlotInfo, ZoneInfo } from 'src/components/PlotSelector';
 
@@ -411,7 +411,7 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
   }, [batchesFromNursery]);
 
   return (
-    <>
+    <PageForm onCancel={onCancel} onSave={onNextHandler} saveButtonText={saveText} saveDisabled={noReadySeedlings}>
       <Container
         maxWidth={false}
         sx={{
@@ -421,7 +421,6 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
           paddingLeft: theme.spacing(isMobile ? 0 : 4),
           paddingRight: theme.spacing(isMobile ? 0 : 4),
           paddingTop: theme.spacing(5),
-          paddingBottom: isMobile ? '185px' : '105px',
         }}
       >
         <Grid
@@ -626,12 +625,6 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
           </Grid>
         </Grid>
       </Container>
-      <FormBottomBar
-        onCancel={onCancel}
-        onSave={onNextHandler}
-        saveButtonText={saveText}
-        saveDisabled={noReadySeedlings}
-      />
-    </>
+    </PageForm>
   );
 }

--- a/src/components/MyAccount/index.tsx
+++ b/src/components/MyAccount/index.tsx
@@ -10,7 +10,7 @@ import dictionary from 'src/strings/dictionary';
 import { ServerOrganization } from 'src/types/Organization';
 import { OrganizationUser, User } from 'src/types/User';
 import useForm from 'src/utils/useForm';
-import FormBottomBar from '../common/FormBottomBar';
+import PageForm from '../common/PageForm';
 import TextField from '../common/Textfield/Textfield';
 import AssignNewOwnerDialog from './AssignNewOwnerModal';
 import { getOrganizationUsers, leaveOrganization, listOrganizationRoles } from 'src/api/organization/organization';
@@ -190,148 +190,148 @@ export default function MyAccount({ user, organizations, edit, reloadUser, reloa
 
   return (
     <TfMain>
-      {removedOrg && (
-        <>
-          <LeaveOrganizationDialog
-            open={leaveOrganizationModalOpened}
-            onClose={() => setLeaveOrganizationModalOpened(false)}
-            onSubmit={leaveOrgHandler}
-            orgName={removedOrg.name}
-          />
-          <AssignNewOwnerDialog
-            open={assignNewOwnerModalOpened}
-            onClose={() => setAssignNewOwnerModalOpened(false)}
-            people={orgPeople || []}
-            onSubmit={saveChanges}
-            setNewOwner={setNewOwner}
-            selectedOwner={newOwner}
-          />
-          <CannotRemoveOrgDialog
-            open={cannotRemoveOrgModalOpened}
-            onClose={() => setCannotRemoveOrgModalOpened(false)}
-            onSubmit={openDeleteOrgModal}
-          />
-          <DeleteOrgDialog
-            open={deleteOrgModalOpened}
-            onClose={() => setDeleteOrgModalOpened(false)}
-            orgName={removedOrg.name}
-            onSubmit={deleteOrgHandler}
-          />
-        </>
-      )}
-      <PageHeaderWrapper nextElement={contentRef.current}>
+      <PageForm onCancel={onCancel} onSave={saveChanges} hideEdit={!edit}>
+        {removedOrg && (
+          <>
+            <LeaveOrganizationDialog
+              open={leaveOrganizationModalOpened}
+              onClose={() => setLeaveOrganizationModalOpened(false)}
+              onSubmit={leaveOrgHandler}
+              orgName={removedOrg.name}
+            />
+            <AssignNewOwnerDialog
+              open={assignNewOwnerModalOpened}
+              onClose={() => setAssignNewOwnerModalOpened(false)}
+              people={orgPeople || []}
+              onSubmit={saveChanges}
+              setNewOwner={setNewOwner}
+              selectedOwner={newOwner}
+            />
+            <CannotRemoveOrgDialog
+              open={cannotRemoveOrgModalOpened}
+              onClose={() => setCannotRemoveOrgModalOpened(false)}
+              onSubmit={openDeleteOrgModal}
+            />
+            <DeleteOrgDialog
+              open={deleteOrgModalOpened}
+              onClose={() => setDeleteOrgModalOpened(false)}
+              orgName={removedOrg.name}
+              onSubmit={deleteOrgHandler}
+            />
+          </>
+        )}
+        <PageHeaderWrapper nextElement={contentRef.current}>
+          <Box
+            display='flex'
+            justifyContent='space-between'
+            marginBottom={theme.spacing(4)}
+            paddingLeft={theme.spacing(3)}
+          >
+            <TitleDescription title={strings.MY_ACCOUNT} description={strings.MY_ACCOUNT_DESC} style={{ padding: 0 }} />
+            <Button
+              id='edit-account'
+              icon='iconEdit'
+              label={isMobile ? '' : dictionary.EDIT_ACCOUNT}
+              onClick={() => history.push(APP_PATHS.MY_ACCOUNT_EDIT)}
+              size='medium'
+              priority='primary'
+            />
+          </Box>
+        </PageHeaderWrapper>
         <Box
-          display='flex'
-          justifyContent='space-between'
-          marginBottom={theme.spacing(4)}
-          paddingLeft={theme.spacing(3)}
+          ref={contentRef}
+          sx={{
+            backgroundColor: theme.palette.TwClrBg,
+            padding: theme.spacing(3),
+            borderRadius: '32px',
+            minWidth: 'fit-content',
+          }}
         >
-          <TitleDescription title={strings.MY_ACCOUNT} description={strings.MY_ACCOUNT_DESC} style={{ padding: 0 }} />
-          <Button
-            id='edit-account'
-            icon='iconEdit'
-            label={isMobile ? '' : dictionary.EDIT_ACCOUNT}
-            onClick={() => history.push(APP_PATHS.MY_ACCOUNT_EDIT)}
-            size='medium'
-            priority='primary'
-          />
-        </Box>
-      </PageHeaderWrapper>
-      <Box
-        ref={contentRef}
-        sx={{
-          backgroundColor: theme.palette.TwClrBg,
-          padding: theme.spacing(3),
-          borderRadius: '32px',
-          minWidth: 'fit-content',
-          marginBottom: edit ? (isMobile ? theme.spacing(16) : theme.spacing(8)) : 0,
-        }}
-      >
-        <Grid container spacing={3}>
-          <Grid item xs={12}>
-            <Typography fontSize='20px' fontWeight={600}>
-              {dictionary.GENERAL}
-            </Typography>
-          </Grid>
-          <Grid item xs={isMobile ? 12 : 4}>
-            <TextField
-              label={strings.FIRST_NAME}
-              id='firstName'
-              type='text'
-              value={record.firstName}
-              display={!edit}
-              onChange={onChange}
-            />
-          </Grid>
-          <Grid item xs={isMobile ? 12 : 4}>
-            <TextField
-              label={strings.LAST_NAME}
-              id='lastName'
-              type='text'
-              value={record.lastName}
-              display={!edit}
-              onChange={onChange}
-            />
-          </Grid>
-          <Grid item xs={isMobile ? 12 : 4}>
-            <TextField
-              label={strings.EMAIL}
-              id='email'
-              type='text'
-              value={record.email}
-              display={!edit}
-              readonly={true}
-            />
-          </Grid>
-          <Grid item xs={12} />
-          <Grid item xs={12}>
-            <Typography fontSize='20px' fontWeight={600} marginBottom={theme.spacing(1.5)}>
-              {dictionary.NOTIFICATIONS}
-            </Typography>
-            <Typography fontSize='14px'>{strings.MY_ACCOUNT_NOTIFICATIONS_DESC}</Typography>
-          </Grid>
-          <Grid item xs={12}>
-            <Checkbox
-              disabled={!edit}
-              id='emailNotificationsEnabled'
-              name={strings.RECEIVE_EMAIL_NOTIFICATIONS}
-              label={strings.RECEIVE_EMAIL_NOTIFICATIONS}
-              value={record.emailNotificationsEnabled}
-              onChange={onChange}
-            />
-          </Grid>
-          <Grid item xs={12} />
-          <Grid item xs={12}>
-            <Typography fontSize='20px' fontWeight={600}>
-              {dictionary.ORGANIZATIONS}
-            </Typography>
-          </Grid>
-          <Grid item xs={12}>
-            <div>
-              <Grid container spacing={4}>
-                <Grid item xs={12}>
-                  {organizations && (
-                    <Table
-                      id='organizations-table'
-                      columns={columns}
-                      rows={personOrganizations}
-                      orderBy='name'
-                      selectedRows={selectedRows}
-                      setSelectedRows={setSelectedRows}
-                      showCheckbox={edit}
-                      showTopBar={edit}
-                      topBarButtons={[
-                        { buttonType: 'destructive', buttonText: strings.REMOVE, onButtonClick: removeSelectedOrgs },
-                      ]}
-                    />
-                  )}
+          <Grid container spacing={3}>
+            <Grid item xs={12}>
+              <Typography fontSize='20px' fontWeight={600}>
+                {dictionary.GENERAL}
+              </Typography>
+            </Grid>
+            <Grid item xs={isMobile ? 12 : 4}>
+              <TextField
+                label={strings.FIRST_NAME}
+                id='firstName'
+                type='text'
+                value={record.firstName}
+                display={!edit}
+                onChange={onChange}
+              />
+            </Grid>
+            <Grid item xs={isMobile ? 12 : 4}>
+              <TextField
+                label={strings.LAST_NAME}
+                id='lastName'
+                type='text'
+                value={record.lastName}
+                display={!edit}
+                onChange={onChange}
+              />
+            </Grid>
+            <Grid item xs={isMobile ? 12 : 4}>
+              <TextField
+                label={strings.EMAIL}
+                id='email'
+                type='text'
+                value={record.email}
+                display={!edit}
+                readonly={true}
+              />
+            </Grid>
+            <Grid item xs={12} />
+            <Grid item xs={12}>
+              <Typography fontSize='20px' fontWeight={600} marginBottom={theme.spacing(1.5)}>
+                {dictionary.NOTIFICATIONS}
+              </Typography>
+              <Typography fontSize='14px'>{strings.MY_ACCOUNT_NOTIFICATIONS_DESC}</Typography>
+            </Grid>
+            <Grid item xs={12}>
+              <Checkbox
+                disabled={!edit}
+                id='emailNotificationsEnabled'
+                name={strings.RECEIVE_EMAIL_NOTIFICATIONS}
+                label={strings.RECEIVE_EMAIL_NOTIFICATIONS}
+                value={record.emailNotificationsEnabled}
+                onChange={onChange}
+              />
+            </Grid>
+            <Grid item xs={12} />
+            <Grid item xs={12}>
+              <Typography fontSize='20px' fontWeight={600}>
+                {dictionary.ORGANIZATIONS}
+              </Typography>
+            </Grid>
+            <Grid item xs={12}>
+              <div>
+                <Grid container spacing={4}>
+                  <Grid item xs={12}>
+                    {organizations && (
+                      <Table
+                        id='organizations-table'
+                        columns={columns}
+                        rows={personOrganizations}
+                        orderBy='name'
+                        selectedRows={selectedRows}
+                        setSelectedRows={setSelectedRows}
+                        showCheckbox={edit}
+                        showTopBar={edit}
+                        topBarButtons={[
+                          { buttonType: 'destructive', buttonText: strings.REMOVE, onButtonClick: removeSelectedOrgs },
+                        ]}
+                      />
+                    )}
+                  </Grid>
                 </Grid>
-              </Grid>
-            </div>
+              </div>
+            </Grid>
           </Grid>
-        </Grid>
-      </Box>
-      {edit && <FormBottomBar onCancel={onCancel} onSave={saveChanges} />}
+        </Box>
+      </PageForm>
     </TfMain>
   );
 }

--- a/src/components/NewNursery/index.tsx
+++ b/src/components/NewNursery/index.tsx
@@ -6,7 +6,7 @@ import strings from 'src/strings';
 import { ServerOrganization } from 'src/types/Organization';
 import TextField from '../common/Textfield/Textfield';
 import useForm from 'src/utils/useForm';
-import FormBottomBar from '../common/FormBottomBar';
+import PageForm from '../common/PageForm';
 import { Facility } from 'src/api/types/facilities';
 import { createFacility, updateFacility } from 'src/api/facility/facility';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
@@ -91,43 +91,44 @@ export default function NurseryView({ organization, reloadOrganizationData }: Si
 
   return (
     <TfMain>
-      <Box marginBottom={theme.spacing(4)} paddingLeft={theme.spacing(3)}>
-        <Typography fontSize='24px' fontWeight={600}>
-          {selectedNursery ? selectedNursery.name : strings.ADD_NURSERY}
-        </Typography>
-        <PageSnackbar />
-      </Box>
-      <Box
-        sx={{
-          backgroundColor: theme.palette.TwClrBg,
-          borderRadius: '32px',
-          padding: theme.spacing(3),
-        }}
-      >
-        <Grid container spacing={3}>
-          <Grid item xs={gridSize()}>
-            <TextField
-              id='name'
-              label={strings.NAME_REQUIRED}
-              type='text'
-              onChange={onChange}
-              value={record.name}
-              errorText={record.name ? '' : nameError}
-            />
+      <PageForm onCancel={goToNurseries} onSave={saveNursery}>
+        <Box marginBottom={theme.spacing(4)} paddingLeft={theme.spacing(3)}>
+          <Typography fontSize='24px' fontWeight={600}>
+            {selectedNursery ? selectedNursery.name : strings.ADD_NURSERY}
+          </Typography>
+          <PageSnackbar />
+        </Box>
+        <Box
+          sx={{
+            backgroundColor: theme.palette.TwClrBg,
+            borderRadius: '32px',
+            padding: theme.spacing(3),
+          }}
+        >
+          <Grid container spacing={3}>
+            <Grid item xs={gridSize()}>
+              <TextField
+                id='name'
+                label={strings.NAME_REQUIRED}
+                type='text'
+                onChange={onChange}
+                value={record.name}
+                errorText={record.name ? '' : nameError}
+              />
+            </Grid>
+            <Grid item xs={gridSize()}>
+              <TextField
+                id='description'
+                label={strings.DESCRIPTION_REQUIRED}
+                type='textarea'
+                onChange={onChange}
+                value={record.description}
+                errorText={record.description ? '' : descriptionError}
+              />
+            </Grid>
           </Grid>
-          <Grid item xs={gridSize()}>
-            <TextField
-              id='description'
-              label={strings.DESCRIPTION_REQUIRED}
-              type='textarea'
-              onChange={onChange}
-              value={record.description}
-              errorText={record.description ? '' : descriptionError}
-            />
-          </Grid>
-        </Grid>
-      </Box>
-      <FormBottomBar onCancel={goToNurseries} onSave={saveNursery} />
+        </Box>
+      </PageForm>
     </TfMain>
   );
 }

--- a/src/components/NewSeedBank/index.tsx
+++ b/src/components/NewSeedBank/index.tsx
@@ -6,7 +6,7 @@ import strings from 'src/strings';
 import { ServerOrganization } from 'src/types/Organization';
 import TextField from '../common/Textfield/Textfield';
 import useForm from 'src/utils/useForm';
-import FormBottomBar from '../common/FormBottomBar';
+import PageForm from '../common/PageForm';
 import { getAllSeedBanks } from 'src/utils/organization';
 import { Facility } from 'src/api/types/facilities';
 import { createFacility, updateFacility } from 'src/api/facility/facility';
@@ -98,43 +98,44 @@ export default function SeedBankView({ organization, reloadOrganizationData }: S
 
   return (
     <TfMain>
-      <Box marginBottom={theme.spacing(4)} paddingLeft={theme.spacing(3)}>
-        <Typography fontSize='24px' fontWeight={600}>
-          {selectedSeedBank ? selectedSeedBank?.name : strings.ADD_SEED_BANK}
-        </Typography>
-        <PageSnackbar />
-      </Box>
-      <Box
-        sx={{
-          backgroundColor: theme.palette.TwClrBg,
-          borderRadius: '32px',
-          padding: theme.spacing(3),
-        }}
-      >
-        <Grid container spacing={3}>
-          <Grid item xs={gridSize()}>
-            <TextField
-              id='name'
-              label={strings.NAME_REQUIRED}
-              type='text'
-              onChange={onChange}
-              value={record.name}
-              errorText={record.name ? '' : nameError}
-            />
+      <PageForm onCancel={goToSeedBanks} onSave={saveSeedBank}>
+        <Box marginBottom={theme.spacing(4)} paddingLeft={theme.spacing(3)}>
+          <Typography fontSize='24px' fontWeight={600}>
+            {selectedSeedBank ? selectedSeedBank?.name : strings.ADD_SEED_BANK}
+          </Typography>
+          <PageSnackbar />
+        </Box>
+        <Box
+          sx={{
+            backgroundColor: theme.palette.TwClrBg,
+            borderRadius: '32px',
+            padding: theme.spacing(3),
+          }}
+        >
+          <Grid container spacing={3}>
+            <Grid item xs={gridSize()}>
+              <TextField
+                id='name'
+                label={strings.NAME_REQUIRED}
+                type='text'
+                onChange={onChange}
+                value={record.name}
+                errorText={record.name ? '' : nameError}
+              />
+            </Grid>
+            <Grid item xs={gridSize()}>
+              <TextField
+                id='description'
+                label={strings.DESCRIPTION_REQUIRED}
+                type='textarea'
+                onChange={onChange}
+                value={record.description}
+                errorText={record.description ? '' : descriptionError}
+              />
+            </Grid>
           </Grid>
-          <Grid item xs={gridSize()}>
-            <TextField
-              id='description'
-              label={strings.DESCRIPTION_REQUIRED}
-              type='textarea'
-              onChange={onChange}
-              value={record.description}
-              errorText={record.description ? '' : descriptionError}
-            />
-          </Grid>
-        </Grid>
-      </Box>
-      <FormBottomBar onCancel={goToSeedBanks} onSave={saveSeedBank} />
+        </Box>
+      </PageForm>
     </TfMain>
   );
 }

--- a/src/components/NurseryWithdrawals/NurseryReassignment.tsx
+++ b/src/components/NurseryWithdrawals/NurseryReassignment.tsx
@@ -15,7 +15,7 @@ import { APP_PATHS } from 'src/constants';
 import TfMain from 'src/components/common/TfMain';
 import TitleDescription from 'src/components/common/TitleDescription';
 import Card from 'src/components/common/Card';
-import FormBottomBar from 'src/components/common/FormBottomBar';
+import PageForm from 'src/components/common/PageForm';
 import ReassignmentRenderer, { Reassignment, PlotInfo } from './ReassignmentRenderer';
 import PageSnackbar from 'src/components/PageSnackbar';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
@@ -221,28 +221,29 @@ export default function NurseryReassignment(props: NurseryReassignmentProps): JS
         </Box>
       )}
       {plots ? (
-        <Box
-          paddingBottom={isMobile ? '185px' : '105px'}
-          paddingRight={theme.spacing(3)}
-          display='flex'
-          flexDirection={isMobile ? 'row' : 'column'}
-          marginTop={theme.spacing(3)}
-          minWidth='fit-content'
-          ref={contentRef}
-        >
-          {reassigning && <BusySpinner withSkrim={true} />}
-          <Card>
-            <Table
-              id='reassignments'
-              columns={columns}
-              rows={plantings as any[]}
-              Renderer={reassignmentRenderer}
-              orderBy='species'
-              showPagination={false}
-            />
-          </Card>
-          <FormBottomBar onCancel={goToWithdrawals} onSave={reassign} saveButtonText={strings.REASSIGN} />
-        </Box>
+        <PageForm onCancel={goToWithdrawals} onSave={reassign} saveButtonText={strings.REASSIGN}>
+          <Box
+            paddingRight={theme.spacing(3)}
+            paddingBottom={theme.spacing(8)}
+            display='flex'
+            flexDirection={isMobile ? 'row' : 'column'}
+            marginTop={theme.spacing(3)}
+            minWidth='fit-content'
+            ref={contentRef}
+          >
+            {reassigning && <BusySpinner withSkrim={true} />}
+            <Card>
+              <Table
+                id='reassignments'
+                columns={columns}
+                rows={plantings as any[]}
+                Renderer={reassignmentRenderer}
+                orderBy='species'
+                showPagination={false}
+              />
+            </Card>
+          </Box>
+        </PageForm>
       ) : (
         <CircularProgress sx={{ margin: 'auto' }} />
       )}

--- a/src/components/Person/NewPerson.tsx
+++ b/src/components/Person/NewPerson.tsx
@@ -13,7 +13,7 @@ import ErrorBox from '../common/ErrorBox/ErrorBox';
 import { getOrganizationUsers } from 'src/api/organization/organization';
 import { APP_PATHS } from 'src/constants';
 import dictionary from 'src/strings/dictionary';
-import FormBottomBar from '../common/FormBottomBar';
+import PageForm from '../common/PageForm';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import PageSnackbar from 'src/components/PageSnackbar';
 import useSnackbar from 'src/utils/useSnackbar';
@@ -187,87 +187,88 @@ export default function PersonView({ organization, reloadOrganizationData }: Per
   // TODO: Handle the case where we cannot find the requested person to edit in the list of people.
   return (
     <TfMain>
-      <Grid container marginBottom={theme.spacing(4)} paddingLeft={theme.spacing(3)}>
-        <Grid item xs={12}>
-          <h2 className={classes.title}>{personSelectedToEdit ? personSelectedToEdit.email : strings.ADD_PERSON}</h2>
-          {!personSelectedToEdit ? <p className={classes.titleSubtitle}>{strings.ADD_PERSON_DESC}</p> : null}
-          <PageSnackbar />
-          {pageError === 'REPEATED_EMAIL' && repeatedEmail && (
-            <ErrorBox
-              text={strings.ALREADY_INVITED_PERSON_ERROR}
-              buttonText={strings.GO_TO_PROFILE}
-              onClick={goToProfile}
-            />
-          )}
-          {pageError === 'INVALID_EMAIL' && (
-            <ErrorBox title={strings.UNABLE_TO_ADD_PERSON} text={strings.FIX_HIGHLIGHTED_FIELDS} />
-          )}
-        </Grid>
-      </Grid>
-      <Box
-        sx={{
-          backgroundColor: theme.palette.TwClrBg,
-          borderRadius: '32px',
-          padding: theme.spacing(3),
-          marginBottom: isMobile ? theme.spacing(32) : theme.spacing(25),
-        }}
-      >
-        <Grid container spacing={3}>
-          <Grid item xs={gridSize()}>
-            <TextField
-              id='email'
-              label={strings.EMAIL_REQUIRED}
-              type='text'
-              onChange={onChange}
-              value={newPerson.email}
-              disabled={!!personSelectedToEdit}
-              errorText={emailError}
-            />
-          </Grid>
-          <Grid item xs={gridSize()}>
-            <TextField
-              id='firstName'
-              label={strings.FIRST_NAME}
-              type='text'
-              onChange={onChange}
-              disabled={true}
-              value={newPerson.firstName}
-            />
-          </Grid>
-          <Grid item xs={gridSize()}>
-            <TextField
-              id='lastName'
-              label={strings.LAST_NAME}
-              type='text'
-              onChange={onChange}
-              disabled={true}
-              value={newPerson.lastName}
-            />
+      <PageForm onCancel={goToPeople} onSave={() => saveUser()}>
+        <Grid container marginBottom={theme.spacing(4)} paddingLeft={theme.spacing(3)}>
+          <Grid item xs={12}>
+            <h2 className={classes.title}>{personSelectedToEdit ? personSelectedToEdit.email : strings.ADD_PERSON}</h2>
+            {!personSelectedToEdit ? <p className={classes.titleSubtitle}>{strings.ADD_PERSON_DESC}</p> : null}
+            <PageSnackbar />
+            {pageError === 'REPEATED_EMAIL' && repeatedEmail && (
+              <ErrorBox
+                text={strings.ALREADY_INVITED_PERSON_ERROR}
+                buttonText={strings.GO_TO_PROFILE}
+                onClick={goToProfile}
+              />
+            )}
+            {pageError === 'INVALID_EMAIL' && (
+              <ErrorBox title={strings.UNABLE_TO_ADD_PERSON} text={strings.FIX_HIGHLIGHTED_FIELDS} />
+            )}
           </Grid>
         </Grid>
-        <Box display='flex' flexDirection='column' marginTop={isDesktop ? theme.spacing(3) : theme.spacing(4)}>
-          <Box>
-            <p className={classes.roleDescription}>{strings.ROLES_INFO}</p>
-            <ul className={classes.rolesList}>
-              <li>{strings.CONTRIBUTOR_INFO}</li>
-              <li>{strings.MANAGER_INFO}</li>
-              <li>{strings.ADMIN_INFO}</li>
-            </ul>
-          </Box>
-          <Box width={roleSelectSize()} marginTop={theme.spacing(4)}>
-            <Select
-              id='role'
-              label={strings.ROLE_REQUIRED}
-              onChange={onChangeRole}
-              options={['Contributor', 'Admin', 'Manager']}
-              disabled={newPerson.role === 'Owner'}
-              selectedValue={newPerson.role}
-              fullWidth
-            />
+        <Box
+          sx={{
+            backgroundColor: theme.palette.TwClrBg,
+            borderRadius: '32px',
+            padding: theme.spacing(3),
+            marginBottom: theme.spacing(8),
+          }}
+        >
+          <Grid container spacing={3}>
+            <Grid item xs={gridSize()}>
+              <TextField
+                id='email'
+                label={strings.EMAIL_REQUIRED}
+                type='text'
+                onChange={onChange}
+                value={newPerson.email}
+                disabled={!!personSelectedToEdit}
+                errorText={emailError}
+              />
+            </Grid>
+            <Grid item xs={gridSize()}>
+              <TextField
+                id='firstName'
+                label={strings.FIRST_NAME}
+                type='text'
+                onChange={onChange}
+                disabled={true}
+                value={newPerson.firstName}
+              />
+            </Grid>
+            <Grid item xs={gridSize()}>
+              <TextField
+                id='lastName'
+                label={strings.LAST_NAME}
+                type='text'
+                onChange={onChange}
+                disabled={true}
+                value={newPerson.lastName}
+              />
+            </Grid>
+          </Grid>
+          <Box display='flex' flexDirection='column' marginTop={isDesktop ? theme.spacing(3) : theme.spacing(4)}>
+            <Box>
+              <p className={classes.roleDescription}>{strings.ROLES_INFO}</p>
+              <ul className={classes.rolesList}>
+                <li>{strings.CONTRIBUTOR_INFO}</li>
+                <li>{strings.MANAGER_INFO}</li>
+                <li>{strings.ADMIN_INFO}</li>
+              </ul>
+            </Box>
+            <Box width={roleSelectSize()} marginTop={theme.spacing(4)}>
+              <Select
+                id='role'
+                label={strings.ROLE_REQUIRED}
+                onChange={onChangeRole}
+                options={['Contributor', 'Admin', 'Manager']}
+                disabled={newPerson.role === 'Owner'}
+                selectedValue={newPerson.role}
+                fullWidth
+              />
+            </Box>
           </Box>
         </Box>
-      </Box>
-      <FormBottomBar onCancel={goToPeople} onSave={() => saveUser()} />
+      </PageForm>
     </TfMain>
   );
 }

--- a/src/components/PlantingSites/PlantingSiteCreate.tsx
+++ b/src/components/PlantingSites/PlantingSiteCreate.tsx
@@ -2,7 +2,7 @@ import { ServerOrganization } from 'src/types/Organization';
 import TfMain from 'src/components/common/TfMain';
 import { Typography, Box, Container, Grid, useTheme } from '@mui/material';
 import strings from 'src/strings';
-import FormBottomBar from '../common/FormBottomBar';
+import PageForm from 'src/components/common/PageForm';
 import { useDeviceInfo } from '@terraware/web-components/utils';
 import useForm from 'src/utils/useForm';
 import {
@@ -116,58 +116,68 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
 
   return (
     <TfMain>
-      <Container
-        maxWidth={false}
-        sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1, paddingBottom: theme.spacing(isMobile ? 20 : 10) }}
-      >
-        {loaded && (
-          <>
-            <Grid container spacing={3} flexGrow={0} display='flex' flexDirection='column'>
-              <Box paddingLeft={theme.spacing(3)} marginBottom={theme.spacing(4)} display='flex' flexDirection='column'>
-                <Typography
-                  fontSize={selectedPlantingSite ? '20px' : '24px'}
-                  fontWeight={600}
-                  margin={theme.spacing(1, 0)}
-                >
-                  {record.id !== -1 && selectedPlantingSite ? selectedPlantingSite.name : strings.ADD_PLANTING_SITE}
-                </Typography>
-              </Box>
-              <PageSnackbar />
-              <Box
-                sx={{
-                  backgroundColor: theme.palette.TwClrBg,
-                  borderRadius: '32px',
-                  padding: theme.spacing(3),
-                }}
+      <PageForm onCancel={goToPlantingSites} onSave={savePlantingSite}>
+        <Container maxWidth={false} sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
+          {loaded && (
+            <>
+              <Grid
+                container
+                spacing={3}
+                flexGrow={0}
+                display='flex'
+                flexDirection='column'
+                marginTop={theme.spacing(3)}
               >
-                <Grid container spacing={3} flexGrow={0}>
-                  <Grid item xs={gridSize()}>
-                    <TextField
-                      id='name'
-                      label={strings.NAME_REQUIRED}
-                      type='text'
-                      onChange={onChange}
-                      value={record.name}
-                      errorText={record.name ? '' : nameError}
-                    />
+                <Box
+                  paddingLeft={theme.spacing(3)}
+                  marginBottom={theme.spacing(4)}
+                  display='flex'
+                  flexDirection='column'
+                >
+                  <Typography
+                    fontSize={selectedPlantingSite ? '20px' : '24px'}
+                    fontWeight={600}
+                    margin={theme.spacing(1, 0)}
+                  >
+                    {record.id !== -1 && selectedPlantingSite ? selectedPlantingSite.name : strings.ADD_PLANTING_SITE}
+                  </Typography>
+                </Box>
+                <PageSnackbar />
+                <Box
+                  sx={{
+                    backgroundColor: theme.palette.TwClrBg,
+                    borderRadius: '32px',
+                    padding: theme.spacing(3),
+                  }}
+                >
+                  <Grid container spacing={3} flexGrow={0}>
+                    <Grid item xs={gridSize()}>
+                      <TextField
+                        id='name'
+                        label={strings.NAME_REQUIRED}
+                        type='text'
+                        onChange={onChange}
+                        value={record.name}
+                        errorText={record.name ? '' : nameError}
+                      />
+                    </Grid>
+                    <Grid item xs={gridSize()}>
+                      <TextField
+                        id='description'
+                        label={strings.DESCRIPTION}
+                        type='textarea'
+                        onChange={onChange}
+                        value={record.description}
+                      />
+                    </Grid>
                   </Grid>
-                  <Grid item xs={gridSize()}>
-                    <TextField
-                      id='description'
-                      label={strings.DESCRIPTION}
-                      type='textarea'
-                      onChange={onChange}
-                      value={record.description}
-                    />
-                  </Grid>
-                </Grid>
-              </Box>
-            </Grid>
-            <BoundariesAndPlots plantingSite={record} />
-          </>
-        )}
-      </Container>
-      <FormBottomBar onCancel={goToPlantingSites} onSave={savePlantingSite} />
+                </Box>
+              </Grid>
+              <BoundariesAndPlots plantingSite={record} />
+            </>
+          )}
+        </Container>
+      </PageForm>
     </TfMain>
   );
 }

--- a/src/components/accession2/create/Accession2Create.tsx
+++ b/src/components/accession2/create/Accession2Create.tsx
@@ -17,7 +17,7 @@ import {
   Species2Dropdown,
 } from '../properties';
 import Textfield from 'src/components/common/Textfield/Textfield';
-import FormBottomBar from 'src/components/common/FormBottomBar';
+import PageForm from 'src/components/common/PageForm';
 import Select from 'src/components/common/Select/Select';
 import { ACCESSION_2_CREATE_STATES } from 'src/types/Accession';
 import { getTodaysDateFormatted } from '@terraware/web-components/utils';
@@ -89,92 +89,99 @@ export default function CreateAccession(props: CreateAccessionProps): JSX.Elemen
 
   return (
     <TfMain>
-      <Typography variant='h2' sx={{ fontSize: '24px', fontWeight: 600, marginBottom: theme.spacing(4) }}>
-        {strings.ADD_AN_ACCESSION}
-      </Typography>
-      <Container
-        maxWidth={false}
-        sx={{
-          margin: '0 auto',
-          width: isMobile ? '100%' : '640px',
-          backgroundColor: theme.palette.TwClrBg,
-          borderRadius: '32px',
-          padding: theme.spacing(3),
-          marginBottom: isMobile ? theme.spacing(32) : theme.spacing(25),
-        }}
-      >
-        <Grid container>
-          <Grid item xs={12} display='flex' flexDirection='column'>
-            <Typography variant='h2' sx={SubTitleStyle}>
-              {strings.SEED_COLLECTION_DETAIL}
-            </Typography>
-            <Typography padding={theme.spacing(1, 0)} fontSize='14px' fontWeight={400}>
-              {strings.SEED_COLLECTION_DETAIL_DESC}
-            </Typography>
+      <PageForm onCancel={goToAccessions} onSave={saveAccession} saveButtonText={strings.CREATE}>
+        <Typography variant='h2' sx={{ fontSize: '24px', fontWeight: 600, marginBottom: theme.spacing(4) }}>
+          {strings.ADD_AN_ACCESSION}
+        </Typography>
+        <Container
+          maxWidth={false}
+          sx={{
+            margin: '0 auto',
+            width: isMobile ? '100%' : '640px',
+            backgroundColor: theme.palette.TwClrBg,
+            borderRadius: '32px',
+            padding: theme.spacing(3),
+            marginBottom: theme.spacing(8),
+          }}
+        >
+          <Grid container>
+            <Grid item xs={12} display='flex' flexDirection='column'>
+              <Typography variant='h2' sx={SubTitleStyle}>
+                {strings.SEED_COLLECTION_DETAIL}
+              </Typography>
+              <Typography padding={theme.spacing(1, 0)} fontSize='14px' fontWeight={400}>
+                {strings.SEED_COLLECTION_DETAIL_DESC}
+              </Typography>
+            </Grid>
+            <Grid item xs={12} sx={marginTop}>
+              <Species2Dropdown
+                record={record}
+                organization={organization}
+                setRecord={setRecord}
+                validate={validateFields}
+              />
+            </Grid>
+            <CollectedReceivedDate2 record={record} onChange={onChange} type='collected' validate={validateFields} />
+            <Grid item xs={12} sx={marginTop}>
+              <Collectors2
+                organizationId={organization.id}
+                id='collectors'
+                collectors={record.collectors}
+                onChange={onChange}
+              />
+            </Grid>
+            <Grid
+              item
+              xs={12}
+              display='flex'
+              flexDirection={isMobile ? 'column' : 'row'}
+              justifyContent='space-between'
+            >
+              <Grid item xs={gridSize()} sx={{ ...marginTop, marginRight: isMobile ? 0 : theme.spacing(2) }}>
+                <Textfield
+                  id='collectionSiteName'
+                  value={record.collectionSiteName}
+                  onChange={onChange}
+                  type='text'
+                  label={strings.COLLECTION_SITE}
+                  tooltipTitle={strings.TOOLTIP_ACCESSIONS_ADD_COLLECTING_SITE}
+                />
+              </Grid>
+              <Grid item xs={gridSize()} sx={marginTop}>
+                <Textfield
+                  id='collectionSiteLandowner'
+                  value={record.collectionSiteLandowner}
+                  onChange={onChange}
+                  type='text'
+                  label={strings.LANDOWNER}
+                />
+              </Grid>
+            </Grid>
+            <Accession2Address record={record} onChange={onChange} />
+            <Accession2GPS record={record} onChange={onChange} />
+            <Accession2PlantSiteDetails record={record} onChange={onChange} />
           </Grid>
-          <Grid item xs={12} sx={marginTop}>
-            <Species2Dropdown
-              record={record}
+          <Grid container>
+            <CollectedReceivedDate2 record={record} onChange={onChange} type='received' validate={validateFields} />
+            <Grid item xs={12} sx={marginTop}>
+              <Select
+                id='state'
+                selectedValue={record.state}
+                onChange={(value: string) => onChange('state', value)}
+                label={strings.PROCESSING_STATUS_REQUIRED}
+                options={ACCESSION_2_CREATE_STATES}
+                fullWidth={true}
+              />
+            </Grid>
+            <SeedBank2Selector
               organization={organization}
-              setRecord={setRecord}
+              record={record}
+              onChange={onChange}
               validate={validateFields}
             />
           </Grid>
-          <CollectedReceivedDate2 record={record} onChange={onChange} type='collected' validate={validateFields} />
-          <Grid item xs={12} sx={marginTop}>
-            <Collectors2
-              organizationId={organization.id}
-              id='collectors'
-              collectors={record.collectors}
-              onChange={onChange}
-            />
-          </Grid>
-          <Grid item xs={12} display='flex' flexDirection={isMobile ? 'column' : 'row'} justifyContent='space-between'>
-            <Grid item xs={gridSize()} sx={{ ...marginTop, marginRight: isMobile ? 0 : theme.spacing(2) }}>
-              <Textfield
-                id='collectionSiteName'
-                value={record.collectionSiteName}
-                onChange={onChange}
-                type='text'
-                label={strings.COLLECTION_SITE}
-                tooltipTitle={strings.TOOLTIP_ACCESSIONS_ADD_COLLECTING_SITE}
-              />
-            </Grid>
-            <Grid item xs={gridSize()} sx={marginTop}>
-              <Textfield
-                id='collectionSiteLandowner'
-                value={record.collectionSiteLandowner}
-                onChange={onChange}
-                type='text'
-                label={strings.LANDOWNER}
-              />
-            </Grid>
-          </Grid>
-          <Accession2Address record={record} onChange={onChange} />
-          <Accession2GPS record={record} onChange={onChange} />
-          <Accession2PlantSiteDetails record={record} onChange={onChange} />
-        </Grid>
-        <Grid container>
-          <CollectedReceivedDate2 record={record} onChange={onChange} type='received' validate={validateFields} />
-          <Grid item xs={12} sx={marginTop}>
-            <Select
-              id='state'
-              selectedValue={record.state}
-              onChange={(value: string) => onChange('state', value)}
-              label={strings.PROCESSING_STATUS_REQUIRED}
-              options={ACCESSION_2_CREATE_STATES}
-              fullWidth={true}
-            />
-          </Grid>
-          <SeedBank2Selector
-            organization={organization}
-            record={record}
-            onChange={onChange}
-            validate={validateFields}
-          />
-        </Grid>
-      </Container>
-      <FormBottomBar onCancel={goToAccessions} onSave={saveAccession} saveButtonText={strings.CREATE} />
+        </Container>
+      </PageForm>
     </TfMain>
   );
 }

--- a/src/components/common/PageForm.tsx
+++ b/src/components/common/PageForm.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from 'react';
+import { Box, useTheme } from '@mui/material';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
+import FormBottomBar from './FormBottomBar';
+
+export interface PageFormProps {
+  children: ReactNode;
+  onCancel: () => void;
+  onSave: () => void;
+  cancelButtonText?: string;
+  saveButtonText?: string;
+  saveDisabled?: boolean;
+  className?: string;
+  hideEdit?: boolean;
+}
+
+export default function PageForm(props: PageFormProps): JSX.Element {
+  const { children, className, hideEdit, ...bottomBarProps } = props;
+  const theme = useTheme();
+  const { isMobile } = useDeviceInfo();
+
+  return (
+    <>
+      <Box className={className} paddingBottom={hideEdit ? theme.spacing(4) : theme.spacing(isMobile ? 25 : 15)}>
+        {children}
+      </Box>
+      {!hideEdit && <FormBottomBar {...bottomBarProps} />}
+    </>
+  );
+}


### PR DESCRIPTION
- created a PageForm components that instantiates children + FormBottomBar with consistent spacing (height of bottom bar + 32px)
- refactored code to use PageForm
- removed margin/padding bottom from various components that were using form bottom bar
- kept a theme spacing(8) in some components that had a dropdown as last element to allow for the dropdown
- ideally would have preferred to remove the fixed position in formbottombar and use some Box magic between the bottom bar and children
- will save that for another review, for now the code is managed in one-place which will make it easier
- tested all those pages in desktop and mobile view