### PR TITLE
SW-2814 Facilty service to search/get/create/update facilities - reused in Nursery and Seedbank views

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 import hexRgb from 'hex-rgb';
 import useStateLocation from './utils/useStateLocation';
 import { DEFAULT_SEED_SEARCH_FILTERS, DEFAULT_SEED_SEARCH_SORT_ORDER } from 'src/api/seeds/search';
-import { SearchSortOrder, SearchCriteria } from 'src/api/search';
+import { SearchSortOrder, SearchCriteria } from 'src/services/SearchService';
 import ContactUs from 'src/components/ContactUs';
 import EditOrganization from 'src/components/EditOrganization';
 import Home from 'src/components/Home';

--- a/src/api/facility/facility.ts
+++ b/src/api/facility/facility.ts
@@ -3,69 +3,6 @@ import { Device } from 'src/types/Device';
 import { Facility, StorageLocationDetails } from '../types/facilities';
 import { paths } from '../types/generated-schema';
 
-const FACILITIES = '/api/v1/facilities';
-type CreateFacilityResponsePayload = paths[typeof FACILITIES]['post']['responses'][200]['content']['application/json'];
-
-type CreateFacilityRequestPayload = paths[typeof FACILITIES]['post']['requestBody']['content']['application/json'];
-
-type CreateFacilityResponse = {
-  facilityId: number | null;
-  requestSucceeded: boolean;
-};
-
-export async function createFacility(facility: Facility): Promise<CreateFacilityResponse> {
-  const response: CreateFacilityResponse = {
-    facilityId: null,
-    requestSucceeded: true,
-  };
-  const createFacilityRequestPayload: CreateFacilityRequestPayload = {
-    name: facility.name,
-    description: facility.description,
-    organizationId: facility.organizationId,
-    type: facility.type,
-    timeZone: facility.timeZone,
-  };
-  try {
-    const serverResponse: CreateFacilityResponsePayload = (await axios.post(FACILITIES, createFacilityRequestPayload))
-      .data;
-    if (serverResponse.status === 'ok') {
-      response.facilityId = serverResponse.id;
-    } else {
-      response.requestSucceeded = false;
-    }
-  } catch {
-    response.requestSucceeded = false;
-  }
-
-  return response;
-}
-
-const FACILITY = '/api/v1/facilities/{facilityId}';
-
-type SimpleResponse = {
-  requestSucceeded: boolean;
-};
-
-type UpdateFacilityRequestPayload = paths[typeof FACILITY]['put']['requestBody']['content']['application/json'];
-
-export async function updateFacility(facility: Facility): Promise<SimpleResponse> {
-  const response: SimpleResponse = {
-    requestSucceeded: true,
-  };
-  const updateFacilityRequestPayload: UpdateFacilityRequestPayload = {
-    name: facility.name,
-    description: facility.description,
-    timeZone: facility.timeZone,
-  };
-  try {
-    await axios.put(FACILITY.replace('{facilityId}', facility.id.toString()), updateFacilityRequestPayload);
-  } catch {
-    response.requestSucceeded = false;
-  }
-
-  return response;
-}
-
 const FACILITY_DEVICES = '/api/v1/facilities/{facilityId}/devices';
 
 type ListFacilityDevices = paths[typeof FACILITY_DEVICES]['get']['responses'][200]['content']['application/json'];

--- a/src/api/search/index.ts
+++ b/src/api/search/index.ts
@@ -1,74 +1,25 @@
-import axios from '..';
-import { components, paths } from 'src/api/types/generated-schema';
-
-export type AndNodePayload = components['schemas']['AndNodePayload'] & { operation: 'and' };
-export type FieldNodePayload = components['schemas']['FieldNodePayload'] & { operation: 'field' };
-export type NotNodePayload = components['schemas']['NotNodePayload'] & { operation: 'not' };
-export type OrNodePayload = components['schemas']['OrNodePayload'] & { operation: 'or' };
-export type SearchNodePayload = AndNodePayload | FieldNodePayload | NotNodePayload | OrNodePayload;
-export type FieldValuesPayload = { [key: string]: components['schemas']['FieldValuesPayload'] };
-
-export type SearchCriteria = Record<string, SearchNodePayload>;
-export type SearchSortOrder = components['schemas']['SearchSortOrderElement'];
-
-/*
- * convertToSearchNodePayload()
- * input: search criteria in the type of SearchCriteria, which is used by the application
- * output: search criteria in the type of SearchNodePayload, which is required by API modules.
- *         undefined if the input represented no search criteria.
+/**
+ * Temporarily re-export types/functions from search service
+ * until concrete services are written with high level functions
+ * that abstract away the underlying search implementation
  */
