### PR TITLE
SW-2721 Look up species dropdown values at render time

### DIFF
--- a/src/components/Species/AddSpeciesModal.tsx
+++ b/src/components/Species/AddSpeciesModal.tsx
@@ -1,11 +1,11 @@
 import { Grid } from '@mui/material';
 import { Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import { IconTooltip } from '@terraware/web-components';
+import { Dropdown, IconTooltip } from '@terraware/web-components';
 import React, { useEffect, useState } from 'react';
 import { createSpecies, getSpeciesDetails, listSpeciesNames, updateSpecies } from 'src/api/species/species';
 import strings from 'src/strings';
-import { GrowthForms, Species, SpeciesRequestError, StorageBehaviors } from 'src/types/Species';
+import { growthForms, Species, SpeciesRequestError, storageBehaviors } from 'src/types/Species';
 import { getRequestId, setRequestId } from 'src/utils/requestsId';
 import useDebounce from 'src/utils/useDebounce';
 import useForm from 'src/utils/useForm';
@@ -288,11 +288,11 @@ export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Elemen
           />
         </Grid>
         <Grid item xs={12}>
-          <Select
+          <Dropdown
             id='growthForm'
             selectedValue={record.growthForm}
             onChange={(value) => onChange('growthForm', value)}
-            options={GrowthForms}
+            options={growthForms()}
             label={strings.GROWTH_FORM}
             aria-label={strings.GROWTH_FORM}
             placeholder={strings.SELECT}
@@ -314,11 +314,11 @@ export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Elemen
           />
         </Grid>
         <Grid item xs={12}>
-          <Select
+          <Dropdown
             id='seedStorageBehavior'
             selectedValue={record.seedStorageBehavior}
             onChange={(value) => onChange('seedStorageBehavior', value)}
-            options={StorageBehaviors}
+            options={storageBehaviors()}
             label={strings.SEED_STORAGE_BEHAVIOR}
             aria-label={strings.SEED_STORAGE_BEHAVIOR}
             placeholder={strings.SELECT}

--- a/src/components/Species/SpeciesFiltersPopover.tsx
+++ b/src/components/Species/SpeciesFiltersPopover.tsx
@@ -3,11 +3,11 @@ import { makeStyles } from '@mui/styles';
 import React, { useEffect, useState } from 'react';
 import Icon from 'src/components/common/icon/Icon';
 import strings from 'src/strings';
-import { GrowthForms, StorageBehaviors } from 'src/types/Species';
+import { conservationStatuses, growthForms, storageBehaviors } from 'src/types/Species';
 import useForm from 'src/utils/useForm';
 import { SpeciesFiltersType } from '.';
 import Button from '../common/button/Button';
-import Select from '../common/Select/Select';
+import { Dropdown } from '@terraware/web-components';
 
 const useStyles = makeStyles((theme: Theme) => ({
   iconContainer: {
@@ -131,11 +131,11 @@ export default function SpeciesFiltersPopover({ filters, setFilters }: SpeciesFi
           <div className={classes.title}>{strings.FILTERS}</div>
           <Grid container spacing={2} className={classes.container}>
             <Grid item xs={12}>
-              <Select
+              <Dropdown
                 id='growthForm'
                 selectedValue={temporalRecord.growthForm}
                 onChange={(value) => onChange('growthForm', value)}
-                options={GrowthForms}
+                options={growthForms()}
                 label={strings.GROWTH_FORM}
                 aria-label={strings.GROWTH_FORM}
                 placeholder={strings.SELECT}
@@ -143,11 +143,11 @@ export default function SpeciesFiltersPopover({ filters, setFilters }: SpeciesFi
               />
             </Grid>
             <Grid item xs={12}>
-              <Select
+              <Dropdown
                 id='conservationStatus'
                 selectedValue={getSelectedConservationStatusValue()}
                 onChange={(value) => onChangeConservationStatus(value)}
-                options={['Rare', 'Endangered']}
+                options={conservationStatuses()}
                 label={strings.CONSERVATION_STATUS}
                 aria-label={strings.SEED_STORAGE_BEHAVIOR}
                 placeholder={strings.SELECT}
@@ -155,11 +155,11 @@ export default function SpeciesFiltersPopover({ filters, setFilters }: SpeciesFi
               />
             </Grid>
             <Grid item xs={12}>
-              <Select
+              <Dropdown
                 id='seedStorageBehavior'
                 selectedValue={temporalRecord.seedStorageBehavior}
                 onChange={(value) => onChange('seedStorageBehavior', value)}
-                options={StorageBehaviors}
+                options={storageBehaviors()}
                 label={strings.SEED_STORAGE_BEHAVIOR}
                 aria-label={strings.SEED_STORAGE_BEHAVIOR}
                 placeholder={strings.SELECT}

--- a/src/strings/strings-en.ts
+++ b/src/strings/strings-en.ts
@@ -936,6 +936,7 @@ export const strings = {
   UNDO_SEND_TO_NURSERY: 'Undo Send to Nursery',
   UNEXPECTED_ERROR: 'An unexpected error occurred.',
   UNITS: 'Units',
+  UNKNOWN: 'Unknown',
   UNSPECIFIED: 'Unspecified',
   UNSURE: 'Unsure',
   UPDATE_STATUS_WARNING: 'You‘re about to update the status',

--- a/src/types/Species.ts
+++ b/src/types/Species.ts
@@ -1,3 +1,5 @@
+import strings from 'src/strings';
+
 export type Species = {
   id: number;
   commonName?: string;
@@ -18,9 +20,31 @@ export type SpeciesProblemElement = {
   suggestedValue?: string;
 };
 
-export const GrowthForms = ['Tree', 'Shrub', 'Forb', 'Graminoid', 'Fern'];
+export function growthForms() {
+  return [
+    { label: strings.TREE, value: 'Tree' },
+    { label: strings.SHRUB, value: 'Shrub' },
+    { label: strings.FORB, value: 'Forb' },
+    { label: strings.GRAMINOID, value: 'Graminoid' },
+    { label: strings.FERN, value: 'Fern' },
+  ];
+}
 
-export const StorageBehaviors = ['Orthodox', 'Recalcitrant', 'Intermediate', 'Unknown'];
+export function storageBehaviors() {
+  return [
+    { label: strings.ORTHODOX, value: 'Orthodox' },
+    { label: strings.RECALCITRANT, value: 'Recalcitrant' },
+    { label: strings.INTERMEDIATE, value: 'Intermediate' },
+    { label: strings.UNKNOWN, value: 'Unknown' },
+  ];
+}
+
+export function conservationStatuses() {
+  return [
+    { label: strings.RARE, value: 'Rare' },
+    { label: strings.ENDANGERED, value: 'Endangered' },
+  ];
+}
 
 export type SpeciesWithScientificName = Species & {
   scientificName?: string;


### PR DESCRIPTION
Use the strings table instead of the English enum values for dropdowns on the
species page:

- Growth forms, storage behaviors, and conservation statuses in the filter popover.
- Growth forms and storage behaviors in the Add Species modal.
