### PR TITLE
SW-2721 Look up deleted-species placeholder at render time

### DIFF
--- a/src/api/tracking/withdrawals.ts
+++ b/src/api/tracking/withdrawals.ts
@@ -13,12 +13,6 @@ import { Batch, NurseryWithdrawal } from 'src/api/types/batch';
 import { Delivery } from 'src/api/types/tracking';
 import strings from 'src/strings';
 
-const DELETED_SPECIES = [
-  {
-    batch_species_scientificName: `<${strings.DELETED_SPECIES}>`,
-  },
-];
-
 /**
  * List nursery withdrawals
  */
@@ -45,12 +39,13 @@ export async function listNurseryWithdrawals(
     sortOrder: sortOrder ? [sortOrder] : [{ field: 'id', direction: 'Ascending' }],
     count: 1000,
   };
+  const deletedSpecies = [{ batch_species_scientificName: strings.DELETED_SPECIES }];
 
   const data = await search(searchParams);
   if (data) {
     return data.map((datum) => {
       const { batchWithdrawals, ...remaining } = datum;
-      const speciesScientificNames = ((batchWithdrawals || DELETED_SPECIES) as any[]).map(
+      const speciesScientificNames = ((batchWithdrawals || deletedSpecies) as any[]).map(
         (batchWithdrawal) => batchWithdrawal.batch_species_scientificName
       );
       // replace batchWithdrawals with species_scientificNames, which is an array of species names

--- a/src/components/Inventory/InventoryCellRenderer.tsx
+++ b/src/components/Inventory/InventoryCellRenderer.tsx
@@ -55,7 +55,7 @@ export default function InventoryCellRenderer(props: RendererProps<TableRowType>
       <CellRenderer
         index={index}
         column={column}
-        value={row.species_id ? createLinkToInventoryDetail(value) : `<${strings.DELETED_SPECIES}>`}
+        value={row.species_id ? createLinkToInventoryDetail(value) : strings.DELETED_SPECIES}
         row={row}
         className={classes.text}
       />

--- a/src/strings/strings-en.ts
+++ b/src/strings/strings-en.ts
@@ -205,7 +205,7 @@ export const strings = {
   DELETE_VIABILITY_TEST_MESSAGE: 'You’re about to delete viability test {0}.',
   DELETE_VIABILITY_TEST: 'Delete Viability Test',
   DELETE: 'Delete',
-  DELETED_SPECIES: 'deleted species',
+  DELETED_SPECIES: '<deleted species>',
   DESCRIPTION_NOTES: 'Description/Notes',
   DESCRIPTION_ORGANIZATION: 'Your organization may include people, and species.',
   DESCRIPTION_PEOPLE: 'Invite those who contribute to the organization’s success.',


### PR DESCRIPTION
On the nursery withdrawal log, we show a client-rendered placeholder instead of
a species name if the species was deleted. Look it up at render time so it uses
the correct translation, and move the angle brackets to the translatable string
so they can be replaced with other symbols as needed in other languages.