-export function convertToSearchNodePayload(
-  criteria: SearchCriteria,
-  organizationId?: number
-): SearchNodePayload | undefined {
-  if (Object.keys(criteria).length === 0 && !organizationId) {
-    return undefined;
-  }
-  let newCriteria = criteria;
-  if (organizationId) {
-    newCriteria = addOrgInfoToSearch(organizationId, criteria);
-  }
-  return {
-    operation: 'and',
-    children: Object.values(newCriteria),
-  };
-}
 
-function addOrgInfoToSearch(organizationId: number, previousCriteria?: SearchCriteria) {
-  const newCriteria = previousCriteria ? Object.values(previousCriteria) : [];
-  newCriteria.unshift({
-    field: 'facility_organization_id',
-    values: [organizationId.toString()],
-    operation: 'field',
-  });
-  return newCriteria;
-}
+import { SearchService } from 'src/services';
 
-const SEARCH_ENDPOINT = '/api/v1/search';
-export type SearchRequestPayload = paths[typeof SEARCH_ENDPOINT]['post']['requestBody']['content']['application/json'];
-export type SearchResponsePayload =
-  paths[typeof SEARCH_ENDPOINT]['post']['responses'][200]['content']['application/json'];
-export type SearchResponseElement = SearchResponsePayload['results'][0];
+export type {
+  AndNodePayload,
+  FieldNodePayload,
+  NotNodePayload,
+  OrNodePayload,
+  SearchNodePayload,
+  FieldValuesPayload,
+  SearchCriteria,
+  SearchSortOrder,
+  SearchRequestPayload,
+  SearchResponsePayload,
+  SearchResponseElement,
+} from 'src/services/SearchService';
 
-export async function search(params: SearchRequestPayload): Promise<SearchResponseElement[] | null> {
-  try {
-    const response: SearchResponsePayload = (await axios.post(SEARCH_ENDPOINT, params)).data;
-    return response.results;
-  } catch {
-    return null;
-  }
-}
+const { convertToSearchNodePayload, search, searchCsv } = SearchService;
 
-export async function searchCsv(params: SearchRequestPayload): Promise<any> {
-  const config = {
-    headers: {
-      accept: 'text/csv',
-    },
-  };
-  try {
-    const response = (await axios.post(SEARCH_ENDPOINT, params, config)).data;
-    return response;
-  } catch {
-    return null;
-  }
-}
+export { convertToSearchNodePayload, search, searchCsv };

--- a/src/components/NewNursery/index.tsx
+++ b/src/components/NewNursery/index.tsx
@@ -7,7 +7,7 @@ import TextField from '../common/Textfield/Textfield';
 import useForm from 'src/utils/useForm';
 import PageForm from '../common/PageForm';
 import { Facility } from 'src/api/types/facilities';
-import { createFacility, updateFacility } from 'src/api/facility/facility';
+import { FacilityService } from 'src/services';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import PageSnackbar from 'src/components/PageSnackbar';
 import useSnackbar from 'src/utils/useSnackbar';
@@ -77,7 +77,9 @@ export default function NurseryView(): JSX.Element {
       setDescriptionError(strings.REQUIRED_FIELD);
       return;
     }
