### PR TITLE
SW-2821 Show localized enums on species list

### DIFF
--- a/src/components/Species/SpeciesFiltersPopover.tsx
+++ b/src/components/Species/SpeciesFiltersPopover.tsx
@@ -135,7 +135,7 @@ export default function SpeciesFiltersPopover({ filters, setFilters }: SpeciesFi
                 id='growthForm'
                 selectedValue={temporalRecord.growthForm}
                 onChange={(value) => onChange('growthForm', value)}
-                options={growthForms()}
+                options={growthForms(true)}
                 label={strings.GROWTH_FORM}
                 aria-label={strings.GROWTH_FORM}
                 placeholder={strings.SELECT}
@@ -159,7 +159,7 @@ export default function SpeciesFiltersPopover({ filters, setFilters }: SpeciesFi
                 id='seedStorageBehavior'
                 selectedValue={temporalRecord.seedStorageBehavior}
                 onChange={(value) => onChange('seedStorageBehavior', value)}
-                options={storageBehaviors()}
+                options={storageBehaviors(true)}
                 label={strings.SEED_STORAGE_BEHAVIOR}
                 aria-label={strings.SEED_STORAGE_BEHAVIOR}
                 placeholder={strings.SELECT}

--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -2,14 +2,14 @@ import { Box, Container, Grid, IconButton, Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useRecoilState } from 'recoil';
-import { deleteSpecies } from 'src/api/species/species';
+import { deleteSpecies, getSpecies } from 'src/api/species/species';
 import Button from 'src/components/common/button/Button';
 import EmptyMessage from 'src/components/common/EmptyMessage';
 import Table from 'src/components/common/table';
 import { TableColumnType } from 'src/components/common/table/types';
 import speciesAtom from 'src/state/species';
 import strings from 'src/strings';
-import { Species, SpeciesProblemElement } from 'src/types/Species';
+import { getGrowthFormString, getSeedStorageBehaviorString, Species, SpeciesProblemElement } from 'src/types/Species';
 import TfMain from 'src/components/common/TfMain';
 import PageSnackbar from 'src/components/PageSnackbar';
 import AddSpeciesModal from './AddSpeciesModal';
@@ -110,13 +110,17 @@ export type SpeciesFiltersType = {
   endangered?: boolean;
 };
 
-type SpeciesCS = Species & { conservationStatus?: string };
+type SpeciesSearchResultRow = Omit<Species, 'growthForm' | 'seedStorageBehavior'> & {
+  conservationStatus?: string;
+  growthForm?: string;
+  seedStorageBehavior?: string;
+};
 
 export default function SpeciesList({ reloadData, species }: SpeciesListProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const classes = useStyles();
   const [selectedSpecies, setSelectedSpecies] = useState<Species>();
-  const [selectedSpeciesRows, setSelectedSpeciesRows] = useState<Species[]>([]);
+  const [selectedSpeciesRows, setSelectedSpeciesRows] = useState<SpeciesSearchResultRow[]>([]);
   const [editSpeciesModalOpen, setEditSpeciesModalOpen] = useState(false);
   const [deleteSpeciesModalOpen, setDeleteSpeciesModalOpen] = useState(false);
   const [importSpeciesModalOpen, setImportSpeciesModalOpen] = useState(false);
@@ -125,10 +129,10 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
   const [speciesState, setSpeciesState] = useRecoilState(speciesAtom);
   const [searchValue, setSearchValue] = useState('');
   const debouncedSearchTerm = useDebounce(searchValue, 250);
-  const [results, setResults] = useState<Species[]>();
+  const [results, setResults] = useState<SpeciesSearchResultRow[]>();
   const [record, setRecord] = useForm<SpeciesFiltersType>({});
   const contentRef = useRef(null);
-  const loadedStringsForLocale = useLocalization().loadedStringsForLocale;
+  const { loadedStringsForLocale } = useLocalization();
 
   const [tooltipLearnMoreModalOpen, setTooltipLearnMoreModalOpen] = useState(false);
   const [tooltipLearnMoreModalData, setTooltipLearnMoreModalData] = useState<TooltipLearnMoreModalData | undefined>(
@@ -153,6 +157,7 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
       return '';
     }
   };
+
   const columns: TableColumnType[] = React.useMemo(() => {
     // No-op to make lint happy so it doesn't think the dependency is unused.
     if (!loadedStringsForLocale) {
@@ -347,9 +352,14 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
   const onApplyFilters = useCallback(
     async (reviewErrors?: boolean) => {
       const getSpeciesListWithCS = () => {
-        const speciesListWithCS: SpeciesCS[] = [];
+        const speciesListWithCS: SpeciesSearchResultRow[] = [];
         species.forEach((sp) => {
-          speciesListWithCS.push({ ...sp, conservationStatus: getConservationStatusString(sp) });
+          speciesListWithCS.push({
+            ...sp,
+            conservationStatus: getConservationStatusString(sp),
+            growthForm: getGrowthFormString(sp),
+            seedStorageBehavior: getSeedStorageBehaviorString(sp),
+          });
         });
         return speciesListWithCS;
       };
@@ -361,7 +371,7 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
         setRequestId('searchSpecies', requestId);
         const searchResults = await search(params);
         if (getRequestId('searchSpecies') === requestId) {
-          const speciesResults: SpeciesCS[] = [];
+          const speciesResults: SpeciesSearchResultRow[] = [];
           searchResults?.forEach((result) => {
             speciesResults.push({
               id: result.id as number,
@@ -386,12 +396,13 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
   );
 
   // When the user switches locales, we need to update the state value that contains the list of
-  // column definitions.
+  // column definitions as well as reset the search filters.
   useEffect(() => {
     if (loadedStringsForLocale) {
+      setRecord({});
       setSelectedColumns(columns);
     }
-  }, [columns, setSelectedColumns, loadedStringsForLocale]);
+  }, [columns, setRecord, setSelectedColumns, loadedStringsForLocale]);
 
   useEffect(() => {
     if (speciesState?.checkData) {
@@ -413,6 +424,7 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
       snackbar.toastSuccess(snackbarMessage);
     }
   };
+
   const onNewSpecies = () => {
     setSelectedSpecies(undefined);
     setEditSpeciesModalOpen(true);
@@ -422,14 +434,18 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
     snackbar.toastError(snackbarMessage);
   };
 
-  const OnEditSpecies = () => {
-    setSelectedSpecies(selectedSpeciesRows[0]);
-    setEditSpeciesModalOpen(true);
+  const openEditSpeciesModal = async (speciesId: number) => {
+    const speciesResponse = await getSpecies(speciesId, selectedOrganization.id.toString());
+    if (speciesResponse.requestSucceeded) {
+      setSelectedSpecies(speciesResponse.species);
+      setEditSpeciesModalOpen(true);
+    } else {
+      setErrorSnackbar(strings.GENERIC_ERROR);
+    }
   };
 
-  const selectAndEditSpecies = (value: Species) => {
-    setSelectedSpeciesRows([value]);
-    setEditSpeciesModalOpen(true);
+  const OnEditSpecies = () => {
+    openEditSpeciesModal(selectedSpeciesRows[0].id);
   };
 
   const OnDeleteSpecies = () => {
@@ -709,7 +725,6 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
                   setSelectedRows={userCanEdit ? setSelectedSpeciesRows : undefined}
                   showTopBar={true}
                   Renderer={SpeciesCellRenderer}
-                  onSelect={userCanEdit ? selectAndEditSpecies : undefined}
                   controlledOnSelect={true}
                   reloadData={reloadDataProblemsHandler}
                   topBarButtons={

--- a/src/types/Species.ts
+++ b/src/types/Species.ts
@@ -20,22 +20,22 @@ export type SpeciesProblemElement = {
   suggestedValue?: string;
 };
 
-export function growthForms() {
+export function growthForms(useLocalizedValues = false) {
   return [
-    { label: strings.TREE, value: 'Tree' },
-    { label: strings.SHRUB, value: 'Shrub' },
-    { label: strings.FORB, value: 'Forb' },
-    { label: strings.GRAMINOID, value: 'Graminoid' },
-    { label: strings.FERN, value: 'Fern' },
+    { label: strings.TREE, value: useLocalizedValues ? strings.TREE : 'Tree' },
+    { label: strings.SHRUB, value: useLocalizedValues ? strings.SHRUB : 'Shrub' },
+    { label: strings.FORB, value: useLocalizedValues ? strings.FORB : 'Forb' },
+    { label: strings.GRAMINOID, value: useLocalizedValues ? strings.GRAMINOID : 'Graminoid' },
+    { label: strings.FERN, value: useLocalizedValues ? strings.FERN : 'Fern' },
   ];
 }
 
-export function storageBehaviors() {
+export function storageBehaviors(useLocalizedValues = false) {
   return [
-    { label: strings.ORTHODOX, value: 'Orthodox' },
-    { label: strings.RECALCITRANT, value: 'Recalcitrant' },
-    { label: strings.INTERMEDIATE, value: 'Intermediate' },
-    { label: strings.UNKNOWN, value: 'Unknown' },
+    { label: strings.ORTHODOX, value: useLocalizedValues ? strings.ORTHODOX : 'Orthodox' },
+    { label: strings.RECALCITRANT, value: useLocalizedValues ? strings.RECALCITRANT : 'Recalcitrant' },
+    { label: strings.INTERMEDIATE, value: useLocalizedValues ? strings.INTERMEDIATE : 'Intermediate' },
+    { label: strings.UNKNOWN, value: useLocalizedValues ? strings.UNKNOWN : 'Unknown' },
   ];
 }
 
@@ -44,6 +44,42 @@ export function conservationStatuses() {
     { label: strings.RARE, value: 'Rare' },
     { label: strings.ENDANGERED, value: 'Endangered' },
   ];
+}
+
+export function getGrowthFormString(species: Species) {
+  if (species.growthForm) {
+    switch (species.growthForm) {
+      case 'Fern':
+        return strings.FERN;
+      case 'Forb':
+        return strings.FORB;
+      case 'Graminoid':
+        return strings.GRAMINOID;
+      case 'Shrub':
+        return strings.SHRUB;
+      case 'Tree':
+        return strings.TREE;
+    }
+  } else {
+    return undefined;
+  }
+}
+
+export function getSeedStorageBehaviorString(species: Species) {
+  if (species.seedStorageBehavior) {
+    switch (species.seedStorageBehavior) {
+      case 'Intermediate':
+        return strings.INTERMEDIATE;
+      case 'Orthodox':
+        return strings.ORTHODOX;
+      case 'Recalcitrant':
+        return strings.RECALCITRANT;
+      case 'Unknown':
+        return strings.UNKNOWN;
+    }
+  } else {
+    return undefined;
+  }
 }
 
 export type SpeciesWithScientificName = Species & {


### PR DESCRIPTION
Update the species list page so it always shows localized strings for the growth
form and seed storage behavior columns.

On locale change, reset all the filters and reload the search results because
simply updating the translations in place might cause the list to be shown in the
wrong order.

This requires a minor change to the way the "edit" button works; it now fetches
the species data explicitly rather than relying on search results being
interchangeable with species API payloads.
