### PR TITLE
SW-1828 Ignore diacritics in species typeahead

### DIFF
--- a/src/components/accession2/properties/Species2Dropdown.tsx
+++ b/src/components/accession2/properties/Species2Dropdown.tsx
@@ -7,6 +7,7 @@ import { Species } from 'src/types/Species';
 import { SelectT } from '@terraware/web-components';
 import useDebounce from 'src/utils/useDebounce';
 import { useOrganization } from 'src/providers/hooks';
+import { removeDiacritics } from 'src/utils/text';
 
 interface SpeciesDropdownProps<T extends AccessionPostRequestBody> {
   speciesId?: number;
@@ -29,12 +30,12 @@ export default function Species2Dropdown<T extends AccessionPostRequestBody>(
   const populateSpecies = useCallback(async () => {
     const response = await getAllSpecies(selectedOrganization.id);
     if (response.requestSucceeded) {
-      const searchValue = debouncedSearchTerm ? debouncedSearchTerm.toLowerCase() : '';
+      const searchValue = debouncedSearchTerm ? removeDiacritics(debouncedSearchTerm).toLowerCase() : '';
       const speciesToUse = searchValue
         ? response.species.filter((species) => {
             return (
               species.scientificName.toLowerCase().includes(searchValue) ||
-              (species.commonName && species.commonName.toLowerCase().includes(searchValue))
+              (species.commonName && removeDiacritics(species.commonName).toLowerCase().includes(searchValue))
             );
           })
         : response.species;

--- a/src/utils/text.tsx
+++ b/src/utils/text.tsx
@@ -1,2 +1,17 @@
 import { isWhitespaces } from '@terraware/web-components/utils';
+
+/**
+ * Removes accents and other diacritics from letters. This is typically used for things like
+ * typeaheads where we want a value of "ábc" to match user input of "abc".
+ */
+export function removeDiacritics(s: string): string {
+  // First, decompose characters into combining forms: "á" gets turned into a two-character sequence
+  // of "a" followed by a combining character that modifies the previous character to add an accent
+  // mark.
+  const normalized = s.normalize('NFD');
+
+  // Now remove all the combining characters, resulting in a string without diacritics.
+  return normalized.replace(/\p{Mn}/gu, '');
+}
+
 export default isWhitespaces;


### PR DESCRIPTION
Some species common names have accented characters, but we don't want to force
users to type the correct accent marks in the species typeahead when adding
accessions or seedling batches.
