### PR TITLE
SW-2761 default all time zone tooltips to lorem ipusum, in preparation for design copy

### DIFF
--- a/src/components/AddNewOrganizationModal.tsx
+++ b/src/components/AddNewOrganizationModal.tsx
@@ -192,7 +192,7 @@ export default function AddNewOrganizationModal(props: AddNewOrganizationModalPr
               label={strings.TIME_ZONE_REQUIRED}
               onTimeZoneSelected={onTimeZoneChange}
               selectedTimeZone={newOrganization.timeZone}
-              tooltip={strings.ORGANIZATION_TIME_ZONE_TOOLTIP}
+              tooltip={strings.TOOLTIP_TIME_ZONE_ORGANIZATION}
               errorText={timeZoneError}
             />
           </Grid>

--- a/src/components/EditOrganization/index.tsx
+++ b/src/components/EditOrganization/index.tsx
@@ -38,7 +38,6 @@ export default function OrganizationView({ organization, reloadOrganizationData 
   const timeZones = useTimeZones();
   const defaultTimeZone = useUserTimeZone()?.id || getUTC(timeZones).id;
   const timeZoneFeatureEnabled = isEnabled('Timezones');
-  const [tzChangedFromDefault, setTzChangedFromDefault] = useState<boolean>(organizationRecord.timeZone !== undefined);
 
   useEffect(() => {
     const populateCountries = async () => {
@@ -96,9 +95,6 @@ export default function OrganizationView({ organization, reloadOrganizationData 
   };
 
   const onChangeTimeZone = (newTimeZone: TimeZoneDescription | undefined) => {
-    if (newTimeZone) {
-      setTzChangedFromDefault(true);
-    }
     setOrganizationRecord((previousRecord: ServerOrganization): ServerOrganization => {
       return {
         ...previousRecord,
@@ -205,7 +201,7 @@ export default function OrganizationView({ organization, reloadOrganizationData 
                 selectedTimeZone={organizationRecord.timeZone || defaultTimeZone}
                 onTimeZoneSelected={onChangeTimeZone}
                 label={strings.TIME_ZONE}
-                tooltip={tzChangedFromDefault ? undefined : strings.TIME_ZONE_DEFAULT_USER}
+                tooltip={strings.TOOLTIP_TIME_ZONE_ORGANIZATION}
               />
             </Grid>
           )}

--- a/src/components/LocationTimeZoneSelector.tsx
+++ b/src/components/LocationTimeZoneSelector.tsx
@@ -67,7 +67,7 @@ export default function LocationTimeZoneSelector(props: LocationTimeZoneSelector
         tooltip={tooltip}
       />
       <Checkbox
-        label={strings.USE_ORG_TZ}
+        label={strings.USE_ORGANIZATION_TIME_ZONE}
         onChange={(value) => onOrgTimeZoneChecked(value)}
         id='orgTZ'
         name='orgTZ'

--- a/src/components/MyAccount/index.tsx
+++ b/src/components/MyAccount/index.tsx
@@ -352,7 +352,7 @@ const MyAccountContent = ({
                     <TimeZoneSelector
                       onTimeZoneSelected={onTimeZoneChange}
                       selectedTimeZone={record.timeZone}
-                      tooltip={strings.MY_ACCOUNT_TIME_ZONE_TOOLTIP}
+                      tooltip={strings.TOOLTIP_TIME_ZONE_MY_ACCOUNT}
                       label={strings.TIME_ZONE}
                     />
                   ) : (
@@ -361,7 +361,7 @@ const MyAccountContent = ({
                       id='timezone'
                       type='text'
                       value={tz.longName}
-                      tooltipTitle={record.timeZone ? undefined : strings.DEFAULT_TIME_ZONE_TOOLTIP}
+                      tooltipTitle={strings.TOOLTIP_TIME_ZONE_MY_ACCOUNT}
                       display={true}
                     />
                   )}

--- a/src/components/Nursery/index.tsx
+++ b/src/components/Nursery/index.tsx
@@ -113,7 +113,7 @@ export default function NurseryDetails(): JSX.Element {
               id='timezone'
               type='text'
               value={tz.longName}
-              tooltipTitle={nursery?.timeZone ? undefined : strings.ORG_TZ_TOOLTIP_INFO}
+              tooltipTitle={strings.TOOLTIP_TIME_ZONE_NURSERY}
               display={true}
             />
           </Grid>

--- a/src/components/Organization/index.tsx
+++ b/src/components/Organization/index.tsx
@@ -163,7 +163,7 @@ export default function OrganizationView(): JSX.Element {
               type='text'
               value={currentTimeZone || utcTimeZone.longName}
               display={true}
-              tooltipTitle={currentTimeZone ? undefined : strings.TIME_ZONE_DEFAULT_UTC}
+              tooltipTitle={strings.TOOLTIP_TIME_ZONE_ORGANIZATION}
             />
           </Grid>
         )}

--- a/src/components/PlantingSites/PlantingSiteView.tsx
+++ b/src/components/PlantingSites/PlantingSiteView.tsx
@@ -111,7 +111,7 @@ export default function PlantingSiteView(): JSX.Element {
               id='timezone'
               type='text'
               value={tz.longName}
-              tooltipTitle={plantingSite?.timeZone ? undefined : strings.ORG_TZ_TOOLTIP_INFO}
+              tooltipTitle={plantingSite?.timeZone ? undefined : strings.TOOLTIP_TIME_ZONE_PLANTING_SITE}
               display={true}
             />
           </Grid>

--- a/src/components/SeedBank/index.tsx
+++ b/src/components/SeedBank/index.tsx
@@ -112,7 +112,7 @@ export default function SeedBankDetails(): JSX.Element {
               id='timezone'
               type='text'
               value={tz.longName}
-              tooltipTitle={seedBank?.timeZone ? undefined : strings.ORG_TZ_TOOLTIP_INFO}
+              tooltipTitle={strings.TOOLTIP_TIME_ZONE_SEEDBANK}
               display={true}
             />
           </Grid>

--- a/src/strings/strings-en.ts
+++ b/src/strings/strings-en.ts
@@ -193,7 +193,6 @@ export const strings = {
   DATE_OF_WITHDRAWAL: 'Date of Withdrawal',
   DATE: 'Date',
   DEAD: 'Dead',
-  DEFAULT_TIME_ZONE_TOOLTIP: 'Time zone default to UTC',
   DELETE_ACCESSION_MESSAGE: 'You’re about to delete accession {0}.',
   DELETE_ACCESSION: 'Delete Accession',
   DELETE_CONFIRMATION_MODAL_MAIN_TEXT:
@@ -281,7 +280,7 @@ export const strings = {
   EXPORT_RECORDS: 'Export Records',
   EXPORT: 'Export',
   FACILITY: 'Facility',
-  USE_ORG_TZ: "Use organization's time zone",
+  USE_ORGANIZATION_TIME_ZONE: "Use organization's time zone",
   FAMILY: 'Family',
   FERN: 'Fern',
   FIELD_NOTES_PLACEHOLDER: 'Important notes about seeds, fruits, or plants',
@@ -453,7 +452,6 @@ export const strings = {
   MY_ACCOUNT_DESC: 'Manage your account information.',
   MY_ACCOUNT_NOTIFICATIONS_DESC:
     'Notifications alert you when there are important updates about your organizations. You will receive them through email.',
-  MY_ACCOUNT_TIME_ZONE_TOOLTIP: 'Lorem ipsum dolor sit amet',
   MY_ACCOUNT: 'My Account',
   NAME_REQUIRED: 'Name *',
   NAME_UNKNOWN: '(name unknown)',
@@ -551,7 +549,6 @@ export const strings = {
   OPT_IN: 'Opt-In Features',
   OR_SEED_WEIGHT: 'or Seed Weight',
   OR: 'OR',
-  ORG_TZ_TOOLTIP_INFO: "This time zone is inherited from your organization's time zone",
   ORGANIZATION_CREATE_FAILED: 'Unable to create organization.',
   ORGANIZATION_CREATED_MSG:
     'You can access the organizations you’re in by clicking the arrow in the top right corner next to your profile.',
@@ -560,7 +557,6 @@ export const strings = {
   ORGANIZATION_DESC: 'Manage your organization.',
   ORGANIZATION_NAME_REQUIRED: 'Organization Name *',
   ORGANIZATION_NAME: 'Organization Name',
-  ORGANIZATION_TIME_ZONE_TOOLTIP: 'Lorem ipsum dolor sit amet',
   ORGANIZATION: 'Organization',
   ORGANIZATIONS: 'Organizations',
   ORIGINAL_PLOT: 'Original Plot',
@@ -855,16 +851,14 @@ export const strings = {
   TEST: 'Test',
   TESTING_STAFF: 'Testing Staff',
   TIME_PERIOD: 'Time Period',
-  TIME_ZONE_DEFAULT_USER: 'Time zone defaulted to user time zone.',
-  TIME_ZONE_DEFAULT_UTC: 'Time zone defaulted to UTC.',
   TIME_ZONE_INITIALIZED_TITLE: 'Time Zone Set',
   TIME_ZONE_INITIALIZED_ORG_MESSAGE:
     "Your organization's time zone was updated to {0} zone. You can edit this setting from Settings > {1}.",
   TIME_ZONE_INITIALIZED_USER_MESSAGE: 'Your time zone was updated to {0} zone. You can edit this setting from {1}.',
   TIME_ZONE_INITIALIZED_USER_ORG_MESSAGE:
     "Your organization's and your time zone was updated to {0} zone. You can edit this setting from Settings > {1} and {2} respectively.",
-  TIME_ZONE: 'Time Zone',
   TIME_ZONE_REQUIRED: 'Time Zone *',
+  TIME_ZONE: 'Time Zone',
   TITLE_REPORT_PROBLEM: 'Report a Problem',
   TITLE_REQUEST_FEATURE: 'Request a Feature',
   TITLE_TEST_APP: 'Test our Mobile App',
@@ -899,6 +893,11 @@ export const strings = {
     'A structural category consisting of individuals or species of the same general habit of growth but not necessarily related.',
   TOOLTIP_SPECIES_SEED_STORAGE_BEHAVIOR:
     'The capacity of seeds to survive desiccation and temperatures to levels necessary for ex site (off site) storage.',
+  TOOLTIP_TIME_ZONE_MY_ACCOUNT: 'Lorem ipsum...',
+  TOOLTIP_TIME_ZONE_NURSERY: 'Lorem ipsum...',
+  TOOLTIP_TIME_ZONE_ORGANIZATION: 'Lorem ipsum...',
+  TOOLTIP_TIME_ZONE_PLANTING_SITE: 'Lorem ipsum...',
+  TOOLTIP_TIME_ZONE_SEEDBANK: 'Lorem ipsum...',
   TOOLTIP_TOTAL_QUANTITY: 'Total quantity is the sum of the not ready and ready quantities.',
   TOOLTIP_VIABILITY_TEST_AGAR_PETRI_DISH: 'A dish that contains a growth medium of solidified agar.',
   TOOLTIP_VIABILITY_TEST_CHEMICAL:


### PR DESCRIPTION
- renamed the string constants to keep with the `TOOLTIP_XYZ_ABC` pattern used elsewhere
- switched to using default placeholder content for all time zone tool tips
- updated use-cases in the JIRA instead https://terraformation.atlassian.net/browse/SW-2761
- will get Ming to supply the copy
- happy to revert any changes here if anyone has suggestions
- I will assign the JIRA to Ming after this gets in, otherwise it will be super confusing for Ming to see the tooltips in the various scenarios