### PR TITLE
SW-2628 Planting Site Creation Map vs No-Map

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "sass": "^1.38.0",
     "styled-components": "^5.3.5",
     "tslint-plugin-cypress": "^1.0.4",
-    "typescript": "^4.3.2",
+    "typescript": "^4.9.4",
     "utm": "^1.1.1",
     "web-vitals": "^1.0.1",
     "worker-loader": "^3.0.8"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "coordinate-parser": "^1.0.7",
     "date-fns": "^2.28.0",
     "hex-rgb": "^5.0.0",
+    "html-react-parser": "^3.0.6",
     "jwt-decode": "^3.1.2",
     "license-report": "^6.0.0",
     "lodash": "^4.17.21",

--- a/src/api/search/index.ts
+++ b/src/api/search/index.ts
@@ -21,7 +21,7 @@ export function convertToSearchNodePayload(
   criteria: SearchCriteria,
   organizationId?: number
 ): SearchNodePayload | undefined {
-  if (criteria === {}) {
+  if (Object.keys(criteria).length === 0) {
     return undefined;
   }
   let newCriteria = criteria;

--- a/src/components/PlantingSites/BoundariesAndPlots.tsx
+++ b/src/components/PlantingSites/BoundariesAndPlots.tsx
@@ -1,7 +1,6 @@
 import { Typography, Box, CircularProgress } from '@mui/material';
-import { Button, theme } from '@terraware/web-components';
+import { theme } from '@terraware/web-components';
 import strings from 'src/strings';
-import { TERRAWARE_SUPPORT_LINK } from 'src/constants';
 import { PlantingSite } from 'src/api/types/tracking';
 import { PlantingSiteMap } from '../Map';
 
@@ -24,33 +23,7 @@ export default function BoundariesAndPlots(props: BoundariesAndPlotsProps): JSX.
           <>
             {plantingSite.boundary ? (
               <PlantingSiteMap plantingSite={plantingSite} style={{ borderRadius: '24px' }} />
-            ) : (
-              <Box
-                sx={{
-                  maxWidth: '800px',
-                  margin: '0 auto',
-                  textAlign: 'center',
-                  marginTop: 3,
-                  backgroundColor: theme.palette.TwClrBg,
-                  borderRadius: '32px',
-                  padding: theme.spacing(3),
-                }}
-              >
-                <Typography fontSize='20px' fontWeight={600} margin={theme.spacing(3, 0)}>
-                  {strings.IMPORT_BOUNDARIES_AND_PLOTS}
-                </Typography>
-                <Typography fontSize='16px' fontWeight={400} padding={theme.spacing(1, 0)}>
-                  {strings.IMPORT_BOUNDARIES_AND_PLOTS_DESCRIPTION}
-                </Typography>
-                <Box sx={{ paddingY: 2 }}>
-                  <Button
-                    label={strings.CONTACT_US}
-                    onClick={() => window.open(TERRAWARE_SUPPORT_LINK, '_blank')}
-                    size='medium'
-                  />
-                </Box>
-              </Box>
-            )}
+            ) : null}
           </>
         ) : (
           <Box sx={{ position: 'fixed', top: '50%', left: '50%' }}>

--- a/src/components/PlantingSites/PlantingSiteCreate.tsx
+++ b/src/components/PlantingSites/PlantingSiteCreate.tsx
@@ -173,7 +173,7 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
                   </Grid>
                 </Box>
               </Grid>
-              <BoundariesAndPlots plantingSite={record} />
+              {record?.boundary && <BoundariesAndPlots plantingSite={record} />}
             </>
           )}
         </Container>

