### PR TITLE
SW-2822 Save user inputted values for all countries outside the us

### DIFF
--- a/src/components/accession2/properties/Accession2Address.tsx
+++ b/src/components/accession2/properties/Accession2Address.tsx
@@ -44,6 +44,9 @@ export default function Accession2Address(props: Accession2AddressProps): JSX.El
   const onChangeCountry = (newValue: string) => {
     setTemporalCountryValue(newValue);
     const found = countries?.find((country) => country.name === newValue);
+    if (getSelectedSubdivision()) {
+      onChangeSubdivision('');
+    }
     if (found) {
       onChange('collectionSiteCountryCode', found.code.toString());
     } else {
@@ -119,15 +122,25 @@ export default function Accession2Address(props: Accession2AddressProps): JSX.El
             />
           </Grid>
           <Grid item xs={gridSize()} sx={{ marginTop: isMobile ? theme.spacing(2) : 0 }}>
-            <Autocomplete
-              id='collectionSiteCountrySubdivision'
-              selected={getSelectedSubdivision()?.name || temporalSubValue}
-              onChange={(value: any) => onChangeSubdivision(value)}
-              label={strings.STATE_PROVINCE_REGION}
-              placeholder={strings.STATE_PROVINCE_REGION}
-              options={getSelectedCountry()?.subdivisions?.map((subdivision) => subdivision.name) || []}
-              freeSolo={true}
-            />
+            {getSelectedCountry()?.subdivisions ? (
+              <Autocomplete
+                id='collectionSiteCountrySubdivision'
+                selected={getSelectedSubdivision()?.name || temporalSubValue}
+                onChange={(value: any) => onChangeSubdivision(value)}
+                label={strings.STATE_PROVINCE_REGION}
+                placeholder={strings.SELECT}
+                options={getSelectedCountry()?.subdivisions?.map((subdivision) => subdivision.name) || []}
+                freeSolo={true}
+              />
+            ) : (
+              <Textfield
+                id='collectionSiteCountrySubdivision'
+                value={record.collectionSiteCountrySubdivision}
+                onChange={(value) => onChange('collectionSiteCountrySubdivision', value)}
+                type='text'
+                label={strings.STATE_PROVINCE_REGION}
+              />
+            )}
           </Grid>
         </Grid>
       )}

--- a/src/components/accession2/view/DetailPanel.tsx
+++ b/src/components/accession2/view/DetailPanel.tsx
@@ -99,7 +99,8 @@ export default function DetailPanel(props: DetailPanelProps): JSX.Element {
     const subdivision = accession?.collectionSiteCountrySubdivision;
     const data = [
       city,
-      countries && country && subdivision ? getSubdivisionByCode(countries, country, subdivision)?.name : '',
+      (countries && country && subdivision && getSubdivisionByCode(countries, country, subdivision)?.name) ??
+        subdivision,
       countries && country ? getCountryByCode(countries, country)?.name : '',
     ];
 


### PR DESCRIPTION
Show dropdown for state only when country has subdivisions, and show textfield for other countries.
Show value on detail page.

<img width="681" alt="Screenshot 2023-02-01 at 16 25 07" src="https://user-images.githubusercontent.com/5919083/216142794-308edc23-9f82-473b-b49c-dc79171d5b88.png">

<img width="1574" alt="Screenshot 2023-02-01 at 16 22 22" src="https://user-images.githubusercontent.com/5919083/216142628-efca2675-2b88-4564-a891-9d4faf99fd74.png">
 