### PR TITLE
SW-2820 Look up title of Notifications dropdown

### DIFF
--- a/src/components/NotificationsDropdown.tsx
+++ b/src/components/NotificationsDropdown.tsx
@@ -253,7 +253,7 @@ export default function NotificationsDropdown(props: NotificationsDropdownProps)
       <DivotPopover
         anchorEl={anchorEl}
         onClose={onPopoverClose}
-        title={'Notifications'}
+        title={strings.NOTIFICATIONS}
         headerMenuItems={getHeaderMenuItems()}
         size='large'
       >


### PR DESCRIPTION
The Notifications dropdown's title was using a hardwired English string.
