### PR TITLE
SW-2735 show time zone selector in org create form

### DIFF
--- a/src/api/organization/organization.ts
+++ b/src/api/organization/organization.ts
@@ -114,6 +114,7 @@ export async function createOrganization(organization: ServerOrganization) {
       description: organization.description,
       countryCode: organization.countryCode,
       countrySubdivisionCode: organization.countrySubdivisionCode,
+      timeZone: organization.timeZone,
     };
     const serverResponse: UpdateOrganizationResponsePayload = (await axios.post(ORGANIZATIONS, newOrganization)).data;
 

--- a/src/components/AddNewOrganizationModal.tsx
+++ b/src/components/AddNewOrganizationModal.tsx
@@ -169,8 +169,11 @@ export default function AddNewOrganizationModal(props: AddNewOrganizationModalPr
             label={strings.ORGANIZATION_NAME_REQUIRED}
             type='text'
             id='name'
-            onChange={(value) => onChange('name', value)}
-            errorText={newOrganization.name ? '' : nameError}
+            onChange={(value) => {
+              onChange('name', value);
+              setNameError('');
+            }}
+            errorText={nameError}
             value={newOrganization.name}
           />
         </Grid>
@@ -190,7 +193,7 @@ export default function AddNewOrganizationModal(props: AddNewOrganizationModalPr
               onTimeZoneSelected={onTimeZoneChange}
               selectedTimeZone={newOrganization.timeZone}
               tooltip={strings.ORGANIZATION_TIME_ZONE_TOOLTIP}
-              errorText={newOrganization.timeZone ? '' : timeZoneError}
+              errorText={timeZoneError}
             />
           </Grid>
         )}

--- a/src/components/AddNewOrganizationModal.tsx
+++ b/src/components/AddNewOrganizationModal.tsx
@@ -11,7 +11,7 @@ import { Country } from 'src/types/Country';
 import { getCountryByCode, getSubdivisionByCode } from 'src/utils/country';
 import { APP_PATHS } from '../constants';
 import DialogBox from './common/DialogBox/DialogBox';
-import { Grid, Typography, useTheme } from '@mui/material';
+import { Grid } from '@mui/material';
 import { useHistory } from 'react-router-dom';
 import useSnackbar from 'src/utils/useSnackbar';
 import { useOrganization } from 'src/providers/hooks';
@@ -39,7 +39,6 @@ export default function AddNewOrganizationModal(props: AddNewOrganizationModalPr
     totalUsers: 0,
   });
   const timeZonesEnabled = isEnabled('Timezones');
-  const theme = useTheme();
 
   useEffect(() => {
     let cancel = false;
@@ -185,21 +184,15 @@ export default function AddNewOrganizationModal(props: AddNewOrganizationModalPr
           />
         </Grid>
         {timeZonesEnabled && (
-          <>
-            <Grid item xs={12}>
-              <Typography fontSize='14px' fontWeight={400} color={theme.palette.TwClrTxtInfo} marginBottom={0.5}>
-                {strings.TIME_ZONE_REQUIRED}
-              </Typography>
-            </Grid>
-            <Grid item xs={12} sx={{ '&.MuiGrid-item': { paddingTop: 0 } }}>
-              <TimeZoneSelector
-                onTimeZoneSelected={onTimeZoneChange}
-                selectedTimeZone={newOrganization.timeZone}
-                tooltip={strings.ORGANIZATION_TIME_ZONE_TOOLTIP}
-                errorText={newOrganization.timeZone ? '' : timeZoneError}
-              />
-            </Grid>
-          </>
+          <Grid item xs={12}>
+            <TimeZoneSelector
+              label={strings.TIME_ZONE_REQUIRED}
+              onTimeZoneSelected={onTimeZoneChange}
+              selectedTimeZone={newOrganization.timeZone}
+              tooltip={strings.ORGANIZATION_TIME_ZONE_TOOLTIP}
+              errorText={newOrganization.timeZone ? '' : timeZoneError}
+            />
+          </Grid>
         )}
         <Grid item xs={12}>
           <Select

--- a/src/components/TimeZoneSelector.tsx
+++ b/src/components/TimeZoneSelector.tsx
@@ -10,10 +10,11 @@ export type TimeZoneSelectorProps = {
   disabled?: boolean;
   label?: string;
   tooltip?: string;
+  errorText?: string;
 };
 
 export default function TimeZoneSelector(props: TimeZoneSelectorProps): JSX.Element {
-  const { onTimeZoneSelected, selectedTimeZone, disabled, label, tooltip } = props;
+  const { onTimeZoneSelected, selectedTimeZone, disabled, label, tooltip, errorText } = props;
   const timeZones = useTimeZones();
 
   const tzToDropdownItem = (tz?: TimeZoneDescription) =>
@@ -52,6 +53,7 @@ export default function TimeZoneSelector(props: TimeZoneSelectorProps): JSX.Elem
       label={label || ''}
       disabled={disabled}
       tooltipTitle={tooltip}
+      errorText={errorText}
     />
   );
 }

--- a/src/strings/strings-en.ts
+++ b/src/strings/strings-en.ts
@@ -560,6 +560,7 @@ export const strings = {
   ORGANIZATION_DESC: 'Manage your organization.',
   ORGANIZATION_NAME_REQUIRED: 'Organization Name *',
   ORGANIZATION_NAME: 'Organization Name',
+  ORGANIZATION_TIME_ZONE_TOOLTIP: 'Lorem ipsum dolor sit amet',
   ORGANIZATION: 'Organization',
   ORGANIZATIONS: 'Organizations',
   ORIGINAL_PLOT: 'Original Plot',
@@ -863,6 +864,7 @@ export const strings = {
   TIME_ZONE_INITIALIZED_USER_ORG_MESSAGE:
     "Your organization's and your time zone was updated to {0} zone. You can edit this setting from Settings > {1} and {2} respectively.",
   TIME_ZONE: 'Time Zone',
+  TIME_ZONE_REQUIRED: 'Time Zone *',
   TITLE_REPORT_PROBLEM: 'Report a Problem',
   TITLE_REQUEST_FEATURE: 'Request a Feature',
   TITLE_TEST_APP: 'Test our Mobile App',


### PR DESCRIPTION
- required input
- use time zone when creating org
- known error: user is informed that time zone was set in info message after org switch (to be addressed separately)

<img width="255" alt="Terraware App 2023-01-19 16-36-57" src="https://user-images.githubusercontent.com/1865174/213593321-5af062b8-de93-4f8a-80eb-655f1de54794.png">

<img width="254" alt="Terraware App 2023-01-19 16-36-44" src="https://user-images.githubusercontent.com/1865174/213593328-e24d8715-895b-43dc-82ad-d43b7d812176.png">

<img width="256" alt="Terraware App 2023-01-19 16-36-28" src="https://user-images.githubusercontent.com/1865174/213593329-657f6d55-eab0-42e5-8ebf-f76145f15f89.png">
