### PR TITLE
SW-2806 Localize notification timestamps

### DIFF
--- a/src/components/NotificationsDropdown.tsx
+++ b/src/components/NotificationsDropdown.tsx
@@ -14,6 +14,7 @@ import preventDefault from 'src/utils/preventDefaultEvent';
 import stopPropagation from 'src/utils/stopPropagationEvent';
 import { makeStyles } from '@mui/styles';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
+import Timestamp from './common/Timestamp';
 
 interface StyleProps {
   isMobile?: boolean;
@@ -350,9 +351,7 @@ function NotificationItem(props: NotificationItemProps): JSX.Element {
         secondary={
           <>
             <span className={classes.notificationBody}>{body}</span>
-            <span className={classes.notificationTimestamp}>
-              {moment(createdTime).format('MMMM Do YYYY \\a\\t h:mm:ss a')}
-            </span>
+            <Timestamp className={classes.notificationTimestamp} isoString={createdTime} />
           </>
         }
       />

--- a/src/components/common/Timestamp.tsx
+++ b/src/components/common/Timestamp.tsx
@@ -8,29 +8,28 @@ export interface TimestampProps {
   isoString: string;
 }
 
-/**
- * Renders a timestamp using the current locale and the user's time zone.
- */
+/** Returns a DateTimeFormat object for a locale and time zone. */
+function newDateTimeFormat(locale?: string, timeZone?: string) {
+  return new Intl.DateTimeFormat(locale, {
+    dateStyle: 'long',
+    timeStyle: 'medium',
+    timeZone,
+    hourCycle: locale === 'gx' ? 'h24' : undefined,
+  });
+}
+
+/** Renders a timestamp using the current locale and the user's time zone. */
 export default function Timestamp({ className, isoString }: TimestampProps): JSX.Element | null {
   const timeZone = useUserTimeZone()?.id;
   const { locale } = useLocalization();
-  const [dateTimeFormat, setDateTimeFormat] = useState<Intl.DateTimeFormat | null>(null);
+  const [dateTimeFormat, setDateTimeFormat] = useState<Intl.DateTimeFormat>(newDateTimeFormat(locale, timeZone));
 
   useEffect(() => {
-    if (locale || timeZone) {
-      setDateTimeFormat(
-        new Intl.DateTimeFormat(locale, {
-          dateStyle: 'long',
-          timeStyle: 'medium',
-          timeZone,
-          hourCycle: locale === 'gx' ? 'h24' : undefined,
-        })
-      );
-    }
+    setDateTimeFormat(newDateTimeFormat(locale, timeZone));
   }, [locale, timeZone, setDateTimeFormat]);
 
   const format = () => {
-    const formatted = dateTimeFormat?.format(new Date(isoString));
+    const formatted = dateTimeFormat.format(new Date(isoString));
     if (locale === 'gx') {
       return formatted?.replace(/[A-Za-z]/g, 'XY');
     } else {

--- a/src/components/common/Timestamp.tsx
+++ b/src/components/common/Timestamp.tsx
@@ -1,0 +1,42 @@
+import { useLocalization } from '../../providers';
+import { useUserTimeZone } from '../../utils/useTimeZoneUtils';
+import { useEffect, useState } from 'react';
+
+export interface TimestampProps {
+  className?: string;
+  /** String representation of timestamp in ISO-8601 YYYY-MM-DDThh:mm:ssZ form. */
+  isoString: string;
+}
+
+/**
+ * Renders a timestamp using the current locale and the user's time zone.
+ */
+export default function Timestamp({ className, isoString }: TimestampProps): JSX.Element | null {
+  const timeZone = useUserTimeZone()?.id;
+  const { locale } = useLocalization();
+  const [dateTimeFormat, setDateTimeFormat] = useState<Intl.DateTimeFormat | null>(null);
+
+  useEffect(() => {
+    if (locale || timeZone) {
+      setDateTimeFormat(
+        new Intl.DateTimeFormat(locale, {
+          dateStyle: 'long',
+          timeStyle: 'medium',
+          timeZone,
+          hourCycle: locale === 'gx' ? 'h24' : undefined,
+        })
+      );
+    }
+  }, [locale, timeZone, setDateTimeFormat]);
+
+  const format = () => {
+    const formatted = dateTimeFormat?.format(new Date(isoString));
+    if (locale === 'gx') {
+      return formatted?.replace(/[A-Za-z]/g, 'XY');
+    } else {
+      return formatted;
+    }
+  };
+
+  return <span className={className}>{format()}</span>;
+}


### PR DESCRIPTION
Currently, the timestamps on notifications are rendered using MomentJS with a
fixed format string. Replace that with a component that renders a timestamp
using the browser's built-in `Intl.DateTimeFormat` class. Since it's not possible
to add custom locales to `Intl`, the component has some special-case code for
the gibberish locale that can be used to test that dates are in fact localized.

Timestamps are rendered in the user's time zone, if one is set.

The default US English date format is similar to the one we were using before,
but not identical.

- Old: `January 21st 2023 at 12:14:54 am`
- New: `January 21, 2023 at 12:14:54 AM`
