### PR TITLE
SW-2897 Pass locale to cookie consent UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
   <head>
     <!-- Google Tag Manager -->
     <script>

--- a/src/providers/LocalizationProvider.tsx
+++ b/src/providers/LocalizationProvider.tsx
@@ -47,6 +47,19 @@ export default function LocalizationProvider({
   }, [locale]);
 
   useEffect(() => {
+    // Switch locales on the cookie consent UI, if enabled. This is an undocumented internal API of
+    // the cookie-script.com code, so it might stop working in future versions.
+    const func = (window as any).CookieScript?.instance?.applyTranslationByCode;
+    if (typeof func === 'function') {
+      try {
+        func(locale);
+      } catch (e) {
+        // Swallow it rather than surfacing an error to the user.
+      }
+    }
+  }, [locale]);
+
+  useEffect(() => {
     const fetchStrings = async () => {
       const language = locale.replace(/[-_].*/, ''); // 'en-US' => 'en'
       const localeDetails =

--- a/src/providers/UserProvider.tsx
+++ b/src/providers/UserProvider.tsx
@@ -42,6 +42,16 @@ export default function UserProvider({ children }: UserProviderProps): JSX.Eleme
         setUser(response.user!);
         if (response.user && !userState?.gtmInstrumented && (window as any).INIT_GTAG) {
           setUserState({ gtmInstrumented: true });
+
+          // Put the language in the "lang" attribute of the <html> tag before initializing Google
+          // Analytics because the cookie consent UI code will look there to determine which
+          // language to use for the consent UI. This needs to happen before the call to INIT_GTAG,
+          // so it lives here instead of in LocalizationProvider.
+          const locale = response.user.locale;
+          if (locale) {
+            document.documentElement.setAttribute('lang', locale);
+          }
+
           (window as any).INIT_GTAG(
             response.user.id.toString(),
             response.user.email?.toLowerCase()?.endsWith('@terraformation.com') ? 'true' : 'false'


### PR DESCRIPTION
We want the cookie consent UI to show in Spanish for Spanish-speaking users. It
gets its initial locale from the `lang` attribute of the `<html>` tag, so update
the code to set that attribute before initializing Google Analytics (which is
what triggers loading the cookie consent UI).
