### PR TITLE
SW-2776 Load and save user locale selection

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -2046,6 +2046,11 @@ export interface components {
       firstName: string;
       lastName: string;
       /**
+       * @description IETF locale code containing user's preferred language.
+       * @example en
+       */
+      locale?: string;
+      /**
        * @description Time zone name in IANA tz database format
        * @example America/New_York
        */
@@ -2141,6 +2146,11 @@ export interface components {
       emailNotificationsEnabled: boolean;
       firstName?: string;
       lastName?: string;
+      /**
+       * @description IETF locale code containing user's preferred language.
+       * @example en
+       */
+      locale?: string;
       /**
        * @description Time zone name in IANA tz database format
        * @example America/New_York
@@ -2684,7 +2694,7 @@ export interface operations {
   listTimeZoneNames: {
     parameters: {
       query: {
-        /** Language code and optional country code suffix. */
+        /** Language code and optional country code suffix. If not specified, the preferred locale from the Accept-Language header is used if supported; otherwise US English is the default. */
         locale?: string;
       };
     };

--- a/src/api/user/user.ts
+++ b/src/api/user/user.ts
@@ -39,6 +39,7 @@ export async function getUser(): Promise<GetUserResponse> {
       lastName: serverResponse.user.lastName,
       emailNotificationsEnabled: serverResponse.user.emailNotificationsEnabled,
       timeZone: serverResponse.user.timeZone,
+      locale: serverResponse.user.locale,
     };
     setCurrentUser(response.user);
   } catch {
@@ -60,6 +61,7 @@ export async function updateUserProfile(user: User, skipAcknowledgeTimeZone?: bo
       firstName: user.firstName || '',
       lastName: user.lastName || '',
       timeZone: user.timeZone,
+      locale: user.locale,
     };
     if (user.emailNotificationsEnabled !== undefined) {
       serverRequest.emailNotificationsEnabled = user.emailNotificationsEnabled;

--- a/src/components/MyAccount/index.tsx
+++ b/src/components/MyAccount/index.tsx
@@ -97,6 +97,7 @@ const MyAccountContent = ({
   const contentRef = useRef(null);
   const timeZonesEnabled = isEnabled('Timezones');
   const weightUnitsEnabled = isEnabled('Weight units');
+  const locale = useLocalization().locale;
   const timeZones = useTimeZones();
   const tz = timeZones.find((timeZone) => timeZone.id === record.timeZone) || getUTC(timeZones);
   const [preferredWeightSystemSelected, setPreferredWeightSystemSelected] = useState(
@@ -197,7 +198,9 @@ const MyAccountContent = ({
   };
 
   const saveProfileChanges = async () => {
-    const updateUserResponse = await updateUserProfile(record);
+    // Save the currently-selected locale, even if it differs from the locale in the profile data we
+    // fetched from the server.
+    const updateUserResponse = await updateUserProfile({ ...record, locale });
     return updateUserResponse;
   };
 

--- a/src/components/MyAccount/index.tsx
+++ b/src/components/MyAccount/index.tsx
@@ -97,7 +97,7 @@ const MyAccountContent = ({
   const contentRef = useRef(null);
   const timeZonesEnabled = isEnabled('Timezones');
   const weightUnitsEnabled = isEnabled('Weight units');
-  const locale = useLocalization().locale;
+  const { locale } = useLocalization();
   const timeZones = useTimeZones();
   const tz = timeZones.find((timeZone) => timeZone.id === record.timeZone) || getUTC(timeZones);
   const [preferredWeightSystemSelected, setPreferredWeightSystemSelected] = useState(

--- a/src/providers/LocalizationProvider.tsx
+++ b/src/providers/LocalizationProvider.tsx
@@ -6,7 +6,7 @@ import strings, { ILocalizedStringsMap } from 'src/strings';
 import { ProvidedLocalizationData, useUser } from '.';
 import { supportedLocales } from '../strings/locales';
 import axios from 'axios';
-import { getUser, updateUserProfile } from 'src/api/user/user';
+import { updateUserProfile } from 'src/api/user/user';
 
 export type LocalizationProviderProps = {
   children?: React.ReactNode;
@@ -24,13 +24,13 @@ export default function LocalizationProvider({
   setLoadedStringsForLocale,
 }: LocalizationProviderProps): JSX.Element | null {
   const [timeZones, setTimeZones] = useState<TimeZoneDescription[]>([]);
-  const user = useUser();
+  const { user, reloadUser } = useUser();
 
   useEffect(() => {
-    if (user.user?.locale) {
-      setLocale(user.user.locale);
+    if (user?.locale) {
+      setLocale(user.locale);
     }
-  }, [user.user?.locale, setLocale]);
+  }, [user?.locale, setLocale]);
 
   useEffect(() => {
     axios.defaults.headers = { ...axios.defaults.headers, 'Accept-Language': locale };
@@ -69,16 +69,14 @@ export default function LocalizationProvider({
 
   useEffect(() => {
     const updateUserLocale = async () => {
-      const oldProfile = (await getUser())?.user;
-
-      if (oldProfile) {
-        const newProfile = { ...oldProfile, locale };
-        await updateUserProfile(newProfile, true);
+      if (user && user.locale !== locale) {
+        await updateUserProfile({ ...user, locale }, true);
+        reloadUser();
       }
     };
 
     updateUserLocale();
-  }, [locale]);
+  }, [locale, user, reloadUser]);
 
   const context: ProvidedLocalizationData = {
     bootstrapped: !!loadedStringsForLocale,

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -7,6 +7,7 @@ export type User = {
   email?: string;
   emailNotificationsEnabled?: boolean;
   timeZone?: string;
+  locale?: string;
 };
 
 export type OrganizationUser = {


### PR DESCRIPTION
At initialization time, use the locale from the user's profile, if any.

When the user changes locales, save the new selection to their profile.

When the user edits their profile, save the currently-selected locale along with
the other profile data.
