### PR TITLE
remove unused strings

### DIFF
--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -314,9 +314,6 @@ const strings = new LocalizedStrings({
     GA3: 'GA3',
     GENERAL: 'General',
     GENERIC_ERROR: 'An error occurred',
-    GENERIC_MAP_MESSAGE_ADMIN: 'To see your plants on this map, please add a shapefile.',
-    GENERIC_MAP_MESSAGE_CONTRIBUTOR:
-      'To see your plants on this map, you need to add a shapefile. Please reach out to an administrator from your organization.',
     GEOLOCATIONS: 'Geolocations',
     GERMINATED: 'Germinated',
     GERMINATING_QUANTITY_REQUIRED: 'Germinating Quantity *',


### PR DESCRIPTION
- the banner is no longer shown on maps (we won't show the map if there's no shapefile)
- the banner property is still useful if we want to show something there later? keeping it for now.. unless anyone feels otherwise