### PR TITLE
SW-2872 avoid redundant preference write when switching orgs

### DIFF
--- a/src/providers/OrganizationProvider.tsx
+++ b/src/providers/OrganizationProvider.tsx
@@ -108,11 +108,11 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
       const organizationId = query.get('organizationId');
       const querySelectionOrg = organizationId && organizations.find((org) => org.id === parseInt(organizationId, 10));
       let orgToUse = querySelectionOrg || organizations.find((org) => org.id === selectedOrganization?.id);
-      if (!orgToUse) {
-        orgToUse = organizations[0];
-      }
       if (!orgToUse && userPreferences.lastVisitedOrg) {
         orgToUse = organizations.find((org) => org.id === userPreferences.lastVisitedOrg);
+      }
+      if (!orgToUse) {
+        orgToUse = organizations[0];
       }
       if (orgToUse) {
         setSelectedOrganization(orgToUse);

--- a/src/providers/OrganizationProvider.tsx
+++ b/src/providers/OrganizationProvider.tsx
@@ -116,9 +116,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
       }
       if (orgToUse) {
         setSelectedOrganization(orgToUse);
-        if (userPreferences?.lastVisitedOrg !== orgToUse.id) {
-          PreferencesService.updateUserPreferences({ lastVisitedOrg: orgToUse.id });
-        }
+        PreferencesService.updateUserPreferences({ lastVisitedOrg: orgToUse.id });
       }
       if (organizationId) {
         query.delete('organizationId');

--- a/src/providers/OrganizationProvider.tsx
+++ b/src/providers/OrganizationProvider.tsx
@@ -107,19 +107,19 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
     if (organizations.length && userPreferences) {
       const organizationId = query.get('organizationId');
       const querySelectionOrg = organizationId && organizations.find((org) => org.id === parseInt(organizationId, 10));
-      setSelectedOrganization((previouslySelectedOrg: Organization | undefined) => {
-        let orgToUse = querySelectionOrg || organizations.find((org) => org.id === previouslySelectedOrg?.id);
-        if (!orgToUse && userPreferences.lastVisitedOrg) {
-          orgToUse = organizations.find((org) => org.id === userPreferences.lastVisitedOrg);
-        }
-        if (!orgToUse) {
-          orgToUse = organizations[0];
-        }
-        if (orgToUse && userPreferences?.lastVisitedOrg !== orgToUse.id) {
+      let orgToUse = querySelectionOrg || organizations.find((org) => org.id === selectedOrganization?.id);
+      if (!orgToUse) {
+        orgToUse = organizations[0];
+      }
+      if (!orgToUse && userPreferences.lastVisitedOrg) {
+        orgToUse = organizations.find((org) => org.id === userPreferences.lastVisitedOrg);
+      }
+      if (orgToUse) {
+        setSelectedOrganization(orgToUse);
+        if (userPreferences?.lastVisitedOrg !== orgToUse.id) {
           PreferencesService.updateUserPreferences({ lastVisitedOrg: orgToUse.id });
         }
-        return orgToUse;
-      });
+      }
       if (organizationId) {
         query.delete('organizationId');
         // preserve other url params


### PR DESCRIPTION
- the setSelectedOrg within callback function was being executed twice every time, this is absurd
- figured we don't need this to be in a callback, moved it out and we don't have the duplicate writes