### PR TITLE
SW-2558 Change font size on withdrawals details pages

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -132,7 +132,7 @@ export default function Map(props: MapProps): JSX.Element {
       }
       const coordinates = feature.geometry.coordinates;
       const bbox = getBoundingBox([[coordinates]]);
-      map.fitBounds([bbox.lowerLeft, bbox.upperRight], { padding: 200 });
+      map.fitBounds([bbox.lowerLeft, bbox.upperRight], { padding: 20 });
     },
     [geoData]
   );

--- a/src/components/NurseryWithdrawals/NurseryWithdrawalsDetails.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawalsDetails.tsx
@@ -174,7 +174,7 @@ export default function NurseryWithdrawalsDetails({
             justifyContent='space-between'
             alignItems='center'
           >
-            <Typography color={theme.palette.TwClrTxt} fontSize='20px' fontWeight={600} fontStyle='italic'>
+            <Typography color={theme.palette.ClrTextFill} fontSize='24px' lineHeight='32px' fontWeight={600}>
               {withdrawal?.withdrawnDate}
             </Typography>
             {withdrawal?.purpose === OUTPLANT && hasPlots && (


### PR DESCRIPTION
- match figma design
- also updated a padding on the map (unrelated change)

<img width="205" alt="Terraware App 2022-12-20 07-27-21" src="https://user-images.githubusercontent.com/1865174/208704262-bd79dab8-3c66-4782-b391-d2a7b7f032af.png">

<img width="571" alt="Terraware App 2022-12-20 07-27-03" src="https://user-images.githubusercontent.com/1865174/208704268-d2f24915-d341-46c4-9bb1-0de090988521.png">
