### PR TITLE
SW-2582 Validate withdrawal quantity for single/outplant withdrawal

### DIFF
--- a/src/components/Inventory/withdraw/flow/SelectPurposeForm.tsx
+++ b/src/components/Inventory/withdraw/flow/SelectPurposeForm.tsx
@@ -192,6 +192,11 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
         if (isNaN(withdrawnQuantity)) {
           setIndividualError('withdrawnQuantity', strings.INVALID_VALUE);
           return false;
+        } else {
+          if (withdrawnQuantity > +batches[0].readyQuantity) {
+            setIndividualError('withdrawnQuantity', strings.WITHDRAWN_QUANTITY_ERROR);
+            return false;
+          }
         }
       } else {
         setIndividualError('withdrawnQuantity', strings.REQUIRED_FIELD);


### PR DESCRIPTION
Add quantity validation for single withdrawal with outplant purpose. Previously, the validation was happening on the backend in the last step of the flow (after photo upload)