### PR TITLE
SW-2721 Look up column labels at render time

### DIFF
--- a/src/api/seeds/search.ts
+++ b/src/api/seeds/search.ts
@@ -1,6 +1,6 @@
 import axios from '..';
 import { paths } from 'src/api/types/generated-schema';
-import { COLUMNS_INDEXED } from 'src/components/seeds/database/columns';
+import { columnsIndexed } from 'src/components/seeds/database/columns';
 import {
   SearchCriteria,
   SearchRequestPayload,
@@ -46,8 +46,10 @@ export async function getPendingAccessions(organizationId: number): Promise<Sear
  *         single or multi select values (as opposed to date range values, for example).
  */
 export function filterSelectFields(fields: string[]): string[] {
+  const columns = columnsIndexed();
+
   return fields.reduce((acum: string[], value) => {
-    const dbColumn: DatabaseColumn = COLUMNS_INDEXED[value];
+    const dbColumn: DatabaseColumn = columns[value];
     if (['multiple_selection', 'single_selection'].includes(dbColumn.filter?.type ?? '')) {
       acum.push(dbColumn.key);
     }

--- a/src/components/Inventory/InventoryTable.tsx
+++ b/src/components/Inventory/InventoryTable.tsx
@@ -10,36 +10,6 @@ import PageSnackbar from 'src/components/PageSnackbar';
 import { APP_PATHS } from 'src/constants';
 import Search from './Search';
 
-const columns: TableColumnType[] = [
-  {
-    key: 'species_scientificName',
-    name: strings.SPECIES,
-    type: 'string',
-    tooltipTitle: strings.TOOLTIP_SCIENTIFIC_NAME,
-  },
-  {
-    key: 'species_commonName',
-    name: strings.COMMON_NAME,
-    type: 'string',
-    tooltipTitle: strings.TOOLTIP_COMMON_NAME,
-  },
-  { key: 'facilityInventories', name: strings.NURSERIES, type: 'string' },
-  {
-    key: 'germinatingQuantity',
-    name: strings.GERMINATING,
-    type: 'string',
-    tooltipTitle: strings.TOOLTIP_GERMINATING_QUANTITY,
-  },
-  {
-    key: 'notReadyQuantity',
-    name: strings.NOT_READY,
-    type: 'string',
-    tooltipTitle: strings.TOOLTIP_NOT_READY_QUANTITY,
-  },
-  { key: 'readyQuantity', name: strings.READY, type: 'string', tooltipTitle: strings.TOOLTIP_READY_QUANTITY },
-  { key: 'totalQuantity', name: strings.TOTAL, type: 'string', tooltipTitle: strings.TOOLTIP_TOTAL_QUANTITY },
-];
-
 interface InventoryTableProps {
   results: SearchResponseElement[];
   temporalSearchValue: string;
@@ -53,6 +23,35 @@ export default function InventoryTable(props: InventoryTableProps): JSX.Element 
   const [selectedRows, setSelectedRows] = useState<any[]>([]);
   const history = useHistory();
   const theme = useTheme();
+  const columns: TableColumnType[] = [
+    {
+      key: 'species_scientificName',
+      name: strings.SPECIES,
+      type: 'string',
+      tooltipTitle: strings.TOOLTIP_SCIENTIFIC_NAME,
+    },
+    {
+      key: 'species_commonName',
+      name: strings.COMMON_NAME,
+      type: 'string',
+      tooltipTitle: strings.TOOLTIP_COMMON_NAME,
+    },
+    { key: 'facilityInventories', name: strings.NURSERIES, type: 'string' },
+    {
+      key: 'germinatingQuantity',
+      name: strings.GERMINATING,
+      type: 'string',
+      tooltipTitle: strings.TOOLTIP_GERMINATING_QUANTITY,
+    },
+    {
+      key: 'notReadyQuantity',
+      name: strings.NOT_READY,
+      type: 'string',
+      tooltipTitle: strings.TOOLTIP_NOT_READY_QUANTITY,
+    },
+    { key: 'readyQuantity', name: strings.READY, type: 'string', tooltipTitle: strings.TOOLTIP_READY_QUANTITY },
+    { key: 'totalQuantity', name: strings.TOTAL, type: 'string', tooltipTitle: strings.TOOLTIP_TOTAL_QUANTITY },
+  ];
 
   const withdrawInventory = () => {
     const speciesIds = selectedRows.filter((row) => row.species_id).map((row) => `speciesId=${row.species_id}`);

--- a/src/components/Inventory/view/InventorySeedlingsTable.tsx
+++ b/src/components/Inventory/view/InventorySeedlingsTable.tsx
@@ -18,20 +18,6 @@ import { APP_PATHS } from 'src/constants';
 import { TopBarButton } from '@terraware/web-components/components/table';
 import { useOrganization } from 'src/providers/hooks';
 
-const columns: TableColumnType[] = [
-  { key: 'batchNumber', name: strings.SEEDLING_BATCH, type: 'string' },
-  { key: 'germinatingQuantity', name: strings.GERMINATING, type: 'string' },
-  { key: 'notReadyQuantity', name: strings.NOT_READY, type: 'string' },
-  { key: 'readyQuantity', name: strings.READY, type: 'string' },
-  { key: 'totalQuantity', name: strings.TOTAL, type: 'string' },
-  { key: 'totalQuantityWithdrawn', name: strings.WITHDRAWN, type: 'string' },
-  { key: 'facility_name', name: strings.NURSERY, type: 'string' },
-  { key: 'readyByDate', name: strings.EST_READY_DATE, type: 'string' },
-  { key: 'addedDate', name: strings.DATE_ADDED, type: 'string' },
-  { key: 'quantitiesMenu', name: '', type: 'string' },
-  { key: 'withdraw', name: '', type: 'string' },
-];
-
 interface InventorySeedslingsTableProps {
   speciesId: number;
   modified: number;
@@ -55,6 +41,19 @@ export default function InventorySeedslingsTable(props: InventorySeedslingsTable
   const debouncedSearchTerm = useDebounce(temporalSearchValue, 250);
   const snackbar = useSnackbar();
   const history = useHistory();
+  const columns: TableColumnType[] = [
+    { key: 'batchNumber', name: strings.SEEDLING_BATCH, type: 'string' },
+    { key: 'germinatingQuantity', name: strings.GERMINATING, type: 'string' },
+    { key: 'notReadyQuantity', name: strings.NOT_READY, type: 'string' },
+    { key: 'readyQuantity', name: strings.READY, type: 'string' },
+    { key: 'totalQuantity', name: strings.TOTAL, type: 'string' },
+    { key: 'totalQuantityWithdrawn', name: strings.WITHDRAWN, type: 'string' },
+    { key: 'facility_name', name: strings.NURSERY, type: 'string' },
+    { key: 'readyByDate', name: strings.EST_READY_DATE, type: 'string' },
+    { key: 'addedDate', name: strings.DATE_ADDED, type: 'string' },
+    { key: 'quantitiesMenu', name: '', type: 'string' },
+    { key: 'withdraw', name: '', type: 'string' },
+  ];
 
   useEffect(() => {
     let activeRequests = true;

--- a/src/components/Nurseries/index.tsx
+++ b/src/components/Nurseries/index.tsx
@@ -21,11 +21,6 @@ type NurseriesListProps = {
   organization: ServerOrganization;
 };
 
-const columns: TableColumnType[] = [
-  { key: 'name', name: 'Name', type: 'string' },
-  { key: 'description', name: 'Description', type: 'string' },
-];
-
 export default function NurseriesList({ organization }: NurseriesListProps): JSX.Element {
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
@@ -35,6 +30,10 @@ export default function NurseriesList({ organization }: NurseriesListProps): JSX
   const [results, setResults] = useState<Facility[]>();
   const contentRef = useRef(null);
   const timeZoneFeatureEnabled = isEnabled('Timezones');
+  const columns: TableColumnType[] = [
+    { key: 'name', name: strings.NAME, type: 'string' },
+    { key: 'description', name: strings.DESCRIPTION, type: 'string' },
+  ];
 
   const goToNewNursery = () => {
     const newNurseryLocation = {

--- a/src/components/NurseryWithdrawals/NurseryReassignment.tsx
+++ b/src/components/NurseryWithdrawals/NurseryReassignment.tsx
@@ -21,16 +21,6 @@ import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import BusySpinner from 'src/components/common/BusySpinner';
 import { useOrganization } from 'src/providers/hooks';
 
-const columns: TableColumnType[] = [
-  { key: 'species', name: strings.SPECIES, type: 'string' },
-  { key: 'siteName', name: strings.PLANTING_SITE, type: 'string' },
-  { key: 'zoneName', name: strings.ZONE, type: 'string' },
-  { key: 'originalPlot', name: strings.ORIGINAL_PLOT, type: 'string' },
-  { key: 'newPlot', name: strings.NEW_PLOT, type: 'string' },
-  { key: 'reassign', name: strings.REASSIGN, type: 'string' },
-  { key: 'notes', name: strings.NOTES, type: 'string' },
-];
-
 export default function NurseryReassignment(): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const theme = useTheme();
@@ -47,6 +37,15 @@ export default function NurseryReassignment(): JSX.Element {
   const [noReassignments, setNoReassignments] = useState<boolean>(false);
   const [reassigning, setReassigning] = useState<boolean>(false);
   const contentRef = useRef(null);
+  const columns: TableColumnType[] = [
+    { key: 'species', name: strings.SPECIES, type: 'string' },
+    { key: 'siteName', name: strings.PLANTING_SITE, type: 'string' },
+    { key: 'zoneName', name: strings.ZONE, type: 'string' },
+    { key: 'originalPlot', name: strings.ORIGINAL_PLOT, type: 'string' },
+    { key: 'newPlot', name: strings.NEW_PLOT, type: 'string' },
+    { key: 'reassign', name: strings.REASSIGN, type: 'string' },
+    { key: 'notes', name: strings.NOTES, type: 'string' },
+  ];
 
   // populate map of species id to scientific name
   useEffect(() => {

--- a/src/components/NurseryWithdrawals/NurseryWithdrawals.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawals.tsx
@@ -37,17 +37,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const columns: TableColumnType[] = [
-  { key: 'withdrawnDate', name: strings.DATE, type: 'string' },
-  { key: 'purpose', name: strings.PURPOSE, type: 'string' },
-  { key: 'facility_name', name: strings.FROM_NURSERY, type: 'string' },
-  { key: 'destinationName', name: strings.DESTINATION, type: 'string' },
-  { key: 'plotNames', name: strings.TO_PLOT, type: 'string' },
-  { key: 'speciesScientificNames', name: strings.SPECIES, type: 'string' },
-  { key: 'totalWithdrawn', name: strings.TOTAL_QUANTITY, type: 'string' },
-  { key: 'hasReassignments', name: '', type: 'string' },
-];
-
 export default function NurseryWithdrawals(): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const theme = useTheme();
@@ -64,6 +53,16 @@ export default function NurseryWithdrawals(): JSX.Element {
     field: 'withdrawnDate',
     direction: 'Descending',
   } as SearchSortOrder);
+  const columns: TableColumnType[] = [
+    { key: 'withdrawnDate', name: strings.DATE, type: 'string' },
+    { key: 'purpose', name: strings.PURPOSE, type: 'string' },
+    { key: 'facility_name', name: strings.FROM_NURSERY, type: 'string' },
+    { key: 'destinationName', name: strings.DESTINATION, type: 'string' },
+    { key: 'plotNames', name: strings.TO_PLOT, type: 'string' },
+    { key: 'speciesScientificNames', name: strings.SPECIES, type: 'string' },
+    { key: 'totalWithdrawn', name: strings.TOTAL_QUANTITY, type: 'string' },
+    { key: 'hasReassignments', name: '', type: 'string' },
+  ];
 
   const onWithdrawalClicked = (withdrawal: any) => {
     history.push({

--- a/src/components/NurseryWithdrawals/WithdrawalDetails/sections/NonOutplantWithdrawalTable.tsx
+++ b/src/components/NurseryWithdrawals/WithdrawalDetails/sections/NonOutplantWithdrawalTable.tsx
@@ -4,13 +4,6 @@ import strings from 'src/strings';
 import { Batch, NurseryWithdrawal } from 'src/api/types/batch';
 import { Species } from 'src/types/Species';
 
-const columns: TableColumnType[] = [
-  { key: 'name', name: strings.SPECIES, type: 'string' },
-  { key: 'notReady', name: strings.NOT_READY, type: 'number' },
-  { key: 'ready', name: strings.READY, type: 'number' },
-  { key: 'total', name: strings.TOTAL, type: 'number' },
-];
-
 type SpeciesWithdrawal = {
   name?: string;
   notReady: number;
@@ -32,6 +25,12 @@ export default function NonOutplantWithdrawalTable({
   batches,
 }: NonOutplantWithdrawalTableProps): JSX.Element {
   const [rowData, setRowData] = useState<SpeciesWithdrawal[]>([]);
+  const columns: TableColumnType[] = [
+    { key: 'name', name: strings.SPECIES, type: 'string' },
+    { key: 'notReady', name: strings.NOT_READY, type: 'number' },
+    { key: 'ready', name: strings.READY, type: 'number' },
+    { key: 'total', name: strings.TOTAL, type: 'number' },
+  ];
 
   useEffect(() => {
     // get map of batch id to species id - for correlation

--- a/src/components/NurseryWithdrawals/WithdrawalDetails/sections/OutplantReassignmentTable.tsx
+++ b/src/components/NurseryWithdrawals/WithdrawalDetails/sections/OutplantReassignmentTable.tsx
@@ -4,15 +4,6 @@ import { Table, TableColumnType } from '@terraware/web-components';
 import strings from 'src/strings';
 import { useEffect, useState } from 'react';
 
-const columns: TableColumnType[] = [
-  { key: 'species', name: strings.SPECIES, type: 'string' },
-  { key: 'from_plot', name: strings.FROM_PLOT, type: 'string' },
-  { key: 'to_plot', name: strings.TO_PLOT, type: 'string' },
-  { key: 'original_qty', name: strings.ORIGINAL_QTY, type: 'string' },
-  { key: 'final_qty', name: strings.FINAL_QTY, type: 'string' },
-  { key: 'notes', name: strings.NOTES, type: 'string' },
-];
-
 type OutplantReassignmentTableProps = {
   species: Species[];
   plotNames: Record<number, string>;
@@ -27,6 +18,14 @@ export default function OutplantReassignmentTable({
   withdrawalNotes,
 }: OutplantReassignmentTableProps): JSX.Element {
   const [rowData, setRowData] = useState<{ [p: string]: unknown }[]>([]);
+  const columns: TableColumnType[] = [
+    { key: 'species', name: strings.SPECIES, type: 'string' },
+    { key: 'from_plot', name: strings.FROM_PLOT, type: 'string' },
+    { key: 'to_plot', name: strings.TO_PLOT, type: 'string' },
+    { key: 'original_qty', name: strings.ORIGINAL_QTY, type: 'string' },
+    { key: 'final_qty', name: strings.FINAL_QTY, type: 'string' },
+    { key: 'notes', name: strings.NOTES, type: 'string' },
+  ];
 
   useEffect(() => {
     // get list of distinct species

--- a/src/components/NurseryWithdrawals/WithdrawalDetails/sections/OutplantWithdrawalTable.tsx
+++ b/src/components/NurseryWithdrawals/WithdrawalDetails/sections/OutplantWithdrawalTable.tsx
@@ -4,12 +4,6 @@ import strings from 'src/strings';
 import { Delivery } from 'src/api/types/tracking';
 import { Species } from 'src/types/Species';
 
-const columns: TableColumnType[] = [
-  { key: 'species', name: strings.SPECIES, type: 'string' },
-  { key: 'to_plot', name: strings.TO_PLOT, type: 'string' },
-  { key: 'quantity', name: strings.QUANTITY, type: 'string' },
-];
-
 type OutplantWithdrawalTableProps = {
   species: Species[];
   plotNames: Record<number, string>;
@@ -22,6 +16,11 @@ export default function OutplantWithdrawalTable({
   delivery,
 }: OutplantWithdrawalTableProps): JSX.Element {
   const [rowData, setRowData] = useState<{ [p: string]: unknown }[]>([]);
+  const columns: TableColumnType[] = [
+    { key: 'species', name: strings.SPECIES, type: 'string' },
+    { key: 'to_plot', name: strings.TO_PLOT, type: 'string' },
+    { key: 'quantity', name: strings.QUANTITY, type: 'string' },
+  ];
 
   useEffect(() => {
     // get list of distinct species

--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -61,14 +61,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const columns: TableColumnType[] = [
-  { key: 'firstName', name: strings.FIRST_NAME, type: 'string' },
-  { key: 'lastName', name: strings.LAST_NAME, type: 'string' },
-  { key: 'email', name: strings.EMAIL, type: 'string' },
-  { key: 'role', name: strings.ROLE, type: 'string' },
-  { key: 'addedTime', name: strings.DATE_ADDED, type: 'date' },
-];
-
 type PeopleListProps = {
   reloadData?: () => void;
   user?: User;
@@ -92,6 +84,13 @@ export default function PeopleList({ reloadData, user }: PeopleListProps): JSX.E
   const snackbar = useSnackbar();
   const { isMobile } = useDeviceInfo();
   const contentRef = useRef(null);
+  const columns: TableColumnType[] = [
+    { key: 'firstName', name: strings.FIRST_NAME, type: 'string' },
+    { key: 'lastName', name: strings.LAST_NAME, type: 'string' },
+    { key: 'email', name: strings.EMAIL, type: 'string' },
+    { key: 'role', name: strings.ROLE, type: 'string' },
+    { key: 'addedTime', name: strings.DATE_ADDED, type: 'date' },
+  ];
 
   useEffect(() => {
     const refreshSearch = async () => {

--- a/src/components/PlantingSites/PlantingSitesTable.tsx
+++ b/src/components/PlantingSites/PlantingSitesTable.tsx
@@ -5,21 +5,6 @@ import strings from 'src/strings';
 import PlantingSitesCellRenderer from './PlantingSitesCellRenderer';
 import isEnabled from 'src/features';
 
-const columns: TableColumnType[] = [
-  {
-    key: 'name',
-    name: strings.NAME,
-    type: 'string',
-  },
-  {
-    key: 'description',
-    name: strings.DESCRIPTION,
-    type: 'string',
-  },
-  { key: 'numPlantingZones', name: strings.PLANTING_ZONES, type: 'string' },
-  { key: 'numPlots', name: strings.PLOTS, type: 'string' },
-];
-
 interface PlantingSitesTableProps {
   results: SearchResponseElement[];
   temporalSearchValue: string;
@@ -30,6 +15,20 @@ export default function PlantingSitesTable(props: PlantingSitesTableProps): JSX.
   const { results, setTemporalSearchValue, temporalSearchValue } = props;
   const theme = useTheme();
   const timeZoneFeatureEnabled = isEnabled('Timezones');
+  const columns: TableColumnType[] = [
+    {
+      key: 'name',
+      name: strings.NAME,
+      type: 'string',
+    },
+    {
+      key: 'description',
+      name: strings.DESCRIPTION,
+      type: 'string',
+    },
+    { key: 'numPlantingZones', name: strings.PLANTING_ZONES, type: 'string' },
+    { key: 'numPlots', name: strings.PLOTS, type: 'string' },
+  ];
 
   return (
     <Box

--- a/src/components/SeedBanks/index.tsx
+++ b/src/components/SeedBanks/index.tsx
@@ -49,11 +49,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const columns: TableColumnType[] = [
-  { key: 'name', name: 'Name', type: 'string' },
-  { key: 'description', name: 'Description', type: 'string' },
-];
-
 type SeedBanksListProps = {
   organization: ServerOrganization;
 };
@@ -69,6 +64,10 @@ export default function SeedBanksList({ organization }: SeedBanksListProps): JSX
   const { isMobile } = useDeviceInfo();
   const contentRef = useRef(null);
   const timeZoneFeatureEnabled = isEnabled('Timezones');
+  const columns: TableColumnType[] = [
+    { key: 'name', name: strings.NAME, type: 'string' },
+    { key: 'description', name: strings.DESCRIPTION, type: 'string' },
+  ];
 
   useEffect(() => {
     const getSeedBanks = () => {

--- a/src/components/emptyStatePages/EmptyStatePage.tsx
+++ b/src/components/emptyStatePages/EmptyStatePage.tsx
@@ -66,36 +66,6 @@ type PageContent = {
   linkLocation?: string;
 };
 
-const NO_SEEDBANKS_CONTENT: PageContent = {
-  title1: strings.SEED_BANKS,
-  title2: strings.ADD_A_SEED_BANK,
-  subtitle: strings.ADD_SEED_BANK_SUBTITLE,
-  listItems: [
-    {
-      icon: 'blobbyIconSeedBank',
-      title: '',
-      description: '',
-    },
-  ],
-  buttonText: strings.ADD_SEED_BANK,
-  buttonIcon: 'plus',
-  linkLocation: APP_PATHS.SEED_BANKS_NEW,
-};
-
-const NO_NURSERIES_CONTENT: PageContent = {
-  title1: strings.NURSERIES,
-  title2: strings.ADD_A_NURSERY,
-  subtitle: strings.ADD_NURSERY_SUBTITLE,
-  listItems: [
-    {
-      icon: 'blobbyIconNursery',
-    },
-  ],
-  buttonText: strings.ADD_NURSERY,
-  buttonIcon: 'plus',
-  linkLocation: APP_PATHS.NURSERIES_NEW,
-};
-
 type EmptyStatePageProps = {
   backgroundImageVisible?: boolean;
   pageName: 'Species' | 'SeedBanks' | 'Nurseries' | 'Inventory' | 'PlantingSites';
@@ -214,6 +184,36 @@ export default function EmptyStatePage({
         },
       },
     ],
+  };
+
+  const NO_SEEDBANKS_CONTENT: PageContent = {
+    title1: strings.SEED_BANKS,
+    title2: strings.ADD_A_SEED_BANK,
+    subtitle: strings.ADD_SEED_BANK_SUBTITLE,
+    listItems: [
+      {
+        icon: 'blobbyIconSeedBank',
+        title: '',
+        description: '',
+      },
+    ],
+    buttonText: strings.ADD_SEED_BANK,
+    buttonIcon: 'plus',
+    linkLocation: APP_PATHS.SEED_BANKS_NEW,
+  };
+
+  const NO_NURSERIES_CONTENT: PageContent = {
+    title1: strings.NURSERIES,
+    title2: strings.ADD_A_NURSERY,
+    subtitle: strings.ADD_NURSERY_SUBTITLE,
+    listItems: [
+      {
+        icon: 'blobbyIconNursery',
+      },
+    ],
+    buttonText: strings.ADD_NURSERY,
+    buttonIcon: 'plus',
+    linkLocation: APP_PATHS.NURSERIES_NEW,
   };
 
   const pageContent = (): PageContent => {

--- a/src/components/seeds/database/EditColumns.tsx
+++ b/src/components/seeds/database/EditColumns.tsx
@@ -4,7 +4,7 @@ import strings from 'src/strings';
 import Checkbox from '../../common/Checkbox';
 import Divisor from '../../common/Divisor';
 import RadioButton from '../../common/RadioButton';
-import { COLUMNS_INDEXED, Preset, searchPresets } from './columns';
+import { columnsIndexed, Preset, searchPresets } from './columns';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
@@ -99,7 +99,7 @@ export default function EditColumnsDialog(props: Props): JSX.Element {
           </Grid>
         </Grid>
 
-        {sections.map(({ name, options }) => (
+        {sections().map(({ name, options }) => (
           <React.Fragment key={name}>
             <Divisor />
             <Typography component='p'>{name}</Typography>
@@ -141,80 +141,80 @@ interface Section {
   options: Option[][];
 }
 
-const sections: Section[] = [
-  {
-    name: 'General',
-    options: [
-      [{ ...COLUMNS_INDEXED.accessionNumber, disabled: true }],
-      [COLUMNS_INDEXED.active],
-      [COLUMNS_INDEXED.state],
-      [COLUMNS_INDEXED.facility_name],
-    ],
-  },
-  {
-    name: 'Seed Collection',
-    options: [
-      [
-        COLUMNS_INDEXED.speciesName,
-        COLUMNS_INDEXED.species_commonName,
-        COLUMNS_INDEXED.species_familyName,
-        COLUMNS_INDEXED.receivedDate,
-        COLUMNS_INDEXED.collectedDate,
-        COLUMNS_INDEXED.collectionSiteName,
+function sections(): Section[] {
+  const columns = columnsIndexed();
+
+  return [
+    {
+      name: 'General',
+      options: [
+        [{ ...columns.accessionNumber, disabled: true }],
+        [columns.active],
+        [columns.state],
+        [columns.facility_name],
       ],
-      [
-        COLUMNS_INDEXED.species_endangered,
-        COLUMNS_INDEXED.species_rare,
-        COLUMNS_INDEXED.collectionSource,
-        COLUMNS_INDEXED.ageYears,
-        COLUMNS_INDEXED.ageMonths,
-        COLUMNS_INDEXED.estimatedCount,
+    },
+    {
+      name: 'Seed Collection',
+      options: [
+        [
+          columns.speciesName,
+          columns.species_commonName,
+          columns.species_familyName,
+          columns.receivedDate,
+          columns.collectedDate,
+          columns.collectionSiteName,
+        ],
+        [
+          columns.species_endangered,
+          columns.species_rare,
+          columns.collectionSource,
+          columns.ageYears,
+          columns.ageMonths,
+          columns.estimatedCount,
+        ],
+        [
+          columns.plantsCollectedFrom,
+          columns.bagNumber,
+          columns.collectionSiteLandowner,
+          columns.collectionSiteNotes,
+          columns.estimatedWeightGrams,
+        ],
       ],
-      [
-        COLUMNS_INDEXED.plantsCollectedFrom,
-        COLUMNS_INDEXED.bagNumber,
-        COLUMNS_INDEXED.collectionSiteLandowner,
-        COLUMNS_INDEXED.collectionSiteNotes,
-        COLUMNS_INDEXED.estimatedWeightGrams,
+    },
+    {
+      name: 'Processing and Drying',
+      options: [[columns.dryingEndDate], [columns.remainingQuantity]],
+    },
+    {
+      name: 'Storing',
+      options: [[columns.storageCondition], [columns.storageLocationName]],
+    },
+    {
+      name: 'Withdrawal',
+      options: [
+        [columns.withdrawalDate, columns.withdrawalQuantity],
+        [columns.withdrawalPurpose],
+        [columns.withdrawalNotes],
       ],
-    ],
-  },
-  {
-    name: 'Processing and Drying',
-    options: [[COLUMNS_INDEXED.dryingEndDate], [COLUMNS_INDEXED.remainingQuantity]],
-  },
-  {
-    name: 'Storing',
-    options: [[COLUMNS_INDEXED.storageCondition], [COLUMNS_INDEXED.storageLocationName]],
-  },
-  {
-    name: 'Withdrawal',
-    options: [
-      [COLUMNS_INDEXED.withdrawalDate, COLUMNS_INDEXED.withdrawalQuantity],
-      [COLUMNS_INDEXED.withdrawalPurpose],
-      [COLUMNS_INDEXED.withdrawalNotes],
-    ],
-  },
-  {
-    name: 'Viability Testing',
-    options: [
-      [
-        COLUMNS_INDEXED.viabilityTests_type,
-        COLUMNS_INDEXED.viabilityTests_seedType,
-        COLUMNS_INDEXED.viabilityTests_treatment,
-        COLUMNS_INDEXED.viabilityTests_seedsFilled,
+    },
+    {
+      name: 'Viability Testing',
+      options: [
+        [
+          columns.viabilityTests_type,
+          columns.viabilityTests_seedType,
+          columns.viabilityTests_treatment,
+          columns.viabilityTests_seedsFilled,
+        ],
+        [
+          columns.viabilityTests_startDate,
+          columns.viabilityTests_seedsSown,
+          columns.viabilityTests_viabilityTestResults_seedsGerminated,
+          columns.viabilityTests_seedsEmpty,
+        ],
+        [columns.viabilityTests_substrate, columns.viabilityTests_seedsCompromised, columns.viabilityTests_notes],
       ],
-      [
-        COLUMNS_INDEXED.viabilityTests_startDate,
-        COLUMNS_INDEXED.viabilityTests_seedsSown,
-        COLUMNS_INDEXED.viabilityTests_viabilityTestResults_seedsGerminated,
-        COLUMNS_INDEXED.viabilityTests_seedsEmpty,
-      ],
-      [
-        COLUMNS_INDEXED.viabilityTests_substrate,
-        COLUMNS_INDEXED.viabilityTests_seedsCompromised,
-        COLUMNS_INDEXED.viabilityTests_notes,
-      ],
-    ],
-  },
-];
+    },
+  ];
+}

--- a/src/components/seeds/database/columns.ts
+++ b/src/components/seeds/database/columns.ts
@@ -1,276 +1,280 @@
 import strings from 'src/strings';
 import { DatabaseColumn } from '@terraware/web-components/components/table/types';
 
-const COLUMNS: DatabaseColumn[] = [
-  {
-    key: 'accessionNumber',
-    name: strings.ACCESSION,
-    type: 'string',
-    filter: { type: 'search' },
-  },
-  {
-    key: 'active',
-    name: strings.ACTIVE_INACTIVE,
-    type: 'string',
-    filter: { type: 'single_selection' },
-  },
-  {
-    key: 'state',
-    name: strings.STATUS,
-    type: 'string',
-    filter: { type: 'multiple_selection' },
-  },
-  {
-    key: 'speciesName',
-    name: strings.SPECIES,
-    type: 'string',
-    filter: { type: 'search' },
-  },
-  {
-    key: 'species_commonName',
-    name: strings.COMMON_NAME,
-    type: 'string',
-    filter: { type: 'search' },
-  },
-  {
-    key: 'receivedDate',
-    name: strings.RECEIVED_DATE,
-    type: 'date',
-    filter: { type: 'date_range' },
-  },
-  {
-    key: 'collectedDate',
-    name: strings.COLLECTION_DATE,
-    type: 'date',
-    filter: { type: 'date_range' },
-  },
-  {
-    key: 'collectionSiteName',
-    name: strings.COLLECTING_SITE,
-    type: 'string',
-    filter: { type: 'search' },
-  },
-  {
-    key: 'species_endangered',
-    name: strings.ENDANGERED,
-    type: 'string',
-    filter: { type: 'single_selection' },
-  },
-  {
-    key: 'species_rare',
-    name: strings.RARE,
-    type: 'string',
-    filter: { type: 'single_selection' },
-  },
-  {
-    key: 'collectionSource',
-    name: strings.COLLECTION_SOURCE,
-    type: 'string',
-    filter: { type: 'single_selection' },
-  },
-  {
-    key: 'plantsCollectedFrom',
-    name: strings.NUMBER_OF_PLANTS,
-    type: 'number',
-    filter: { type: 'number_range' },
-  },
-  {
-    key: 'estimatedSeedsIncoming',
-    name: strings.ESTIMATED_SEEDS_INCOMING,
-    type: 'number',
-    filter: { type: 'number_range' },
-  },
-  {
-    key: 'species_familyName',
-    name: strings.FAMILY,
-    type: 'string',
-    filter: { type: 'search' },
-  },
-  {
-    key: 'collectionSiteLandowner',
-    name: strings.LANDOWNER,
-    type: 'string',
-    filter: { type: 'search' },
-  },
-  { key: 'collectionSiteNotes', name: strings.NOTES, type: 'notes' },
-  {
-    key: 'totalUnits',
-    name: strings.SEEDS_UNITS,
-    type: 'string',
-  },
-  {
-    key: 'processingStartDate',
-    name: strings.PROCESSING_START_DATE,
-    type: 'date',
-    filter: { type: 'date_range' },
-  },
-  {
-    key: 'processingMethod',
-    name: strings.PROCESSING_METHOD,
-    type: 'string',
-    filter: { type: 'single_selection' },
-  },
-  {
-    key: 'dryingEndDate',
-    name: strings.DRYING_END_DATE,
-    type: 'string',
-    filter: { type: 'date_range' },
-  },
-  {
-    key: 'remainingQuantity',
-    additionalKeys: ['remainingUnits'],
-    name: strings.SEEDS_REMAINING,
-    type: 'number',
-    filter: { type: 'count_weight' },
-    operation: 'or',
-  },
-  {
-    key: 'remainingUnits',
-    name: strings.REMAINING_UNITS,
-    type: 'string',
-  },
-  {
-    key: 'storageCondition',
-    name: strings.STORAGE_CONDITION,
-    type: 'string',
-    filter: { type: 'single_selection' },
-  },
-  {
-    key: 'storageLocationName',
-    name: strings.SUB_LOCATION,
-    type: 'string',
-    filter: { type: 'multiple_selection' },
-  },
-  {
-    key: 'withdrawalQuantity',
-    additionalKeys: ['withdrawalUnits'],
-    name: strings.SEEDS_WITHDRAWN,
-    type: 'number',
-    filter: { type: 'count_weight' },
-    operation: 'or',
-  },
-  {
-    key: 'withdrawalUnits',
-    name: strings.SEEDS_WITHDRAWN_UNITS,
-    type: 'string',
-  },
-  {
-    key: 'withdrawalDate',
-    name: strings.DATE_OF_WITHDRAWAL,
-    type: 'date',
-    filter: { type: 'date_range' },
-  },
-  {
-    key: 'withdrawalPurpose',
-    name: strings.PURPOSE,
-    type: 'string',
-    filter: { type: 'single_selection' },
-  },
-  { key: 'withdrawalNotes', name: strings.NOTES, type: 'notes' },
-  {
-    key: 'viabilityTests_type',
-    name: strings.TEST_METHOD,
-    type: 'string',
-    filter: { type: 'single_selection' },
-  },
-  {
-    key: 'viabilityTests_seedType',
-    name: strings.SEED_TYPE,
-    type: 'string',
-    filter: { type: 'single_selection' },
-  },
-  {
-    key: 'viabilityTests_treatment',
-    name: strings.VIABILITY_TREATMENT,
-    type: 'string',
-    filter: { type: 'multiple_selection' },
-  },
-  {
-    key: 'viabilityTests_seedsFilled',
-    name: strings.NUMBER_OF_SEEDS_FILLED,
-    type: 'number',
-    filter: { type: 'number_range' },
-  },
-  { key: 'viabilityTests_notes', name: strings.NOTES, type: 'notes' },
-  {
-    key: 'viabilityTests_startDate',
-    name: strings.VIABILITY_START_DATE,
-    type: 'date',
-    filter: { type: 'date_range' },
-  },
-  {
-    key: 'viabilityTests_seedsSown',
-    name: strings.NUMBER_OF_SEEDS_TESTED,
-    type: 'number',
-    filter: { type: 'number_range' },
-  },
-  {
-    key: 'viabilityTests_viabilityTestResults_seedsGerminated',
-    name: strings.TOTAL_OF_SEEDS_GERMINATED,
-    type: 'number',
-    filter: { type: 'number_range' },
-  },
-  {
-    key: 'viabilityTests_seedsEmpty',
-    name: strings.NUMBER_OF_SEEDS_EMPTY,
-    type: 'number',
-    filter: { type: 'number_range' },
-  },
-  {
-    key: 'viabilityTests_substrate',
-    name: strings.VIABILITY_SUBSTRATE,
-    type: 'number',
-    filter: { type: 'multiple_selection' },
-  },
-  {
-    key: 'viabilityTests_seedsCompromised',
-    name: strings.NUMBER_OF_SEEDS_COMPROMISED,
-    type: 'number',
-    filter: { type: 'number_range' },
-  },
-  {
-    key: 'bagNumber',
-    name: strings.BAG_IDS,
-    type: 'string',
-    filter: { type: 'search' },
-  },
-  {
-    key: 'facility_name',
-    name: strings.SEED_BANKS,
-    type: 'string',
-    filter: { type: 'multiple_selection' },
-  },
-  {
-    key: 'ageMonths',
-    name: strings.AGE_MONTHS,
-    type: 'string',
-    filter: { type: 'number_range' },
-  },
-  {
-    key: 'ageYears',
-    name: strings.AGE_YEARS,
-    type: 'string',
-    filter: { type: 'number_range' },
-  },
-  {
-    key: 'estimatedWeightGrams',
-    name: strings.WEIGHT_GRAMS,
-    type: 'string',
-    filter: { type: 'number_range' },
-  },
-  {
-    key: 'estimatedCount',
-    name: strings.COUNT,
-    type: 'string',
-    filter: { type: 'number_range' },
-  },
-];
+function columns(): DatabaseColumn[] {
+  return [
+    {
+      key: 'accessionNumber',
+      name: strings.ACCESSION,
+      type: 'string',
+      filter: { type: 'search' },
+    },
+    {
+      key: 'active',
+      name: strings.ACTIVE_INACTIVE,
+      type: 'string',
+      filter: { type: 'single_selection' },
+    },
+    {
+      key: 'state',
+      name: strings.STATUS,
+      type: 'string',
+      filter: { type: 'multiple_selection' },
+    },
+    {
+      key: 'speciesName',
+      name: strings.SPECIES,
+      type: 'string',
+      filter: { type: 'search' },
+    },
+    {
+      key: 'species_commonName',
+      name: strings.COMMON_NAME,
+      type: 'string',
+      filter: { type: 'search' },
+    },
+    {
+      key: 'receivedDate',
+      name: strings.RECEIVED_DATE,
+      type: 'date',
+      filter: { type: 'date_range' },
+    },
+    {
+      key: 'collectedDate',
+      name: strings.COLLECTION_DATE,
+      type: 'date',
+      filter: { type: 'date_range' },
+    },
+    {
+      key: 'collectionSiteName',
+      name: strings.COLLECTING_SITE,
+      type: 'string',
+      filter: { type: 'search' },
+    },
+    {
+      key: 'species_endangered',
+      name: strings.ENDANGERED,
+      type: 'string',
+      filter: { type: 'single_selection' },
+    },
+    {
+      key: 'species_rare',
+      name: strings.RARE,
+      type: 'string',
+      filter: { type: 'single_selection' },
+    },
+    {
+      key: 'collectionSource',
+      name: strings.COLLECTION_SOURCE,
+      type: 'string',
+      filter: { type: 'single_selection' },
+    },
+    {
+      key: 'plantsCollectedFrom',
+      name: strings.NUMBER_OF_PLANTS,
+      type: 'number',
+      filter: { type: 'number_range' },
+    },
+    {
+      key: 'estimatedSeedsIncoming',
+      name: strings.ESTIMATED_SEEDS_INCOMING,
+      type: 'number',
+      filter: { type: 'number_range' },
+    },
+    {
+      key: 'species_familyName',
+      name: strings.FAMILY,
+      type: 'string',
+      filter: { type: 'search' },
+    },
+    {
+      key: 'collectionSiteLandowner',
+      name: strings.LANDOWNER,
+      type: 'string',
+      filter: { type: 'search' },
+    },
+    { key: 'collectionSiteNotes', name: strings.NOTES, type: 'notes' },
+    {
+      key: 'totalUnits',
+      name: strings.SEEDS_UNITS,
+      type: 'string',
+    },
+    {
+      key: 'processingStartDate',
+      name: strings.PROCESSING_START_DATE,
+      type: 'date',
+      filter: { type: 'date_range' },
+    },
+    {
+      key: 'processingMethod',
+      name: strings.PROCESSING_METHOD,
+      type: 'string',
+      filter: { type: 'single_selection' },
+    },
+    {
+      key: 'dryingEndDate',
+      name: strings.DRYING_END_DATE,
+      type: 'string',
+      filter: { type: 'date_range' },
+    },
+    {
+      key: 'remainingQuantity',
+      additionalKeys: ['remainingUnits'],
+      name: strings.SEEDS_REMAINING,
+      type: 'number',
+      filter: { type: 'count_weight' },
+      operation: 'or',
+    },
+    {
+      key: 'remainingUnits',
+      name: strings.REMAINING_UNITS,
+      type: 'string',
+    },
+    {
+      key: 'storageCondition',
+      name: strings.STORAGE_CONDITION,
+      type: 'string',
+      filter: { type: 'single_selection' },
+    },
+    {
+      key: 'storageLocationName',
+      name: strings.SUB_LOCATION,
+      type: 'string',
+      filter: { type: 'multiple_selection' },
+    },
+    {
+      key: 'withdrawalQuantity',
+      additionalKeys: ['withdrawalUnits'],
+      name: strings.SEEDS_WITHDRAWN,
+      type: 'number',
+      filter: { type: 'count_weight' },
+      operation: 'or',
+    },
+    {
+      key: 'withdrawalUnits',
+      name: strings.SEEDS_WITHDRAWN_UNITS,
+      type: 'string',
+    },
+    {
+      key: 'withdrawalDate',
+      name: strings.DATE_OF_WITHDRAWAL,
+      type: 'date',
+      filter: { type: 'date_range' },
+    },
+    {
+      key: 'withdrawalPurpose',
+      name: strings.PURPOSE,
+      type: 'string',
+      filter: { type: 'single_selection' },
+    },
+    { key: 'withdrawalNotes', name: strings.NOTES, type: 'notes' },
+    {
+      key: 'viabilityTests_type',
+      name: strings.TEST_METHOD,
+      type: 'string',
+      filter: { type: 'single_selection' },
+    },
+    {
+      key: 'viabilityTests_seedType',
+      name: strings.SEED_TYPE,
+      type: 'string',
+      filter: { type: 'single_selection' },
+    },
+    {
+      key: 'viabilityTests_treatment',
+      name: strings.VIABILITY_TREATMENT,
+      type: 'string',
+      filter: { type: 'multiple_selection' },
+    },
+    {
+      key: 'viabilityTests_seedsFilled',
+      name: strings.NUMBER_OF_SEEDS_FILLED,
+      type: 'number',
+      filter: { type: 'number_range' },
+    },
+    { key: 'viabilityTests_notes', name: strings.NOTES, type: 'notes' },
+    {
+      key: 'viabilityTests_startDate',
+      name: strings.VIABILITY_START_DATE,
+      type: 'date',
+      filter: { type: 'date_range' },
+    },
+    {
+      key: 'viabilityTests_seedsSown',
+      name: strings.NUMBER_OF_SEEDS_TESTED,
+      type: 'number',
+      filter: { type: 'number_range' },
+    },
+    {
+      key: 'viabilityTests_viabilityTestResults_seedsGerminated',
+      name: strings.TOTAL_OF_SEEDS_GERMINATED,
+      type: 'number',
+      filter: { type: 'number_range' },
+    },
+    {
+      key: 'viabilityTests_seedsEmpty',
+      name: strings.NUMBER_OF_SEEDS_EMPTY,
+      type: 'number',
+      filter: { type: 'number_range' },
+    },
+    {
+      key: 'viabilityTests_substrate',
+      name: strings.VIABILITY_SUBSTRATE,
+      type: 'number',
+      filter: { type: 'multiple_selection' },
+    },
+    {
+      key: 'viabilityTests_seedsCompromised',
+      name: strings.NUMBER_OF_SEEDS_COMPROMISED,
+      type: 'number',
+      filter: { type: 'number_range' },
+    },
+    {
+      key: 'bagNumber',
+      name: strings.BAG_IDS,
+      type: 'string',
+      filter: { type: 'search' },
+    },
+    {
+      key: 'facility_name',
+      name: strings.SEED_BANKS,
+      type: 'string',
+      filter: { type: 'multiple_selection' },
+    },
+    {
+      key: 'ageMonths',
+      name: strings.AGE_MONTHS,
+      type: 'string',
+      filter: { type: 'number_range' },
+    },
+    {
+      key: 'ageYears',
+      name: strings.AGE_YEARS,
+      type: 'string',
+      filter: { type: 'number_range' },
+    },
+    {
+      key: 'estimatedWeightGrams',
+      name: strings.WEIGHT_GRAMS,
+      type: 'string',
+      filter: { type: 'number_range' },
+    },
+    {
+      key: 'estimatedCount',
+      name: strings.COUNT,
+      type: 'string',
+      filter: { type: 'number_range' },
+    },
+  ];
+}
 
-export const COLUMNS_INDEXED = COLUMNS.reduce((acum, value) => {
-  acum[value.key] = value;
+export function columnsIndexed(): Record<string, DatabaseColumn> {
+  return columns().reduce((acum, value) => {
+    acum[value.key] = value;
 
-  return acum;
-}, {} as Record<string, DatabaseColumn>);
+    return acum;
+  }, {} as Record<string, DatabaseColumn>);
+}
 
 export interface Preset {
   name: string;

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -204,6 +204,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
   const updateSearchColumns = useCallback(
     (columnNames?: string[]) => {
       if (columnNames) {
+        const columns = columnsIndexed();
         const searchSelectedColumns = columnNames.reduce((acum, value) => {
           acum.push(value);
           const additionalColumns = columns[value].additionalKeys;
@@ -218,7 +219,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
         setDisplayColumnNames(columnNames);
       }
     },
-    [columns, setSearchColumns, setDisplayColumnNames]
+    [setSearchColumns, setDisplayColumnNames]
   );
 
   useEffect(() => {

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -218,7 +218,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
         setDisplayColumnNames(columnNames);
       }
     },
-    [setSearchColumns, setDisplayColumnNames]
+    [columns, setSearchColumns, setDisplayColumnNames]
   );
 
   useEffect(() => {

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -204,10 +204,10 @@ export default function Database(props: DatabaseProps): JSX.Element {
   const updateSearchColumns = useCallback(
     (columnNames?: string[]) => {
       if (columnNames) {
-        const columns = columnsIndexed();
+        const columnInfo = columnsIndexed();
         const searchSelectedColumns = columnNames.reduce((acum, value) => {
           acum.push(value);
-          const additionalColumns = columns[value].additionalKeys;
+          const additionalColumns = columnInfo[value].additionalKeys;
           if (additionalColumns) {
             return acum.concat(additionalColumns);
           }

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -27,7 +27,7 @@ import strings from 'src/strings';
 import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
 import { getAllSeedBanks } from 'src/utils/organization';
 import PageHeader from '../PageHeader';
-import { COLUMNS_INDEXED, RIGHT_ALIGNED_COLUMNS } from './columns';
+import { columnsIndexed, RIGHT_ALIGNED_COLUMNS } from './columns';
 import DownloadReportModal from './DownloadReportModal';
 import EditColumns from './EditColumns';
 import Filters from './Filters';
@@ -166,8 +166,9 @@ export default function Database(props: DatabaseProps): JSX.Element {
     reloadData,
     orgScopedPreferences,
   } = props;
+  const columns = columnsIndexed();
   const displayColumnDetails = displayColumnNames.map((name) => {
-    const detail = { ...COLUMNS_INDEXED[name] };
+    const detail = { ...columns[name] };
 
     // set the classname for right aligned columns
     if (RIGHT_ALIGNED_COLUMNS.indexOf(name) !== -1) {
@@ -205,7 +206,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
       if (columnNames) {
         const searchSelectedColumns = columnNames.reduce((acum, value) => {
           acum.push(value);
-          const additionalColumns = COLUMNS_INDEXED[value].additionalKeys;
+          const additionalColumns = columns[value].additionalKeys;
           if (additionalColumns) {
             return acum.concat(additionalColumns);
           }


### PR DESCRIPTION
Update the table views so they look up the display names of the columns at the
time the render function is called rather than at the time the module is imported.

For most of the tables, this is a simple matter of moving the column list from the
top level of the module into the body of the render function.

The list of columns on the accessions table, though, is referenced in multiple
places and is also pretty large. Change it from a constant to a function and call
the function in the places that used to reference the constant.

No user-visible behavior change here; the English strings table is still imported
statically as before.
