### PR TITLE
Improve accession weight quantity styles

### DIFF
--- a/src/components/ConvertedValue.tsx
+++ b/src/components/ConvertedValue.tsx
@@ -7,16 +7,18 @@ type ConvertedValueProps = {
   quantity: number;
   unit: string;
   isEstimated?: boolean;
+  showTooltip?: boolean;
 };
 
 export default function ConvertedValue(props: ConvertedValueProps): JSX.Element {
-  const { quantity, unit, isEstimated } = props;
+  const { quantity, unit, isEstimated, showTooltip } = props;
   return (
     <Box display='flex'>
-      <Typography>
-        {isEstimated && '~'} {convertValue(quantity, unit)}
+      <Typography fontWeight={500}>
+        ({isEstimated && '~'}
+        {convertValue(quantity, unit)})
       </Typography>
-      <IconTooltip title={strings.CONVERTED_VALUE_INFO} />
+      {showTooltip && <IconTooltip title={strings.CONVERTED_VALUE_INFO} />}
     </Box>
   );
 }

--- a/src/components/accession2/edit/QuantityModal.tsx
+++ b/src/components/accession2/edit/QuantityModal.tsx
@@ -210,7 +210,11 @@ export default function QuantityModal(props: QuantityModalProps): JSX.Element {
                 record.remainingQuantity.units,
                 userPreferences.preferredWeightSystem as string
               ) && (
-                <ConvertedValue quantity={record.remainingQuantity.quantity} unit={record.remainingQuantity.units} />
+                <ConvertedValue
+                  quantity={record.remainingQuantity.quantity}
+                  unit={record.remainingQuantity.units}
+                  showTooltip={true}
+                />
               )}
           </Grid>
           <Grid item xs={12} sx={{ marginTop: theme.spacing(2) }}>

--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -210,10 +210,10 @@ export default function Accession2View(): JSX.Element {
   const showValueAndConversion = (quantity: number, unit: string, isEstimated?: boolean) => {
     if (weightUnitsEnabled && !isUnitInPreferredSystem(unit, userPreferences.preferredWeightSystem as string)) {
       return (
-        <>
+        <Box marginBottom={1}>
           {isEstimated && '~'} {quantity} {getUnitName(unit)}
           <ConvertedValue quantity={quantity} unit={unit} isEstimated={isEstimated} />
-        </>
+        </Box>
       );
     } else {
       return `${quantity} ${getUnitName(unit)}`;


### PR DESCRIPTION
According to Ming's feedback:

- Add parenthesis for converted weight
- Remove info icon because user is already informed in the quantity form
- Increase vertical spacing to separate weight and count display

<img width="324" alt="Screenshot 2023-02-02 at 12 03 53" src="https://user-images.githubusercontent.com/5919083/216361119-4af9b2f4-50a6-41ce-81f0-69ae778c397e.png">
