### PR TITLE
SW-2762 Add label to allow showing tooltip

### DIFF
--- a/src/components/MyAccount/index.tsx
+++ b/src/components/MyAccount/index.tsx
@@ -347,21 +347,17 @@ const MyAccountContent = ({
             <Grid item xs={12} />
             {timeZonesEnabled && (
               <>
-                <Grid item xs={12}>
-                  <Typography fontSize='20px' fontWeight={600}>
-                    {strings.TIME_ZONE}
-                  </Typography>
-                </Grid>
                 <Grid item xs={12} sx={{ '&.MuiGrid-item': { paddingTop: theme.spacing(2) } }}>
                   {edit ? (
                     <TimeZoneSelector
                       onTimeZoneSelected={onTimeZoneChange}
                       selectedTimeZone={record.timeZone}
                       tooltip={strings.MY_ACCOUNT_TIME_ZONE_TOOLTIP}
+                      label={strings.TIME_ZONE}
                     />
                   ) : (
                     <TextField
-                      label=''
+                      label={strings.TIME_ZONE}
                       id='timezone'
                       type='text'
                       value={tz.longName}


### PR DESCRIPTION
Tooltip was not showing on time selector because tooltip shows next to the label. Remove Title and add label to allow showing tooltip

<img width="1575" alt="Screenshot 2023-01-20 at 11 08 07" src="https://user-images.githubusercontent.com/5919083/213716560-19391aba-215a-4274-bc8f-f6486b3bd29d.png">