--- a/src/components/PlantingSites/PlantingSiteSelectTypeModal.tsx
+++ b/src/components/PlantingSites/PlantingSiteSelectTypeModal.tsx
@@ -1,0 +1,83 @@
+import strings from 'src/strings';
+import Button from 'src/components/common/button/Button';
+import React, { useState } from 'react';
+import DialogBox from 'src/components/common/DialogBox/DialogBox';
+import { FormControlLabel, Radio, RadioGroup, Theme, Typography, useTheme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  buttonSpacing: {
+    marginRight: theme.spacing(2),
+  },
+}));
+
+export type PlantingSiteSelectTypeModalProps = {
+  open: boolean;
+  onNext: (goToCreate: boolean) => void;
+  onClose: () => void;
+};
+
+export default function PlantingSiteSelectTypeModal(props: PlantingSiteSelectTypeModalProps): JSX.Element {
+  const { open, onNext, onClose } = props;
+  const classes = useStyles();
+  const theme = useTheme();
+  const [withMap, setWithMap] = useState<boolean | null>(null);
+
+  const handleClose = () => {
+    setWithMap(null);
+    onClose();
+  };
+
+  const handleNext = () => {
+    onNext(withMap === false);
+    handleClose();
+  };
+
+  const handleTypeChange = (_: React.ChangeEvent<HTMLInputElement>, value: string) => {
+    if (value === 'withMap') {
+      setWithMap(true);
+    } else {
+      setWithMap(false);
+    }
+  };
+
+  return (
+    <DialogBox
+      scrolled
+      onClose={handleClose}
+      open={open}
+      title={strings.SELECT_PLANTING_SITE_TYPE}
+      size={'medium'}
+      middleButtons={[
+        <Button
+          onClick={handleClose}
+          id='cancel'
+          label={strings.CANCEL}
+          priority='secondary'
+          type='passive'
+          className={classes.buttonSpacing}
+          key='button-1'
+        />,
+        <Button onClick={handleNext} id='next' label={strings.NEXT} key='button-2' disabled={withMap === null} />,
+      ]}
+    >
+      <Typography marginBottom={theme.spacing(3)} justifyContent='center'>
+        {strings.SELECT_PLANTING_SITE_TYPE_DESCRIPTION_1}
+      </Typography>
+      <Typography marginBottom={theme.spacing(3)} justifyContent='center'>
+        {strings.SELECT_PLANTING_SITE_TYPE_DESCRIPTION_2}
+      </Typography>
+      <Typography marginBottom={theme.spacing(3)} justifyContent='center'>
+        {strings.SELECT_PLANTING_SITE_TYPE_DESCRIPTION_3}
+      </Typography>
+
+      <Typography color={theme.palette.TwClrTxtSecondary} display='flex' fontSize={14}>
+        {strings.PLANTING_SITE_TYPE}
+      </Typography>
+      <RadioGroup defaultValue={null} name='radio-buttons-group' onChange={handleTypeChange}>
+        <FormControlLabel value='withMap' control={<Radio />} label={strings.WITH_MAP} />
+        <FormControlLabel value='withoutMap' control={<Radio />} label={strings.WITHOUT_MAP} />
+      </RadioGroup>
+    </DialogBox>
+  );
+}

--- a/src/components/PlantingSites/PlantingSiteSelectTypeModal.tsx
+++ b/src/components/PlantingSites/PlantingSiteSelectTypeModal.tsx
@@ -1,9 +1,8 @@
 import strings from 'src/strings';
-import Button from 'src/components/common/button/Button';
 import React, { useState } from 'react';
