### PR TITLE
SW-2737 Add locale selector and gibberish locale

### DIFF
--- a/src/components/LocaleSelector.tsx
+++ b/src/components/LocaleSelector.tsx
@@ -13,13 +13,7 @@ export default function LocaleSelector(): JSX.Element {
     <LocalizationContext.Consumer>
       {({ locale, setLocale }) => {
         return (
-          <Dropdown
-            id={'localeSelector'}
-            label={''}
-            onChange={setLocale}
-            selected={locale}
-            values={localeItems}
-          />
+          <Dropdown id={'localeSelector'} label={''} onChange={setLocale} selected={locale} values={localeItems} />
         );
       }}
     </LocalizationContext.Consumer>

--- a/src/components/LocaleSelector.tsx
+++ b/src/components/LocaleSelector.tsx
@@ -1,0 +1,27 @@
+import { DropdownItem } from '@terraware/web-components';
+import { supportedLocales } from '../strings/locales';
+import { LocalizationContext } from '../providers/contexts';
+import Dropdown from './common/Dropdown';
+
+export default function LocaleSelector(): JSX.Element {
+  const localeItems: DropdownItem[] = supportedLocales.map((supportedLocale) => ({
+    value: supportedLocale.id,
+    label: supportedLocale.name,
+  }));
+
+  return (
+    <LocalizationContext.Consumer>
+      {({ locale, setLocale }) => {
+        return (
+          <Dropdown
+            id={'localeSelector'}
+            label={''}
+            onChange={setLocale}
+            selected={locale}
+            values={localeItems}
+          />
+        );
+      }}
+    </LocalizationContext.Consumer>
+  );
+}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -11,6 +11,8 @@ import { hasNurseryWithdrawals } from 'src/api/tracking/withdrawals';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import NavFooter from './common/Navbar/NavFooter';
 import { useOrganization } from 'src/providers/hooks';
+import LocaleSelector from './LocaleSelector';
+import isEnabled from '../features';
 
 type NavBarProps = {
   setShowNavBar: React.Dispatch<React.SetStateAction<boolean>>;
@@ -237,6 +239,8 @@ export default function NavBar({
           }}
           id='contactus'
         />
+
+        {isEnabled('Locale selection') && <LocaleSelector />}
       </NavFooter>
     </Navbar>
   );

--- a/src/features.ts
+++ b/src/features.ts
@@ -52,6 +52,19 @@ export const OPT_IN_FEATURES: Feature[] = [
     description: ['Allow choosing preferred weight units'],
     disclosure: ['This is WIP.'],
   },
+  {
+    name: 'Locale selection',
+    preferenceName: 'enableLocales',
+    active: true,
+    enabled: false,
+    allowInternalProduction: false,
+    description: ['Allow switching to different locales (languages)'],
+    disclosure: [
+      'This is WIP.',
+      'Locale selection is not saved, so will reset when you reload the page.',
+      'Some values such as accession statuses are currently still in English.',
+    ],
+  },
 ];
 
 type FeatureMap = { [key: string]: Feature };

--- a/src/providers/LocalizationProvider.tsx
+++ b/src/providers/LocalizationProvider.tsx
@@ -2,8 +2,9 @@ import React, { useEffect, useState } from 'react';
 import { LocalizationContext } from './contexts';
 import { getTimeZones } from 'src/api/timezones/timezones';
 import { TimeZoneDescription } from 'src/types/TimeZones';
-import strings, { ILocalizedStrings, ILocalizedStringsMap } from 'src/strings';
+import strings, { ILocalizedStringsMap } from 'src/strings';
 import { ProvidedLocalizationData } from '.';
