### PR TITLE
SW-2583 / SW-2574 Show planting site data for sites that don't have zones/plots

### DIFF
--- a/src/components/Plants/PlantingSiteDashboardMap.tsx
+++ b/src/components/Plants/PlantingSiteDashboardMap.tsx
@@ -59,12 +59,10 @@ export default function PlantingSiteDashboardMap(props: PlantingSiteDashboardMap
 
   const contextRenderer = useSpeciesPlantsRenderer(plotsMap);
   const hasPolygons = plantingSite && plantingSite.boundary && plantingSite.boundary.coordinates?.length > 0;
-  // we don't want to show the map if there are no plots with plants, in mobile-web
-  const hasPlotsWithPlants = plotsMap && Object.keys(plotsMap).length > 0;
 
   return (
     <Box display='flex' height='100%'>
-      {hasPolygons && (!isMobile || hasPlotsWithPlants) ? (
+      {hasPolygons ? (
         <PlantingSiteMap
           plantingSite={plantingSite}
           key={plantingSite?.id}

--- a/src/components/Plants/PlantingSiteDetails.tsx
+++ b/src/components/Plants/PlantingSiteDetails.tsx
@@ -26,11 +26,6 @@ export type PlantingSiteZone = {
   plots: PlantingSitePlot[];
 };
 
-export type PlantingSiteSpecies = {
-  species_scientificName: string;
-  totalPlants: string;
-};
-
 type PlantingSiteDetailsProps = {
   plantingSite?: PlantingSite;
   organization: ServerOrganization;
@@ -110,7 +105,7 @@ export default function PlantingSiteDetails(props: PlantingSiteDetailsProps): JS
 
     const populateTotals = async () => {
       if (plantingSite) {
-        const serverResponse: PlantingSiteSpecies[] | null = (await search({
+        const serverResponse: Population[] | null = (await search({
           prefix: 'plantingSites.populations',
           fields: ['species_scientificName', 'totalPlants'],
           search: {
@@ -119,7 +114,7 @@ export default function PlantingSiteDetails(props: PlantingSiteDetailsProps): JS
             values: [plantingSite.id],
           },
           count: 0,
-        })) as unknown as PlantingSiteSpecies[] | null;
+        })) as unknown as Population[] | null;
 
         if (serverResponse) {
           let totalPlantsOfSite = 0;
@@ -171,6 +166,7 @@ export default function PlantingSiteDetails(props: PlantingSiteDetailsProps): JS
         {(!plantingSite || hasZones) && (
           <Box sx={{ ...widgetCardStyle, minHeight: '240px' }}>
             <SpeciesByPlotChart
+              siteId={plantingSite?.id}
               zones={zonesWithPlants}
               plantsDashboardPreferences={plantsDashboardPreferences}
               setPlantsDashboardPreferences={setPlantsDashboardPreferences}

--- a/src/components/Plants/SpeciesByPlotChart.tsx
+++ b/src/components/Plants/SpeciesByPlotChart.tsx
@@ -6,6 +6,7 @@ import DashboardChart from './DashboardChart';
 import PlotSelector, { PlotInfo, ZoneInfo } from 'src/components/PlotSelector';
 
 export interface Props {
+  siteId?: number;
   zones?: PlantingSiteZone[];
   plantsDashboardPreferences?: { [key: string]: unknown };
   setPlantsDashboardPreferences: React.Dispatch<React.SetStateAction<{ [key: string]: unknown } | undefined>>;
@@ -14,8 +15,14 @@ export interface Props {
 }
 
 export default function SpeciesByPlotChart(props: Props): JSX.Element {
-  const { zones, plantsDashboardPreferences, setPlantsDashboardPreferences, setSelectedPlotId, setSelectedZoneId } =
-    props;
+  const {
+    zones,
+    plantsDashboardPreferences,
+    setPlantsDashboardPreferences,
+    setSelectedPlotId,
+    setSelectedZoneId,
+    siteId,
+  } = props;
   const [selectedPlot, setSelectedPlot] = useState<PlantingSitePlot>();
   const [selectedZone, setSelectedZone] = useState<PlantingSiteZone>();
   const [labels, setLabels] = useState<string[]>();
@@ -97,9 +104,9 @@ export default function SpeciesByPlotChart(props: Props): JSX.Element {
     <>
       <Typography sx={cardTitleStyle}>{strings.NUMBER_OF_PLANTS_BY_PLOT_AND_SPECIES}</Typography>
       <Box sx={{ marginTop: theme.spacing(2) }}>
-        {zones && (
+        {(zones || !siteId) && (
           <PlotSelector
-            zones={zones as ZoneInfo[]}
+            zones={(zones || []) as ZoneInfo[]}
             onZoneSelected={onChangeZone}
             onPlotSelected={onChangePlot}
             horizontalLayout={true}


### PR DESCRIPTION
- code was only processing zones/plots driven info
- using a separate query now for totals and by species
- also show map on mobile for planting sites with plots even if there are no plants
- also show the plot selector for empty state in species chart

<img width="766" alt="Terraware App 2022-12-21 09-19-00" src="https://user-images.githubusercontent.com/1865174/208966410-7e9c1adb-bb82-455c-b292-3bdb4df93acc.png">
