### PR TITLE
Fix file name for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: 'weekly'
+      day: 'sunday'
     open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    open-pull-requests-limit: 5

--- a/.github/version: 2 updates:   - package-ecosystem: "npm"     directory: "/"     schedule:       interval: "weekly"       day: "sunday"     ignore:       - dependency-name: "example-name"         # For Lodash, ignore all updates     open-pull-requests-limit: 15
+++ b/.github/version: 2 updates:   - package-ecosystem: "npm"     directory: "/"     schedule:       interval: "weekly"       day: "sunday"     ignore:       - dependency-name: "example-name"         # For Lodash, ignore all updates     open-pull-requests-limit: 15
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-    open-pull-requests-limit: 15


### PR DESCRIPTION
- The previous diff commit some strange file name, reverting that change and recreating the file

Revert "terraware-web: Enable version upgrades to dependencies (https://github.com/terraware/terraware-web/pull/972)"

This reverts commit https://github.com/terraware/terraware-web/commit/72fd2194f0a878a24975f78d3c170962a53bf6d6.