### PR TITLE
SW-2736 Fix can't edit newly-invited user

### DIFF
--- a/src/components/People/TableCellRenderer.tsx
+++ b/src/components/People/TableCellRenderer.tsx
@@ -14,7 +14,7 @@ export default function Renderer(props: RendererProps<TableRowType>): JSX.Elemen
     return <Link to={personLocation.pathname}>{iValue as React.ReactNode}</Link>;
   };
 
-  if (column.key === 'firstName' || column.key === 'lastName') {
+  if (column.key === 'email') {
     return <CellRenderer index={index} column={column} value={createLinkToPerson(value)} row={row} />;
   }
 

--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -81,9 +81,9 @@ export default function PeopleList(): JSX.Element {
   const { isMobile } = useDeviceInfo();
   const contentRef = useRef(null);
   const columns: TableColumnType[] = [
+    { key: 'email', name: strings.EMAIL, type: 'string' },
     { key: 'firstName', name: strings.FIRST_NAME, type: 'string' },
     { key: 'lastName', name: strings.LAST_NAME, type: 'string' },
-    { key: 'email', name: strings.EMAIL, type: 'string' },
     { key: 'role', name: strings.ROLE, type: 'string' },
     { key: 'addedTime', name: strings.DATE_ADDED, type: 'date' },
   ];
@@ -114,6 +114,11 @@ export default function PeopleList(): JSX.Element {
             },
           ],
         },
+        sortOrder: [
+          {
+            field: 'user_email',
+          },
+        ],
         count: 0,
       };
 


### PR DESCRIPTION
In people table in people page:
- Make email clikable instead of Name and Last Name to allow editing users with no name/lastname
- Sort rows on table by email