### PR TITLE
SW-2667 Add a user-provider in the web-app react tree

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,7 @@ import PlantsDashboard from './components/Plants';
 import { NurseryWithdrawals, NurseryWithdrawalsDetails, NurseryReassignment } from './components/NurseryWithdrawals';
 import { listPlantingSites } from './api/tracking/tracking';
 import { PlantingSite } from './api/types/tracking';
+import { UserProvider } from './providers';
 
 interface StyleProps {
   isDesktop?: boolean;
@@ -350,19 +351,19 @@ export default function App() {
     if (organizations?.length === 0) {
       return (
         <StyledEngineProvider injectFirst>
-          <TopBar fullWidth={true}>
-            <TopBarContent
-              organizations={organizations}
-              selectedOrganization={selectedOrganization}
-              setSelectedOrganization={setSelectedOrganization}
-              reloadOrganizationData={reloadData}
-              user={user}
-              reloadUser={reloadUser}
-              setShowNavBar={setShowNavBar}
-            />
-          </TopBar>
-          <ToastSnackbar />
-          <NoOrgLandingPage reloadOrganizationData={reloadData} />
+          <UserProvider data={{ user, reloadUser }}>
+            <TopBar fullWidth={true}>
+              <TopBarContent
+                organizations={organizations}
+                selectedOrganization={selectedOrganization}
+                setSelectedOrganization={setSelectedOrganization}
+                reloadOrganizationData={reloadData}
+                setShowNavBar={setShowNavBar}
+              />
+            </TopBar>
+            <ToastSnackbar />
+            <NoOrgLandingPage reloadOrganizationData={reloadData} />
+          </UserProvider>
         </StyledEngineProvider>
       );
     } else if (!selectedOrganization) {
@@ -433,9 +434,8 @@ export default function App() {
     return false;
   };
 
-  return (
-    <StyledEngineProvider injectFirst>
-      <CssBaseline />
+  const getContent = () => (
+    <>
       <ToastSnackbar />
       <TopBar>
         <TopBarContent
@@ -443,8 +443,6 @@ export default function App() {
           selectedOrganization={selectedOrganization}
           setSelectedOrganization={setSelectedOrganization}
           reloadOrganizationData={reloadData}
-          user={user}
-          reloadUser={reloadUser}
           setShowNavBar={setShowNavBar}
         />
       </TopBar>
@@ -518,7 +516,7 @@ export default function App() {
               )}
               {selectedOrganization && user && (
                 <Route path={APP_PATHS.ACCESSIONS2_ITEM}>
-                  <Accession2View organization={selectedOrganization} user={user} />
+                  <Accession2View organization={selectedOrganization} />
                 </Route>
               )}
               {selectedOrganization && (
@@ -574,7 +572,7 @@ export default function App() {
                 <PersonDetails organization={organizationWithoutSB()} />
               </Route>
               <Route exact path={APP_PATHS.PEOPLE}>
-                <People organization={selectedOrganization} reloadData={reloadData} user={user} />
+                <People organization={selectedOrganization} reloadData={reloadData} />
               </Route>
               {selectedOrganization && (
                 <Route exact path={APP_PATHS.SEED_BANKS_NEW}>
@@ -699,18 +697,12 @@ export default function App() {
               </Route>
               {user && (
                 <Route exact path={APP_PATHS.MY_ACCOUNT_EDIT}>
-                  <MyAccount
-                    user={user}
-                    organizations={organizations}
-                    edit={true}
-                    reloadUser={reloadUser}
-                    reloadData={reloadData}
-                  />
+                  <MyAccount organizations={organizations} edit={true} reloadData={reloadData} />
                 </Route>
               )}
               {user && (
                 <Route exact path={APP_PATHS.MY_ACCOUNT}>
-                  <MyAccount user={user} organizations={organizations} edit={false} reloadUser={reloadUser} />
+                  <MyAccount organizations={organizations} edit={false} />
                 </Route>
               )}
 
@@ -750,6 +742,13 @@ export default function App() {
           </ErrorBoundary>
         </div>
       </div>
+    </>
+  );
+
+  return (
+    <StyledEngineProvider injectFirst>
+      <CssBaseline />
+      <UserProvider data={{ user, reloadUser }}>{getContent()}</UserProvider>
     </StyledEngineProvider>
   );
 }

--- a/src/components/MyAccount/index.tsx
+++ b/src/components/MyAccount/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { updateOrganizationUser, updateUserProfile } from 'src/api/user/user';
 import Button from 'src/components/common/button/Button';
@@ -24,7 +24,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 import TfMain from 'src/components/common/TfMain';
 import PageHeaderWrapper from '../common/PageHeaderWrapper';
 import TitleDescription from '../common/TitleDescription';
-import { UserContext } from 'src/providers';
+import { useUser } from 'src/providers';
 
 const columns: TableColumnType[] = [
   { key: 'name', name: strings.ORGANIZATION_NAME, type: 'string' },
@@ -40,7 +40,7 @@ type MyAccountProps = {
 };
 
 export default function MyAccount(props: MyAccountProps): JSX.Element | null {
-  const { user, reloadUser } = useContext(UserContext);
+  const { user, reloadUser } = useUser();
 
   if (!user) {
     return null;

--- a/src/components/MyAccount/index.tsx
+++ b/src/components/MyAccount/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { updateOrganizationUser, updateUserProfile } from 'src/api/user/user';
 import Button from 'src/components/common/button/Button';
@@ -24,6 +24,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 import TfMain from 'src/components/common/TfMain';
 import PageHeaderWrapper from '../common/PageHeaderWrapper';
 import TitleDescription from '../common/TitleDescription';
+import { UserContext } from 'src/providers';
 
 const columns: TableColumnType[] = [
   { key: 'name', name: strings.ORGANIZATION_NAME, type: 'string' },
@@ -33,6 +34,22 @@ const columns: TableColumnType[] = [
 ];
 
 type MyAccountProps = {
+  organizations?: ServerOrganization[];
+  edit: boolean;
+  reloadData?: () => void;
+};
+
+export default function MyAccount(props: MyAccountProps): JSX.Element | null {
+  const { user, reloadUser } = useContext(UserContext);
+
+  if (!user) {
+    return null;
+  }
+
+  return <MyAccountContent user={user} reloadUser={reloadUser} {...props} />;
+}
+
+type MyAccountContentProps = {
   user: User;
   organizations?: ServerOrganization[];
   edit: boolean;
@@ -40,7 +57,13 @@ type MyAccountProps = {
   reloadData?: () => void;
 };
 
-export default function MyAccount({ user, organizations, edit, reloadUser, reloadData }: MyAccountProps): JSX.Element {
+const MyAccountContent = ({
+  user,
+  organizations,
+  edit,
+  reloadUser,
+  reloadData,
+}: MyAccountContentProps): JSX.Element => {
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
   const [selectedRows, setSelectedRows] = useState<ServerOrganization[]>([]);
@@ -339,4 +362,4 @@ export default function MyAccount({ user, organizations, edit, reloadUser, reloa
       </PageForm>
     </TfMain>
   );
-}
+};

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -94,6 +94,7 @@ export default function NavBar({
           closeAndNavigateTo(APP_PATHS.INVENTORY);
         }}
         id='inventory'
+        key='inventory'
       />
     );
 
@@ -104,7 +105,8 @@ export default function NavBar({
         onClick={() => {
           closeAndNavigateTo(APP_PATHS.NURSERY_WITHDRAWALS);
         }}
-        id='inventory'
+        id='withdrawallog'
+        key='withdrawallog'
       />
     );
 

--- a/src/components/SmallDeviceUserMenu.tsx
+++ b/src/components/SmallDeviceUserMenu.tsx
@@ -13,7 +13,7 @@ import {
   useTheme,
 } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import { useEffect, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import hexRgb from 'hex-rgb';
@@ -24,7 +24,7 @@ import { User } from 'src/types/User';
 import AddNewOrganizationModal from './AddNewOrganizationModal';
 import Icon from './common/icon/Icon';
 import useEnvironment from 'src/utils/useEnvironment';
-import { UserContext } from 'src/providers';
+import { useUser } from 'src/providers';
 
 const useStyles = makeStyles((theme: Theme) => ({
   icon: {
@@ -109,7 +109,7 @@ export default function SmallDeviceUserMenu({
   onLogout,
   hasOrganizations,
 }: SmallDeviceUserMenuProps): JSX.Element | null {
-  const { user } = useContext(UserContext);
+  const { user } = useUser();
   const classes = useStyles();
   const theme = useTheme();
   const history = useHistory();

--- a/src/components/SmallDeviceUserMenu.tsx
+++ b/src/components/SmallDeviceUserMenu.tsx
@@ -13,7 +13,7 @@ import {
   useTheme,
 } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { useEffect, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import hexRgb from 'hex-rgb';
@@ -24,6 +24,7 @@ import { User } from 'src/types/User';
 import AddNewOrganizationModal from './AddNewOrganizationModal';
 import Icon from './common/icon/Icon';
 import useEnvironment from 'src/utils/useEnvironment';
+import { UserContext } from 'src/providers';
 
 const useStyles = makeStyles((theme: Theme) => ({
   icon: {
@@ -106,9 +107,9 @@ export default function SmallDeviceUserMenu({
   setSelectedOrganization,
   reloadOrganizationData,
   onLogout,
-  user,
   hasOrganizations,
 }: SmallDeviceUserMenuProps): JSX.Element | null {
+  const { user } = useContext(UserContext);
   const classes = useStyles();
   const theme = useTheme();
   const history = useHistory();

--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -4,7 +4,6 @@ import { Svg } from '@terraware/web-components';
 import React from 'react';
 
 import { ServerOrganization } from 'src/types/Organization';
-import { User } from 'src/types/User';
 import Icon from '../common/icon/Icon';
 import NotificationsDropdown from '../NotificationsDropdown';
 import OrganizationsDropdown from '../OrganizationsDropdown';
@@ -51,22 +50,12 @@ type TopBarProps = {
   setSelectedOrganization: React.Dispatch<React.SetStateAction<ServerOrganization | undefined>>;
   selectedOrganization?: ServerOrganization;
   reloadOrganizationData: (selectedOrgId?: number) => void;
-  user?: User;
-  reloadUser: () => void;
   setShowNavBar: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export default function TopBarContent(props: TopBarProps): JSX.Element | null {
   const classes = useStyles();
-  const {
-    setSelectedOrganization,
-    selectedOrganization,
-    organizations,
-    reloadOrganizationData,
-    user,
-    reloadUser,
-    setShowNavBar,
-  } = props;
+  const { setSelectedOrganization, selectedOrganization, organizations, reloadOrganizationData, setShowNavBar } = props;
   const { isDesktop } = useDeviceInfo();
 
   const onHandleLogout = () => {
@@ -97,7 +86,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
           reloadOrganizationData={reloadOrganizationData}
         />
         <div className={classes.separator} />
-        <UserMenu user={user} reloadUser={reloadUser} hasOrganizations={organizations && organizations.length > 0} />
+        <UserMenu hasOrganizations={organizations && organizations.length > 0} />
       </div>
     </>
   ) : (
@@ -119,7 +108,6 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
         />
         <SmallDeviceUserMenu
           onLogout={onHandleLogout}
-          user={user}
           organizations={organizations}
           selectedOrganization={selectedOrganization}
           setSelectedOrganization={setSelectedOrganization}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { User } from 'src/types/User';
 import strings from '../../src/strings';
 import Icon from './common/icon/Icon';
 import { APP_PATHS, TERRAFORMATION_PRIVACY_POLICY } from 'src/constants';
@@ -9,6 +8,7 @@ import { makeStyles } from '@mui/styles';
 import useEnvironment from 'src/utils/useEnvironment';
 import PopoverMenu from './common/PopoverMenu';
 import { DropdownItem } from '@terraware/web-components';
+import { UserContext } from 'src/providers';
 
 const useStyles = makeStyles((theme: Theme) => ({
   iconContainer: {
@@ -32,12 +32,11 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 type UserMenuProps = {
-  user?: User;
-  reloadUser: () => void;
   hasOrganizations?: boolean;
 };
-export default function UserMenu({ user, reloadUser, hasOrganizations }: UserMenuProps): JSX.Element {
+export default function UserMenu({ hasOrganizations }: UserMenuProps): JSX.Element {
   const classes = useStyles();
+  const { user } = useContext(UserContext);
   const { isProduction } = useEnvironment();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const history = useHistory();

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import strings from '../../src/strings';
 import Icon from './common/icon/Icon';
@@ -8,7 +8,7 @@ import { makeStyles } from '@mui/styles';
 import useEnvironment from 'src/utils/useEnvironment';
 import PopoverMenu from './common/PopoverMenu';
 import { DropdownItem } from '@terraware/web-components';
-import { UserContext } from 'src/providers';
+import { useUser } from 'src/providers';
 
 const useStyles = makeStyles((theme: Theme) => ({
   iconContainer: {
@@ -36,7 +36,7 @@ type UserMenuProps = {
 };
 export default function UserMenu({ hasOrganizations }: UserMenuProps): JSX.Element {
   const classes = useStyles();
-  const { user } = useContext(UserContext);
+  const { user } = useUser();
   const { isProduction } = useEnvironment();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const history = useHistory();

--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -3,7 +3,7 @@ import { useTheme, Box, Link as LinkMUI, Menu, Tab, Theme, Typography, Grid, Men
 import { makeStyles } from '@mui/styles';
 import { Button, Icon } from '@terraware/web-components';
 import moment from 'moment';
-import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { Accession2, getAccession2 } from 'src/api/accessions2/accession';
 import { checkIn } from 'src/api/seeds/accession';
@@ -35,7 +35,7 @@ import PageHeaderWrapper from '../../common/PageHeaderWrapper';
 import { APP_PATHS } from 'src/constants';
 import OverviewItemCard from '../../common/OverviewItemCard';
 import BackToLink from 'src/components/common/BackToLink';
-import { UserContext } from 'src/providers';
+import { useUser } from 'src/providers';
 
 const useStyles = makeStyles((theme: Theme) => ({
   iconStyle: {
@@ -74,7 +74,7 @@ interface Accession2ViewProps {
 }
 
 export default function Accession2View(props: Accession2ViewProps): JSX.Element {
-  const { user } = useContext(UserContext);
+  const { user } = useUser();
   const query = useQuery();
   const history = useHistory();
   const location = useStateLocation();

--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -3,13 +3,12 @@ import { useTheme, Box, Link as LinkMUI, Menu, Tab, Theme, Typography, Grid, Men
 import { makeStyles } from '@mui/styles';
 import { Button, Icon } from '@terraware/web-components';
 import moment from 'moment';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { Accession2, getAccession2 } from 'src/api/accessions2/accession';
 import { checkIn } from 'src/api/seeds/accession';
 import strings from 'src/strings';
 import { ServerOrganization } from 'src/types/Organization';
-import { User } from 'src/types/User';
 import TfMain from 'src/components/common/TfMain';
 import DeleteAccessionModal from '../edit/DeleteAccessionModal';
 import DetailPanel from './DetailPanel';
@@ -36,6 +35,7 @@ import PageHeaderWrapper from '../../common/PageHeaderWrapper';
 import { APP_PATHS } from 'src/constants';
 import OverviewItemCard from '../../common/OverviewItemCard';
 import BackToLink from 'src/components/common/BackToLink';
+import { UserContext } from 'src/providers';
 
 const useStyles = makeStyles((theme: Theme) => ({
   iconStyle: {
@@ -71,10 +71,10 @@ const TABS = ['detail', 'history', 'viabilityTesting'];
 
 interface Accession2ViewProps {
   organization: ServerOrganization;
-  user: User;
 }
 
 export default function Accession2View(props: Accession2ViewProps): JSX.Element {
+  const { user } = useContext(UserContext);
   const query = useQuery();
   const history = useHistory();
   const location = useStateLocation();
@@ -99,7 +99,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
   const [selectedTest, setSelectedTest] = useState<ViabilityTest>();
   const [age, setAge] = useState({ value: '', unit: '' });
   const [snackbar] = useState(useSnackbar());
-  const { organization, user } = props;
+  const { organization } = props;
   const userCanEdit = !isContributor(organization);
   const { isMobile, isTablet } = useDeviceInfo();
   const classes = useStyles({ isMobile });
@@ -363,18 +363,20 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
             />
           )}
 
-          <NewViabilityTestModal
-            open={openNewViabilityTest}
-            reload={reloadData}
-            accession={accession}
-            onClose={() => {
-              setOpenNewViabilityTest(false);
-              setSelectedTest(undefined);
-            }}
-            organization={organization}
-            user={user}
-            viabilityTest={selectedTest}
-          />
+          {user && (
+            <NewViabilityTestModal
+              open={openNewViabilityTest}
+              reload={reloadData}
+              accession={accession}
+              onClose={() => {
+                setOpenNewViabilityTest(false);
+                setSelectedTest(undefined);
+              }}
+              organization={organization}
+              user={user}
+              viabilityTest={selectedTest}
+            />
+          )}
 
           <CheckedInConfirmationModal
             open={openCheckInConfirmationModal}
@@ -414,7 +416,7 @@ export default function Accession2View(props: Accession2ViewProps): JSX.Element 
               accession={accession}
             />
           )}
-          {openWithdrawModal && (
+          {user && openWithdrawModal && (
             <WithdrawModal
               open={openWithdrawModal}
               onClose={() => setOpenWithdrawModal(false)}

--- a/src/providers/DataTypes.ts
+++ b/src/providers/DataTypes.ts
@@ -1,0 +1,6 @@
+import { User } from 'src/types/User';
+
+export type ProvidedUserData = {
+  user?: User;
+  reloadUser: () => void;
+};

--- a/src/providers/UserProvider.tsx
+++ b/src/providers/UserProvider.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { UserContext } from './contexts';
+import { ProvidedUserData } from './DataTypes';
+
+export type UserProviderProps = {
+  children?: React.ReactNode;
+  data: ProvidedUserData;
+};
+
+export default function UserProvider({ children, data }: UserProviderProps): JSX.Element {
+  return <UserContext.Provider value={data}>{children}</UserContext.Provider>;
+}

--- a/src/providers/contexts.ts
+++ b/src/providers/contexts.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+import { ProvidedUserData } from './DataTypes';
+
+export const UserContext = createContext<ProvidedUserData>({
+  reloadUser: () => {
+    // default no-op implementation
+    return;
+  },
+});

--- a/src/providers/hooks.ts
+++ b/src/providers/hooks.ts
@@ -1,0 +1,4 @@
+import { useContext } from 'react';
+import { UserContext } from './contexts';
+
+export const useUser = () => useContext(UserContext);

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,5 @@
+import UserProvider from './UserProvider';
+import { UserContext } from './contexts';
+export type { ProvidedUserData } from './DataTypes';
+
+export { UserContext, UserProvider };

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,5 +1,5 @@
 import UserProvider from './UserProvider';
-import { UserContext } from './contexts';
-export type { ProvidedUserData } from './DataTypes';
+import { useUser } from './hooks';
 
-export { UserContext, UserProvider };
+export type { ProvidedUserData } from './DataTypes';
+export { useUser, UserProvider };


### PR DESCRIPTION
- this PR primarily introduces how to use a provider
- introduced a directory and export structure, this is totally changeable and not set in stone
- application of user provider is a bit forced at this point since we don't have that many uses
- we can re-evaluate this later, good start for now
- tested all occurrences of user/reloadUser
- cleaned up props