### PR TITLE
SW-2647 / SW-2649 Add time zone display/selection to seed bank and planting site workflows

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/styled-engine-sc": "^5.8.0",
     "@mui/styles": "^5.11.2",
     "@mui/x-date-pickers": "^5.0.0-alpha.7",
-    "@terraware/web-components": "^2.0.63",
+    "@terraware/web-components": "^2.0.66",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^12.1.10",

--- a/src/components/LocationTimeZoneSelector.tsx
+++ b/src/components/LocationTimeZoneSelector.tsx
@@ -2,7 +2,7 @@ import { Checkbox } from '@terraware/web-components';
 import { useEffect, useState } from 'react';
 import strings from 'src/strings';
 import { TimeZoneDescription } from 'src/types/TimeZones';
-import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
+import { useLocationTimeZone } from 'src/utils/useTimeZoneUtils';
 import TimeZoneSelector from './TimeZoneSelector';
 
 type TimeZoneEntity = {
@@ -17,7 +17,7 @@ type LocationTimeZoneSelectorProps = {
 export default function LocationTimeZoneSelector(props: LocationTimeZoneSelectorProps): JSX.Element {
   const { onChangeTimeZone, location } = props;
   const [orgTZChecked, setOrgTZChecked] = useState<boolean>(!!location.timeZone);
-  const defaultTimeZone = useDefaultTimeZone();
+  const timeZone = useLocationTimeZone(location);
 
   useEffect(() => {
     if (!location?.timeZone) {
@@ -25,7 +25,7 @@ export default function LocationTimeZoneSelector(props: LocationTimeZoneSelector
     } else {
       setOrgTZChecked(false);
     }
-  }, [location]);
+  }, [location?.timeZone]);
 
   const onOrgTimeZoneChecked = (checked: boolean) => {
     if (checked) {
@@ -33,14 +33,14 @@ export default function LocationTimeZoneSelector(props: LocationTimeZoneSelector
       onChangeTimeZone(undefined);
     } else {
       setOrgTZChecked(false);
-      onChangeTimeZone(defaultTimeZone);
+      onChangeTimeZone(timeZone);
     }
   };
 
   return (
     <>
       <TimeZoneSelector
-        selectedTimeZone={location.timeZone || defaultTimeZone.id}
+        selectedTimeZone={timeZone.id}
         onTimeZoneSelected={onChangeTimeZone}
         label={strings.TIME_ZONE}
         disabled={orgTZChecked}

--- a/src/components/NewSeedBank/index.tsx
+++ b/src/components/NewSeedBank/index.tsx
@@ -14,6 +14,9 @@ import PageSnackbar from 'src/components/PageSnackbar';
 import useSnackbar from 'src/utils/useSnackbar';
 import TfMain from 'src/components/common/TfMain';
 import { useOrganization } from 'src/providers/hooks';
+import { TimeZoneDescription } from 'src/types/TimeZones';
+import isEnabled from 'src/features';
+import LocationTimeZoneSelector from '../LocationTimeZoneSelector';
 
 export default function SeedBankView(): JSX.Element {
   const { selectedOrganization, reloadData } = useOrganization();
@@ -21,6 +24,7 @@ export default function SeedBankView(): JSX.Element {
   const [nameError, setNameError] = useState('');
   const [descriptionError, setDescriptionError] = useState('');
   const snackbar = useSnackbar();
+  const timeZoneFeatureEnabled = isEnabled('Timezones');
 
   const [record, setRecord, onChange] = useForm<Facility>({
     name: '',
@@ -53,6 +57,7 @@ export default function SeedBankView(): JSX.Element {
       organizationId: selectedOrganization.id,
       type: 'Seed Bank',
       connectionState: 'Not Connected',
+      timeZone: selectedSeedBank?.timeZone,
     });
   }, [selectedSeedBank, setRecord, selectedOrganization]);
 
@@ -90,6 +95,15 @@ export default function SeedBankView(): JSX.Element {
       }
     }
     goToSeedBanks();
+  };
+
+  const onChangeTimeZone = (newTimeZone: TimeZoneDescription | undefined) => {
+    setRecord((previousRecord: Facility): Facility => {
+      return {
+        ...previousRecord,
+        timeZone: newTimeZone ? newTimeZone.id : undefined,
+      };
+    });
   };
 
   return (
@@ -134,6 +148,11 @@ export default function SeedBankView(): JSX.Element {
                 errorText={record.description ? '' : descriptionError}
               />
             </Grid>
+            {timeZoneFeatureEnabled && (
+              <Grid item xs={gridSize()}>
+                <LocationTimeZoneSelector location={record} onChangeTimeZone={onChangeTimeZone} />
+              </Grid>
+            )}
           </Grid>
         </Box>
       </PageForm>

--- a/src/components/Nurseries/TableCellRenderer.tsx
+++ b/src/components/Nurseries/TableCellRenderer.tsx
@@ -3,11 +3,11 @@ import { APP_PATHS } from 'src/constants';
 import CellRenderer, { TableRowType } from '../common/table/TableCellRenderer';
 import { RendererProps } from '../common/table/types';
 import Link from '../common/Link';
-import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
+import { useGetTimeZone } from 'src/utils/useTimeZoneUtils';
 
 export default function NurseriesCellRenderer(props: RendererProps<TableRowType>): JSX.Element {
   const { column, row, value, index } = props;
-  const defaultTimeZone = useDefaultTimeZone();
+  const tz = useGetTimeZone(value as string);
 
   const createLinkToNursery = (iValue: React.ReactNode | unknown[]) => {
     return (
@@ -20,7 +20,7 @@ export default function NurseriesCellRenderer(props: RendererProps<TableRowType>
   }
 
   if (column.key === 'timeZone') {
-    return <CellRenderer index={index} column={column} value={value || defaultTimeZone.longName} row={row} />;
+    return <CellRenderer index={index} column={column} value={tz.longName} row={row} />;
   }
 
   return <CellRenderer {...props} />;

--- a/src/components/Nurseries/TableCellRenderer.tsx
+++ b/src/components/Nurseries/TableCellRenderer.tsx
@@ -7,7 +7,7 @@ import { useGetTimeZone } from 'src/utils/useTimeZoneUtils';
 
 export default function NurseriesCellRenderer(props: RendererProps<TableRowType>): JSX.Element {
   const { column, row, value, index } = props;
-  const tz = useGetTimeZone(value as string);
+  const tz = useGetTimeZone();
 
   const createLinkToNursery = (iValue: React.ReactNode | unknown[]) => {
     return (
@@ -20,7 +20,7 @@ export default function NurseriesCellRenderer(props: RendererProps<TableRowType>
   }
 
   if (column.key === 'timeZone') {
-    return <CellRenderer index={index} column={column} value={tz.longName} row={row} />;
+    return <CellRenderer index={index} column={column} value={tz.get(value as string).longName} row={row} />;
   }
 
   return <CellRenderer {...props} />;

--- a/src/components/Nursery/index.tsx
+++ b/src/components/Nursery/index.tsx
@@ -31,7 +31,7 @@ export default function NurseryDetails(): JSX.Element {
   const { nurseryId } = useParams<{ nurseryId: string }>();
   const [nursery, setNursery] = useState<Facility>();
   const history = useHistory();
-  const tz = useLocationTimeZone(nursery);
+  const tz = useLocationTimeZone().get(nursery);
   const timeZoneFeatureEnabled = isEnabled('Timezones');
 
   useEffect(() => {

--- a/src/components/Nursery/index.tsx
+++ b/src/components/Nursery/index.tsx
@@ -13,8 +13,7 @@ import TfMain from '../common/TfMain';
 import PageSnackbar from '../PageSnackbar';
 import BackToLink from 'src/components/common/BackToLink';
 import { useOrganization } from 'src/providers/hooks';
-import TimeZoneSelector from '../TimeZoneSelector';
-import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
+import { useLocationTimeZone } from 'src/utils/useTimeZoneUtils';
 import isEnabled from 'src/features';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -32,7 +31,7 @@ export default function NurseryDetails(): JSX.Element {
   const { nurseryId } = useParams<{ nurseryId: string }>();
   const [nursery, setNursery] = useState<Facility>();
   const history = useHistory();
-  const defaultTimeZone = useDefaultTimeZone();
+  const tz = useLocationTimeZone(nursery);
   const timeZoneFeatureEnabled = isEnabled('Timezones');
 
   useEffect(() => {
@@ -108,13 +107,8 @@ export default function NurseryDetails(): JSX.Element {
           />
         </Grid>
         {timeZoneFeatureEnabled && (
-          <Grid item xs={gridSize()}>
-            <TimeZoneSelector
-              selectedTimeZone={nursery?.timeZone || defaultTimeZone.id}
-              onTimeZoneSelected={() => true}
-              disabled={true}
-              label={strings.TIME_ZONE}
-            />
+          <Grid item xs={gridSize()} marginTop={isMobile ? 3 : 0}>
+            <TextField label={strings.TIME_ZONE} id='timezone' type='text' value={tz.longName} display={true} />
           </Grid>
         )}
       </Grid>

--- a/src/components/PlantingSites/PlantingSiteCreate.tsx
+++ b/src/components/PlantingSites/PlantingSiteCreate.tsx
@@ -20,6 +20,9 @@ import PageSnackbar from '../PageSnackbar';
 import { PlantingSite } from 'src/api/types/tracking';
 import BoundariesAndPlots from './BoundariesAndPlots';
 import { useOrganization } from 'src/providers/hooks';
+import { TimeZoneDescription } from 'src/types/TimeZones';
+import isEnabled from 'src/features';
+import LocationTimeZoneSelector from '../LocationTimeZoneSelector';
 
 type CreatePlantingSiteProps = {
   reloadPlantingSites: () => void;
@@ -36,6 +39,7 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
   const [nameError, setNameError] = useState('');
   const [selectedPlantingSite, setSelectedPlantingSite] = useState<PlantingSite>();
   const [loaded, setLoaded] = useState(false);
+  const timeZoneFeatureEnabled = isEnabled('Timezones');
 
   const defaultPlantingSite = (): PlantingSite => ({
     id: -1,
@@ -66,6 +70,7 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
       description: selectedPlantingSite?.description,
       boundary: selectedPlantingSite?.boundary,
       plantingZones: selectedPlantingSite?.plantingZones,
+      timeZone: selectedPlantingSite?.timeZone,
     });
   }, [selectedPlantingSite, setRecord]);
 
@@ -88,12 +93,14 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
         name: record.name,
         description: record.description,
         organizationId: selectedOrganization.id,
+        timeZone: record.timeZone,
       };
       response = await postPlantingSite(newPlantingSite);
     } else {
       const updatedPlantingSite: PlantingSitePutRequestBody = {
         name: record.name,
         description: record.description,
+        timeZone: record.timeZone,
       };
       response = await updatePlantingSite(record.id, updatedPlantingSite);
     }
@@ -105,6 +112,15 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
     } else {
       snackbar.toastError();
     }
+  };
+
+  const onChangeTimeZone = (newTimeZone: TimeZoneDescription | undefined) => {
+    setRecord((previousRecord: PlantingSite): PlantingSite => {
+      return {
+        ...previousRecord,
+        timeZone: newTimeZone ? newTimeZone.id : undefined,
+      };
+    });
   };
 
   const gridSize = () => {
@@ -176,6 +192,11 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
                       />
                     </Grid>
                   </Grid>
+                  {timeZoneFeatureEnabled && (
+                    <Grid item xs={gridSize()} marginTop={3}>
+                      <LocationTimeZoneSelector location={record} onChangeTimeZone={onChangeTimeZone} />
+                    </Grid>
+                  )}
                 </Box>
               </Grid>
               {record?.boundary && <BoundariesAndPlots plantingSite={record} />}

--- a/src/components/PlantingSites/PlantingSiteView.tsx
+++ b/src/components/PlantingSites/PlantingSiteView.tsx
@@ -13,6 +13,8 @@ import { makeStyles } from '@mui/styles';
 import { PlantingSite } from 'src/api/types/tracking';
 import BoundariesAndPlots from './BoundariesAndPlots';
 import BackToLink from 'src/components/common/BackToLink';
+import { useLocationTimeZone } from 'src/utils/useTimeZoneUtils';
+import isEnabled from 'src/features';
 
 const useStyles = makeStyles((theme: Theme) => ({
   titleWithButton: {
@@ -30,6 +32,8 @@ export default function PlantingSiteView(): JSX.Element {
   const { plantingSiteId } = useParams<{ plantingSiteId: string }>();
   const [plantingSite, setPlantingSite] = useState<PlantingSite>();
   const history = useHistory();
+  const tz = useLocationTimeZone(plantingSite);
+  const timeZoneFeatureEnabled = isEnabled('Timezones');
 
   useEffect(() => {
     const loadPlantingSite = async () => {
@@ -100,6 +104,11 @@ export default function PlantingSiteView(): JSX.Element {
             display={true}
           />
         </Grid>
+        {timeZoneFeatureEnabled && (
+          <Grid item xs={gridSize()} marginTop={isMobile ? 3 : 0}>
+            <TextField label={strings.TIME_ZONE} id='timezone' type='text' value={tz.longName} display={true} />
+          </Grid>
+        )}
       </Grid>
       {plantingSite?.boundary && <BoundariesAndPlots plantingSite={plantingSite} />}
     </TfMain>

--- a/src/components/PlantingSites/PlantingSiteView.tsx
+++ b/src/components/PlantingSites/PlantingSiteView.tsx
@@ -32,8 +32,8 @@ export default function PlantingSiteView(): JSX.Element {
   const { plantingSiteId } = useParams<{ plantingSiteId: string }>();
   const [plantingSite, setPlantingSite] = useState<PlantingSite>();
   const history = useHistory();
-  const tz = useLocationTimeZone(plantingSite);
   const timeZoneFeatureEnabled = isEnabled('Timezones');
+  const tz = useLocationTimeZone().get(plantingSite);
 
   useEffect(() => {
     const loadPlantingSite = async () => {

--- a/src/components/PlantingSites/PlantingSitesCellRenderer.tsx
+++ b/src/components/PlantingSites/PlantingSitesCellRenderer.tsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles(() => ({
 export default function PlantingSitesCellRenderer(props: RendererProps<TableRowType>): JSX.Element {
   const classes = useStyles();
   const { column, row, value, index } = props;
-  const tz = useGetTimeZone(value as string);
+  const tz = useGetTimeZone();
 
   const createLinkToPlantingSiteView = (iValue: React.ReactNode | unknown[]) => {
     return (
@@ -41,7 +41,7 @@ export default function PlantingSitesCellRenderer(props: RendererProps<TableRowT
   }
 
   if (column.key === 'timeZone') {
-    return <CellRenderer index={index} column={column} value={tz.longName} row={row} />;
+    return <CellRenderer index={index} column={column} value={tz.get(value as string).longName} row={row} />;
   }
 
   return <CellRenderer {...props} className={classes.text} />;

--- a/src/components/PlantingSites/PlantingSitesCellRenderer.tsx
+++ b/src/components/PlantingSites/PlantingSitesCellRenderer.tsx
@@ -4,6 +4,7 @@ import CellRenderer, { TableRowType } from '../common/table/TableCellRenderer';
 import { RendererProps } from '../common/table/types';
 import { APP_PATHS } from 'src/constants';
 import Link from '../common/Link';
+import { useGetTimeZone } from 'src/utils/useTimeZoneUtils';
 
 const useStyles = makeStyles(() => ({
   text: {
@@ -17,6 +18,7 @@ const useStyles = makeStyles(() => ({
 export default function PlantingSitesCellRenderer(props: RendererProps<TableRowType>): JSX.Element {
   const classes = useStyles();
   const { column, row, value, index } = props;
+  const tz = useGetTimeZone(value as string);
 
   const createLinkToPlantingSiteView = (iValue: React.ReactNode | unknown[]) => {
     return (
@@ -36,6 +38,10 @@ export default function PlantingSitesCellRenderer(props: RendererProps<TableRowT
         className={classes.text}
       />
     );
+  }
+
+  if (column.key === 'timeZone') {
+    return <CellRenderer index={index} column={column} value={tz.longName} row={row} />;
   }
 
   return <CellRenderer {...props} className={classes.text} />;

--- a/src/components/PlantingSites/PlantingSitesList.tsx
+++ b/src/components/PlantingSites/PlantingSitesList.tsx
@@ -35,7 +35,7 @@ export default function PlantingSitesList(): JSX.Element {
       : null;
 
     const params = {
-      fields: ['boundary', 'id', 'name', 'numPlantingZones', 'numPlots', 'description'],
+      fields: ['boundary', 'id', 'name', 'numPlantingZones', 'numPlots', 'description', 'timeZone'],
       prefix: 'plantingSites',
       search: {
         operation: 'and',

--- a/src/components/PlantingSites/PlantingSitesTable.tsx
+++ b/src/components/PlantingSites/PlantingSitesTable.tsx
@@ -3,6 +3,7 @@ import { Table, TableColumnType, Textfield } from '@terraware/web-components';
 import { SearchResponseElement } from 'src/api/search';
 import strings from 'src/strings';
 import PlantingSitesCellRenderer from './PlantingSitesCellRenderer';
+import isEnabled from 'src/features';
 
 const columns: TableColumnType[] = [
   {
@@ -28,6 +29,7 @@ interface PlantingSitesTableProps {
 export default function PlantingSitesTable(props: PlantingSitesTableProps): JSX.Element {
   const { results, setTemporalSearchValue, temporalSearchValue } = props;
   const theme = useTheme();
+  const timeZoneFeatureEnabled = isEnabled('Timezones');
 
   return (
     <Box
@@ -58,7 +60,11 @@ export default function PlantingSitesTable(props: PlantingSitesTableProps): JSX.
             <Grid item xs={12}>
               <Table
                 id='planting-sites-table'
-                columns={columns}
+                columns={
+                  timeZoneFeatureEnabled
+                    ? [...columns, { key: 'timeZone', name: strings.TIME_ZONE, type: 'string' }]
+                    : columns
+                }
                 rows={results}
                 orderBy='name'
                 Renderer={PlantingSitesCellRenderer}

--- a/src/components/SeedBank/index.tsx
+++ b/src/components/SeedBank/index.tsx
@@ -32,7 +32,7 @@ export default function SeedBankDetails(): JSX.Element {
   const [seedBank, setSeedBank] = useState<Facility>();
   const history = useHistory();
   const timeZoneFeatureEnabled = isEnabled('Timezones');
-  const tz = useLocationTimeZone(seedBank);
+  const tz = useLocationTimeZone().get(seedBank);
 
   useEffect(() => {
     if (selectedOrganization) {

--- a/src/components/SeedBank/index.tsx
+++ b/src/components/SeedBank/index.tsx
@@ -13,6 +13,8 @@ import PageSnackbar from 'src/components/PageSnackbar';
 import TfMain from '../common/TfMain';
 import BackToLink from 'src/components/common/BackToLink';
 import { useOrganization } from 'src/providers/hooks';
+import isEnabled from 'src/features';
+import { useLocationTimeZone } from 'src/utils/useTimeZoneUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
   titleWithButton: {
@@ -29,6 +31,8 @@ export default function SeedBankDetails(): JSX.Element {
   const { seedBankId } = useParams<{ seedBankId: string }>();
   const [seedBank, setSeedBank] = useState<Facility>();
   const history = useHistory();
+  const timeZoneFeatureEnabled = isEnabled('Timezones');
+  const tz = useLocationTimeZone(seedBank);
 
   useEffect(() => {
     if (selectedOrganization) {
@@ -101,6 +105,11 @@ export default function SeedBankDetails(): JSX.Element {
             display={true}
           />
         </Grid>
+        {timeZoneFeatureEnabled && (
+          <Grid item xs={gridSize()} marginTop={isMobile ? 3 : 0}>
+            <TextField label={strings.TIME_ZONE} id='timezone' type='text' value={tz.longName} display={true} />
+          </Grid>
+        )}
       </Grid>
     </TfMain>
   );

--- a/src/components/SeedBanks/TableCellRenderer.tsx
+++ b/src/components/SeedBanks/TableCellRenderer.tsx
@@ -3,9 +3,11 @@ import { APP_PATHS } from 'src/constants';
 import CellRenderer, { TableRowType } from '../common/table/TableCellRenderer';
 import { RendererProps } from '../common/table/types';
 import Link from '../common/Link';
+import { useGetTimeZone } from 'src/utils/useTimeZoneUtils';
 
 export default function SeedBanksCellRenderer(props: RendererProps<TableRowType>): JSX.Element {
   const { column, row, value, index } = props;
+  const tz = useGetTimeZone(value as string);
 
   const createLinkToSeedBank = (iValue: React.ReactNode | unknown[]) => {
     const seedBankLocation = {
@@ -16,6 +18,10 @@ export default function SeedBanksCellRenderer(props: RendererProps<TableRowType>
 
   if (column.key === 'name') {
     return <CellRenderer index={index} column={column} value={createLinkToSeedBank(value)} row={row} />;
+  }
+
+  if (column.key === 'timeZone') {
+    return <CellRenderer index={index} column={column} value={tz.longName} row={row} />;
   }
 
   return <CellRenderer {...props} />;

--- a/src/components/SeedBanks/TableCellRenderer.tsx
+++ b/src/components/SeedBanks/TableCellRenderer.tsx
@@ -7,7 +7,7 @@ import { useGetTimeZone } from 'src/utils/useTimeZoneUtils';
 
 export default function SeedBanksCellRenderer(props: RendererProps<TableRowType>): JSX.Element {
   const { column, row, value, index } = props;
-  const tz = useGetTimeZone(value as string);
+  const tz = useGetTimeZone();
 
   const createLinkToSeedBank = (iValue: React.ReactNode | unknown[]) => {
     const seedBankLocation = {
@@ -21,7 +21,7 @@ export default function SeedBanksCellRenderer(props: RendererProps<TableRowType>
   }
 
   if (column.key === 'timeZone') {
-    return <CellRenderer index={index} column={column} value={tz.longName} row={row} />;
+    return <CellRenderer index={index} column={column} value={tz.get(value as string).longName} row={row} />;
   }
 
   return <CellRenderer {...props} />;

--- a/src/components/SeedBanks/index.tsx
+++ b/src/components/SeedBanks/index.tsx
@@ -19,6 +19,7 @@ import { Box, Grid, Theme, useTheme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import PageHeaderWrapper from '../common/PageHeaderWrapper';
+import isEnabled from 'src/features';
 
 const useStyles = makeStyles((theme: Theme) => ({
   title: {
@@ -67,6 +68,7 @@ export default function SeedBanksList({ organization }: SeedBanksListProps): JSX
   const [results, setResults] = useState<Facility[]>();
   const { isMobile } = useDeviceInfo();
   const contentRef = useRef(null);
+  const timeZoneFeatureEnabled = isEnabled('Timezones');
 
   useEffect(() => {
     const getSeedBanks = () => {
@@ -100,7 +102,7 @@ export default function SeedBanksList({ organization }: SeedBanksListProps): JSX
       if (debouncedSearchTerm) {
         const params: SearchNodePayload = {
           prefix: 'facilities',
-          fields: ['id', 'name', 'description', 'type', 'organization_id'],
+          fields: ['id', 'name', 'description', 'type', 'organization_id', 'timeZone'],
           search: {
             operation: 'and',
             children: [
@@ -134,6 +136,7 @@ export default function SeedBanksList({ organization }: SeedBanksListProps): JSX
             organizationId: parseInt(result.organization_id as string, 10),
             type: result.type as FacilityType,
             connectionState: result.connectionState as 'Not Connected' | 'Connected' | 'Configured',
+            timeZone: result.timeZone as string,
           });
         });
         if (getRequestId('searchSeedbanks') === requestId) {
@@ -194,7 +197,11 @@ export default function SeedBanksList({ organization }: SeedBanksListProps): JSX
                     {seedBanks && (
                       <Table
                         id='seed-banks-table'
-                        columns={columns}
+                        columns={
+                          timeZoneFeatureEnabled
+                            ? [...columns, { key: 'timeZone', name: strings.TIME_ZONE, type: 'string' }]
+                            : columns
+                        }
                         rows={results || seedBanks}
                         orderBy='name'
                         Renderer={SeedBanksCellRenderer}

--- a/src/utils/useTimeZoneUtils.ts
+++ b/src/utils/useTimeZoneUtils.ts
@@ -18,9 +18,11 @@ const getTimeZone = (timeZones: TimeZoneDescription[], id?: string): TimeZoneDes
 /**
  * util to get time zone or default to UTC
  */
-export const useGetTimeZone = (id: string): TimeZoneDescription => {
+export const useGetTimeZone = () => {
   const timeZones = useTimeZones();
-  return getTimeZone(timeZones, id) ?? getUTC(timeZones);
+  return {
+    get: (id: string): TimeZoneDescription => getTimeZone(timeZones, id) ?? getUTC(timeZones),
+  };
 };
 
 /**
@@ -33,32 +35,40 @@ export const getUTC = (timeZones: TimeZoneDescription[]): TimeZoneDescription =>
 /**
  * Get a fallback time zone (based on org, user, etc.)
  */
-export const useDefaultTimeZone = (forEdit?: boolean) => {
+export const useDefaultTimeZone = () => {
   const { user } = useUser();
   const { selectedOrganization } = useOrganization();
   const timeZones = useTimeZones();
 
-  const orgTimeZone = getTimeZone(timeZones, selectedOrganization.timeZone);
-  if (orgTimeZone) {
-    return orgTimeZone;
-  }
+  return {
+    get: (forEdit?: boolean) => {
+      const orgTimeZone = getTimeZone(timeZones, selectedOrganization.timeZone);
+      if (orgTimeZone) {
+        return orgTimeZone;
+      }
 
-  const userTimeZone = forEdit ? getTimeZone(timeZones, user?.timeZone) : undefined;
-  if (userTimeZone) {
-    return userTimeZone;
-  }
+      const userTimeZone = forEdit ? getTimeZone(timeZones, user?.timeZone) : undefined;
+      if (userTimeZone) {
+        return userTimeZone;
+      }
 
-  return getUTC(timeZones);
+      return getUTC(timeZones);
+    },
+  };
 };
 
 /**
  * Get a fallback time zone for a location (based on location org, user, etc.)
  */
-export const useLocationTimeZone = (location?: Location, forEdit?: boolean) => {
+export const useLocationTimeZone = () => {
   const timeZones = useTimeZones();
-  const defaultTimeZone = useDefaultTimeZone(forEdit);
+  const defaultTimeZone = useDefaultTimeZone();
 
-  return getTimeZone(timeZones, location?.timeZone) ?? defaultTimeZone;
+  return {
+    get: (location?: Location, forEdit?: boolean) => {
+      return getTimeZone(timeZones, location?.timeZone) ?? defaultTimeZone.get(forEdit);
+    },
+  };
 };
 
 // TODO - add more utilities as we see fit

--- a/src/utils/useTimeZoneUtils.ts
+++ b/src/utils/useTimeZoneUtils.ts
@@ -16,6 +16,14 @@ const getTimeZone = (timeZones: TimeZoneDescription[], id?: string): TimeZoneDes
 };
 
 /**
+ * util to get time zone or default to UTC
+ */
+export const useGetTimeZone = (id: string): TimeZoneDescription => {
+  const timeZones = useTimeZones();
+  return getTimeZone(timeZones, id) ?? getUTC(timeZones);
+};
+
+/**
  * Helper function to return UTC as per the supported time zones list
  */
 export const getUTC = (timeZones: TimeZoneDescription[]): TimeZoneDescription => {
@@ -46,11 +54,11 @@ export const useDefaultTimeZone = (forEdit?: boolean) => {
 /**
  * Get a fallback time zone for a location (based on location org, user, etc.)
  */
-export const useLocationTimeZone = (location: Location, forEdit?: boolean) => {
+export const useLocationTimeZone = (location?: Location, forEdit?: boolean) => {
   const timeZones = useTimeZones();
   const defaultTimeZone = useDefaultTimeZone(forEdit);
 
-  return getTimeZone(timeZones, location.timeZone) ?? defaultTimeZone;
+  return getTimeZone(timeZones, location?.timeZone) ?? defaultTimeZone;
 };
 
 // TODO - add more utilities as we see fit

--- a/src/utils/useTimeZoneUtils.ts
+++ b/src/utils/useTimeZoneUtils.ts
@@ -20,8 +20,9 @@ const getTimeZone = (timeZones: TimeZoneDescription[], id?: string): TimeZoneDes
  */
 export const useGetTimeZone = () => {
   const timeZones = useTimeZones();
+  const defaultTz = useDefaultTimeZone();
   return {
-    get: (id: string): TimeZoneDescription => getTimeZone(timeZones, id) ?? getUTC(timeZones),
+    get: (id: string): TimeZoneDescription => getTimeZone(timeZones, id) ?? defaultTz.get(),
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1387,7 +1387,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
   integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
 
-"@emotion/react@^11.9.3":
+"@emotion/react@^11.10.5", "@emotion/react@^11.9.3":
   version "11.10.5"
   resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.10.5.tgz#95fff612a5de1efa9c0d535384d3cfa115fe175d"
   integrity sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==
@@ -2267,27 +2267,28 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^2.0.63":
-  version "2.0.63"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.63.tgz#6cb10eb8551656513cda8dead96825036826a4f4"
-  integrity sha512-eGkW2m0QtuzfXk+i4CA5TuVbNvpIdhWIiw9hG4fykgOjDcQBVBNEchwKHPd/4Pidh891kPmZFfSLOOT0V7rJIA==
+"@terraware/web-components@^2.0.66":
+  version "2.0.66"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.0.66.tgz#cad9b48ff4c081a4d57f139e8c5e810af7fc4a4b"
+  integrity sha512-9Y2VrjYyE5IZhDHirdwsYgkzHpywZbG3g0PrcOnkJBlN9U/AbDvmUgevw0/VKIfT1O0pS2YLPjDHnhWEnEogbg==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.16.1"
     "@dnd-kit/core" "^6.0.5"
     "@dnd-kit/sortable" "^7.0.1"
-    "@emotion/react" "^11.9.3"
+    "@emotion/react" "^11.10.5"
     "@mui/icons-material" "^5.8.4"
     "@mui/material" "^5.8.7"
     "@mui/styles" "^5.11.2"
     "@mui/x-date-pickers" "^5.0.12"
     classnames "^2.3.2"
     date-fns "^2.29.3"
+    luxon "^3.2.1"
     moment "^2.29.4"
     moment-timezone "^0.5.37"
     react "^17.0.2"
     react-dom "^17.0.2"
-    react-responsive "^9.0.0-beta.6"
+    react-responsive "^9.0.2"
     react-sortable-hoc "^2.0.0"
     sass "^1.35.1"
     tinycolor2 "^1.4.2"
@@ -7960,6 +7961,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+luxon@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.2.1.tgz#14f1af209188ad61212578ea7e3d518d18cee45f"
+  integrity sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==
+
 lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
@@ -9683,7 +9689,7 @@ react-refresh@^0.11.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
-react-responsive@^9.0.0-beta.6:
+react-responsive@^9.0.0-beta.6, react-responsive@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-9.0.2.tgz#34531ca77a61e7a8775714016d21241df7e4205c"
   integrity sha512-+4CCab7z8G8glgJoRjAwocsgsv6VA2w7JPxFWHRc7kvz8mec1/K5LutNC2MG28Mn8mu6+bu04XZxHv5gyfT7xQ==


### PR DESCRIPTION
- copied boilerplate stuff from Constanza's PR for nursery
- add time zone display to seed bank and planting site tables
- add time zone selection in create/edit flows for seed bank and planting site
- updated nursery view to use a Textfield replacing the disabled selector
- updated all views to use the useLocationTimeZone hook which handles location vs default time zones, for reusability across views
- screenshots are for planting sites but same applies to nursery and seed bank (test in vercel)

<img width="194" alt="Terraware App 2023-01-11 16-11-57" src="https://user-images.githubusercontent.com/1865174/211946207-2825b951-5b35-407d-afaf-d532c7cda4e8.png">

<img width="817" alt="Terraware App 2023-01-11 16-11-16" src="https://user-images.githubusercontent.com/1865174/211946211-c706bb2a-f5b4-4247-8ffe-9ba30751105b.png">

<img width="186" alt="Terraware App 2023-01-11 16-11-01" src="https://user-images.githubusercontent.com/1865174/211946213-c8243b45-a35e-40b6-bad3-c5126104390f.png">

<img width="821" alt="Terraware App 2023-01-11 16-09-45" src="https://user-images.githubusercontent.com/1865174/211946216-69a580a8-e26d-4844-ace5-269aa18b18c3.png">

<img width="812" alt="Terraware App 2023-01-11 16-09-14" src="https://user-images.githubusercontent.com/1865174/211946217-d0e5485d-42b0-4fd8-b6cf-172eea68e310.png">
