### PR TITLE
Fix flapping when non-English locale is selected

### DIFF
--- a/src/components/LocaleSelector.tsx
+++ b/src/components/LocaleSelector.tsx
@@ -2,8 +2,11 @@ import { DropdownItem } from '@terraware/web-components';
 import { supportedLocales } from '../strings/locales';
 import { LocalizationContext } from '../providers/contexts';
 import Dropdown from './common/Dropdown';
+import { updateUserProfile } from '../api/user/user';
+import { useUser } from '../providers';
 
 export default function LocaleSelector(): JSX.Element {
+  const { user, reloadUser } = useUser();
   const localeItems: DropdownItem[] = supportedLocales.map((supportedLocale) => ({
     value: supportedLocale.id,
     label: supportedLocale.name,
@@ -12,9 +15,22 @@ export default function LocaleSelector(): JSX.Element {
   return (
     <LocalizationContext.Consumer>
       {({ locale, setLocale }) => {
-        return (
-          <Dropdown id={'localeSelector'} label={''} onChange={setLocale} selected={locale} values={localeItems} />
-        );
+        const onChange = (newValue: string) => {
+          if (locale !== newValue) {
+            setLocale(newValue);
+          }
+
+          if (user && user.locale !== newValue) {
+            const updateUserLocale = async () => {
+              await updateUserProfile({ ...user, locale: newValue }, true);
+              reloadUser();
+            };
+
+            updateUserLocale();
+          }
+        };
+
+        return <Dropdown id={'localeSelector'} label={''} onChange={onChange} selected={locale} values={localeItems} />;
       }}
     </LocalizationContext.Consumer>
   );

--- a/src/providers/LocalizationProvider.tsx
+++ b/src/providers/LocalizationProvider.tsx
@@ -6,7 +6,6 @@ import strings, { ILocalizedStringsMap } from 'src/strings';
 import { ProvidedLocalizationData, useUser } from '.';
 import { supportedLocales } from '../strings/locales';
 import axios from 'axios';
-import { updateUserProfile } from 'src/api/user/user';
 
 export type LocalizationProviderProps = {
   children?: React.ReactNode;
@@ -24,7 +23,7 @@ export default function LocalizationProvider({
   setLoadedStringsForLocale,
 }: LocalizationProviderProps): JSX.Element | null {
   const [timeZones, setTimeZones] = useState<TimeZoneDescription[]>([]);
-  const { user, reloadUser } = useUser();
+  const { user } = useUser();
 
   useEffect(() => {
     if (user?.locale) {
@@ -66,17 +65,6 @@ export default function LocalizationProvider({
 
     fetchStrings();
   }, [locale, setLoadedStringsForLocale]);
-
-  useEffect(() => {
-    const updateUserLocale = async () => {
-      if (user && user.locale !== locale) {
-        await updateUserProfile({ ...user, locale }, true);
-        reloadUser();
-      }
-    };
-
-    updateUserLocale();
-  }, [locale, user, reloadUser]);
 
   const context: ProvidedLocalizationData = {
     bootstrapped: !!loadedStringsForLocale,


### PR DESCRIPTION
Commit fe1261459 introduced a bug: if the user's profile had a non-English locale,
the UI would flap back and forth between English and the selected locale.

This was because LocalizationProvider was treating any update of the locale as a
trigger to save the new value to the user's profile. So when the user's profile
was loaded and the locale was set based on that, it triggered a write to the
user's profile, which then triggered another locale update, and so on.

Fix it by only updating the user's profile when they actually change the locale
selector.
