### PR TITLE
SW-2658 Default date/time in nursery time zone for inventory add batch

### DIFF
--- a/src/components/Inventory/InventoryCreate.tsx
+++ b/src/components/Inventory/InventoryCreate.tsx
@@ -124,7 +124,7 @@ export default function CreateInventory(): JSX.Element {
   const paddingSeparator = () => (isMobile ? 0 : 1.5);
 
   const changeDate = (id: string, value?: any) => {
-    setAddedDateChanged(true);
+    setAddedDateChanged(id === 'addedDate');
     const date = value ? getDateDisplayValue(value.getTime(), timeZone) : null;
     onChange(id, date);
   };

--- a/src/components/Inventory/InventoryCreate.tsx
+++ b/src/components/Inventory/InventoryCreate.tsx
@@ -43,6 +43,7 @@ export default function CreateInventory(): JSX.Element {
   const [selectedNursery, setSelectedNursery] = useState<Facility>();
   const tz = useLocationTimeZone().get(timeZoneFeatureEnabled ? selectedNursery : undefined);
   const [timeZone, setTimeZone] = useState(tz.id);
+  const [addedDateChanged, setAddedDateChanged] = useState(false);
 
   const defaultBatch = (): CreateBatchRequestPayload =>
     ({
@@ -73,10 +74,10 @@ export default function CreateInventory(): JSX.Element {
     setRecord((previousRecord: CreateBatchRequestPayload): CreateBatchRequestPayload => {
       return {
         ...previousRecord,
-        addedDate: getTodaysDateFormatted(timeZone),
+        addedDate: addedDateChanged ? previousRecord.addedDate : getTodaysDateFormatted(timeZone),
       };
     });
-  }, [timeZone, setRecord]);
+  }, [timeZone, setRecord, addedDateChanged]);
 
   useEffect(() => {
     setTotalQuantity(
@@ -123,6 +124,7 @@ export default function CreateInventory(): JSX.Element {
   const paddingSeparator = () => (isMobile ? 0 : 1.5);
 
   const changeDate = (id: string, value?: any) => {
+    setAddedDateChanged(true);
     const date = value ? getDateDisplayValue(value.getTime(), timeZone) : null;
     onChange(id, date);
   };

--- a/src/components/Inventory/InventoryCreate.tsx
+++ b/src/components/Inventory/InventoryCreate.tsx
@@ -170,11 +170,11 @@ export default function CreateInventory(): JSX.Element {
               </Grid>
               <Grid item xs={gridSize()} sx={marginTop} paddingLeft={paddingSeparator}>
                 <DatePicker
-                  id='dateAdded'
+                  id='addedDate'
                   label={strings.DATE_ADDED_REQUIRED}
                   aria-label={strings.DATE_ADDED_REQUIRED}
                   value={record.addedDate}
-                  onChange={(value) => changeDate('dateAdded', value)}
+                  onChange={(value) => changeDate('addedDate', value)}
                   errorText={validateFields && !record.addedDate ? strings.REQUIRED_FIELD : ''}
                   defaultTimeZone={timeZone}
                 />

--- a/src/components/Inventory/view/BatchDetailsModal.tsx
+++ b/src/components/Inventory/view/BatchDetailsModal.tsx
@@ -45,6 +45,8 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
   const tz = useLocationTimeZone().get(timeZoneFeatureEnabled ? facility : undefined);
   const [timeZone, setTimeZone] = useState(tz.id);
 
+  const [addedDateChanged, setAddedDateChanged] = useState(false);
+
   useEffect(() => {
     if (record) {
       const populateSpecies = async () => {
@@ -82,10 +84,10 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
     setRecord((previousRecord: CreateBatchRequestPayload): CreateBatchRequestPayload => {
       return {
         ...previousRecord,
-        addedDate: getTodaysDateFormatted(timeZone),
+        addedDate: addedDateChanged ? previousRecord.addedDate : getTodaysDateFormatted(timeZone),
       };
     });
-  }, [timeZone, setRecord]);
+  }, [timeZone, setRecord, addedDateChanged]);
 
   useEffect(() => {
     const newBatch: CreateBatchRequestPayload = {
@@ -173,6 +175,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
   const paddingSeparator = () => (isMobile ? 0 : 1.5);
 
   const changeDate = (id: string, value?: any) => {
+    setAddedDateChanged(true);
     const date = value ? getDateDisplayValue(value.getTime(), tz.id) : null;
     onChange(id, date);
   };

--- a/src/components/Inventory/view/BatchDetailsModal.tsx
+++ b/src/components/Inventory/view/BatchDetailsModal.tsx
@@ -175,7 +175,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
   const paddingSeparator = () => (isMobile ? 0 : 1.5);
 
   const changeDate = (id: string, value?: any) => {
-    setAddedDateChanged(true);
+    setAddedDateChanged(id === 'addedDate');
     const date = value ? getDateDisplayValue(value.getTime(), tz.id) : null;
     onChange(id, date);
   };

--- a/src/utils/organization.tsx
+++ b/src/utils/organization.tsx
@@ -32,6 +32,6 @@ export const getAllNurseries = (organization: ServerOrganization): Facility[] =>
 
 export const getNurseryById = (organization: ServerOrganization, id: number): Facility => {
   const allNurseries = getAllNurseries(organization);
-  const found = allNurseries.filter((nurs) => nurs.id === id);
+  const found = allNurseries.filter((nurs) => nurs.id.toString() === id.toString());
   return found[0];
 };


### PR DESCRIPTION
- Added timezone to create inventory and add batch.
- Noticed that updating the "addedDate" when editing a batch doesn't update it in the backend, the api doesn't accept an addedDate. Is it correct that "addedDate" is editable in the frontend?