### PR TITLE
SW-2614 Avoid zooming into zone on plot selection

### DIFF
--- a/src/components/Map/PlantingSiteMap.tsx
+++ b/src/components/Map/PlantingSiteMap.tsx
@@ -4,7 +4,7 @@ import hexRgb from 'hex-rgb';
 import { MultiPolygon, PlantingSite } from 'src/api/types/tracking';
 import useSnackbar from 'src/utils/useSnackbar';
 import GenericMap from './GenericMap';
-import { MapEntityOptions, MapGeometry, MapOptions, MapPopupRenderer, MapSource } from './MapModels';
+import { MapEntityId, MapEntityOptions, MapGeometry, MapOptions, MapPopupRenderer, MapSource } from './MapModels';
 import { getBoundingBox } from './MapUtils';
 import _ from 'lodash';
 
@@ -169,12 +169,16 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
     fetchPlantingSite();
   }, [plantingSite, snackbar, extractPlantingSite, extractPlantingZones, extractPlots, mapOptions]);
 
+  const plotEntity: MapEntityId = useMemo(() => ({ sourceId: 'plots', id: selectedPlotId }), [selectedPlotId]);
+
+  const zoneEntity: MapEntityId = useMemo(() => ({ sourceId: 'zones', id: selectedZoneId }), [selectedZoneId]);
+
   const entityOptions: MapEntityOptions = useMemo(
     () => ({
-      highlight: { sourceId: 'plots', id: selectedPlotId },
-      focus: { sourceId: 'zones', id: selectedZoneId },
+      highlight: plotEntity,
+      focus: zoneEntity,
     }),
-    [selectedPlotId, selectedZoneId]
+    [plotEntity, zoneEntity]
   );
 
   if (!mapOptions) {


### PR DESCRIPTION
- zoom into zone on new zone selection only
- bug was from useEffect triggerring even when there were no changes to selected zone
- behavior was due to parent prop being reconstructed from scratch even if a plot was changed
- fixed that by using separate memoization for plot and zone objects