### PR TITLE
Revert index.html change that removed lang attribute

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <!-- Google Tag Manager -->
     <script>


### PR DESCRIPTION
The W3C recommendation is to always include a `lang` attribute on `<html>`
tags.  We can't set it to the user's locale in our static `index.html` since
it's not known until after we fetch the user's profile information from the
server, so hardwire it to English on initial page load. The default will be
overwritten by the application code once it loads the user's information.
