### PR TITLE
Ignore Yalc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /node_modules
 /.pnp
 .pnp.js
+/.yalc
+yalc.lock
 
 # testing
 /coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules
+.yalc
 
 # Tools
 .nyc_output


### PR DESCRIPTION
To make it easier to use Yalc to test web-components changes locally, add
Yalc's cache directory and its lockfile to the Git and Prettier ignore lists.
