### PR TITLE
SW-2470 Use zoom instead of pan - to zone, in plants dashboard

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -4,7 +4,6 @@ import 'mapbox-gl/dist/mapbox-gl.css';
 import ReactMapGL, { AttributionControl, Layer, NavigationControl, Popup, Source } from 'react-map-gl';
 import { MapSource, MapEntityId, MapEntityOptions, MapOptions, MapPopupRenderer } from './MapModels';
 import { getBoundingBox } from './MapUtils';
-import isEnabled from 'src/features';
 
 /**
  * The following is needed to deal with a mapbox bug
@@ -133,15 +132,7 @@ export default function Map(props: MapProps): JSX.Element {
       }
       const coordinates = feature.geometry.coordinates;
       const bbox = getBoundingBox([[coordinates]]);
-      const [llx, lly] = bbox.lowerLeft;
-      const [urx, ury] = bbox.upperRight;
-      if (isEnabled('zoom to zone')) {
-        map.fitBounds([bbox.lowerLeft, bbox.upperRight], { padding: 200 });
-      } else {
-        // default pan to
-        const center = [(llx + urx) / 2, (lly + ury) / 2];
-        map.panTo(center, { padding: 200 });
-      }
+      map.fitBounds([bbox.lowerLeft, bbox.upperRight], { padding: 200 });
     },
     [geoData]
   );

--- a/src/features.ts
+++ b/src/features.ts
@@ -43,15 +43,6 @@ export const OPT_IN_FEATURES: Feature[] = [
     get: env().isForcedProductionView,
     set: env().forceProductionView,
   },
-  {
-    name: 'zoom to zone',
-    preferenceName: 'enableZoomTo',
-    active: true,
-    enabled: false,
-    allowInternalProduction: false,
-    description: ['zoom to zone instead of pan to'],
-    disclosure: ['this is for internal evaluation'],
-  },
 ];
 
 type FeatureMap = { [key: string]: Feature };


### PR DESCRIPTION
- Rachel chose zoom over pan, both were functional
- removed the feature based if/else and default to zoom
- Pan-to will center the zone but won’t change the zoom level. If you are zoomed in or out that won’t change.
- With new change the map will fit the sleeted zone boundary on screen