### PR TITLE
Fix github workflow deprecations in terraware-web

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "name=dir::$(yarn cache dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,9 +30,9 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "name=dir::$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Configure AWS Credentials
         if: env.IS_CD == 'true'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: ${{ secrets[env.AWS_REGION_SECRET_NAME] }}
           role-to-assume: ${{ secrets[env.AWS_ROLE_SECRET_NAME] }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Docker login
         if: env.IS_CD == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,19 +29,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set Environment
         run: ./.github/scripts/set-environment.sh
 
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "name=dir::$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -97,19 +94,21 @@ jobs:
           REACT_APP_TERRAWARE_FE_BUILD_VERSION: ${{ env.APP_VERSION }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Docker login
         if: env.IS_CD == 'true'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker build/push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
+          cache-from: type=gha
+          cache-to: type=gha, mode=max
           tags: ${{ env.DOCKER_TAGS }}
           platforms: linux/amd64,linux/arm64
           push: ${{ env.IS_CD == 'true' }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "name=dir::$(yarn cache dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache


### PR DESCRIPTION
With this PR, I don't see any of the deprecation warnings anymore.
Compare [new build](https://github.com/terraware/terraware-web/actions/runs/3736048733) vs [old build](https://github.com/terraware/terraware-web/actions/runs/3735661301).

1. Use newer versions of github actions that support newer Nodejs versions
2. Replace set-output with GITHUB_OUTPUT workflow (see references)
3. Remove usage of satackey/action-docker-layer-caching, use github action buildx support `cache-from` and `cache-to` tags for docker layers caching. Tested by resubmitting a build and saw cached docker layers being used.

<img width="613" alt="Fix github workflow deprecations in terraware-web · terraware:terraware-web@2c3e8fc 2022-12-19 15-58-47" src="https://user-images.githubusercontent.com/1865174/208550906-36aa4824-d74d-4a1a-9834-a15374487c9c.png">

References:
1. https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
5. https://depot.dev/blog/docker-layer-caching-in-github-actions