### PR TITLE
SW-2869 Add component for text with embedded link

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "coordinate-parser": "^1.0.7",
     "date-fns": "^2.29.3",
     "hex-rgb": "^5.0.0",
-    "html-react-parser": "^3.0.8",
     "jwt-decode": "^3.1.2",
     "license-report": "^6.0.0",
     "lodash": "^4.17.21",

--- a/src/components/PlantingSites/PlantingSiteWithMapHelpModal.tsx
+++ b/src/components/PlantingSites/PlantingSiteWithMapHelpModal.tsx
@@ -2,8 +2,8 @@ import strings from 'src/strings';
 import React from 'react';
 import { Typography } from '@mui/material';
 import { TERRAWARE_SUPPORT_LINK } from 'src/constants';
-import parseHtml from 'html-react-parser';
 import { Button, DialogBox } from '@terraware/web-components';
+import TextWithLink from '../common/TextWithLink';
 
 export type PlantingSiteWithMapHelpModalProps = {
   open: boolean;
@@ -23,12 +23,7 @@ export default function PlantingSiteWithMapHelpModal(props: PlantingSiteWithMapH
       middleButtons={[<Button onClick={onClose} id='done' label={strings.DONE} key='button-1' />]}
     >
       <Typography>
-        {parseHtml(
-          strings.formatString(
-            strings.PLANTING_SITE_WITH_MAP_HELP,
-            `<a href=${TERRAWARE_SUPPORT_LINK}>` + strings.CONTACT_US.toLowerCase() + '</a>'
-          ) as string
-        )}
+        <TextWithLink href={TERRAWARE_SUPPORT_LINK} text={strings.PLANTING_SITE_WITH_MAP_HELP} />
       </Typography>
     </DialogBox>
   );

--- a/src/components/common/TextWithLink.tsx
+++ b/src/components/common/TextWithLink.tsx
@@ -10,14 +10,26 @@ export interface TextWithLinkProps {
  *
  * @param className
  * @param text The text to render. The link should be surrounded by square brackets. For
- * example, `'See [Jane] run'` would be rendered as `See <a href=...>Jane</a> run`.
+ * example, `'See [Jane] run'` would be rendered as `See <a href=...>Jane</a> run`. If there are
+ * no square brackets, [text] is rendered as a link. For example, `'See Jane run'` would be rendered
+ * as, `<a href=...>See Jane run</a>`.
  */
 export default function TextWithLink({ className, href, onClick, text }: TextWithLinkProps): JSX.Element {
   const linkStart = text.indexOf('[');
   const linkEnd = text.indexOf(']');
-  const prefix = text.substring(0, linkStart);
-  const linkText = text.substring(linkStart + 1, linkEnd);
-  const suffix = text.substring(linkEnd + 1);
+  let prefix: string;
+  let linkText: string;
+  let suffix: string;
+
+  if (linkStart >= 0 && linkEnd >= 0) {
+    prefix = text.substring(0, linkStart);
+    linkText = text.substring(linkStart + 1, linkEnd);
+    suffix = text.substring(linkEnd + 1);
+  } else {
+    prefix = '';
+    linkText = text;
+    suffix = '';
+  }
 
   return (
     <>

--- a/src/components/common/TextWithLink.tsx
+++ b/src/components/common/TextWithLink.tsx
@@ -21,7 +21,7 @@ export default function TextWithLink({ className, href, onClick, text }: TextWit
   let linkText: string;
   let suffix: string;
 
-  if (linkStart >= 0 && linkEnd >= 0) {
+  if (linkStart >= 0 && linkEnd >= 0 && linkStart < linkEnd) {
     prefix = text.substring(0, linkStart);
     linkText = text.substring(linkStart + 1, linkEnd);
     suffix = text.substring(linkEnd + 1);

--- a/src/components/common/TextWithLink.tsx
+++ b/src/components/common/TextWithLink.tsx
@@ -1,0 +1,31 @@
+export interface TextWithLinkProps {
+  className?: string;
+  href?: string;
+  onClick?: () => void;
+  text: string;
+}
+
+/**
+ * Renders a string with an embedded link.
+ *
+ * @param className
+ * @param text The text to render. The link should be surrounded by square brackets. For
+ * example, `'See [Jane] run'` would be rendered as `See <a href=...>Jane</a> run`.
+ */
+export default function TextWithLink({ className, href, onClick, text }: TextWithLinkProps): JSX.Element {
+  const linkStart = text.indexOf('[');
+  const linkEnd = text.indexOf(']');
+  const prefix = text.substring(0, linkStart);
+  const linkText = text.substring(linkStart + 1, linkEnd);
+  const suffix = text.substring(linkEnd + 1);
+
+  return (
+    <>
+      {prefix}
+      <a className={className} href={href} onClick={onClick}>
+        {linkText}
+      </a>
+      {suffix}
+    </>
+  );
+}

--- a/src/strings/strings-en.ts
+++ b/src/strings/strings-en.ts
@@ -622,7 +622,7 @@ export const strings = {
   PLANT: 'plant',
   PLANTING_SITE_TYPE: 'Planting Site Type',
   PLANTING_SITE_WITH_MAP_HELP:
-    'If you are a Terraformation partner or accelerator participant, please {0} to create a site with a map.',
+    'If you are a Terraformation partner or accelerator participant, please [contact us] to create a site with a map.',
   PLANTING_SITE: 'Planting Site',
   PLANTING_SITES: 'Planting Sites',
   PLANTING_ZONE: 'Planting Zone',


### PR DESCRIPTION
To make it easier to translate strings with embedded links, add a new component
that replaces delimiter characters with the HTML link tags. This will allow
translators to use the grammatically correct text for the link based on its
surrounding context.

This initial implementation is pretty limited; it only supports a single link
per string.

We no longer need the `html-react-parser` library, which was only being used
to construct an embedded link.
