### PR TITLE
Set Accept-Language header to current locale

### DIFF
--- a/src/api/timezones/timezones.ts
+++ b/src/api/timezones/timezones.ts
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import addQueryParams from '../helpers/addQueryParams';
 import { paths } from '../types/generated-schema';
 import { addError } from '../utils';
 

--- a/src/api/timezones/timezones.ts
+++ b/src/api/timezones/timezones.ts
@@ -16,17 +16,17 @@ type GetTimeZonesResponse = {
   error?: string;
 };
 
-type GetTimeZonesQuery = paths[typeof TIMEZONES_ENDPOINT]['get']['parameters']['query'];
-
-export const getTimeZones = async (locale?: string): Promise<GetTimeZonesResponse> => {
+/**
+ * Gets the time zone definitions for the current locale. This assumes that Axios has already
+ * been configured to send the currently-selected locale in the Accept-Language header.
+ */
+export const getTimeZones = async (): Promise<GetTimeZonesResponse> => {
   const response: GetTimeZonesResponse = {
     requestSucceeded: true,
     timeZones: undefined,
   };
   try {
-    const queryParams: GetTimeZonesQuery = { locale };
-    const endpoint = addQueryParams(TIMEZONES_ENDPOINT, queryParams);
-    const serverResponse: ListTimeZoneNamesResponsePayload = (await axios.get(endpoint)).data;
+    const serverResponse: ListTimeZoneNamesResponsePayload = (await axios.get(TIMEZONES_ENDPOINT)).data;
     response.timeZones = serverResponse.timeZones;
     if (serverResponse.status === 'error') {
       response.requestSucceeded = false;

--- a/src/providers/LocalizationProvider.tsx
+++ b/src/providers/LocalizationProvider.tsx
@@ -5,6 +5,7 @@ import { TimeZoneDescription } from 'src/types/TimeZones';
 import strings, { ILocalizedStringsMap } from 'src/strings';
 import { ProvidedLocalizationData } from '.';
 import { supportedLocales } from '../strings/locales';
+import axios from 'axios';
 
 export type LocalizationProviderProps = {
   children?: React.ReactNode;
@@ -24,8 +25,13 @@ export default function LocalizationProvider({
   const [timeZones, setTimeZones] = useState<TimeZoneDescription[]>([]);
 
   useEffect(() => {
+    axios.defaults.headers = { ...axios.defaults.headers, 'Accept-Language': locale };
+  }, [locale]);
+
+  // This must come after the effect that configures the Accept-Language header.
+  useEffect(() => {
     const fetchTimeZones = async () => {
-      const timeZoneResponse = await getTimeZones(locale);
+      const timeZoneResponse = await getTimeZones();
       if (!timeZoneResponse.error && timeZoneResponse.timeZones) {
         setTimeZones(timeZoneResponse.timeZones.sort((a, b) => a.longName.localeCompare(b.longName, locale)));
       }


### PR DESCRIPTION
The server looks at the `Accept-Language` header to figure out which locale to use
in its API responses. Update the client to set that header on outgoing requests.
