### PR TITLE
SW-2613 Disable outplant option on withdraw when no seeds are ready

### DIFF
--- a/src/components/Inventory/withdraw/flow/SelectPurposeForm.tsx
+++ b/src/components/Inventory/withdraw/flow/SelectPurposeForm.tsx
@@ -18,7 +18,7 @@ import { NurseryWithdrawalRequest, NurseryWithdrawalPurposes } from 'src/api/typ
 import getDateDisplayValue, { getTodaysDateFormatted, isInTheFuture } from '@terraware/web-components/utils/date';
 import { APP_PATHS } from 'src/constants';
 import Divisor from 'src/components/common/Divisor';
-import { DatePicker, Dropdown, Textfield, DropdownItem } from '@terraware/web-components';
+import { DatePicker, Dropdown, Textfield, DropdownItem, IconTooltip } from '@terraware/web-components';
 import { getAllNurseries, getNurseryById, isContributor } from 'src/utils/organization';
 import { listPlantingSites } from 'src/api/tracking/tracking';
 import { getAllSpecies } from 'src/api/species/species';
@@ -413,15 +413,12 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
       if (!hasReadyQuantities) {
         if (!noReadySeedlings) {
           setNoReadySeedlings(true);
-          snackbar.toastError(
-            strings.NO_SEEDLINGS_AVAILABLE_TO_OUTPLANT_DESCRIPTION,
-            strings.NO_SEEDLINGS_AVAILABLE_TO_OUTPLANT_TITLE
-          );
+          updateField('purpose', NurseryWithdrawalPurposes.NURSERY_TRANSFER);
+          setIsNurseryTransfer(true);
         }
         return;
       }
     }
-    setNoReadySeedlings(false);
   }, [localRecord.purpose, noReadySeedlings, snackbar, selectedNursery, OUTPLANT, batches]);
 
   useEffect(() => {
@@ -455,6 +452,15 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
   const totalReadyQuantity = useMemo(() => {
     return batchesFromNursery.reduce((acc, batch) => acc + (+batch.readyQuantity || 0), 0);
   }, [batchesFromNursery]);
+
+  const getOutplantLabel = () => {
+    return (
+      <>
+        {OUTPLANT}
+        {noReadySeedlings && <IconTooltip placement='top' title={strings.OUTPLANTS_REQUIRE_READY_SEEDLINGS} />}
+      </>
+    );
+  };
 
   return (
     <PageForm
@@ -512,12 +518,18 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
                   {strings.PURPOSE_REQUIRED}
                 </FormLabel>
                 <RadioGroup name='radio-buttons-purpose' value={localRecord.purpose} onChange={onChangePurpose}>
-                  {!contributor && <FormControlLabel value={OUTPLANT} control={<Radio />} label={strings.OUTPLANT} />}
+                  {!contributor && (
+                    <FormControlLabel
+                      value={OUTPLANT}
+                      control={<Radio />}
+                      label={getOutplantLabel()}
+                      disabled={noReadySeedlings}
+                    />
+                  )}
                   <FormControlLabel value={NURSERY_TRANSFER} control={<Radio />} label={strings.NURSERY_TRANSFER} />
                   <FormControlLabel value={DEAD} control={<Radio />} label={strings.DEAD} />
                   <FormControlLabel value={OTHER} control={<Radio />} label={strings.OTHER} />
                 </RadioGroup>
-                {noReadySeedlings && <ErrorMessage message={strings.OUTPLANTS_REQUIRE_READY_SEEDLINGS} />}
               </FormControl>
             </Grid>
             <Grid display='flex'>

--- a/src/components/Inventory/withdraw/flow/SelectPurposeForm.tsx
+++ b/src/components/Inventory/withdraw/flow/SelectPurposeForm.tsx
@@ -121,19 +121,26 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
     }
   }, [selectedOrganization, plantingSites, snackbar]);
 
+  const updatePurpose = useCallback(
+    (value: string) => {
+      updateField('purpose', value);
+      if (value === NURSERY_TRANSFER) {
+        setIsNurseryTransfer(true);
+      } else {
+        setIsNurseryTransfer(false);
+      }
+      const outplant = value === OUTPLANT;
+      setIsOutplant(outplant);
+      if (outplant) {
+        fetchPlantingSites();
+      }
+    },
+    [NURSERY_TRANSFER, OUTPLANT, fetchPlantingSites]
+  );
+
   const onChangePurpose = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = (event.target as HTMLInputElement).value;
-    updateField('purpose', value);
-    if (value === NURSERY_TRANSFER) {
-      setIsNurseryTransfer(true);
-    } else {
-      setIsNurseryTransfer(false);
-    }
-    const outplant = value === OUTPLANT;
-    setIsOutplant(outplant);
-    if (outplant) {
-      fetchPlantingSites();
-    }
+    updatePurpose(value);
   };
 
   const onChangePlantingSite = (value: string) => {
@@ -412,13 +419,12 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
       if (!hasReadyQuantities) {
         if (!noReadySeedlings) {
           setNoReadySeedlings(true);
-          updateField('purpose', NurseryWithdrawalPurposes.NURSERY_TRANSFER);
-          setIsNurseryTransfer(true);
+          updatePurpose(NurseryWithdrawalPurposes.NURSERY_TRANSFER);
         }
         return;
       }
     }
-  }, [localRecord.purpose, noReadySeedlings, snackbar, selectedNursery, OUTPLANT, batches]);
+  }, [localRecord.purpose, noReadySeedlings, snackbar, selectedNursery, OUTPLANT, batches, updatePurpose]);
 
   useEffect(() => {
     const fetchSpecies = async () => {

--- a/src/components/Inventory/withdraw/flow/SelectPurposeForm.tsx
+++ b/src/components/Inventory/withdraw/flow/SelectPurposeForm.tsx
@@ -25,7 +25,6 @@ import { getAllSpecies } from 'src/api/species/species';
 import { PlantingSite } from 'src/api/types/tracking';
 import useSnackbar from 'src/utils/useSnackbar';
 import PageForm from 'src/components/common/PageForm';
-import ErrorMessage from 'src/components/common/ErrorMessage';
 import PlotSelector, { PlotInfo, ZoneInfo } from 'src/components/PlotSelector';
 import { useOrganization } from 'src/providers/hooks';
 import isEnabled from 'src/features';
@@ -469,7 +468,6 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
       onCancel={onCancel}
       onSave={onNextHandler}
       saveButtonText={saveText}
-      saveDisabled={noReadySeedlings}
     >
       <Container
         maxWidth={false}


### PR DESCRIPTION
When no seeds are ready, instead of selecting OUTPLANT purpose and show an error, disable that option and default selection to NURSERY_TRANSFER.

Error message is now shown in an info tooltip

<img width="770" alt="Screenshot 2023-01-19 at 14 53 48" src="https://user-images.githubusercontent.com/5919083/213522938-2d5d4a4b-0728-4f34-a9df-643c655a9f4a.png">