-import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import { FormControlLabel, Radio, RadioGroup, Theme, Typography, useTheme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
+import { Button, DialogBox } from '@terraware/web-components';
 
 const useStyles = makeStyles((theme: Theme) => ({
   buttonSpacing: {

--- a/src/components/PlantingSites/PlantingSiteTypeSelect.tsx
+++ b/src/components/PlantingSites/PlantingSiteTypeSelect.tsx
@@ -1,0 +1,54 @@
+import PlantingSiteSelectTypeModal from './PlantingSiteSelectTypeModal';
+import { APP_PATHS } from 'src/constants';
+import PlantingSiteWithMapHelpModal from './PlantingSiteWithMapHelpModal';
+import { useHistory } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+
+export type PlantingSiteTypeSelectProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export default function PlantingSiteTypeSelect(props: PlantingSiteTypeSelectProps): JSX.Element {
+  const { open, onClose } = props;
+  const [plantingSiteTypeModalOpen, setPlantingSiteTypeModalOpen] = useState(false);
+  const [plantingSiteTypeHelpModalOpen, setPlantingSiteTypeHelpModalOpen] = useState(false);
+  const history = useHistory();
+
+  useEffect(() => {
+    setPlantingSiteTypeModalOpen(open);
+  }, [open]);
+
+  const goTo = (appPath: string) => {
+    const appPathLocation = {
+      pathname: appPath,
+    };
+    history.push(appPathLocation);
+  };
+
+  return (
+    <>
+      <PlantingSiteSelectTypeModal
+        open={plantingSiteTypeModalOpen}
+        onNext={(goToCreate) => {
+          if (goToCreate) {
+            goTo(APP_PATHS.PLANTING_SITES_NEW);
+          } else {
+            setPlantingSiteTypeHelpModalOpen(true);
+          }
+        }}
+        onClose={() => {
+          setPlantingSiteTypeModalOpen(false);
+          onClose();
+        }}
+      />
+      <PlantingSiteWithMapHelpModal
+        open={plantingSiteTypeHelpModalOpen}
+        onClose={() => {
+          setPlantingSiteTypeHelpModalOpen(false);
+          onClose();
+        }}
+      />
+    </>
+  );
+}

--- a/src/components/PlantingSites/PlantingSiteView.tsx
+++ b/src/components/PlantingSites/PlantingSiteView.tsx
@@ -101,7 +101,7 @@ export default function PlantingSiteView(): JSX.Element {
           />
         </Grid>
       </Grid>
-      {plantingSite && <BoundariesAndPlots plantingSite={plantingSite} />}
+      {plantingSite?.boundary && <BoundariesAndPlots plantingSite={plantingSite} />}
     </TfMain>
   );
 }

--- a/src/components/PlantingSites/PlantingSiteWithMapHelpModal.tsx
+++ b/src/components/PlantingSites/PlantingSiteWithMapHelpModal.tsx
@@ -1,0 +1,36 @@
+import strings from 'src/strings';
+import Button from 'src/components/common/button/Button';
+import React from 'react';
+import DialogBox from 'src/components/common/DialogBox/DialogBox';
+import { Typography } from '@mui/material';
+import { TERRAWARE_SUPPORT_LINK } from 'src/constants';
+import parseHtml from 'html-react-parser';
+
+export type PlantingSiteWithMapHelpModalProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export default function PlantingSiteWithMapHelpModal(props: PlantingSiteWithMapHelpModalProps): JSX.Element {
+  const { open, onClose } = props;
+
+  return (
+    <DialogBox
+      scrolled
+      onClose={onClose}
+      open={open}
+      title={strings.SELECT_PLANTING_SITE_TYPE}
+      size={'medium'}
+      middleButtons={[<Button onClick={onClose} id='done' label={strings.DONE} key='button-1' />]}
+    >
+      <Typography>
+        {parseHtml(
+          strings.formatString(
+            strings.PLANTING_SITE_WITH_MAP_HELP,
+            `<a href=${TERRAWARE_SUPPORT_LINK}>` + strings.CONTACT_US.toLowerCase() + '</a>'
+          ) as string
+        )}
+      </Typography>
+    </DialogBox>
+  );
+}

--- a/src/components/PlantingSites/PlantingSiteWithMapHelpModal.tsx
+++ b/src/components/PlantingSites/PlantingSiteWithMapHelpModal.tsx
@@ -1,10 +1,9 @@
 import strings from 'src/strings';
-import Button from 'src/components/common/button/Button';
 import React from 'react';
-import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import { Typography } from '@mui/material';
 import { TERRAWARE_SUPPORT_LINK } from 'src/constants';
 import parseHtml from 'html-react-parser';
+import { Button, DialogBox } from '@terraware/web-components';
 
 export type PlantingSiteWithMapHelpModalProps = {
   open: boolean;

--- a/src/components/PlantingSites/PlantingSitesList.tsx
+++ b/src/components/PlantingSites/PlantingSitesList.tsx
@@ -13,6 +13,8 @@ import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import TfMain from 'src/components/common/TfMain';
 import EmptyStatePage from 'src/components/emptyStatePages/EmptyStatePage';
 import PlantingSitesTable from './PlantingSitesTable';
+import PlantingSiteSelectTypeModal from './PlantingSiteSelectTypeModal';
+import PlantingSiteWithMapHelpModal from './PlantingSiteWithMapHelpModal';
 
 type PlantingSitesListProps = {
   organization: ServerOrganization;
@@ -23,6 +25,8 @@ export default function PlantingSitesList(props: PlantingSitesListProps): JSX.El
   const contentRef = useRef(null);
   const [searchResults, setSearchResults] = useState<SearchResponseElement[] | null>();
   const [plantingSites, setPlantingSites] = useState<SearchResponseElement[] | null>();
+  const [plantingSiteTypeModalOpen, setPlantingSiteTypeModalOpen] = useState(false);
+  const [plantingSiteTypeHelpModalOpen, setPlantingSiteTypeHelpModalOpen] = useState(false);
   const [temporalSearchValue, setTemporalSearchValue] = useState('');
   const debouncedSearchTerm = useDebounce(temporalSearchValue, 250);
   const { isMobile } = useDeviceInfo();
@@ -84,6 +88,23 @@ export default function PlantingSitesList(props: PlantingSitesListProps): JSX.El
 
   return (
     <TfMain>
+      <>
+        <PlantingSiteSelectTypeModal
+          open={plantingSiteTypeModalOpen}
+          onNext={(goToCreate) => {
+            if (goToCreate) {
+              goTo(APP_PATHS.PLANTING_SITES_NEW);
+            } else {
+              setPlantingSiteTypeHelpModalOpen(true);
+            }
+          }}
+          onClose={() => setPlantingSiteTypeModalOpen(false)}
+        />
+        <PlantingSiteWithMapHelpModal
+          open={plantingSiteTypeHelpModalOpen}
+          onClose={() => setPlantingSiteTypeHelpModalOpen(false)}
+        />
+      </>
       <PageHeaderWrapper nextElement={contentRef.current}>
         <Box sx={{ padding: theme.spacing(0, 0, 4, 3), display: 'flex', justifyContent: 'space-between' }}>
           <Grid item xs={6}>
@@ -97,7 +118,7 @@ export default function PlantingSitesList(props: PlantingSitesListProps): JSX.El
                 <Button
                   id='new-planting-site'
                   icon='plus'
-                  onClick={() => goTo(APP_PATHS.PLANTING_SITES_NEW)}
+                  onClick={() => setPlantingSiteTypeModalOpen(true)}
                   size='medium'
                 />
               ) : (
@@ -105,7 +126,7 @@ export default function PlantingSitesList(props: PlantingSitesListProps): JSX.El
                   id='new-planting-site'
                   icon='plus'
                   label={strings.ADD_PLANTING_SITE}
-                  onClick={() => goTo(APP_PATHS.PLANTING_SITES_NEW)}
+                  onClick={() => setPlantingSiteTypeModalOpen(true)}
                   size='medium'
                 />
               )}

--- a/src/components/PlantingSites/PlantingSitesList.tsx
+++ b/src/components/PlantingSites/PlantingSitesList.tsx
@@ -2,9 +2,7 @@ import { Box, CircularProgress, Grid, Typography } from '@mui/material';
 import { Button, theme } from '@terraware/web-components';
 import { useDeviceInfo } from '@terraware/web-components/utils';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useHistory } from 'react-router-dom';
 import { search, SearchResponseElement } from 'src/api/search';
-import { APP_PATHS } from 'src/constants';
 import strings from 'src/strings';
 import { ServerOrganization } from 'src/types/Organization';
 import useDebounce from 'src/utils/useDebounce';
@@ -13,8 +11,7 @@ import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import TfMain from 'src/components/common/TfMain';
 import EmptyStatePage from 'src/components/emptyStatePages/EmptyStatePage';
 import PlantingSitesTable from './PlantingSitesTable';
-import PlantingSiteSelectTypeModal from './PlantingSiteSelectTypeModal';
-import PlantingSiteWithMapHelpModal from './PlantingSiteWithMapHelpModal';
+import PlantingSiteTypeSelect from './PlantingSiteTypeSelect';
 
 type PlantingSitesListProps = {
   organization: ServerOrganization;
@@ -25,19 +22,10 @@ export default function PlantingSitesList(props: PlantingSitesListProps): JSX.El
   const contentRef = useRef(null);
   const [searchResults, setSearchResults] = useState<SearchResponseElement[] | null>();
   const [plantingSites, setPlantingSites] = useState<SearchResponseElement[] | null>();
-  const [plantingSiteTypeModalOpen, setPlantingSiteTypeModalOpen] = useState(false);
-  const [plantingSiteTypeHelpModalOpen, setPlantingSiteTypeHelpModalOpen] = useState(false);
+  const [plantingSiteTypeSelectOpen, setPlantingSiteTypeSelectOpen] = useState(false);
   const [temporalSearchValue, setTemporalSearchValue] = useState('');
   const debouncedSearchTerm = useDebounce(temporalSearchValue, 250);
   const { isMobile } = useDeviceInfo();
-  const history = useHistory();
-
-  const goTo = (appPath: string) => {
-    const appPathLocation = {
-      pathname: appPath,
-    };
-    history.push(appPathLocation);
-  };
 
   const onSearch = useCallback(async () => {
     const searchField = debouncedSearchTerm
@@ -88,23 +76,7 @@ export default function PlantingSitesList(props: PlantingSitesListProps): JSX.El
 
   return (
     <TfMain>
-      <>
-        <PlantingSiteSelectTypeModal
-          open={plantingSiteTypeModalOpen}
-          onNext={(goToCreate) => {
-            if (goToCreate) {
-              goTo(APP_PATHS.PLANTING_SITES_NEW);
-            } else {
-              setPlantingSiteTypeHelpModalOpen(true);
-            }
-          }}
-          onClose={() => setPlantingSiteTypeModalOpen(false)}
-        />
-        <PlantingSiteWithMapHelpModal
-          open={plantingSiteTypeHelpModalOpen}
-          onClose={() => setPlantingSiteTypeHelpModalOpen(false)}
-        />
-      </>
+      <PlantingSiteTypeSelect open={plantingSiteTypeSelectOpen} onClose={() => setPlantingSiteTypeSelectOpen(false)} />
       <PageHeaderWrapper nextElement={contentRef.current}>
         <Box sx={{ padding: theme.spacing(0, 0, 4, 3), display: 'flex', justifyContent: 'space-between' }}>
           <Grid item xs={6}>
@@ -118,7 +90,7 @@ export default function PlantingSitesList(props: PlantingSitesListProps): JSX.El
                 <Button
                   id='new-planting-site'
                   icon='plus'
-                  onClick={() => setPlantingSiteTypeModalOpen(true)}
+                  onClick={() => setPlantingSiteTypeSelectOpen(true)}
                   size='medium'
                 />
               ) : (
@@ -126,7 +98,7 @@ export default function PlantingSitesList(props: PlantingSitesListProps): JSX.El
                   id='new-planting-site'
                   icon='plus'
                   label={strings.ADD_PLANTING_SITE}
-                  onClick={() => setPlantingSiteTypeModalOpen(true)}
+                  onClick={() => setPlantingSiteTypeSelectOpen(true)}
                   size='medium'
                 />
               )}

--- a/src/components/emptyStatePages/EmptyStateContent.tsx
+++ b/src/components/emptyStatePages/EmptyStateContent.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   }),
   listItem: {
     flex: '1 1 auto',
-    maxWidth: '205px',
+    maxWidth: '220px',
     textAlign: 'center',
     margin: (props: EmptyStateStyleProps) => (props.isMobile ? theme.spacing(4, 3, 0, 3) : theme.spacing(0, 3)),
     '&:first-child': {

--- a/src/components/emptyStatePages/EmptyStatePage.tsx
+++ b/src/components/emptyStatePages/EmptyStatePage.tsx
@@ -18,8 +18,7 @@ import { isContributor } from 'src/utils/organization';
 import EmptyMessage from 'src/components/common/EmptyMessage';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import ImportInventoryModal, { downloadInventoryCsvTemplate } from '../Inventory/ImportInventoryModal';
-import PlantingSiteSelectTypeModal from 'src/components/PlantingSites/PlantingSiteSelectTypeModal';
-import PlantingSiteWithMapHelpModal from 'src/components/PlantingSites/PlantingSiteWithMapHelpModal';
+import PlantingSiteTypeSelect from '../PlantingSites/PlantingSiteTypeSelect';
 
 interface StyleProps {
   isMobile: boolean;
@@ -123,13 +122,6 @@ export default function EmptyStatePage({
     history.push(newLocation);
   };
 
-  const goTo = (appPath: string) => {
-    const appPathLocation = {
-      pathname: appPath,
-    };
-    history.push(appPathLocation);
-  };
-
   const downloadCsvTemplateHandler = () => {
     downloadCsvTemplate();
   };
@@ -141,8 +133,7 @@ export default function EmptyStatePage({
   const [addSpeciesModalOpened, setAddSpeciesModalOpened] = useState(false);
   const [importSpeciesModalOpened, setImportSpeciesModalOpened] = useState(false);
   const [importInventoryModalOpened, setImportInventoryModalOpened] = useState(false);
-  const [plantingSiteTypeModalOpen, setPlantingSiteTypeModalOpen] = useState(false);
-  const [plantingSiteTypeHelpModalOpen, setPlantingSiteTypeHelpModalOpen] = useState(false);
+  const [plantingSiteTypeSelectOpen, setPlantingSiteTypeSelectOpen] = useState(false);
 
   const NO_SPECIES_CONTENT: PageContent = {
     title1: strings.SPECIES,
@@ -220,7 +211,7 @@ export default function EmptyStatePage({
         buttonText: strings.ADD_PLANTING_SITE,
         buttonIcon: 'plus',
         onClickButton: () => {
-          setPlantingSiteTypeModalOpen(true);
+          setPlantingSiteTypeSelectOpen(true);
         },
       },
     ],
@@ -309,23 +300,7 @@ export default function EmptyStatePage({
           />
         </>
       )}
-      <>
-        <PlantingSiteSelectTypeModal
-          open={plantingSiteTypeModalOpen}
-          onNext={(goToCreate) => {
-            if (goToCreate) {
-              goTo(APP_PATHS.PLANTING_SITES_NEW);
-            } else {
-              setPlantingSiteTypeHelpModalOpen(true);
-            }
-          }}
-          onClose={() => setPlantingSiteTypeModalOpen(false)}
-        />
-        <PlantingSiteWithMapHelpModal
-          open={plantingSiteTypeHelpModalOpen}
-          onClose={() => setPlantingSiteTypeHelpModalOpen(false)}
-        />
-      </>
+      <PlantingSiteTypeSelect open={plantingSiteTypeSelectOpen} onClose={() => setPlantingSiteTypeSelectOpen(false)} />
       {content.title1 && (
         <>
           <PageHeader title={content.title1} subtitle='' />

--- a/src/components/emptyStatePages/EmptyStatePage.tsx
+++ b/src/components/emptyStatePages/EmptyStatePage.tsx
@@ -18,6 +18,8 @@ import { isContributor } from 'src/utils/organization';
 import EmptyMessage from 'src/components/common/EmptyMessage';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import ImportInventoryModal, { downloadInventoryCsvTemplate } from '../Inventory/ImportInventoryModal';
+import PlantingSiteSelectTypeModal from 'src/components/PlantingSites/PlantingSiteSelectTypeModal';
+import PlantingSiteWithMapHelpModal from 'src/components/PlantingSites/PlantingSiteWithMapHelpModal';
 
 interface StyleProps {
   isMobile: boolean;
@@ -95,20 +97,6 @@ const NO_NURSERIES_CONTENT: PageContent = {
   linkLocation: APP_PATHS.NURSERIES_NEW,
 };
 
-const NO_PLANTING_SITES_CONTENT: PageContent = {
-  title1: strings.PLANTING_SITES,
-  title2: strings.ADD_A_PLANTING_SITE,
-  subtitle: strings.ADD_A_PLANTING_SITE_SUBTITLE,
-  listItems: [
-    {
-      icon: 'blobbyIconSite',
-    },
-  ],
-  buttonText: strings.ADD_PLANTING_SITE,
-  buttonIcon: 'plus',
-  linkLocation: APP_PATHS.PLANTING_SITES_NEW,
-};
-
 type EmptyStatePageProps = {
   backgroundImageVisible?: boolean;
   pageName: 'Species' | 'SeedBanks' | 'Nurseries' | 'Inventory' | 'PlantingSites';
@@ -135,6 +123,13 @@ export default function EmptyStatePage({
     history.push(newLocation);
   };
 
+  const goTo = (appPath: string) => {
+    const appPathLocation = {
+      pathname: appPath,
+    };
+    history.push(appPathLocation);
+  };
+
   const downloadCsvTemplateHandler = () => {
     downloadCsvTemplate();
   };
@@ -146,6 +141,8 @@ export default function EmptyStatePage({
   const [addSpeciesModalOpened, setAddSpeciesModalOpened] = useState(false);
   const [importSpeciesModalOpened, setImportSpeciesModalOpened] = useState(false);
   const [importInventoryModalOpened, setImportInventoryModalOpened] = useState(false);
+  const [plantingSiteTypeModalOpen, setPlantingSiteTypeModalOpen] = useState(false);
+  const [plantingSiteTypeHelpModalOpen, setPlantingSiteTypeHelpModalOpen] = useState(false);
 
   const NO_SPECIES_CONTENT: PageContent = {
     title1: strings.SPECIES,
@@ -211,6 +208,22 @@ export default function EmptyStatePage({
     title2: strings.REACH_OUT_TO_ADMIN_TITLE,
     subtitle: strings.NO_SPECIES_CONTRIBUTOR_MSG,
     listItems: [],
+  };
+
+  const NO_PLANTING_SITES_CONTENT: PageContent = {
+    title1: strings.PLANTING_SITES,
+    title2: strings.ADD_A_PLANTING_SITE,
+    subtitle: strings.ADD_A_PLANTING_SITE_SUBTITLE,
+    listItems: [
+      {
+        icon: 'blobbyIconSite',
+        buttonText: strings.ADD_PLANTING_SITE,
+        buttonIcon: 'plus',
+        onClickButton: () => {
+          setPlantingSiteTypeModalOpen(true);
+        },
+      },
+    ],
   };
 
   const pageContent = (): PageContent => {
@@ -296,6 +309,23 @@ export default function EmptyStatePage({
           />
         </>
       )}
+      <>
+        <PlantingSiteSelectTypeModal
+          open={plantingSiteTypeModalOpen}
+          onNext={(goToCreate) => {
+            if (goToCreate) {
+              goTo(APP_PATHS.PLANTING_SITES_NEW);
+            } else {
+              setPlantingSiteTypeHelpModalOpen(true);
+            }
+          }}
+          onClose={() => setPlantingSiteTypeModalOpen(false)}
+        />
+        <PlantingSiteWithMapHelpModal
+          open={plantingSiteTypeHelpModalOpen}
+          onClose={() => setPlantingSiteTypeHelpModalOpen(false)}
+        />
+      </>
       {content.title1 && (
         <>
           <PageHeader title={content.title1} subtitle='' />

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -348,9 +348,6 @@ const strings = new LocalizedStrings({
     IMPORT_ACCESSIONS_DESC: 'Browse or drag and drop a CSV with accessions.',
     IMPORT_ACCESSIONS_WITH_TEMPLATE: 'Import accessions using our CSV template.',
     IMPORT_ACCESSIONS: 'Import Accessions',
-    IMPORT_BOUNDARIES_AND_PLOTS_DESCRIPTION:
-      'You’ll need to talk to your representative at Terraformation to import your map files to Terraware so you can work with your site’s boundaries and plots.',
-    IMPORT_BOUNDARIES_AND_PLOTS: 'Import boundaries and plots',
     IMPORT_DATA: 'Import Data',
     IMPORT_INVENTORY_ALT_TITLE: 'Already have an inventory database?',
     IMPORT_INVENTORY_DESC: 'Browse or drag and drop a CSV with inventory data.',

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -581,6 +581,9 @@ const strings = new LocalizedStrings({
     PLANT_ID: 'Plant ID',
     PLANT_LABEL: 'Plant',
     PLANT: 'plant',
+    PLANTING_SITE_TYPE: 'Planting Site Type',
+    PLANTING_SITE_WITH_MAP_HELP:
+      'If you are a Terraformation partner or accelerator participant, please {0} to create a site with a map.',
     PLANTING_SITE: 'Planting Site',
     PLANTING_SITES: 'Planting Sites',
     PLANTING_ZONE: 'Planting Zone',
@@ -718,6 +721,12 @@ const strings = new LocalizedStrings({
     SEEDS: 'Seeds',
     SELECT_BATCHES: 'Select Batches',
     SELECT_BUTTON: 'Select',
+    SELECT_PLANTING_SITE_TYPE_DESCRIPTION_1: 'Please select which type of planting site to add.',
+    SELECT_PLANTING_SITE_TYPE_DESCRIPTION_2:
+      'Sites with maps allow you to track the location of plants within the site and perform live/dead monitoring. Sites without maps allow you to track how many and which species of plants have been planted on the site.',
+    SELECT_PLANTING_SITE_TYPE_DESCRIPTION_3:
+      'Please note that if you create a site without a map, you won’t be able to add a map to it later on.',
+    SELECT_PLANTING_SITE_TYPE: 'Select Planting Site Type',
     SELECT_SEED_BANK_INFO: 'Accessions require a seed bank storage location. Please select a seed bank.',
     SELECT_SEED_BANK: 'Select Seed Bank',
     SELECT: 'Select...',
@@ -968,6 +977,7 @@ const strings = new LocalizedStrings({
     WILD_IN_SITU_DESCRIPTION: 'Plants that occur naturally in wild areas and were not planted by people.',
     WILD_IN_SITU: 'Wild (In Situ)',
     WILD: 'Wild',
+    WITH_MAP: 'With Map',
     WITHDRAW_ALL: 'Withdraw all',
     WITHDRAW_DATE_REQUIRED: 'Withdraw Date *',
     WITHDRAW_FROM_BATCHES: 'Withdraw from Batches',
@@ -988,6 +998,7 @@ const strings = new LocalizedStrings({
     WITHDRAWN_ON: 'Withdrawn On',
     WITHDRAWN_QUANTITY_ERROR: 'Exceeds remaining quantity',
     WITHDRAWN: 'Withdrawn',
+    WITHOUT_MAP: 'Without Map',
     YES: 'Yes',
     ZERO: 'zero',
     ZONE_REQUIRED: 'Zone *',

--- a/yarn.lock
+++ b/yarn.lock
@@ -14080,10 +14080,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.3.2:
-  version "4.4.4"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+typescript@^4.9.4:
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 umd@^3.0.0:
   version "3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5831,6 +5831,15 @@ dom-serializer@^1.0.1:
     domhandler "^4.2.0"
     entities "^2.0.0"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
 domain-browser@^1.1.1, domain-browser@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz"
@@ -5846,12 +5855,24 @@ domelementtype@^2.0.1, domelementtype@^2.2.0:
   resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz"
   integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
 
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
 domexception@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz"
   integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
   dependencies:
     webidl-conversions "^5.0.0"
+
+domhandler@5.0.3, domhandler@^5.0.1, domhandler@^5.0.2:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
 
 domhandler@^4.0.0, domhandler@^4.2.0:
   version "4.2.2"
@@ -5876,6 +5897,15 @@ domutils@^2.5.2, domutils@^2.6.0:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
+
+domutils@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.0.1.tgz#696b3875238338cb186b6c0612bd4901c89a4f1c"
+  integrity sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.1"
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -6027,6 +6057,11 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
+entities@^4.2.0, entities@^4.3.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
+  integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
 
 eol@^0.9.1:
   version "0.9.1"
@@ -7491,6 +7526,14 @@ hsla-regex@^1.0.0:
   resolved "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
+html-dom-parser@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/html-dom-parser/-/html-dom-parser-3.1.2.tgz#c137c42df80e17d185ff35a806925d96cc73f408"
+  integrity sha512-mLTtl3pVn3HnqZSZzW3xVs/mJAKrG1yIw3wlp+9bdoZHHLaBRvELdpfShiPVLyjPypq1Fugv2KMDoGHW4lVXnw==
+  dependencies:
+    domhandler "5.0.3"
+    htmlparser2 "8.0.1"
+
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz"
@@ -7521,6 +7564,16 @@ html-minifier-terser@^5.0.1:
     relateurl "^0.2.7"
     terser "^4.6.3"
 
+html-react-parser@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/html-react-parser/-/html-react-parser-3.0.6.tgz#356b861e6ad48e3221337d5a5929c5e452f8dfdd"
+  integrity sha512-kFh/qJkz4KJudCcILfI1hQKXTheRyMREXuL/WbWYUAsMsu0EOwV4nO5jA3ecu1LUNpCcebkNcBECxqpswBDlLw==
+  dependencies:
+    domhandler "5.0.3"
+    html-dom-parser "3.1.2"
+    react-property "2.0.0"
+    style-to-js "1.1.2"
+
 html-webpack-plugin@4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.5.0.tgz"
@@ -7540,6 +7593,16 @@ htmlescape@^1.1.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz"
   integrity sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=
+
+htmlparser2@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.1.tgz#abaa985474fcefe269bc761a779b544d7196d010"
+  integrity sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    entities "^4.3.0"
 
 htmlparser2@^6.1.0:
   version "6.1.0"
@@ -7838,6 +7901,11 @@ inline-source-map@~0.6.0:
   integrity sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=
   dependencies:
     source-map "~0.5.3"
+
+inline-style-parser@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
+  integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
 
 insert-module-globals@^7.0.0:
   version "7.2.1"
@@ -11879,6 +11947,11 @@ react-multi-carousel@^2.8.2:
   resolved "https://registry.yarnpkg.com/react-multi-carousel/-/react-multi-carousel-2.8.2.tgz#4bbd7a9656d8e49e081745331593e5500eefdbe4"
   integrity sha512-M9Y7DfAp8bA/r6yexttU6RLA7uyppje4c0ELRuCHZWswH+u7nr0uVP6qHNPjc4XGOEY1MYFOb5nBg7JvoKutuQ==
 
+react-property@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-property/-/react-property-2.0.0.tgz#2156ba9d85fa4741faf1918b38efc1eae3c6a136"
+  integrity sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==
+
 react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz"
@@ -13373,6 +13446,20 @@ style-loader@1.3.0:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^2.7.0"
+
+style-to-js@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/style-to-js/-/style-to-js-1.1.2.tgz#6821c53b86a236571236d9d15688389e81a2a893"
+  integrity sha512-aMG8jJpEF0SCGbQFY8W8CT+EjQ9ubp35FOZG3prWkNjxW/a1bEeSod0tkWiP+6iiOCDIIrQykUDkPY5LbNF87g==
+  dependencies:
+    style-to-object "0.4.0"
+
+style-to-object@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.4.0.tgz#fdcee2ba7f195f96023a44a124683f70d463dd24"
+  integrity sha512-dAjq2m87tPn/TcYTeqMhXJRhu96WYWcxMFQxs3Y9jfYpq2jG+38u4tj0Lst6DOiYXmDuNxVJ2b1Z2uPC6wTEeg==
+  dependencies:
+    inline-style-parser "0.1.1"
 
 styled-components@^5.3.5:
   version "5.3.5"


### PR DESCRIPTION
- add modal to choose between having map data or not when creating
  a new planting site.
- when 'with map' is selected, show a modal with a link to a contact 
  form page saying that they will need help from Terraformation
- when 'without map' is selected, proceed to the planting site creation
  flow
- don't show the Boundaries and Plot section for planting sites without
  map data during creating, viewing, or editing

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/114949086/210447807-f338953e-bf3e-496a-9f7a-ac2624268bc3.png">
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/114949086/210447824-cdb5254f-e1c1-43e0-8872-5acb1ad765ad.png">
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/114949086/210447852-bc06809d-fdb5-4491-a7d7-0160cf9fdd6a.png">
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/114949086/210447877-179724cd-bbd1-4731-9214-ec842e1928f0.png">
