### PR TITLE
SW-2056 Remove hardcoded colors from index.css

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -9,7 +9,6 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   min-height: 100%;
-  background: #ffffff;
   letter-spacing: normal;
 }
 


### PR DESCRIPTION
- we don't need this style, probably an artifact from initial project setup
- all our pages are styled by themes and override this index.css background