+import { supportedLocales } from '../strings/locales';
 
 export type LocalizationProviderProps = {
   children?: React.ReactNode;
@@ -35,19 +36,14 @@ export default function LocalizationProvider({
 
   useEffect(() => {
     const fetchStrings = async () => {
-      let stringsModule: Promise<{ strings: ILocalizedStrings }>;
-
-      // These dynamic imports will cause Webpack to generate a separate chunk file for each
-      // locale's strings.
-      //
-      // This is hardwired to English initially, but as we add locales, they'll be conditionally
-      // imported here.
-      stringsModule = import('../strings/strings-en');
-
-      const stringsTable = (await stringsModule).strings;
+      const language = locale.replace(/[-_].*/, '');  // 'en-US' => 'en'
+      const localeDetails =
+        supportedLocales.find((details) => details.id === locale) ||
+        supportedLocales.find((details) => details.id === language) ||
+        supportedLocales[0];
 
       const localeMap: ILocalizedStringsMap = {};
-      localeMap[locale] = stringsTable;
+      localeMap[locale] = (await localeDetails.loadModule()).strings;
       strings.setContent(localeMap);
       strings.setLanguage(locale);
 

--- a/src/providers/LocalizationProvider.tsx
+++ b/src/providers/LocalizationProvider.tsx
@@ -36,7 +36,7 @@ export default function LocalizationProvider({
 
   useEffect(() => {
     const fetchStrings = async () => {
-      const language = locale.replace(/[-_].*/, '');  // 'en-US' => 'en'
+      const language = locale.replace(/[-_].*/, ''); // 'en-US' => 'en'
       const localeDetails =
         supportedLocales.find((details) => details.id === locale) ||
         supportedLocales.find((details) => details.id === language) ||

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -6,6 +6,29 @@ export type ILocalizedStrings = typeof english;
 
 export type ILocalizedStringsMap = GlobalStrings<ILocalizedStrings>;
 
+interface StringsModule {
+  strings: ILocalizedStrings;
+}
+
+export interface LocaleDetails {
+  /**
+   * Locale identifier. This must start with a language tag (2 or 3 letters) and may optionally
+   * have a hyphen and a location code. For example, 'en' or 'en-US'.
+   */
+  id: string;
+  /**
+   * Name of the locale as it appears in the locale selector dropdown. This will typically be the
+   * name of the locale in whatever language the locale uses. That is, 'Español' and not 'Spanish'.
+   */
+  name: string;
+  /**
+   * Dynamic import of the strings module for the locale. This must be an import of a constant
+   * module name (as opposed to a function that constructs the module name on the fly) so that
+   * Webpack knows to split the strings modules out into separate downloadable artifacts.
+   */
+  loadModule: () => Promise<StringsModule>;
+}
+
 // By default, we have no strings to show, but react-localization requires there to be at least
 // one locale in the LocalizedStrings constructor's argument. We will dynamically update this when
 // we've loaded the strings for the current locale.

--- a/src/strings/locales.ts
+++ b/src/strings/locales.ts
@@ -1,0 +1,7 @@
+import { LocaleDetails } from '.';
+
+/** Supported locales in the order they should appear in the locale selector. */
+export const supportedLocales: LocaleDetails[] = [
+  { id: 'en', name: 'English', loadModule: () => import('./strings-en') },
+  { id: 'gx', name: 'Gibberish', loadModule: () => import('./strings-gx') },
+];

--- a/src/strings/strings-gx.ts
+++ b/src/strings/strings-gx.ts
@@ -1,0 +1,36 @@
+import { strings as english } from './strings-en';
+import { ILocalizedStrings } from './index';
+
+/**
+ * Transforms the English strings table into gibberish.
+ *
+ * 1. Split the English string into whitespace-delimited words.
+ * 2. Reverse the order of the words.
+ * 3. Render each word as a base64 encoding of its UTF-8 representation, except for words that look
+ *    like format string placeholders.
+ */
+function generateGibberish(): ILocalizedStrings {
+  const encoder = new TextEncoder();
+  const gibberish = Object.assign({}, english);
+  Object.keys(english).forEach((key) => {
+    const englishString = english[key as keyof ILocalizedStrings];
+    const words = englishString.split(' ').reverse();
+    const encodedWords = words.map((word: string) => {
+      if (word.startsWith('{')) {
+        return word;
+      } else {
+        const uint8Array = encoder.encode(word);
+        const binary = Array(uint8Array.length)
+          .fill('')
+          .map((_, i) => String.fromCharCode(uint8Array[i]))
+          .join('');
+        return btoa(binary).replace(/=/g, '');
+      }
+    });
+    gibberish[key as keyof ILocalizedStrings] = encodedWords.join(' ');
+  });
+
+  return gibberish;
+}
+
+export const strings = generateGibberish();


### PR DESCRIPTION
Add an opt-in feature to show a locale selector in the left nav footer.

A selector is no good without things to select, so add a programmatically
generated "gibberish" locale that transforms the English strings.
