### PR TITLE
SW-2442 Fix popover behavior on chart inconsistent

### DIFF
--- a/src/components/Plants/DashboardChart.tsx
+++ b/src/components/Plants/DashboardChart.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import { makeStyles } from '@mui/styles';
-import { useTheme } from '@mui/material';
+import { Theme, useTheme } from '@mui/material';
 import { generateTerrawareRandomColors } from 'src/utils/generateRandomColor';
 import { Chart } from 'chart.js';
 
-const useStyles = makeStyles(() => ({
+export interface StyleProps {
+  minHeight?: string;
+}
+
+const useStyles = makeStyles<Theme, StyleProps>(() => ({
   chart: {
-    minHeight: '200px',
+    minHeight: (props) => props.minHeight ?? '200px',
   },
 }));
 
@@ -14,11 +18,12 @@ export interface DashboardChartProps {
   chartId: string;
   chartLabels?: string[];
   chartValues?: number[];
+  minHeight?: string;
 }
 
 export default function DashboardChart(props: DashboardChartProps): JSX.Element {
-  const { chartId, chartLabels, chartValues } = props;
-  const classes = useStyles();
+  const { chartId, chartLabels, chartValues, minHeight } = props;
+  const classes = useStyles({ minHeight });
   const chartRef = React.useRef<HTMLCanvasElement>(null);
   const theme = useTheme();
 

--- a/src/components/Plants/SpeciesByPlotChart.tsx
+++ b/src/components/Plants/SpeciesByPlotChart.tsx
@@ -107,8 +107,8 @@ export default function SpeciesByPlotChart(props: Props): JSX.Element {
             selectedPlot={selectedPlot}
           />
         )}
-        <Box sx={{ height: '180px', marginTop: 2 }}>
-          <DashboardChart chartId='speciesByPlotChart' chartLabels={labels} chartValues={values} />
+        <Box sx={{ marginTop: 2 }}>
+          <DashboardChart chartId='speciesByPlotChart' chartLabels={labels} chartValues={values} minHeight='126px' />
         </Box>
       </Box>
     </>


### PR DESCRIPTION
The bottom part of the Species by plot chart could not be hovered, because it was "out" of the limits of the chart.
The fix was moving the height of the chart to the chart itself and not to the box containing the chart, so that any part of the chart can be hovered.

<img width="520" alt="Screenshot 2022-12-20 at 15 14 07" src="https://user-images.githubusercontent.com/5919083/208737589-3f1beb19-0e2a-4713-a9f8-354ff0ac728f.png">