-    const response = selectedNursery ? await updateFacility({ ...record } as Facility) : await createFacility(record);
+    const response = selectedNursery
+      ? await FacilityService.updateFacility({ ...record } as Facility)
+      : await FacilityService.createFacility(record);
 
     if (response.requestSucceeded) {
       reloadData();

--- a/src/components/NewSeedBank/index.tsx
+++ b/src/components/NewSeedBank/index.tsx
@@ -8,7 +8,7 @@ import useForm from 'src/utils/useForm';
 import PageForm from '../common/PageForm';
 import { getAllSeedBanks } from 'src/utils/organization';
 import { Facility } from 'src/api/types/facilities';
-import { createFacility, updateFacility } from 'src/api/facility/facility';
+import { FacilityService } from 'src/services';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import PageSnackbar from 'src/components/PageSnackbar';
 import useSnackbar from 'src/utils/useSnackbar';
@@ -78,7 +78,7 @@ export default function SeedBankView(): JSX.Element {
       return;
     }
     if (selectedSeedBank) {
-      const response = await updateFacility({ ...record } as Facility);
+      const response = await FacilityService.updateFacility({ ...record } as Facility);
       if (response.requestSucceeded) {
         reloadData();
         snackbar.toastSuccess(strings.CHANGES_SAVED);
@@ -86,7 +86,7 @@ export default function SeedBankView(): JSX.Element {
         snackbar.toastError();
       }
     } else {
-      const response = await createFacility(record);
+      const response = await FacilityService.createFacility(record);
       if (response.requestSucceeded) {
         reloadData();
         snackbar.toastSuccess(strings.SEED_BANK_ADDED);

--- a/src/components/Nursery/index.tsx
+++ b/src/components/Nursery/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { APP_PATHS } from 'src/constants';
 import strings from 'src/strings';
-import { getAllNurseries } from 'src/utils/organization';
+import { FacilityService } from 'src/services';
 import TextField from '../common/Textfield/Textfield';
 import Button from '../common/button/Button';
 import { Facility } from 'src/api/types/facilities';
@@ -36,11 +36,15 @@ export default function NurseryDetails(): JSX.Element {
 
   useEffect(() => {
     if (selectedOrganization) {
-      const selectedNursery = getAllNurseries(selectedOrganization).find((n) => n?.id.toString() === nurseryId);
+      const selectedNursery = FacilityService.getFacility({
+        organization: selectedOrganization,
+        facilityId: nurseryId,
+        type: 'Nursery',
+      });
       if (selectedNursery) {
         setNursery(selectedNursery);
       } else {
-        history.push(APP_PATHS.SEED_BANKS);
+        history.push(APP_PATHS.NURSERIES);
       }
     }
   }, [nurseryId, selectedOrganization, history]);

--- a/src/components/SeedBank/index.tsx
+++ b/src/components/SeedBank/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { APP_PATHS } from 'src/constants';
 import strings from 'src/strings';
-import { getAllSeedBanks } from 'src/utils/organization';
+import { FacilityService } from 'src/services';
 import TextField from '../common/Textfield/Textfield';
 import Button from '../common/button/Button';
 import { Facility } from 'src/api/types/facilities';
@@ -36,7 +36,11 @@ export default function SeedBankDetails(): JSX.Element {
 
   useEffect(() => {
     if (selectedOrganization) {
-      const selectedSeedBank = getAllSeedBanks(selectedOrganization).find((sb) => sb?.id.toString() === seedBankId);
+      const selectedSeedBank = FacilityService.getFacility({
+        organization: selectedOrganization,
+        facilityId: seedBankId,
+        type: 'Seed Bank',
+      });
       if (selectedSeedBank) {
         setSeedBank(selectedSeedBank);
       } else {

--- a/src/services/FacilityService.ts
+++ b/src/services/FacilityService.ts
@@ -1,0 +1,79 @@
+import { Facility, FacilityType } from 'src/api/types/facilities';
+import SearchService, { SearchNodePayload } from './SearchService';
+
+/**
+ * Service for facility related functionality
+ */
+
+/**
+ * Types exported from service
+ */
+export type Facilities = Facility[];
+
+export type FacilitySearchParams = {
+  type: FacilityType;
+  organizationId: number | string;
+  query?: string;
+};
+
+/**
+ * Search facilities by parameters
+ */
+const getFacilities = async ({ type, organizationId, query }: FacilitySearchParams): Promise<Facilities> => {
+  const searchField = query
+    ? {
+        operation: 'or',
+        children: [
+          { operation: 'field', field: 'name', type: 'Fuzzy', values: [query] },
+          { operation: 'field', field: 'description', type: 'Fuzzy', values: [query] },
+        ],
+      }
+    : null;
+
+  const params: SearchNodePayload = {
+    prefix: 'facilities',
+    fields: ['id', 'name', 'description', 'type', 'organization_id', 'timeZone'],
+    search: {
+      operation: 'and',
+      children: [
+        { operation: 'field', field: 'type', type: 'Exact', values: [type] },
+        {
+          operation: 'field',
+          field: 'organization_id',
+          type: 'Exact',
+          values: [organizationId.toString()],
+        },
+      ],
+    },
+    count: 0,
+  };
+
+  if (searchField) {
+    params.search.children.push(searchField);
+  }
+
+  const searchResults = await SearchService.search(params);
+  const facilities: Facility[] =
+    searchResults?.map((result) => {
+      return {
+        id: result.id as number,
+        name: result.name as string,
+        description: result.description as string,
+        organizationId: parseInt(result.organization_id as string, 10),
+        type: result.type as FacilityType,
+        connectionState: result.connectionState as 'Not Connected' | 'Connected' | 'Configured',
+        timeZone: result.timeZone as string,
+      };
+    }) ?? [];
+
+  return facilities;
+};
+
+/**
+ * Exported functions
+ */
+const FacilityService = {
+  getFacilities,
+};
+
+export default FacilityService;

--- a/src/services/SearchService.ts
+++ b/src/services/SearchService.ts
@@ -1,0 +1,91 @@
+import { paths, components } from 'src/api/types/generated-schema';
+import HttpService from './HttpService';
+
+/**
+ * Service for user related functionality
+ */
+
+// endpoint
+const SEARCH_ENDPOINT = '/api/v1/search';
+
+/**
+ * Types exported from service
+ */
+
+export type AndNodePayload = components['schemas']['AndNodePayload'] & { operation: 'and' };
+export type FieldNodePayload = components['schemas']['FieldNodePayload'] & { operation: 'field' };
+export type NotNodePayload = components['schemas']['NotNodePayload'] & { operation: 'not' };
+export type OrNodePayload = components['schemas']['OrNodePayload'] & { operation: 'or' };
+export type SearchNodePayload = AndNodePayload | FieldNodePayload | NotNodePayload | OrNodePayload;
+export type FieldValuesPayload = { [key: string]: components['schemas']['FieldValuesPayload'] };
+export type SearchCriteria = Record<string, SearchNodePayload>;
+export type SearchSortOrder = components['schemas']['SearchSortOrderElement'];
+export type SearchRequestPayload = paths[typeof SEARCH_ENDPOINT]['post']['requestBody']['content']['application/json'];
+export type SearchResponsePayload =
+  paths[typeof SEARCH_ENDPOINT]['post']['responses'][200]['content']['application/json'];
+export type SearchResponseElement = SearchResponsePayload['results'][0];
+
+const httpSearch = HttpService.root(SEARCH_ENDPOINT);
+
+/*
+ * convertToSearchNodePayload()
+ * input: search criteria in the type of SearchCriteria, which is used by the application
+ * output: search criteria in the type of SearchNodePayload, which is required by API modules.
+ *         undefined if the input represented no search criteria.
+ */
+function convertToSearchNodePayload(criteria: SearchCriteria, organizationId?: number): SearchNodePayload | undefined {
+  if (Object.keys(criteria).length === 0 && !organizationId) {
+    return undefined;
+  }
+  let newCriteria = criteria;
+  if (organizationId) {
+    newCriteria = addOrgInfoToSearch(organizationId, criteria);
+  }
+  return {
+    operation: 'and',
+    children: Object.values(newCriteria),
+  };
+}
+
+function addOrgInfoToSearch(organizationId: number, previousCriteria?: SearchCriteria) {
+  const newCriteria = previousCriteria ? Object.values(previousCriteria) : [];
+  newCriteria.unshift({
+    field: 'facility_organization_id',
+    values: [organizationId.toString()],
+    operation: 'field',
+  });
+
+  return newCriteria;
+}
+
+async function search(entity: SearchRequestPayload): Promise<SearchResponseElement[] | null> {
+  try {
+    const response: SearchResponsePayload = (await httpSearch.post({ entity })).data;
+    return response.results;
+  } catch {
+    return null;
+  }
+}
+
+async function searchCsv(entity: SearchRequestPayload): Promise<any> {
+  const headers = {
+    accept: 'text/csv',
+  };
+  try {
+    const response = (await httpSearch.post({ entity, headers })).data;
+    return response;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Exported functions
+ */
+const SearchService = {
+  convertToSearchNodePayload,
+  search,
+  searchCsv,
+};
+
+export default SearchService;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -3,6 +3,7 @@ import HttpService from './HttpService';
 import OrganizationUserService from './OrganizationUserService';
 import OrganizationService from './OrganizationService';
 import PreferencesService from './PreferencesService';
+import SearchService from './SearchService';
 import SystemService from './SystemService';
 import UserService from './UserService';
 
@@ -14,6 +15,7 @@ export {
   OrganizationService,
   OrganizationUserService,
   PreferencesService,
+  SearchService,
   SystemService,
   UserService,
 };

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,4 +1,5 @@
 import CachedUserService from './CachedUserService';
+import FacilityService from './FacilityService';
 import HttpService from './HttpService';
 import OrganizationUserService from './OrganizationUserService';
 import OrganizationService from './OrganizationService';
@@ -11,6 +12,7 @@ export type { Response } from './HttpService';
 
 export {
   CachedUserService,
+  FacilityService,
   HttpService,
   OrganizationService,
   OrganizationUserService,


### PR DESCRIPTION
- moved existing code into a search service
- re-exporting search types and functions in original file to avoid breaking other use-cases that rely on a direct search.. until refactored
- introduced a facility service which leverages search service, updated seedbanks and nurseries views to use this service and rely less on how search works
- refactored seed banks view to always search (avoid using cached seed banks) similar to nurseries