### PR TITLE
SW-2871 Fix race condition that allowed org selection to occur before…

### DIFF
--- a/src/providers/DataTypes.ts
+++ b/src/providers/DataTypes.ts
@@ -11,6 +11,7 @@ export type ProvidedUserData = {
   bootstrapped: boolean;
   userPreferences: PreferencesType;
   reloadUserPreferences: () => void;
+  updateUserPreferences: (preferences: PreferencesType) => Promise<boolean>;
 };
 
 export type ProvidedOrganizationData = {

--- a/src/providers/OrganizationProvider.tsx
+++ b/src/providers/OrganizationProvider.tsx
@@ -31,7 +31,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
   const history = useHistory();
   const query = useQuery();
   const location = useStateLocation();
-  const { userPreferences } = useUser();
+  const { userPreferences, updateUserPreferences, bootstrapped: userBootstrapped } = useUser();
 
   const reloadOrganizations = useCallback(async (selectedOrgId?: number) => {
     const populateOrganizations = async () => {
@@ -43,7 +43,6 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
           const orgToSelect = response.organizations.find((org) => org.id === selectedOrgId);
           if (orgToSelect) {
             setSelectedOrganization(orgToSelect);
-            PreferencesService.updateUserPreferences({ lastVisitedOrg: orgToSelect.id });
           }
         }
         if (response.organizations.length === 0) {
@@ -56,6 +55,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
         setOrgAPIRequestStatus(APIRequestStatus.FAILED);
       }
     };
+
     await populateOrganizations();
   }, []);
 
@@ -96,6 +96,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
         setBootstrapped(true);
       }
     };
+
     getOrgPreferences();
   }, [selectedOrganization]);
 
@@ -104,7 +105,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
   }, [reloadOrgPreferences, selectedOrganization]);
 
   useEffect(() => {
-    if (organizations.length && userPreferences) {
+    if (userBootstrapped && organizations.length && userPreferences) {
       const organizationId = query.get('organizationId');
       const querySelectionOrg = organizationId && organizations.find((org) => org.id === parseInt(organizationId, 10));
       let orgToUse = querySelectionOrg || organizations.find((org) => org.id === selectedOrganization?.id);
@@ -116,7 +117,6 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
       }
       if (orgToUse) {
         setSelectedOrganization(orgToUse);
-        PreferencesService.updateUserPreferences({ lastVisitedOrg: orgToUse.id });
       }
       if (organizationId) {
         query.delete('organizationId');
@@ -124,7 +124,13 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
         history.push(getLocation(location.pathname, location, query.toString()));
       }
     }
-  }, [organizations, selectedOrganization, query, location, history, userPreferences]);
+  }, [organizations, selectedOrganization, query, location, history, userPreferences, userBootstrapped]);
+
+  useEffect(() => {
+    if (selectedOrganization?.id && userPreferences.lastVisitedOrg !== selectedOrganization.id) {
+      updateUserPreferences({ lastVisitedOrg: selectedOrganization.id });
+    }
+  }, [selectedOrganization?.id, updateUserPreferences, userPreferences.lastVisitedOrg]);
 
   if (orgAPIRequestStatus === APIRequestStatus.FAILED) {
     history.push(APP_PATHS.ERROR_FAILED_TO_FETCH_ORG_DATA);

--- a/src/providers/contexts.ts
+++ b/src/providers/contexts.ts
@@ -13,6 +13,7 @@ export const UserContext = createContext<ProvidedUserData>({
   },
   userPreferences: {},
   bootstrapped: false,
+  updateUserPreferences: () => Promise.resolve(true),
 });
 
 export const defaultSelectedOrg: Organization = {


### PR DESCRIPTION
… user preferences were loaded

- user is considered bootstrapped after preferences are fetched (regardless of success/failure in fetch)
- org selection happens only after the user preferences are loaded
- orgs data loading happens concurrently as usual
- moved the setting of last visited org out into a separate useEffect, cleaner this way