### PR TITLE
SW-2721 Load strings dynamically

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,7 @@ import { PlantingSite } from './api/types/tracking';
 import isEnabled from 'src/features';
 import useSnackbar from 'src/utils/useSnackbar';
 import { TimeZoneDescription, InitializedTimeZone } from 'src/types/TimeZones';
-import { useOrganization, useTimeZones, useUser } from 'src/providers';
+import { useLocalization, useOrganization, useTimeZones, useUser } from 'src/providers';
 import { updatePreferences } from 'src/api/preferences/preferences';
 import { initializeUserTimeZone } from 'src/api/user/user';
 import { initializeOrganizationTimeZone } from 'src/api/organization/organization';
@@ -626,6 +626,10 @@ function AppContent() {
       </div>
     </>
   );
+
+  // Localized strings are stored outside of React's state, but there's a state change when they're
+  // updated. Declare the dependency here so the app rerenders when the locale changes.
+  useLocalization();
 
   return (
     <StyledEngineProvider injectFirst>

--- a/src/AppBootstrap.tsx
+++ b/src/AppBootstrap.tsx
@@ -56,12 +56,18 @@ export type AppBootstrapProps = {
 };
 
 export default function AppBootstrap({ children }: AppBootstrapProps): JSX.Element {
-  const [locale] = useState('en');
+  const [locale, setLocale] = useState('en');
+  const [loadedStringsForLocale, setLoadedStringsForLocale] = useState<string | null>(null);
 
   return (
     <UserProvider>
       <OrganizationProvider>
-        <LocalizationProvider locale={locale}>
+        <LocalizationProvider
+          locale={locale}
+          setLocale={setLocale}
+          loadedStringsForLocale={loadedStringsForLocale}
+          setLoadedStringsForLocale={setLoadedStringsForLocale}
+        >
           <BlockingBootstrap>{children}</BlockingBootstrap>
         </LocalizationProvider>
       </OrganizationProvider>

--- a/src/providers/DataTypes.ts
+++ b/src/providers/DataTypes.ts
@@ -23,7 +23,9 @@ export type ProvidedOrganizationData = {
 };
 
 export type ProvidedLocalizationData = {
+  locale: string;
   supportedTimeZones: TimeZoneDescription[];
-  strings: { [key: string]: string };
+  setLocale: (locale: string) => void;
+  loadedStringsForLocale: string | null;
   bootstrapped: boolean;
 };

--- a/src/providers/contexts.ts
+++ b/src/providers/contexts.ts
@@ -38,7 +38,9 @@ export const OrganizationContext = createContext<ProvidedOrganizationData>({
 });
 
 export const LocalizationContext = createContext<ProvidedLocalizationData>({
+  loadedStringsForLocale: null,
+  locale: 'en',
+  setLocale: () => undefined,
   supportedTimeZones: [],
-  strings: {},
   bootstrapped: false,
 });

--- a/src/providers/hooks.ts
+++ b/src/providers/hooks.ts
@@ -3,8 +3,6 @@ import { LocalizationContext, OrganizationContext, UserContext } from './context
 
 export const useOrganization = () => useContext(OrganizationContext);
 
-export const useStrings = () => useContext(LocalizationContext).strings;
-
 export const useTimeZones = () => useContext(LocalizationContext).supportedTimeZones;
 
 export const useLocalization = () => useContext(LocalizationContext);

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -6,7 +6,9 @@ export type ILocalizedStrings = typeof english;
 
 export type ILocalizedStringsMap = GlobalStrings<ILocalizedStrings>;
 
-export const stringsMap = { en: english } as unknown as ILocalizedStringsMap;
-const strings = new LocalizedStrings(stringsMap);
+// By default, we have no strings to show, but react-localization requires there to be at least
+// one locale in the LocalizedStrings constructor's argument. We will dynamically update this when
+// we've loaded the strings for the current locale.
+const strings = new LocalizedStrings({ _: {} } as unknown as ILocalizedStringsMap);
 
 export default strings;


### PR DESCRIPTION
Use dynamic import instead of a static import to load the strings table for the
user's locale.

Currently, only the default locale of English is supported, but this change is
a prerequisite for loading other locales.
