### PR TITLE
SW-2586 Fix date column on withdrawal log not sortable

### DIFF
--- a/src/api/tracking/withdrawals.ts
+++ b/src/api/tracking/withdrawals.ts
@@ -7,6 +7,7 @@ import {
   SearchResponseElement,
   convertToSearchNodePayload,
   search,
+  SearchSortOrder,
 } from 'src/api/search';
 import { Batch, NurseryWithdrawal } from 'src/api/types/batch';
 import { Delivery } from 'src/api/types/tracking';
@@ -17,7 +18,8 @@ import { Delivery } from 'src/api/types/tracking';
 export async function listNurseryWithdrawals(
   organizationId: number,
   searchCriteria: SearchCriteria,
-  count = 1000
+  count = 1000,
+  sortOrder?: SearchSortOrder
 ): Promise<SearchResponseElement[] | null> {
   const searchParams: SearchRequestPayload = {
     prefix: 'nurseryWithdrawals',
@@ -34,7 +36,7 @@ export async function listNurseryWithdrawals(
       'hasReassignments',
     ],
     search: convertToSearchNodePayload(searchCriteria, organizationId),
-    sortOrder: [{ field: 'id', direction: 'Ascending' }],
+    sortOrder: sortOrder ? [sortOrder] : [{ field: 'id', direction: 'Ascending' }],
     count,
   };
 

--- a/src/components/NurseryWithdrawals/NurseryWithdrawals.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawals.tsx
@@ -7,9 +7,9 @@ import PageSnackbar from 'src/components/PageSnackbar';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import TfMain from 'src/components/common/TfMain';
 import { makeStyles } from '@mui/styles';
-import { Table, TableColumnType } from '@terraware/web-components';
+import { SortOrder, Table, TableColumnType } from '@terraware/web-components';
 import { listNurseryWithdrawals } from 'src/api/tracking/withdrawals';
-import { FieldNodePayload, SearchResponseElement } from 'src/api/search';
+import { FieldNodePayload, SearchResponseElement, SearchSortOrder } from 'src/api/search';
 import WithdrawalLogRenderer from './WithdrawalLogRenderer';
 import { APP_PATHS } from 'src/constants';
 import { useHistory } from 'react-router-dom';
@@ -64,6 +64,10 @@ export default function NurseryWithdrawals(props: NurseryWithdrawalsProps): JSX.
   const [filters, setFilters] = useForm<NurseryWithdrawalsFiltersType>({});
   const [species, setSpecies] = useState<Species[]>();
   const [snackbar] = useState(useSnackbar());
+  const [searchSortOrder, setSearchSortOrder] = useState<SearchSortOrder>({
+    field: 'withdrawnDate',
+    direction: 'Descending',
+  } as SearchSortOrder);
 
   const onWithdrawalClicked = (withdrawal: any) => {
     history.push({
@@ -192,13 +196,13 @@ export default function NurseryWithdrawals(props: NurseryWithdrawalsProps): JSX.
     const searchChildren: FieldNodePayload[] = getSearchChildren();
     const requestId = Math.random().toString();
     setRequestId('searchWithdrawals', requestId);
-    const apiSearchResults = await listNurseryWithdrawals(organization.id, searchChildren);
+    const apiSearchResults = await listNurseryWithdrawals(organization.id, searchChildren, 1000, searchSortOrder);
     if (apiSearchResults) {
       if (getRequestId('searchWithdrawals') === requestId) {
         setSearchResults(apiSearchResults);
       }
     }
-  }, [getSearchChildren, organization.id]);
+  }, [getSearchChildren, organization.id, searchSortOrder]);
 
   useEffect(() => {
     onApplyFilters();
@@ -262,6 +266,13 @@ export default function NurseryWithdrawals(props: NurseryWithdrawalsProps): JSX.
         return filter;
       }
     }
+  };
+
+  const onSortChange = (order: SortOrder, orderBy: string) => {
+    setSearchSortOrder({
+      field: orderBy as string,
+      direction: order === 'asc' ? 'Ascending' : 'Descending',
+    });
   };
 
   return (
@@ -330,9 +341,11 @@ export default function NurseryWithdrawals(props: NurseryWithdrawalsProps): JSX.
                 columns={columns}
                 rows={searchResults || []}
                 Renderer={WithdrawalLogRenderer}
-                orderBy={'name'}
+                orderBy={searchSortOrder.field}
+                order={searchSortOrder.direction === 'Ascending' ? 'asc' : 'desc'}
                 onSelect={onWithdrawalClicked}
                 controlledOnSelect={true}
+                sortHandler={onSortChange}
               />
             </Grid>
           </Grid>


### PR DESCRIPTION
Add sortOrder to search nursery withdrawals api to allow sorting by date.
MUI front end default sorter doesn't work for dates.