### PR TITLE
 SW-2629 Set id to all onChange() functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/styled-engine-sc": "^5.8.0",
     "@mui/styles": "^5.8.7",
     "@mui/x-date-pickers": "^5.0.0-alpha.7",
-    "@terraware/web-components": "^2.0.56",
+    "@terraware/web-components": "2.0.58",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/components/AddNewOrganizationModal.tsx
+++ b/src/components/AddNewOrganizationModal.tsx
@@ -144,7 +144,7 @@ export default function AddNewOrganizationModal(props: AddNewOrganizationModalPr
             label={strings.ORGANIZATION_NAME_REQUIRED}
             type='text'
             id='name'
-            onChange={onChange}
+            onChange={(value) => onChange('name', value)}
             errorText={newOrganization.name ? '' : nameError}
             value={newOrganization.name}
           />
@@ -154,7 +154,7 @@ export default function AddNewOrganizationModal(props: AddNewOrganizationModalPr
             label={strings.DESCRIPTION}
             type='text'
             id='description'
-            onChange={onChange}
+            onChange={(value) => onChange('description', value)}
             value={newOrganization.description}
           />
         </Grid>

--- a/src/components/EditOrganization/index.tsx
+++ b/src/components/EditOrganization/index.tsx
@@ -140,7 +140,7 @@ export default function OrganizationView({ organization, reloadOrganizationData 
               id='name'
               label={strings.ORGANIZATION_NAME_REQUIRED}
               type='text'
-              onChange={onChange}
+              onChange={(value) => onChange('name', value)}
               value={organizationRecord.name}
               errorText={organizationRecord.name ? '' : nameError}
             />
@@ -150,7 +150,7 @@ export default function OrganizationView({ organization, reloadOrganizationData 
               id='description'
               label={strings.DESCRIPTION}
               type='textarea'
-              onChange={onChange}
+              onChange={(value) => onChange('description', value)}
               value={organizationRecord.description}
             />
           </Grid>

--- a/src/components/Inventory/InventoryCreate.tsx
+++ b/src/components/Inventory/InventoryCreate.tsx
@@ -197,7 +197,7 @@ export default function CreateInventory(props: CreateInventoryProps): JSX.Elemen
                   label={strings.ESTIMATED_READY_DATE}
                   aria-label={strings.ESTIMATED_READY_DATE}
                   value={record.readyByDate}
-                  onChange={(value) => onChange('readyByDate', value)}
+                  onChange={(value) => changeDate('readyByDate', value)}
                 />
               </Grid>
               <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>

--- a/src/components/Inventory/InventoryCreate.tsx
+++ b/src/components/Inventory/InventoryCreate.tsx
@@ -152,7 +152,7 @@ export default function CreateInventory(props: CreateInventoryProps): JSX.Elemen
                   label={strings.DATE_ADDED_REQUIRED}
                   aria-label={strings.DATE_ADDED_REQUIRED}
                   value={record.addedDate}
-                  onChange={changeDate}
+                  onChange={(value) => changeDate('dateAdded', value)}
                   errorText={validateFields && !record.addedDate ? strings.REQUIRED_FIELD : ''}
                 />
               </Grid>
@@ -170,7 +170,7 @@ export default function CreateInventory(props: CreateInventoryProps): JSX.Elemen
                 <Textfield
                   id='germinatingQuantity'
                   value={record.germinatingQuantity}
-                  onChange={onChange}
+                  onChange={(value) => onChange('germinatingQuantity', value)}
                   type='text'
                   label={strings.GERMINATING_QUANTITY_REQUIRED}
                   tooltipTitle={strings.TOOLTIP_GERMINATING_QUANTITY}
@@ -184,7 +184,7 @@ export default function CreateInventory(props: CreateInventoryProps): JSX.Elemen
                 <Textfield
                   id='notReadyQuantity'
                   value={record.notReadyQuantity}
-                  onChange={onChange}
+                  onChange={(value) => onChange('notReadyQuantity', value)}
                   type='text'
                   label={strings.NOT_READY_QUANTITY_REQUIRED}
                   tooltipTitle={strings.TOOLTIP_NOT_READY_QUANTITY}
@@ -197,14 +197,14 @@ export default function CreateInventory(props: CreateInventoryProps): JSX.Elemen
                   label={strings.ESTIMATED_READY_DATE}
                   aria-label={strings.ESTIMATED_READY_DATE}
                   value={record.readyByDate}
-                  onChange={changeDate}
+                  onChange={(value) => onChange('readyByDate', value)}
                 />
               </Grid>
               <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>
                 <Textfield
                   id='readyQuantity'
                   value={record.readyQuantity}
-                  onChange={onChange}
+                  onChange={(value) => onChange('readyQuantity', value)}
                   type='text'
                   label={strings.READY_QUANTITY_REQUIRED}
                   tooltipTitle={strings.TOOLTIP_READY_QUANTITY}
@@ -215,7 +215,7 @@ export default function CreateInventory(props: CreateInventoryProps): JSX.Elemen
                 <Textfield
                   id='totalQuantity'
                   value={totalQuantity}
-                  onChange={onChange}
+                  onChange={(value) => onChange('totalQuantity', value)}
                   type='text'
                   label={strings.TOTAL_QUANTITY}
                   display={true}
@@ -223,7 +223,13 @@ export default function CreateInventory(props: CreateInventoryProps): JSX.Elemen
                 />
               </Grid>
               <Grid item xs={12} sx={{ marginTop: theme.spacing(4) }}>
-                <Textfield id='notes' value={record.notes} onChange={onChange} type='textarea' label={strings.NOTES} />
+                <Textfield
+                  id='notes'
+                  value={record.notes}
+                  onChange={(value) => onChange('notes', value)}
+                  type='textarea'
+                  label={strings.NOTES}
+                />
               </Grid>
             </Grid>
           </Box>

--- a/src/components/Inventory/InventoryFiltersPopover.tsx
+++ b/src/components/Inventory/InventoryFiltersPopover.tsx
@@ -168,7 +168,7 @@ export default function InventoryFiltersPopover({
                     name={n.name}
                     label={n.name}
                     value={hasFilter(n.id)}
-                    onChange={onChange}
+                    onChange={(value) => onChange(n.id.toString(), value)}
                   />
                 </Grid>
               ))}

--- a/src/components/Inventory/Search.tsx
+++ b/src/components/Inventory/Search.tsx
@@ -28,7 +28,7 @@ export default function Search(props: SearchProps): JSX.Element {
             label=''
             id='search'
             type='text'
-            onChange={(id, value) => onSearch(value as string)}
+            onChange={(value) => onSearch(value as string)}
             value={searchValue}
             iconRight='cancel'
             onClickRightIcon={() => onSearch('')}

--- a/src/components/Inventory/view/BatchDetailsModal.tsx
+++ b/src/components/Inventory/view/BatchDetailsModal.tsx
@@ -190,7 +190,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
               </Grid>
               <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>
                 <Textfield
-                  id='seedlingBatch'
+                  id='seedlingsBatch'
                   value={record.batchNumber}
                   type='text'
                   label={strings.SEEDLING_BATCH}

--- a/src/components/Inventory/view/BatchDetailsModal.tsx
+++ b/src/components/Inventory/view/BatchDetailsModal.tsx
@@ -174,7 +174,6 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
                 <Textfield
                   id='scientificName'
                   value={speciesSelected?.scientificName}
-                  onChange={(value) => onChange('scientificName', value)}
                   type='text'
                   label={strings.SPECIES}
                   display={true}
@@ -184,7 +183,6 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
                 <Textfield
                   id='commonName'
                   value={speciesSelected?.commonName}
-                  onChange={(value) => onChange('commonName', value)}
                   type='text'
                   label={strings.COMMON_NAME}
                   display={true}
@@ -192,9 +190,8 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
               </Grid>
               <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>
                 <Textfield
-                  id='seedilingBatch'
+                  id='seedlingBatch'
                   value={record.batchNumber}
-                  onChange={(value) => onChange('seedilingBatch', value)}
                   type='text'
                   label={strings.SEEDLING_BATCH}
                   display={true}
@@ -214,14 +211,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
                 )}
               </Grid>
               <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>
-                <Textfield
-                  id='nursery'
-                  value={facilityName}
-                  onChange={(value) => onChange('nursery', value)}
-                  type='text'
-                  label={strings.NURSERY}
-                  display={true}
-                />
+                <Textfield id='nursery' value={facilityName} type='text' label={strings.NURSERY} display={true} />
               </Grid>
             </Grid>
           )}
@@ -298,7 +288,6 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
               <Textfield
                 id='totalQuantity'
                 value={totalQuantity}
-                onChange={(value) => onChange('totalQuantity', value)}
                 type='text'
                 label={strings.TOTAL_QUANTITY}
                 display={true}

--- a/src/components/Inventory/view/BatchDetailsModal.tsx
+++ b/src/components/Inventory/view/BatchDetailsModal.tsx
@@ -278,7 +278,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
                 label={strings.ESTIMATED_READY_DATE}
                 aria-label={strings.ESTIMATED_READY_DATE}
                 value={record.readyByDate}
-                onChange={(value) => onChange('readyByDate', value)}
+                onChange={(value) => changeDate('readyByDate', value)}
               />
             </Grid>
             <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>

--- a/src/components/Inventory/view/BatchDetailsModal.tsx
+++ b/src/components/Inventory/view/BatchDetailsModal.tsx
@@ -174,7 +174,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
                 <Textfield
                   id='scientificName'
                   value={speciesSelected?.scientificName}
-                  onChange={onChange}
+                  onChange={(value) => onChange('scientificName', value)}
                   type='text'
                   label={strings.SPECIES}
                   display={true}
@@ -184,7 +184,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
                 <Textfield
                   id='commonName'
                   value={speciesSelected?.commonName}
-                  onChange={onChange}
+                  onChange={(value) => onChange('commonName', value)}
                   type='text'
                   label={strings.COMMON_NAME}
                   display={true}
@@ -194,7 +194,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
                 <Textfield
                   id='seedilingBatch'
                   value={record.batchNumber}
-                  onChange={onChange}
+                  onChange={(value) => onChange('seedilingBatch', value)}
                   type='text'
                   label={strings.SEEDLING_BATCH}
                   display={true}
@@ -217,7 +217,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
                 <Textfield
                   id='nursery'
                   value={facilityName}
-                  onChange={onChange}
+                  onChange={(value) => onChange('nursery', value)}
                   type='text'
                   label={strings.NURSERY}
                   display={true}
@@ -251,7 +251,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
               <Textfield
                 id='germinatingQuantity'
                 value={record.germinatingQuantity}
-                onChange={onChange}
+                onChange={(value) => onChange('germinatingQuantity', value)}
                 type='text'
                 label={strings.GERMINATING_QUANTITY_REQUIRED}
                 tooltipTitle={strings.TOOLTIP_GERMINATING_QUANTITY}
@@ -265,7 +265,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
               <Textfield
                 id='notReadyQuantity'
                 value={record.notReadyQuantity}
-                onChange={onChange}
+                onChange={(value) => onChange('notReadyQuantity', value)}
                 type='text'
                 label={strings.NOT_READY_QUANTITY_REQUIRED}
                 tooltipTitle={strings.TOOLTIP_NOT_READY_QUANTITY}
@@ -278,14 +278,14 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
                 label={strings.ESTIMATED_READY_DATE}
                 aria-label={strings.ESTIMATED_READY_DATE}
                 value={record.readyByDate}
-                onChange={changeDate}
+                onChange={(value) => onChange('readyByDate', value)}
               />
             </Grid>
             <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>
               <Textfield
                 id='readyQuantity'
                 value={record.readyQuantity}
-                onChange={onChange}
+                onChange={(value) => onChange('readyQuantity', value)}
                 type='text'
                 label={strings.READY_QUANTITY_REQUIRED}
                 tooltipTitle={strings.TOOLTIP_READY_QUANTITY}
@@ -298,7 +298,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
               <Textfield
                 id='totalQuantity'
                 value={totalQuantity}
-                onChange={onChange}
+                onChange={(value) => onChange('totalQuantity', value)}
                 type='text'
                 label={strings.TOTAL_QUANTITY}
                 display={true}
@@ -312,11 +312,17 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
                 label={strings.DATE_ADDED_REQUIRED}
                 aria-label={strings.DATE_ADDED}
                 value={record.addedDate}
-                onChange={changeDate}
+                onChange={(value) => changeDate('dateAdded', value)}
               />
             </Grid>
             <Grid padding={theme.spacing(3, 0, 1, 2)} xs={12}>
-              <Textfield id='notes' value={record?.notes} onChange={onChange} type='textarea' label={strings.NOTES} />
+              <Textfield
+                id='notes'
+                value={record?.notes}
+                onChange={(value) => onChange('notes', value)}
+                type='textarea'
+                label={strings.NOTES}
+              />
             </Grid>
           </Grid>
         </DialogBox>

--- a/src/components/Inventory/view/ChangeQuantityModal.tsx
+++ b/src/components/Inventory/view/ChangeQuantityModal.tsx
@@ -108,7 +108,7 @@ export default function ChangeQuantityModal(props: ChangeQuantityModalProps): JS
               label={strings.MOVE}
               id={'movedValue'}
               type={'number'}
-              onChange={(id, value) => onChangeMovedValue(value)}
+              onChange={(value) => onChangeMovedValue(value)}
             />
           </Box>
           <Box paddingLeft={1} paddingRight={3} paddingTop={4}>

--- a/src/components/Inventory/view/WithdrawalModal.tsx
+++ b/src/components/Inventory/view/WithdrawalModal.tsx
@@ -194,7 +194,7 @@ export default function WithdrawalsModal(props: WithdrawalsModalProps): JSX.Elem
             </Grid>
             <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>
               <Textfield
-                id='seedlingBatch'
+                id='seedlingsBatch'
                 value={selectedBatch.batchNumber}
                 type='text'
                 label={strings.SEEDLING_BATCH}

--- a/src/components/Inventory/view/WithdrawalModal.tsx
+++ b/src/components/Inventory/view/WithdrawalModal.tsx
@@ -178,7 +178,6 @@ export default function WithdrawalsModal(props: WithdrawalsModalProps): JSX.Elem
               <Textfield
                 id='scientificName'
                 value={speciesSelected?.scientificName}
-                onChange={(value) => onChange('scientificName', value)}
                 type='text'
                 label={strings.SPECIES}
                 display={true}
@@ -188,7 +187,6 @@ export default function WithdrawalsModal(props: WithdrawalsModalProps): JSX.Elem
               <Textfield
                 id='commonName'
                 value={speciesSelected?.commonName}
-                onChange={(value) => onChange('commonName', value)}
                 type='text'
                 label={strings.COMMON_NAME}
                 display={true}
@@ -196,9 +194,8 @@ export default function WithdrawalsModal(props: WithdrawalsModalProps): JSX.Elem
             </Grid>
             <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>
               <Textfield
-                id='seedilingBatch'
+                id='seedlingBatch'
                 value={selectedBatch.batchNumber}
-                onChange={(value) => onChange('seedilingBatch', value)}
                 type='text'
                 label={strings.SEEDLING_BATCH}
                 display={true}
@@ -286,7 +283,6 @@ export default function WithdrawalsModal(props: WithdrawalsModalProps): JSX.Elem
                       <Textfield
                         id='withdrawnQuantity'
                         value={withdrawQuantity}
-                        onChange={(value) => onChange('withdrawnQuantity', value)}
                         type='text'
                         label={strings.WITHDRAW_QUANTITY}
                         display={true}

--- a/src/components/Inventory/view/WithdrawalModal.tsx
+++ b/src/components/Inventory/view/WithdrawalModal.tsx
@@ -178,7 +178,7 @@ export default function WithdrawalsModal(props: WithdrawalsModalProps): JSX.Elem
               <Textfield
                 id='scientificName'
                 value={speciesSelected?.scientificName}
-                onChange={onChange}
+                onChange={(value) => onChange('scientificName', value)}
                 type='text'
                 label={strings.SPECIES}
                 display={true}
@@ -188,7 +188,7 @@ export default function WithdrawalsModal(props: WithdrawalsModalProps): JSX.Elem
               <Textfield
                 id='commonName'
                 value={speciesSelected?.commonName}
-                onChange={onChange}
+                onChange={(value) => onChange('commonName', value)}
                 type='text'
                 label={strings.COMMON_NAME}
                 display={true}
@@ -198,7 +198,7 @@ export default function WithdrawalsModal(props: WithdrawalsModalProps): JSX.Elem
               <Textfield
                 id='seedilingBatch'
                 value={selectedBatch.batchNumber}
-                onChange={onChange}
+                onChange={(value) => onChange('seedilingBatch', value)}
                 type='text'
                 label={strings.SEEDLING_BATCH}
                 display={true}
@@ -232,7 +232,7 @@ export default function WithdrawalsModal(props: WithdrawalsModalProps): JSX.Elem
                       <Textfield
                         id='readyQuantityWithdrawn'
                         value={bw.readyQuantityWithdrawn}
-                        onChange={(id, value) => onChangeQuantity('readyQuantityWithdrawn', value)}
+                        onChange={(value) => onChangeQuantity('readyQuantityWithdrawn', value)}
                         type='text'
                         label={strings.WITHDRAW_QUANTITY_REQUIRED}
                         errorText={validateFields && bw.readyQuantityWithdrawn === 0 ? strings.REQUIRED_FIELD : ''}
@@ -266,7 +266,7 @@ export default function WithdrawalsModal(props: WithdrawalsModalProps): JSX.Elem
                       <Textfield
                         id='notReadyQuantityWithdrawn'
                         value={bw.notReadyQuantityWithdrawn}
-                        onChange={(id, value) => onChangeQuantity('notReadyQuantityWithdrawn', value)}
+                        onChange={(value) => onChangeQuantity('notReadyQuantityWithdrawn', value)}
                         type='text'
                         label={strings.NOT_READY_QUANTITY_REQUIRED}
                         errorText={validateFields && bw.notReadyQuantityWithdrawn === 0 ? strings.REQUIRED_FIELD : ''}
@@ -276,7 +276,7 @@ export default function WithdrawalsModal(props: WithdrawalsModalProps): JSX.Elem
                       <Textfield
                         id='readyQuantityWithdrawn'
                         value={bw.readyQuantityWithdrawn}
-                        onChange={(id, value) => onChangeQuantity('readyQuantityWithdrawn', value)}
+                        onChange={(value) => onChangeQuantity('readyQuantityWithdrawn', value)}
                         type='text'
                         label={strings.READY_QUANTITY_REQUIRED}
                         errorText={validateFields && bw.readyQuantityWithdrawn === 0 ? strings.REQUIRED_FIELD : ''}
@@ -286,7 +286,7 @@ export default function WithdrawalsModal(props: WithdrawalsModalProps): JSX.Elem
                       <Textfield
                         id='withdrawnQuantity'
                         value={withdrawQuantity}
-                        onChange={onChange}
+                        onChange={(value) => onChange('withdrawnQuantity', value)}
                         type='text'
                         label={strings.WITHDRAW_QUANTITY}
                         display={true}
@@ -308,12 +308,18 @@ export default function WithdrawalsModal(props: WithdrawalsModalProps): JSX.Elem
                 label={strings.WITHDRAW_DATE_REQUIRED}
                 aria-label={strings.WITHDRAW_DATE_REQUIRED}
                 value={record.withdrawnDate}
-                onChange={changeDate}
+                onChange={(value) => changeDate('withdrawnDate', value)}
                 errorText={validateFields && !record.withdrawnDate ? strings.REQUIRED_FIELD : ''}
               />
             </Grid>
             <Grid padding={theme.spacing(3, 0, 1, 2)} xs={12}>
-              <Textfield id='notes' value={record.notes} onChange={onChange} type='textarea' label={strings.NOTES} />
+              <Textfield
+                id='notes'
+                value={record.notes}
+                onChange={(value) => onChange('notes', value)}
+                type='textarea'
+                label={strings.NOTES}
+              />
             </Grid>
           </Grid>
         </DialogBox>

--- a/src/components/Inventory/withdraw/flow/SelectPurposeForm.tsx
+++ b/src/components/Inventory/withdraw/flow/SelectPurposeForm.tsx
@@ -563,7 +563,7 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
                     <Textfield
                       label={strings.WITHDRAW_QUANTITY_REQUIRED}
                       id='withdrawnQuantity'
-                      onChange={(id: string, value: unknown) => setWithdrawnQuantity(value as number)}
+                      onChange={(value: unknown) => setWithdrawnQuantity(value as number)}
                       type='text'
                       value={withdrawnQuantity}
                       errorText={fieldsErrors.withdrawnQuantity}
@@ -590,7 +590,7 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
                       <Textfield
                         label={strings.NOT_READY_QUANTITY_REQUIRED}
                         id='notReadyQuantityWithdrawn'
-                        onChange={(id: string, value: unknown) => setNotReadyQuantityWithdrawn(value as number)}
+                        onChange={(value: unknown) => setNotReadyQuantityWithdrawn(value as number)}
                         type='text'
                         value={notReadyQuantityWithdrawn}
                         tooltipTitle={strings.TOOLTIP_NOT_READY_QUANTITY}
@@ -604,7 +604,7 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
                         label={strings.ESTIMATED_READY_DATE}
                         aria-label={strings.ESTIMATED_READY_DATE}
                         value={localRecord.readyByDate}
-                        onChange={onChangeDate}
+                        onChange={(value) => onChangeDate('withdrawnDate', value)}
                       />
                     </Grid>
                   </Grid>
@@ -613,7 +613,7 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
                       <Textfield
                         label={strings.READY_QUANTITY_REQUIRED}
                         id='readyQuantityWithdrawn'
-                        onChange={(id: string, value: unknown) => setReadyQuantityWithdrawn(value as number)}
+                        onChange={(value: unknown) => setReadyQuantityWithdrawn(value as number)}
                         type='text'
                         value={readyQuantityWithdrawn}
                         tooltipTitle={strings.TOOLTIP_READY_QUANTITY}
@@ -625,7 +625,7 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
                       <Textfield
                         label={strings.WITHDRAW_QUANTITY}
                         id='withdrawQuantity'
-                        onChange={(id: string, value: unknown) => setWithdrawnQuantity(value as number)}
+                        onChange={(value: unknown) => setWithdrawnQuantity(value as number)}
                         type='text'
                         value={withdrawnQuantity}
                         display={true}
@@ -640,7 +640,7 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
                   label={strings.WITHDRAW_DATE_REQUIRED}
                   aria-label={strings.WITHDRAW_DATE_REQUIRED}
                   value={localRecord.withdrawnDate}
-                  onChange={onChangeDate}
+                  onChange={(value) => onChangeDate('withdrawnDate', value)}
                   errorText={fieldsErrors.withdrawnDate}
                 />
               </Grid>
@@ -649,7 +649,7 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
               <Textfield
                 id='notes'
                 value={localRecord.notes}
-                onChange={(id, value) => updateField('notes', value)}
+                onChange={(value) => updateField('notes', value)}
                 type='textarea'
                 label={strings.NOTES}
               />

--- a/src/components/Inventory/withdraw/flow/WithdrawalBatchesCellRenderer.tsx
+++ b/src/components/Inventory/withdraw/flow/WithdrawalBatchesCellRenderer.tsx
@@ -45,7 +45,7 @@ export default function WithdrawalBatchesCellRenderer(props: RendererProps<Table
           <Textfield
             id={id}
             type='number'
-            onChange={(_, newValue) => onRowClick(newValue as string)}
+            onChange={(newValue) => onRowClick(newValue as string)}
             value={row[id]}
             label={''}
             errorText={row.error[id]}
@@ -66,7 +66,7 @@ export default function WithdrawalBatchesCellRenderer(props: RendererProps<Table
         <Textfield
           id='readyQuantityWithdrawn'
           type='number'
-          onChange={(_, newValue) => onRowClick(newValue as string)}
+          onChange={(newValue) => onRowClick(newValue as string)}
           value={row.readyQuantityWithdrawn}
           label={''}
           errorText={row.error.readyQuantityWithdrawn}

--- a/src/components/Monitoring/sensorKitSetup/SensorKitID.tsx
+++ b/src/components/Monitoring/sensorKitSetup/SensorKitID.tsx
@@ -110,7 +110,7 @@ export default function SensorKitID(props: SensorKitIDProps): JSX.Element {
             id='sensor-kit-id'
             label={strings.ENTER_SIX_DIGIT_KEY}
             type='text'
-            onChange={onChange}
+            onChange={(value) => onChange('sensor-kit-id', value)}
             value={sensorKitId}
             errorText={error}
             placeholder={strings.SENSOR_KIT_ID_PLACEHOLDER}

--- a/src/components/MyAccount/index.tsx
+++ b/src/components/MyAccount/index.tsx
@@ -265,7 +265,7 @@ export default function MyAccount({ user, organizations, edit, reloadUser, reloa
                 type='text'
                 value={record.firstName}
                 display={!edit}
-                onChange={onChange}
+                onChange={(value) => onChange('firstName', value)}
               />
             </Grid>
             <Grid item xs={isMobile ? 12 : 4}>
@@ -275,7 +275,7 @@ export default function MyAccount({ user, organizations, edit, reloadUser, reloa
                 type='text'
                 value={record.lastName}
                 display={!edit}
-                onChange={onChange}
+                onChange={(value) => onChange('lastName', value)}
               />
             </Grid>
             <Grid item xs={isMobile ? 12 : 4}>
@@ -302,7 +302,7 @@ export default function MyAccount({ user, organizations, edit, reloadUser, reloa
                 name={strings.RECEIVE_EMAIL_NOTIFICATIONS}
                 label={strings.RECEIVE_EMAIL_NOTIFICATIONS}
                 value={record.emailNotificationsEnabled}
-                onChange={onChange}
+                onChange={(value) => onChange('emailNotificationsEnabled', value)}
               />
             </Grid>
             <Grid item xs={12} />

--- a/src/components/NewNursery/index.tsx
+++ b/src/components/NewNursery/index.tsx
@@ -111,7 +111,7 @@ export default function NurseryView({ organization, reloadOrganizationData }: Si
                 id='name'
                 label={strings.NAME_REQUIRED}
                 type='text'
-                onChange={onChange}
+                onChange={(value) => onChange('name', value)}
                 value={record.name}
                 errorText={record.name ? '' : nameError}
               />
@@ -121,7 +121,7 @@ export default function NurseryView({ organization, reloadOrganizationData }: Si
                 id='description'
                 label={strings.DESCRIPTION_REQUIRED}
                 type='textarea'
-                onChange={onChange}
+                onChange={(value) => onChange('description', value)}
                 value={record.description}
                 errorText={record.description ? '' : descriptionError}
               />

--- a/src/components/NewSeedBank/index.tsx
+++ b/src/components/NewSeedBank/index.tsx
@@ -123,7 +123,7 @@ export default function SeedBankView({ organization, reloadOrganizationData }: S
                 id='name'
                 label={strings.NAME_REQUIRED}
                 type='text'
-                onChange={onChange}
+                onChange={(value) => onChange('name', value)}
                 value={record.name}
                 errorText={record.name ? '' : nameError}
               />
@@ -133,7 +133,7 @@ export default function SeedBankView({ organization, reloadOrganizationData }: S
                 id='description'
                 label={strings.DESCRIPTION_REQUIRED}
                 type='textarea'
-                onChange={onChange}
+                onChange={(value) => onChange('description', value)}
                 value={record.description}
                 errorText={record.description ? '' : descriptionError}
               />

--- a/src/components/Nurseries/index.tsx
+++ b/src/components/Nurseries/index.tsx
@@ -145,7 +145,7 @@ export default function NurseriesList({ organization }: NurseriesListProps): JSX
               label=''
               id='search'
               type='text'
-              onChange={onChangeSearch}
+              onChange={(value) => onChangeSearch('search', value)}
               value={temporalSearchValue}
               iconRight='cancel'
               onClickRightIcon={clearSearch}

--- a/src/components/NurseryWithdrawals/NurseryWithdrawals.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawals.tsx
@@ -311,7 +311,7 @@ export default function NurseryWithdrawals(props: NurseryWithdrawalsProps): JSX.
                 className={classes.searchField}
                 iconRight='cancel'
                 value={searchValue}
-                onChange={(_id, value) => setSearchValue(value as string)}
+                onChange={(value) => setSearchValue(value as string)}
               />
               <NurseryWithdrawalsFiltersPopover
                 filters={filters}

--- a/src/components/NurseryWithdrawals/NurseryWithdrawalsFiltersPopover.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawalsFiltersPopover.tsx
@@ -236,7 +236,7 @@ export default function NurseryWithdrawalsFiltersPopover({
                       name={n.name}
                       label={n.name}
                       value={hasFilter('fromNurseryIds', n.id)}
-                      onChange={(id, value) => onChangeHandler(id, value, 'fromNurseryIds')}
+                      onChange={(value) => onChangeHandler(n.id.toString(), value, 'fromNurseryIds')}
                     />
                   </Grid>
                 ))}
@@ -252,7 +252,7 @@ export default function NurseryWithdrawalsFiltersPopover({
                       name={purpose}
                       label={purpose}
                       value={hasFilter('purposes', purpose)}
-                      onChange={(id, value) => onChangeHandler(id, value, 'purposes')}
+                      onChange={(value) => onChangeHandler(purpose, value, 'purposes')}
                     />
                   </Grid>
                 ))}
@@ -266,14 +266,14 @@ export default function NurseryWithdrawalsFiltersPopover({
                   label={strings.START}
                   aria-label={strings.DATE}
                   value={temporalRecord.withdrawnDates ? temporalRecord.withdrawnDates[0] : ''}
-                  onChange={onChangeDate}
+                  onChange={(value) => onChangeDate('startDate', value)}
                 />
                 <DatePicker
                   id='endDate'
                   label={strings.END}
                   aria-label={strings.DATE}
                   value={temporalRecord.withdrawnDates ? temporalRecord.withdrawnDates[1] : ''}
-                  onChange={onChangeDate}
+                  onChange={(value) => onChangeDate('endDate', value)}
                 />
               </Grid>
               <Grid item xs={6}>
@@ -287,7 +287,7 @@ export default function NurseryWithdrawalsFiltersPopover({
                       name={plantingSite.name}
                       label={plantingSite.name}
                       value={hasFilter('destinationNames', plantingSite.name)}
-                      onChange={(id, value) => onChangeHandler(id, value, 'destinationNames')}
+                      onChange={(value) => onChangeHandler(plantingSite.name.toString(), value, 'destinationNames')}
                     />
                   </Grid>
                 ))}
@@ -303,7 +303,7 @@ export default function NurseryWithdrawalsFiltersPopover({
                       name={iSpecies.scientificName}
                       label={iSpecies.scientificName}
                       value={hasFilter('speciesId', iSpecies.id)}
-                      onChange={(id, value) => onChangeHandler(id, value, 'speciesId')}
+                      onChange={(value) => onChangeHandler(iSpecies.id.toString(), value, 'speciesId')}
                     />
                   </Grid>
                 ))}

--- a/src/components/NurseryWithdrawals/ReassignmentRenderer.tsx
+++ b/src/components/NurseryWithdrawals/ReassignmentRenderer.tsx
@@ -53,7 +53,7 @@ export default function ReassignmentRenderer({ plots, setReassignment }: Reassig
       .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }))
       .map((otherPlot) => ({ ...otherPlot, value: otherPlot.id, label: otherPlot.name }));
 
-    const onUpdateQuantity = (unused: string, value: any) => {
+    const onUpdateQuantity = (value: any) => {
       if (value === '') {
         updateReassignment('quantity', undefined);
         return;
@@ -97,7 +97,7 @@ export default function ReassignmentRenderer({ plots, setReassignment }: Reassig
             id={`quantity_${plantingId}`}
             type='number'
             min={0}
-            onChange={(newValue) => onUpdateQuantity(`quantity_${plantingId}`, newValue)}
+            onChange={onUpdateQuantity}
             value={quantity}
             label={''}
             errorText={error.quantity}

--- a/src/components/NurseryWithdrawals/ReassignmentRenderer.tsx
+++ b/src/components/NurseryWithdrawals/ReassignmentRenderer.tsx
@@ -97,7 +97,7 @@ export default function ReassignmentRenderer({ plots, setReassignment }: Reassig
             id={`quantity_${plantingId}`}
             type='number'
             min={0}
-            onChange={(value) => onUpdateQuantity(`quantity_${plantingId}`, value)}
+            onChange={(newValue) => onUpdateQuantity(`quantity_${plantingId}`, newValue)}
             value={quantity}
             label={''}
             errorText={error.quantity}

--- a/src/components/NurseryWithdrawals/ReassignmentRenderer.tsx
+++ b/src/components/NurseryWithdrawals/ReassignmentRenderer.tsx
@@ -72,7 +72,7 @@ export default function ReassignmentRenderer({ plots, setReassignment }: Reassig
         <Autocomplete
           id={`newPlot_${plantingId}`}
           selected={newPlot}
-          onChange={(unused, newPlotValue: any) => {
+          onChange={(newPlotValue: any) => {
             if (newPlotValue.value) {
               updateReassignment('newPlot', newPlotValue);
             }
@@ -97,7 +97,7 @@ export default function ReassignmentRenderer({ plots, setReassignment }: Reassig
             id={`quantity_${plantingId}`}
             type='number'
             min={0}
-            onChange={onUpdateQuantity}
+            onChange={(value) => onUpdateQuantity(`quantity_${plantingId}`, value)}
             value={quantity}
             label={''}
             errorText={error.quantity}
@@ -117,7 +117,7 @@ export default function ReassignmentRenderer({ plots, setReassignment }: Reassig
         <Textfield
           id={`notes_${plantingId}`}
           type='text'
-          onChange={(unused, text: any) => updateReassignment('notes', text)}
+          onChange={(text: any) => updateReassignment('notes', text)}
           value={notes}
           label={''}
           className={classes.text}

--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -321,7 +321,7 @@ export default function PeopleList({ organization, reloadData, user }: PeopleLis
             id='search'
             type='text'
             className={classes.searchField}
-            onChange={onChangeSearch}
+            onChange={(value) => onChangeSearch('search', value)}
             value={temporalSearchValue}
             iconRight='cancel'
             onClickRightIcon={clearSearch}

--- a/src/components/Person/NewPerson.tsx
+++ b/src/components/Person/NewPerson.tsx
@@ -218,7 +218,7 @@ export default function PersonView({ organization, reloadOrganizationData }: Per
                 id='email'
                 label={strings.EMAIL_REQUIRED}
                 type='text'
-                onChange={onChange}
+                onChange={(value) => onChange('email', value)}
                 value={newPerson.email}
                 disabled={!!personSelectedToEdit}
                 errorText={emailError}
@@ -229,7 +229,7 @@ export default function PersonView({ organization, reloadOrganizationData }: Per
                 id='firstName'
                 label={strings.FIRST_NAME}
                 type='text'
-                onChange={onChange}
+                onChange={(value) => onChange('firstName', value)}
                 disabled={true}
                 value={newPerson.firstName}
               />
@@ -239,7 +239,7 @@ export default function PersonView({ organization, reloadOrganizationData }: Per
                 id='lastName'
                 label={strings.LAST_NAME}
                 type='text'
-                onChange={onChange}
+                onChange={(value) => onChange('lastName', value)}
                 disabled={true}
                 value={newPerson.lastName}
               />

--- a/src/components/PlantingSites/PlantingSiteCreate.tsx
+++ b/src/components/PlantingSites/PlantingSiteCreate.tsx
@@ -161,7 +161,7 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
                         id='name'
                         label={strings.NAME_REQUIRED}
                         type='text'
-                        onChange={onChange}
+                        onChange={(value) => onChange('name', value)}
                         value={record.name}
                         errorText={record.name ? '' : nameError}
                       />
@@ -171,7 +171,7 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
                         id='description'
                         label={strings.DESCRIPTION}
                         type='textarea'
-                        onChange={onChange}
+                        onChange={(value) => onChange('description', value)}
                         value={record.description}
                       />
                     </Grid>

--- a/src/components/PlantingSites/PlantingSitesTable.tsx
+++ b/src/components/PlantingSites/PlantingSitesTable.tsx
@@ -47,7 +47,7 @@ export default function PlantingSitesTable(props: PlantingSitesTableProps): JSX.
             label=''
             id='search'
             type='text'
-            onChange={(id, value) => setTemporalSearchValue(value as string)}
+            onChange={(value) => setTemporalSearchValue(value as string)}
             value={temporalSearchValue}
             iconRight='cancel'
             onClickRightIcon={() => setTemporalSearchValue('')}

--- a/src/components/PlotSelector/index.tsx
+++ b/src/components/PlotSelector/index.tsx
@@ -118,7 +118,7 @@ export default function PlotSelector(props: PlotSelectorProps): JSX.Element {
           label={horizontalLayout ? '' : strings.ZONE_REQUIRED}
           selected={zoneToDropdownItem(selectedZone)}
           values={zoneOptions}
-          onChange={(id, value) => onChangeZone(value)}
+          onChange={(value) => onChangeZone(value)}
           errorText={zoneError}
           disabled={!zones.length}
           isEqual={isEqual}
@@ -134,7 +134,7 @@ export default function PlotSelector(props: PlotSelectorProps): JSX.Element {
           label={horizontalLayout ? '' : strings.PLOT_REQUIRED}
           selected={plotToDropdownItem(selectedPlot)}
           values={plotOptions}
-          onChange={(id, value) => onChangePlot(value)}
+          onChange={(value) => onChangePlot(value)}
           errorText={plotError}
           disabled={!selectedZone?.plots?.length}
           isEqual={isEqual}

--- a/src/components/SeedBanks/index.tsx
+++ b/src/components/SeedBanks/index.tsx
@@ -181,7 +181,7 @@ export default function SeedBanksList({ organization }: SeedBanksListProps): JSX
                 id='search'
                 type='text'
                 className={classes.searchField}
-                onChange={onChangeSearch}
+                onChange={(value) => onChangeSearch('search', value)}
                 value={temporalSearchValue}
                 iconRight='cancel'
                 onClickRightIcon={clearSearch}

--- a/src/components/Species/AddSpeciesModal.tsx
+++ b/src/components/Species/AddSpeciesModal.tsx
@@ -243,7 +243,7 @@ export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Elemen
           <TextField
             id='familyName'
             value={record.familyName}
-            onChange={onChange}
+            onChange={(value) => onChange('familyName', value)}
             label={strings.FAMILY}
             aria-label={strings.FAMILY}
             type={'text'}

--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -637,7 +637,7 @@ export default function SpeciesList({ organization, reloadData, species }: Speci
               id='search'
               type='text'
               className={classes.searchField}
-              onChange={onChangeSearch}
+              onChange={(value) => onChangeSearch('search', value)}
               value={searchValue}
               iconRight='cancel'
               onClickRightIcon={clearSearch}

--- a/src/components/accession2/create/Accession2Create.tsx
+++ b/src/components/accession2/create/Accession2Create.tsx
@@ -129,12 +129,7 @@ export default function CreateAccession(props: CreateAccessionProps): JSX.Elemen
             </Grid>
             <CollectedReceivedDate2 record={record} onChange={onChange} type='collected' validate={validateFields} />
             <Grid item xs={12} sx={marginTop}>
-              <Collectors2
-                organizationId={organization.id}
-                id='collectors'
-                collectors={record.collectors}
-                onChange={(value) => onChange('collectors', value)}
-              />
+              <Collectors2 organizationId={organization.id} collectors={record.collectors} onChange={onChange} />
             </Grid>
             <Grid
               item

--- a/src/components/accession2/create/Accession2Create.tsx
+++ b/src/components/accession2/create/Accession2Create.tsx
@@ -133,7 +133,7 @@ export default function CreateAccession(props: CreateAccessionProps): JSX.Elemen
                 organizationId={organization.id}
                 id='collectors'
                 collectors={record.collectors}
-                onChange={onChange}
+                onChange={(value) => onChange('collectors', value)}
               />
             </Grid>
             <Grid
@@ -147,7 +147,7 @@ export default function CreateAccession(props: CreateAccessionProps): JSX.Elemen
                 <Textfield
                   id='collectionSiteName'
                   value={record.collectionSiteName}
-                  onChange={onChange}
+                  onChange={(value) => onChange('collectionSiteName', value)}
                   type='text'
                   label={strings.COLLECTION_SITE}
                   tooltipTitle={strings.TOOLTIP_ACCESSIONS_ADD_COLLECTING_SITE}
@@ -157,7 +157,7 @@ export default function CreateAccession(props: CreateAccessionProps): JSX.Elemen
                 <Textfield
                   id='collectionSiteLandowner'
                   value={record.collectionSiteLandowner}
-                  onChange={onChange}
+                  onChange={(value) => onChange('collectionSiteLandowner', value)}
                   type='text'
                   label={strings.LANDOWNER}
                 />

--- a/src/components/accession2/edit/Accession2EditModal.tsx
+++ b/src/components/accession2/edit/Accession2EditModal.tsx
@@ -103,12 +103,7 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
         />
         <CollectedReceivedDate2 record={record} onChange={onChange} type='collected' validate={validateFields} />
         <Grid item xs={12}>
-          <Collectors2
-            organizationId={organization.id}
-            id='collectors'
-            onChange={onChange}
-            collectors={record.collectors}
-          />
+          <Collectors2 organizationId={organization.id} onChange={onChange} collectors={record.collectors} />
         </Grid>
         <Grid item xs={12}>
           <Typography>{strings.SITE_DETAIL} </Typography>

--- a/src/components/accession2/edit/Accession2EditModal.tsx
+++ b/src/components/accession2/edit/Accession2EditModal.tsx
@@ -89,7 +89,7 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
             type='text'
             label={strings.ID}
             value={record?.accessionNumber}
-            onChange={onChange}
+            onChange={(value) => onChange('accessionNumber', value)}
             readonly={true}
             tooltipTitle={strings.TOOLTIP_ACCESSIONS_ID}
           />
@@ -119,7 +119,7 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
             type='text'
             label={strings.COLLECTING_SITE}
             value={record?.collectionSiteName}
-            onChange={onChange}
+            onChange={(value) => onChange('collectionSiteName', value)}
             tooltipTitle={strings.TOOLTIP_ACCESSIONS_ADD_COLLECTING_SITE}
           />
         </Grid>
@@ -130,7 +130,7 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
             type='text'
             label={strings.LANDOWNER}
             value={record?.collectionSiteLandowner}
-            onChange={onChange}
+            onChange={(value) => onChange('collectionSiteLandowner', value)}
           />
         </Grid>
         <Accession2Address record={record} onChange={onChange} opened={true} />

--- a/src/components/accession2/edit/CalculatorModal.tsx
+++ b/src/components/accession2/edit/CalculatorModal.tsx
@@ -125,7 +125,7 @@ export default function CalculatorModal(props: CalculatorModalProps): JSX.Elemen
                 <Textfield
                   label={strings.SUBSET_WEIGHT}
                   id='subsetWeight'
-                  onChange={(id, value) => onChangeSubsetWeight(value as number)}
+                  onChange={(value) => onChangeSubsetWeight(Number(value))}
                   type='text'
                   value={record.subsetWeight?.quantity}
                   errorText={subsetError}
@@ -147,7 +147,7 @@ export default function CalculatorModal(props: CalculatorModalProps): JSX.Elemen
             <Textfield
               label={strings.SUBSET_COUNT}
               id='subsetCount'
-              onChange={onChange}
+              onChange={(value) => onChange('subsetCount', value)}
               type='text'
               value={record.subsetCount}
             />
@@ -157,7 +157,7 @@ export default function CalculatorModal(props: CalculatorModalProps): JSX.Elemen
               <Textfield
                 label={strings.TOTAL_WEIGHT}
                 id='remainingQuantity'
-                onChange={(id, value) => onChangeRemainingQuantity(value as number)}
+                onChange={(value) => onChangeRemainingQuantity(Number(value))}
                 type='text'
                 value={record.remainingQuantity?.quantity}
               />

--- a/src/components/accession2/edit/EndDryingReminderModal.tsx
+++ b/src/components/accession2/edit/EndDryingReminderModal.tsx
@@ -118,7 +118,7 @@ export default function EndDryingReminderModal(props: EndDryingReminderModalProp
             id='enable'
             name=''
             label={strings.TURN_ON_END_DRYING_REMINDER}
-            onChange={onEnable}
+            onChange={(value) => onEnable('enable', value)}
             value={enable}
           />
         </Grid>
@@ -127,7 +127,7 @@ export default function EndDryingReminderModal(props: EndDryingReminderModalProp
           label={strings.REMINDER_DATE}
           aria-label={strings.REMINDER_DATE}
           value={date}
-          onChange={changeDate}
+          onChange={(value) => changeDate('dryingEndDate', value)}
           errorText={dateError}
           disabled={!enable}
         />

--- a/src/components/accession2/edit/QuantityModal.tsx
+++ b/src/components/accession2/edit/QuantityModal.tsx
@@ -166,7 +166,7 @@ export default function QuantityModal(props: QuantityModalProps): JSX.Element {
             <Textfield
               label={strings.SEED_COUNT}
               id='seedsQuantity'
-              onChange={(id, value) => onChangeRemainingQuantity(id, value as number)}
+              onChange={(value) => onChangeRemainingQuantity('seedsQuantity', Number(value))}
               type='text'
               value={
                 record.remainingQuantity?.units === 'Seeds' ? record.remainingQuantity?.quantity : record.estimatedCount
@@ -185,7 +185,7 @@ export default function QuantityModal(props: QuantityModalProps): JSX.Element {
               <Textfield
                 label={strings.OR_SEED_WEIGHT}
                 id='quantity'
-                onChange={(id, value) => onChangeRemainingQuantity(id, value as number)}
+                onChange={(value) => onChangeRemainingQuantity('quantity', Number(value))}
                 type='text'
                 value={record.remainingQuantity?.units !== 'Seeds' ? record.remainingQuantity?.quantity : ''}
               />

--- a/src/components/accession2/edit/ViabilityModal.tsx
+++ b/src/components/accession2/edit/ViabilityModal.tsx
@@ -88,7 +88,7 @@ export default function ViabilityDialog(props: ViabilityDialogProps): JSX.Elemen
               <Textfield
                 label={strings.VIABILITY_RATE}
                 id='viabilityPercent'
-                onChange={onChange}
+                onChange={(value) => onChange('viabilityPercent', value)}
                 type='text'
                 value={record.viabilityPercent}
                 errorText={error}

--- a/src/components/accession2/properties/Accession2Address.tsx
+++ b/src/components/accession2/properties/Accession2Address.tsx
@@ -96,7 +96,7 @@ export default function Accession2Address(props: Accession2AddressProps): JSX.El
         <Textfield
           id='collectionSiteCity'
           value={record.collectionSiteCity}
-          onChange={onChange}
+          onChange={(value) => onChange('collectionSiteCity', value)}
           type='text'
           label={strings.CITY}
         />
@@ -107,7 +107,7 @@ export default function Accession2Address(props: Accession2AddressProps): JSX.El
             <Autocomplete
               id='collectionSiteCountryCode'
               selected={getSelectedCountry()?.name || temporalCountryValue}
-              onChange={(index, value: any) => onChangeCountry(value)}
+              onChange={(value: any) => onChangeCountry(value)}
               label={strings.COUNTRY}
               placeholder={strings.COUNTRY}
               values={countries?.map((country) => country.name) || []}
@@ -118,7 +118,7 @@ export default function Accession2Address(props: Accession2AddressProps): JSX.El
             <Autocomplete
               id='collectionSiteCountrySubdivision'
               selected={getSelectedSubdivision()?.name || temporalSubValue}
-              onChange={(index, value: any) => onChangeSubdivision(value)}
+              onChange={(value: any) => onChangeSubdivision(value)}
               label={strings.STATE_PROVINCE_REGION}
               placeholder={strings.STATE_PROVINCE_REGION}
               values={getSelectedCountry()?.subdivisions?.map((subdivision) => subdivision.name) || []}
@@ -131,7 +131,7 @@ export default function Accession2Address(props: Accession2AddressProps): JSX.El
         <Textfield
           id='collectionSiteNotes'
           value={record.collectionSiteNotes}
-          onChange={onChange}
+          onChange={(value) => onChange('collectionSiteNotes', value)}
           type='textarea'
           label={strings.DESCRIPTION_NOTES}
         />

--- a/src/components/accession2/properties/Accession2GPS.tsx
+++ b/src/components/accession2/properties/Accession2GPS.tsx
@@ -97,7 +97,7 @@ export default function Accession2GPS(props: Accession2GPSProps): JSX.Element {
           <Textfield
             id={`gpsCoords${index}`}
             value={gpsCoords}
-            onChange={(unused, value) => onUpdateGPS(value, index)}
+            onChange={(value) => onUpdateGPS(value, index)}
             label={index === 0 ? strings.LATITUDE_LONGITUDE : ''}
             type='text'
           />

--- a/src/components/accession2/properties/Accession2PlantSiteDetails.tsx
+++ b/src/components/accession2/properties/Accession2PlantSiteDetails.tsx
@@ -52,7 +52,7 @@ export default function Accession2PlantSiteDetails(props: Accession2PlantSiteDet
           <Textfield
             id='plantsCollectedFrom'
             value={record.plantsCollectedFrom}
-            onChange={onChange}
+            onChange={(value) => onChange('plantsCollectedFrom', value)}
             type='number'
             min={0}
             label={strings.NUMBER_PLANTS_COLLECTED_FROM}
@@ -62,7 +62,7 @@ export default function Accession2PlantSiteDetails(props: Accession2PlantSiteDet
           <Textfield
             id='plantId'
             value={record.plantId}
-            onChange={onChange}
+            onChange={(value) => onChange('plantId', value)}
             type='text'
             label={strings.PLANT_ID + ' ' + strings.IF_APPLICABLE}
             tooltipTitle={strings.TOOLTIP_ACCESSIONS_ADD_PLANT_ID}
@@ -73,7 +73,7 @@ export default function Accession2PlantSiteDetails(props: Accession2PlantSiteDet
         <Textfield
           id='notes'
           value={record.notes}
-          onChange={onChange}
+          onChange={(value) => onChange('notes', value)}
           type='textarea'
           label={strings.PLANT_DESCRIPTION}
         />

--- a/src/components/accession2/properties/CollectedReceivedDate2.tsx
+++ b/src/components/accession2/properties/CollectedReceivedDate2.tsx
@@ -82,7 +82,7 @@ export default function CollectedReceivedDate2({ onChange, record, type, validat
           label={strings.COLLECTION_DATE_REQUIRED}
           aria-label={strings.COLLECTION_DATE_REQUIRED}
           value={dates.collectedDate}
-          onChange={changeDate}
+          onChange={(value) => changeDate('collectedDate', value)}
           errorText={dateErrors.collectedDate}
           maxDate={Date.now()}
         />
@@ -92,7 +92,7 @@ export default function CollectedReceivedDate2({ onChange, record, type, validat
           label={strings.RECEIVING_DATE_REQUIRED}
           aria-label={strings.RECEIVING_DATE_REQUIRED}
           value={dates.receivedDate}
-          onChange={changeDate}
+          onChange={(value) => changeDate('receivedDate', value)}
           errorText={dateErrors.receivedDate}
         />
       )}

--- a/src/components/accession2/properties/Collectors2.tsx
+++ b/src/components/accession2/properties/Collectors2.tsx
@@ -59,7 +59,7 @@ export default function Collectors2({ organizationId, id, collectors = [''], onC
           <Autocomplete
             id={`collector${index}`}
             selected={collector}
-            onChange={(unused, value) => onCollectorChange(value, index)}
+            onChange={(value) => onCollectorChange(value, index)}
             label={index === 0 ? strings.COLLECTORS : ''}
             placeholder={strings.COLLECTORS}
             values={collectorsOpt || []}

--- a/src/components/accession2/properties/Collectors2.tsx
+++ b/src/components/accession2/properties/Collectors2.tsx
@@ -9,12 +9,11 @@ import AddLink from 'src/components/common/AddLink';
 
 interface Props {
   organizationId: number;
-  id: string;
   collectors?: string[];
   onChange: (id: string, value: string[]) => void;
 }
 
-export default function Collectors2({ organizationId, id, collectors = [''], onChange }: Props): JSX.Element {
+export default function Collectors2({ organizationId, collectors = [''], onChange }: Props): JSX.Element {
   const [collectorsList, setCollectorsList] = useState<string[]>([...collectors]);
   const [collectorsOpt, setCollectorsOpt] = useState<string[]>();
   const theme = useTheme();
@@ -38,7 +37,7 @@ export default function Collectors2({ organizationId, id, collectors = [''], onC
     setCollectorsList((prev) => {
       const updatedCollectors = [...prev];
       updatedCollectors[index] = value as string;
-      onChange(id, getNonEmptyCollectors(updatedCollectors));
+      onChange('collectors', getNonEmptyCollectors(updatedCollectors));
       return updatedCollectors;
     });
   };
@@ -47,7 +46,7 @@ export default function Collectors2({ organizationId, id, collectors = [''], onC
     setCollectorsList((prev) => {
       const updatedCollectors = [...prev];
       updatedCollectors.splice(index, 1);
-      onChange(id, getNonEmptyCollectors(updatedCollectors));
+      onChange('collectors', getNonEmptyCollectors(updatedCollectors));
       return updatedCollectors;
     });
   };

--- a/src/components/accession2/viabilityTesting/NewViabilityTestModal.tsx
+++ b/src/components/accession2/viabilityTesting/NewViabilityTestModal.tsx
@@ -564,7 +564,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
                     label={record?.testType === 'Cut' ? strings.TEST_DATE_REQUIRED : strings.START_DATE_REQUIRED}
                     aria-label={strings.DATE}
                     value={record?.startDate}
-                    onChange={onChange}
+                    onChange={(value) => onChange('startDate', value)}
                     disabled={readOnly}
                     errorText={viabilityFieldsErrors.startDate}
                   />
@@ -574,7 +574,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
                     <Textfield
                       label={strings.NUMBER_OF_SEEDS_FILLED_REQUIRED}
                       type='text'
-                      onChange={onChangeCutValue}
+                      onChange={(value) => onChangeCutValue('seedsFilled', value)}
                       id='seedsFilled'
                       value={record?.seedsFilled}
                       errorText={validateFields && !record?.seedsFilled ? strings.REQUIRED_FIELD : ''}
@@ -583,7 +583,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
                     <Textfield
                       label={strings.NUMBER_OF_SEEDS_TESTED_REQUIRED}
                       type='text'
-                      onChange={onChangeSeedsTested}
+                      onChange={(value) => onChangeSeedsTested('seedsTested', value)}
                       id='seedsTested'
                       value={record?.seedsTested}
                       disabled={readOnly}
@@ -600,7 +600,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
                       <Textfield
                         label={strings.NUMBER_OF_SEEDS_COMPROMISED_REQUIRED}
                         type='text'
-                        onChange={onChangeCutValue}
+                        onChange={(value) => onChangeCutValue('seedsCompromised', value)}
                         id='seedsCompromised'
                         value={record?.seedsCompromised}
                         errorText={validateFields && !record?.seedsCompromised ? strings.REQUIRED_FIELD : ''}
@@ -610,7 +610,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
                       <Textfield
                         label={strings.NUMBER_OF_SEEDS_EMPTY_REQUIRED}
                         type='text'
-                        onChange={onChangeCutValue}
+                        onChange={(value) => onChangeCutValue('seedsEmpty', value)}
                         id='seedsEmpty'
                         value={record?.seedsEmpty}
                         errorText={validateFields && !record?.seedsEmpty ? strings.REQUIRED_FIELD : ''}
@@ -640,7 +640,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
                       label={strings.CHECK_DATE_REQUIRED}
                       aria-label={strings.DATE}
                       value={testResult.recordingDate}
-                      onChange={(id, value) => onResultChange(id, value, index)}
+                      onChange={(value) => onResultChange('recordingDate', value, index)}
                       disabled={readOnly}
                       errorText={viabilityFieldsErrors[`recordingDate${index}`]}
                     />
@@ -650,7 +650,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
                       <Textfield
                         label={strings.NUMBER_OF_SEEDS_GERMINATED_REQUIRED}
                         type='text'
-                        onChange={(id, value) => onResultChange(id, value, index)}
+                        onChange={(value) => onResultChange('seedsGerminated', value, index)}
                         id='seedsGerminated'
                         value={testResult.seedsGerminated}
                         disabled={readOnly}
@@ -696,7 +696,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
                   {record?.testResults && record.testResults.length > 0 && (
                     <Checkbox
                       label={strings.MARK_AS_COMPLETE}
-                      onChange={(id, value) => markTestAsComplete(value)}
+                      onChange={(value) => markTestAsComplete(value)}
                       id='markAsComplete'
                       name='markAsComplete'
                       value={testCompleted}
@@ -709,7 +709,13 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
             </Grid>
           </Grid>
           <Grid padding={theme.spacing(1, 3, 1, 5)} xs={12}>
-            <Textfield id='notes' value={record?.notes} onChange={onChange} type='textarea' label={strings.NOTES} />
+            <Textfield
+              id='notes'
+              value={record?.notes}
+              onChange={(value) => onChange('notes', value)}
+              type='textarea'
+              label={strings.NOTES}
+            />
           </Grid>
         </Grid>
       </DialogBox>

--- a/src/components/accession2/withdraw/WithdrawModal.tsx
+++ b/src/components/accession2/withdraw/WithdrawModal.tsx
@@ -415,7 +415,7 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
                 )
                 .toString()}
               id='withdrawnQuantity'
-              onChange={(id, value) => onChangeWithdrawnQuantity(value as number)}
+              onChange={(value) => onChangeWithdrawnQuantity(Number(value))}
               type='text'
               value={
                 isNurseryTransfer
@@ -444,7 +444,7 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
             id='withdrawAll'
             name=''
             label={strings.WITHDRAW_ALL}
-            onChange={onSelectAll}
+            onChange={(value) => onSelectAll('withdrawAll', value)}
             value={withdrawAllSelected}
           />
         </Grid>
@@ -471,7 +471,7 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
                 label={strings.ESTIMATED_READY_DATE}
                 aria-label={strings.ESTIMATED_READY_DATE}
                 value={nurseryTransferRecord.readyByDate}
-                onChange={onChangeDate}
+                onChange={(value) => onChangeDate('readyByDate', value)}
                 errorText={fieldsErrors.readyByDate}
               />
             </Grid>
@@ -483,13 +483,19 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
             label={strings.DATE}
             aria-label={strings.DATE}
             value={record.date}
-            onChange={onChangeDate}
+            onChange={(value) => onChangeDate('date', value)}
             errorText={fieldsErrors.date}
           />
         </Grid>
         <Grid item xs={12} sx={{ marginTop: theme.spacing(2) }}>
           {isNotesOpened ? (
-            <Textfield id='notes' value={record.notes} onChange={onChangeNotes} type='textarea' label={strings.NOTES} />
+            <Textfield
+              id='notes'
+              value={record.notes}
+              onChange={(value) => onChangeNotes('notes', value)}
+              type='textarea'
+              label={strings.NOTES}
+            />
           ) : (
             <Box display='flex' justifyContent='flex-start'>
               <AddLink id='addNotes' onClick={() => setIsNotesOpened(true)} text={strings.ADD_NOTES} large={true} />

--- a/src/components/seeds/database/DownloadReportModal.tsx
+++ b/src/components/seeds/database/DownloadReportModal.tsx
@@ -71,7 +71,7 @@ export default function DownloadReportModal(props: DownloadReportModalProps): JS
             type='text'
             id='reportName'
             value={name}
-            onChange={(id, value) => {
+            onChange={(value) => {
               setName(value as string);
             }}
             label={strings.REPORT_NAME}

--- a/src/components/seeds/database/EditColumns.tsx
+++ b/src/components/seeds/database/EditColumns.tsx
@@ -115,7 +115,7 @@ export default function EditColumnsDialog(props: Props): JSX.Element {
                           name={key}
                           label={oName}
                           value={value.includes(key)}
-                          onChange={(id, newValue) => onChange(key, newValue)}
+                          onChange={(newValue) => onChange(key, newValue)}
                         />
                       </Grid>
                     ))}

--- a/src/components/seeds/database/filters/FilterCountWeight.tsx
+++ b/src/components/seeds/database/filters/FilterCountWeight.tsx
@@ -167,34 +167,72 @@ export default function FilterCountWeight(props: Props): JSX.Element {
     <div className={classes.box}>
       <Grid container spacing={4}>
         <Grid item xs={12}>
-          <Checkbox id='seedCount' name='Seed Count' label='Seed Count' value={seedCount} onChange={onChange} />
+          <Checkbox
+            id='seedCount'
+            name='Seed Count'
+            label='Seed Count'
+            value={seedCount}
+            onChange={(value) => onChange('seedCount', value)}
+          />
         </Grid>
         <Grid item xs={5}>
-          <TextField id='countMinValue' value={countMinValue} onChange={onChange} label='Min' />
+          <TextField
+            id='countMinValue'
+            value={countMinValue}
+            onChange={(value) => onChange('countMinValue', value)}
+            label='Min'
+          />
         </Grid>
         <Grid item xs={1} className={classes.flexContainer}>
           <ArrowForward />
         </Grid>
         <Grid item xs={5}>
-          <TextField id='countMaxValue' value={countMaxValue} onChange={onChange} label='Max' />
+          <TextField
+            id='countMaxValue'
+            value={countMaxValue}
+            onChange={(value) => onChange('countMaxValue', value)}
+            label='Max'
+          />
         </Grid>
         <Grid item xs={5}>
-          <TextField id='seeds' disabled={true} value='seeds' onChange={onChange} label='Units' />
+          <TextField
+            id='seeds'
+            disabled={true}
+            value='seeds'
+            onChange={(value) => onChange('seeds', value)}
+            label='Units'
+          />
         </Grid>
         <Grid item xs={12}>
           <Divisor mt={0} />
         </Grid>
         <Grid item xs={12}>
-          <Checkbox id='seedWeight' name='Seed Weight' label='Seed Weight' value={seedWeight} onChange={onChange} />
+          <Checkbox
+            id='seedWeight'
+            name='Seed Weight'
+            label='Seed Weight'
+            value={seedWeight}
+            onChange={(value) => onChange('seedWeight', value)}
+          />
         </Grid>
         <Grid item xs={5}>
-          <TextField id='weightMinValue' value={weightMinValue} onChange={onChange} label='Min' />
+          <TextField
+            id='weightMinValue'
+            value={weightMinValue}
+            onChange={(value) => onChange('weightMinValue', value)}
+            label='Min'
+          />
         </Grid>
         <Grid item xs={1} className={classes.flexContainer}>
           <ArrowForward />
         </Grid>
         <Grid item xs={5}>
-          <TextField id='weightMaxValue' value={weightMaxValue} onChange={onChange} label='Max' />
+          <TextField
+            id='weightMaxValue'
+            value={weightMaxValue}
+            onChange={(value) => onChange('weightMaxValue', value)}
+            label='Max'
+          />
         </Grid>
         <Grid item xs={5}>
           <Dropdown
@@ -202,7 +240,7 @@ export default function FilterCountWeight(props: Props): JSX.Element {
             label={strings.UNITS}
             selected={weightUnit}
             values={WEIGHT_UNITS}
-            onChange={onChange}
+            onChange={(value) => onChange('processingUnit', value)}
           />
         </Grid>
         <Grid item xs={12}>
@@ -214,7 +252,7 @@ export default function FilterCountWeight(props: Props): JSX.Element {
             name='Empty Fields'
             label='Include empty fields'
             value={emptyFields}
-            onChange={onChange}
+            onChange={(value) => onChange('emptyFields', value)}
           />
         </Grid>
       </Grid>

--- a/src/components/seeds/database/filters/FilterDateRange.tsx
+++ b/src/components/seeds/database/filters/FilterDateRange.tsx
@@ -74,7 +74,7 @@ export default function DateRange(props: Props): JSX.Element {
             id='startDate'
             autoFocus={true}
             value={startDate}
-            onChange={onChangeDate}
+            onChange={(value) => onChangeDate('startDate', value)}
             label={strings.START}
             aria-label='Start date'
             onKeyPress={(e) => onEnter(e)}
@@ -87,7 +87,7 @@ export default function DateRange(props: Props): JSX.Element {
           <DatePicker
             id='endDate'
             value={endDate}
-            onChange={onChangeDate}
+            onChange={(value) => onChangeDate('endDate', value)}
             label={strings.END}
             aria-label='End date'
             onKeyPress={(e) => onEnter(e)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1304,6 +1304,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.18.9", "@babel/runtime@^7.20.7":
+  version "7.20.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.7.tgz#fcb41a5a70550e04a7b708037c7c32f7f356d8fd"
+  integrity sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/runtime@^7.2.0":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
@@ -1464,12 +1471,24 @@
   resolved "https://registry.yarnpkg.com/@date-io/core/-/core-2.15.0.tgz#8133860c8ce163b8d0cca3c1caed8d5d1fbfb14e"
   integrity sha512-3CRvQUEK7aF87NUOwcTtmJ2Rc1kN0D4jFQUfRoanuAnE4o5HzHx4E2YenjaKjSPWeZYiWG6ZhDomx5hp1AaCJA==
 
+"@date-io/core@^2.16.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-2.16.0.tgz#7871bfc1d9bca9aa35ad444a239505589d0f22f6"
+  integrity sha512-DYmSzkr+jToahwWrsiRA2/pzMEtz9Bq1euJwoOuYwuwIYXnZFtHajY2E6a1VNVDc9jP8YUXK1BvnZH9mmT19Zg==
+
 "@date-io/date-fns@^2.11.0", "@date-io/date-fns@^2.14.0":
   version "2.14.0"
   resolved "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-2.14.0.tgz"
   integrity sha512-4fJctdVyOd5cKIKGaWUM+s3MUXMuzkZaHuTY15PH70kU1YTMrCoauA7hgQVx9qj0ZEbGrH9VSPYJYnYro7nKiA==
   dependencies:
     "@date-io/core" "^2.14.0"
+
+"@date-io/date-fns@^2.15.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-2.16.0.tgz#bd5e09b6ecb47ee55e593fc3a87e7b2caaa3da40"
+  integrity sha512-bfm5FJjucqlrnQcXDVU5RD+nlGmL3iWgkHTq3uAZWVIuBu6dDmGa3m8a6zo2VQQpu8ambq9H22UyUpn7590joA==
+  dependencies:
+    "@date-io/core" "^2.16.0"
 
 "@date-io/dayjs@^2.11.0", "@date-io/dayjs@^2.14.0":
   version "2.14.0"
@@ -1478,12 +1497,26 @@
   dependencies:
     "@date-io/core" "^2.14.0"
 
+"@date-io/dayjs@^2.15.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@date-io/dayjs/-/dayjs-2.16.0.tgz#0d2c254ad8db1306fdc4b8eda197cb53c9af89dc"
+  integrity sha512-y5qKyX2j/HG3zMvIxTobYZRGnd1FUW2olZLS0vTj7bEkBQkjd2RO7/FEwDY03Z1geVGlXKnzIATEVBVaGzV4Iw==
+  dependencies:
+    "@date-io/core" "^2.16.0"
+
 "@date-io/luxon@^2.11.1", "@date-io/luxon@^2.14.0":
   version "2.14.0"
   resolved "https://registry.npmjs.org/@date-io/luxon/-/luxon-2.14.0.tgz"
   integrity sha512-KmpBKkQFJ/YwZgVd0T3h+br/O0uL9ZdE7mn903VPAG2ZZncEmaUfUdYKFT7v7GyIKJ4KzCp379CRthEbxevEVg==
   dependencies:
     "@date-io/core" "^2.14.0"
+
+"@date-io/luxon@^2.15.0":
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/@date-io/luxon/-/luxon-2.16.1.tgz#b08786614cb58831c729a15807753011e4acb966"
+  integrity sha512-aeYp5K9PSHV28946pC+9UKUi/xMMYoaGelrpDibZSgHu2VWHXrr7zWLEr+pMPThSs5vt8Ei365PO+84pCm37WQ==
+  dependencies:
+    "@date-io/core" "^2.16.0"
 
 "@date-io/moment@^1.3.13":
   version "1.3.13"
@@ -1492,19 +1525,19 @@
   dependencies:
     "@date-io/core" "^1.3.13"
 
-"@date-io/moment@^2.10.11":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-2.15.0.tgz#d6c2c88b58534d0c44644abcfefc27cb32182dd8"
-  integrity sha512-AcYBjl3EnEGsByaM5ir644CKbhgJsgc1iWFa9EXfdb4fQexxOC8oCdPAurK2ZDTwg62odyyKa/05YE7ElYh5ag==
-  dependencies:
-    "@date-io/core" "^2.15.0"
-
 "@date-io/moment@^2.11.0", "@date-io/moment@^2.14.0":
   version "2.14.0"
   resolved "https://registry.npmjs.org/@date-io/moment/-/moment-2.14.0.tgz"
   integrity sha512-VsoLXs94GsZ49ecWuvFbsa081zEv2xxG7d+izJsqGa2L8RPZLlwk27ANh87+SNnOUpp+qy2AoCAf0mx4XXhioA==
   dependencies:
     "@date-io/core" "^2.14.0"
+
+"@date-io/moment@^2.15.0", "@date-io/moment@^2.16.1":
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-2.16.1.tgz#ec6e0daa486871e0e6412036c6f806842a0eeed4"
+  integrity sha512-JkxldQxUqZBfZtsaCcCMkm/dmytdyq5pS1RxshCQ4fHhsvP5A7gSqPD22QbVXMcJydi3d3v1Y8BQdUKEuGACZQ==
+  dependencies:
+    "@date-io/core" "^2.16.0"
 
 "@dnd-kit/accessibility@^3.0.0":
   version "3.0.1"
@@ -2168,6 +2201,17 @@
   resolved "https://registry.npmjs.org/@mui/types/-/types-7.1.4.tgz"
   integrity sha512-uveM3byMbthO+6tXZ1n2zm0W3uJCQYtwt/v5zV5I77v2v18u0ITkb8xwhsDD2i3V2Kye7SaNR6FFJ6lMuY/WqQ==
 
+"@mui/utils@^5.10.3":
+  version "5.11.2"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.11.2.tgz#29764311acb99425159b159b1cb382153ad9be1f"
+  integrity sha512-AyizuHHlGdAtH5hOOXBW3kriuIwUIKUIgg0P7LzMvzf6jPhoQbENYqY6zJqfoZ7fAWMNNYT8mgN5EftNGzwE2w==
+  dependencies:
+    "@babel/runtime" "^7.20.7"
+    "@types/prop-types" "^15.7.5"
+    "@types/react-is" "^16.7.1 || ^17.0.0"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
+
 "@mui/utils@^5.4.1", "@mui/utils@^5.6.0", "@mui/utils@^5.8.6":
   version "5.8.6"
   resolved "https://registry.npmjs.org/@mui/utils/-/utils-5.8.6.tgz"
@@ -2208,6 +2252,24 @@
     clsx "^1.1.1"
     prop-types "^15.7.2"
     react-transition-group "^4.4.2"
+    rifm "^0.12.1"
+
+"@mui/x-date-pickers@^5.0.12":
+  version "5.0.13"
+  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-5.0.13.tgz#0188f17483984ffe3f615444bff225256f7b4a0c"
+  integrity sha512-nUc35Zvah/l4bEWcPNRtSvWBL+7uAlokd6G6PzQfLe2TQo4GNlK1JVRfoVpBY5FsdM09uWLrpvfWLbka87k7GA==
+  dependencies:
+    "@babel/runtime" "^7.18.9"
+    "@date-io/core" "^2.15.0"
+    "@date-io/date-fns" "^2.15.0"
+    "@date-io/dayjs" "^2.15.0"
+    "@date-io/luxon" "^2.15.0"
+    "@date-io/moment" "^2.15.0"
+    "@mui/utils" "^5.10.3"
+    "@types/react-transition-group" "^4.4.5"
+    clsx "^1.2.1"
+    prop-types "^15.7.2"
+    react-transition-group "^4.4.5"
     rifm "^0.12.1"
 
 "@nodelib/fs.scandir@2.1.5":
@@ -2446,23 +2508,23 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^2.0.56":
-  version "2.0.56"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.56.tgz#e93332a09079d3eb55298ac3b039c808047437f5"
-  integrity sha512-G+xAkGvs2tT8liqxbnJhG2K/I0F8FSrv4FfXFiUna3MC00NXZSL/4cpScoZdF6VBc4fSQpXMFFWUMoOHpl6Qog==
+"@terraware/web-components@2.0.58":
+  version "2.0.58"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.58.tgz#4a98cb74b0075d4d733a5b6b1f68602ea52c60d9"
+  integrity sha512-DxD8HPkpNBrVv7EpISEHr+Am4mcBZkPlgI6Jw+ZSy+VAxiGxfipcTBIyfntLyQRaTucOGbbydOSRd7e8QveZow==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
-    "@date-io/moment" "^2.10.11"
+    "@date-io/moment" "^2.16.1"
     "@dnd-kit/core" "^6.0.5"
     "@dnd-kit/sortable" "^7.0.1"
     "@emotion/react" "^11.9.3"
     "@mui/icons-material" "^5.8.4"
     "@mui/material" "^5.8.7"
     "@mui/styles" "^5.8.7"
-    "@mui/x-date-pickers" "^5.0.0-alpha.7"
-    classnames "^2.3.1"
-    date-fns "^2.28.0"
-    moment "^2.29.1"
+    "@mui/x-date-pickers" "^5.0.12"
+    classnames "^2.3.2"
+    date-fns "^2.29.3"
+    moment "^2.29.4"
     moment-timezone "^0.5.37"
     react "^17.0.2"
     react-dom "^17.0.2"
@@ -4632,6 +4694,11 @@ classnames@^2.3.1:
   resolved "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
+classnames@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
 clean-css@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz"
@@ -4703,6 +4770,11 @@ clsx@^1.1.1, clsx@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/clsx/-/clsx-1.2.0.tgz"
   integrity sha512-EPRP7XJsM1y0iCU3Z7C7jFKdQboXSeHgEfzQUTlz7m5NP3hDrlz48aUsmNGp4pC+JOW9WA3vIRqlYuo/bl4Drw==
+
+clsx@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
 
 co@^4.6.0:
   version "4.6.0"
@@ -5482,7 +5554,7 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-date-fns@^2.28.0, date-fns@^2.29.3:
+date-fns@^2.29.3:
   version "2.29.3"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
   integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
@@ -9951,7 +10023,7 @@ moment-timezone@^0.5.37:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0":
+"moment@>= 2.9.0", moment@^2.29.4:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
@@ -11948,6 +12020,11 @@ react-is@^17.0.1, react-is@^17.0.2:
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-is@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
 react-localization@^1.0.17:
   version "1.0.17"
   resolved "https://registry.npmjs.org/react-localization/-/react-localization-1.0.17.tgz"
@@ -12101,6 +12178,16 @@ react-transition-group@^4.4.2:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
+react-transition-group@^4.4.5:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+
 react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.npmjs.org/react/-/react-17.0.2.tgz"
@@ -12216,6 +12303,11 @@ regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
+
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.9"


### PR DESCRIPTION
This is to follow up on onChange signature change from `(id, value)` to just `(value)` - see https://github.com/terraware/web-components/pull/233