### PR TITLE
terraware-web: Enable version upgrades to dependencies

### DIFF
--- a/.github/version: 2 updates:   - package-ecosystem: "npm"     directory: "/"     schedule:       interval: "weekly"       day: "sunday"     ignore:       - dependency-name: "example-name"         # For Lodash, ignore all updates     open-pull-requests-limit: 15
+++ b/.github/version: 2 updates:   - package-ecosystem: "npm"     directory: "/"     schedule:       interval: "weekly"       day: "sunday"     ignore:       - dependency-name: "example-name"         # For Lodash, ignore all updates     open-pull-requests-limit: 15
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    open-pull-requests-limit: 15


### PR DESCRIPTION
Enable dependabot opening PRs for version upgrades. Let's see how this works. Charlie did something similar, wondering if this will interfere.