### PR TITLE
Fix eslint warning

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -49,4 +49,6 @@ axios.interceptors.response.use((x) => {
   return x;
 });
 
-export default new Proxy(axios, handler);
+const proxy = new Proxy(axios, handler);
+
+export default proxy;


### PR DESCRIPTION
eslint was warning that we should assign a value to a const before
exporting it as a module default, so do what it suggests.
