### PR TITLE
SW-2714 Simplify "has withdrawals?" search request

### DIFF
--- a/src/api/tracking/withdrawals.ts
+++ b/src/api/tracking/withdrawals.ts
@@ -25,7 +25,6 @@ const DELETED_SPECIES = [
 export async function listNurseryWithdrawals(
   organizationId: number,
   searchCriteria: SearchCriteria,
-  count = 1000,
   sortOrder?: SearchSortOrder
 ): Promise<SearchResponseElement[] | null> {
   const searchParams: SearchRequestPayload = {
@@ -44,7 +43,7 @@ export async function listNurseryWithdrawals(
     ],
     search: convertToSearchNodePayload(searchCriteria, organizationId),
     sortOrder: sortOrder ? [sortOrder] : [{ field: 'id', direction: 'Ascending' }],
-    count,
+    count: 1000,
   };
 
   const data = await search(searchParams);
@@ -69,7 +68,14 @@ export async function listNurseryWithdrawals(
  * Check if an org has nursery withdrawals
  */
 export async function hasNurseryWithdrawals(organizationId: number): Promise<boolean> {
-  const response = await listNurseryWithdrawals(organizationId, [], 1);
+  const searchParams: SearchRequestPayload = {
+    prefix: 'nurseryWithdrawals',
+    fields: ['id'],
+    search: convertToSearchNodePayload({}, organizationId),
+    count: 1,
+  };
+
+  const response = await search(searchParams);
   return response !== null && response !== undefined && response.length > 0;
 }
 

--- a/src/components/NurseryWithdrawals/NurseryWithdrawals.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawals.tsx
@@ -192,12 +192,7 @@ export default function NurseryWithdrawals(): JSX.Element {
     const searchChildren: FieldNodePayload[] = getSearchChildren();
     const requestId = Math.random().toString();
     setRequestId('searchWithdrawals', requestId);
-    const apiSearchResults = await listNurseryWithdrawals(
-      selectedOrganization.id,
-      searchChildren,
-      1000,
-      searchSortOrder
-    );
+    const apiSearchResults = await listNurseryWithdrawals(selectedOrganization.id, searchChildren, searchSortOrder);
     if (apiSearchResults) {
       if (getRequestId('searchWithdrawals') === requestId) {
         setSearchResults(apiSearchResults);


### PR DESCRIPTION
At page load, we query the backend to find out if there are any nursery
withdrawals; if not, we don't show the "Withdrawal Log" item in the left nav.
Previously, this was searching for all the withdrawal details, but really we
only need to know if a withdrawal exists. Change it to just search for the ID.
