### PR TITLE
SW-2898 accession history should refresh when there are changes to the accession

### DIFF
--- a/src/components/accession2/history/Accession2History.tsx
+++ b/src/components/accession2/history/Accession2History.tsx
@@ -29,7 +29,7 @@ export default function Accession2History(props: Accession2HistoryProps): JSX.El
       }
     };
     loadHistory();
-  }, [accession.id, snackbar, history]);
+  }, [accession, snackbar, history]);
 
   if (!history) {
     return (


### PR DESCRIPTION
- the useEffect was capturing changes to the id alone
- updated that to capture any accession change, this may be redundant but captures all cases