### PR TITLE
SW-2921 fix inventory withdraw math on formatted numbers

### DIFF
--- a/src/components/Inventory/InventoryTable.tsx
+++ b/src/components/Inventory/InventoryTable.tsx
@@ -68,7 +68,7 @@ export default function InventoryTable(props: InventoryTableProps): JSX.Element 
   };
 
   const isSelectionWithdrawable = () => {
-    return selectedRows.some((row) => row.species_id && Number(row.totalQuantity) > 0);
+    return selectedRows.some((row) => row.species_id && row.totalQuantity !== '0');
   };
 
   return (

--- a/src/components/Inventory/view/InventorySeedlingsTable.tsx
+++ b/src/components/Inventory/view/InventorySeedlingsTable.tsx
@@ -209,7 +209,7 @@ export default function InventorySeedslingsTable(props: InventorySeedslingsTable
   };
 
   const selectionHasWithdrawableQuantities = () => {
-    return selectedRows.some((row) => Number(row.totalQuantity) > 0);
+    return selectedRows.some((row) => row.totalQuantity !== '0');
   };
 
   const isSelectionBulkWithdrawable = () => {

--- a/src/components/Inventory/withdraw/BatchWithdrawFlow.tsx
+++ b/src/components/Inventory/withdraw/BatchWithdrawFlow.tsx
@@ -16,6 +16,8 @@ import SelectPurposeForm from './flow/SelectPurposeForm';
 import TfMain from 'src/components/common/TfMain';
 import BusySpinner from 'src/components/common/BusySpinner';
 import { useOrganization } from 'src/providers/hooks';
+import { useNumberParser } from 'src/utils/useNumber';
+import { useUser } from 'src/providers';
 
 type FlowStates = 'purpose' | 'select batches' | 'photos';
 
@@ -27,6 +29,8 @@ type BatchWithdrawFlowProps = {
 
 export default function BatchWithdrawFlow(props: BatchWithdrawFlowProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
+  const { user } = useUser();
+  const numberParser = useNumberParser();
   const { batchIds, sourcePage, withdrawalCreatedCallback } = props;
   const { OUTPLANT, NURSERY_TRANSFER } = NurseryWithdrawalPurposes;
   const [flowState, setFlowState] = useState<FlowStates>('purpose');
@@ -75,10 +79,25 @@ export default function BatchWithdrawFlow(props: BatchWithdrawFlowProps): JSX.El
       return;
     }
 
+    const numericParser = numberParser(user?.locale);
+
     // first create the withdrawal
-    record.batchWithdrawals = record.batchWithdrawals.filter((batchWithdrawal) => {
-      return Number(batchWithdrawal.readyQuantityWithdrawn) + Number(batchWithdrawal.notReadyQuantityWithdrawn) > 0;
-    });
+    record.batchWithdrawals = record.batchWithdrawals
+      .map((batchWithdrawal) => {
+        const readyQuantityWithdrawn = numericParser.parse(batchWithdrawal.readyQuantityWithdrawn?.toString() ?? '');
+        const notReadyQuantityWithdrawn = numericParser.parse(
+          batchWithdrawal.notReadyQuantityWithdrawn?.toString() ?? ''
+        );
+
+        return {
+          ...batchWithdrawal,
+          readyQuantityWithdrawn: isNaN(readyQuantityWithdrawn) ? 0 : readyQuantityWithdrawn,
+          notReadyQuantityWithdrawn: isNaN(notReadyQuantityWithdrawn) ? 0 : notReadyQuantityWithdrawn,
+        };
+      })
+      .filter((batchWithdrawal) => {
+        return batchWithdrawal.readyQuantityWithdrawn + batchWithdrawal.notReadyQuantityWithdrawn > 0;
+      });
 
     if (record.batchWithdrawals.length === 0) {
       snackbar.toastError(strings.NO_BATCHES_TO_WITHDRAW_FROM); // temporary until we have a solution from design

--- a/src/components/Inventory/withdraw/BatchWithdrawFlow.tsx
+++ b/src/components/Inventory/withdraw/BatchWithdrawFlow.tsx
@@ -46,7 +46,7 @@ export default function BatchWithdrawFlow(props: BatchWithdrawFlowProps): JSX.El
       const searchResponse = await NurseryBatchService.getBatches(batchIds.map((id) => Number(id)));
 
       if (searchResponse) {
-        const withdrawable = searchResponse.filter((batch) => Number(batch.totalQuantity) > 0);
+        const withdrawable = searchResponse.filter((batch) => batch.totalQuantity !== '0');
         if (!withdrawable.length) {
           snackbar.toastError(strings.NO_BATCHES_TO_WITHDRAW_FROM); // temporary until we have a solution from design
         }

--- a/src/components/Inventory/withdraw/flow/SelectBatchesWithdrawnQuantity.tsx
+++ b/src/components/Inventory/withdraw/flow/SelectBatchesWithdrawnQuantity.tsx
@@ -28,6 +28,7 @@ type BatchWithdrawalForTable = {
   readyQuantityWithdrawn: number;
   notReadyQuantity: number;
   readyQuantity: number;
+  totalQuantity: number;
   speciesId: number;
   facilityName: string;
   error: { [key: string]: string | undefined };
@@ -66,6 +67,7 @@ export default function SelectBatches(props: SelectBatchesWithdrawnQuantityProps
             readyQuantityWithdrawn: bw.readyQuantityWithdrawn,
             notReadyQuantity: associatedBatch.notReadyQuantity,
             readyQuantity: associatedBatch.readyQuantity,
+            totalQuantity: associatedBatch.totalQuantity,
             batchNumber: associatedBatch.batchNumber,
             speciesId: associatedBatch.species_id,
             facilityName: associatedBatch.facility_name,

--- a/src/components/Inventory/withdraw/flow/SelectBatchesWithdrawnQuantity.tsx
+++ b/src/components/Inventory/withdraw/flow/SelectBatchesWithdrawnQuantity.tsx
@@ -10,6 +10,8 @@ import useForm from 'src/utils/useForm';
 import { makeStyles } from '@mui/styles';
 import { useOrganization } from 'src/providers/hooks';
 import Table from 'src/components/common/table';
+import { useUser } from 'src/providers';
+import useNumberParser from 'src/utils/useNumberParser';
 
 type SelectBatchesWithdrawnQuantityProps = {
   onNext: (withdrawal: NurseryWithdrawalRequest) => void;
@@ -40,7 +42,9 @@ const useStyles = makeStyles(() => ({
 }));
 
 export default function SelectBatches(props: SelectBatchesWithdrawnQuantityProps): JSX.Element {
+  const numberParser = useNumberParser();
   const { selectedOrganization } = useOrganization();
+  const { user } = useUser();
   const { onNext, onCancel, saveText, batches, nurseryWithdrawal } = props;
   const { OUTPLANT } = NurseryWithdrawalPurposes;
   const theme = useTheme();
@@ -149,11 +153,16 @@ export default function SelectBatches(props: SelectBatchesWithdrawnQuantityProps
   const isInvalidQuantity = (val: any) => isNaN(val) || +val < 0;
 
   const validateQuantities = () => {
+    const numericParser = numberParser(user?.locale ?? 'en');
     let noErrors = true;
     let newRecords: BatchWithdrawalForTable[] = [];
     if (nurseryWithdrawal.purpose === OUTPLANT) {
       let unsetValues = 0;
-      newRecords = record.map((rec) => {
+      newRecords = record.map((recordData) => {
+        const rec = {
+          ...recordData,
+          readyQuantity: numericParser.parse(recordData.readyQuantity.toString()),
+        };
         let readyQuantityWithdrawnError = '';
         if (rec.readyQuantityWithdrawn) {
           if (isInvalidQuantity(rec.readyQuantityWithdrawn)) {
@@ -182,7 +191,12 @@ export default function SelectBatches(props: SelectBatchesWithdrawnQuantityProps
       });
     } else {
       let unsetValues = 0;
-      newRecords = record.map((rec) => {
+      newRecords = record.map((recordData) => {
+        const rec = {
+          ...recordData,
+          notReadyQuantity: numericParser.parse(recordData.notReadyQuantity.toString()),
+          readyQuantity: numericParser.parse(recordData.readyQuantity.toString()),
+        };
         let readyQuantityWithdrawnError = '';
         let notReadyQuantityWithdrawnError = '';
         if (rec.readyQuantityWithdrawn) {

--- a/src/components/Inventory/withdraw/flow/SelectBatchesWithdrawnQuantity.tsx
+++ b/src/components/Inventory/withdraw/flow/SelectBatchesWithdrawnQuantity.tsx
@@ -11,7 +11,7 @@ import { makeStyles } from '@mui/styles';
 import { useOrganization } from 'src/providers/hooks';
 import Table from 'src/components/common/table';
 import { useUser } from 'src/providers';
-import useNumberParser from 'src/utils/useNumberParser';
+import { useNumberParser } from 'src/utils/useNumber';
 
 type SelectBatchesWithdrawnQuantityProps = {
   onNext: (withdrawal: NurseryWithdrawalRequest) => void;
@@ -155,7 +155,7 @@ export default function SelectBatches(props: SelectBatchesWithdrawnQuantityProps
   const isInvalidQuantity = (val: any) => isNaN(val) || +val < 0;
 
   const validateQuantities = () => {
-    const numericParser = numberParser(user?.locale ?? 'en');
+    const numericParser = numberParser(user?.locale);
     let noErrors = true;
     let newRecords: BatchWithdrawalForTable[] = [];
     if (nurseryWithdrawal.purpose === OUTPLANT) {

--- a/src/components/Inventory/withdraw/flow/WithdrawalBatchesCellRenderer.tsx
+++ b/src/components/Inventory/withdraw/flow/WithdrawalBatchesCellRenderer.tsx
@@ -115,15 +115,7 @@ export default function WithdrawalBatchesCellRenderer(props: RendererProps<Table
   }
 
   if (column.key === 'totalQuantity') {
-    return (
-      <CellRenderer
-        index={index}
-        column={column}
-        value={+row.readyQuantity + +row.notReadyQuantity}
-        row={row}
-        className={classes.text}
-      />
-    );
+    return <CellRenderer index={index} column={column} row={row} value={row.totalQuantity} className={classes.text} />;
   }
 
   if (column.key === 'totalWithdraw') {

--- a/src/components/Inventory/withdraw/flow/WithdrawalBatchesCellRenderer.tsx
+++ b/src/components/Inventory/withdraw/flow/WithdrawalBatchesCellRenderer.tsx
@@ -6,6 +6,8 @@ import { RendererProps, TableRowType } from '@terraware/web-components';
 import { Textfield } from '@terraware/web-components';
 import Link from 'src/components/common/Link';
 import CellRenderer from 'src/components/common/table/TableCellRenderer';
+import { useNumberFormatter } from 'src/utils/useNumber';
+import { useUser } from 'src/providers';
 
 const useStyles = makeStyles(() => ({
   text: {
@@ -26,6 +28,8 @@ const useStyles = makeStyles(() => ({
 
 export default function WithdrawalBatchesCellRenderer(props: RendererProps<TableRowType>): JSX.Element {
   const classes = useStyles();
+  const { user } = useUser();
+  const numberFormatter = useNumberFormatter()(user?.locale);
   const { column, row, value, index, onRowClick } = props;
 
   const createLinkToBatchDetail = (iValue: React.ReactNode | unknown[]) => {
@@ -123,7 +127,7 @@ export default function WithdrawalBatchesCellRenderer(props: RendererProps<Table
       <CellRenderer
         index={index}
         column={column}
-        value={+row.readyQuantityWithdrawn + +row.notReadyQuantityWithdrawn}
+        value={numberFormatter.format(+row.readyQuantityWithdrawn + +row.notReadyQuantityWithdrawn)}
         row={row}
         className={classes.text}
       />

--- a/src/utils/useNumber.ts
+++ b/src/utils/useNumber.ts
@@ -4,9 +4,11 @@ import { useMemo } from 'react';
  * See: https://observablehq.com/@mbostock/localized-number-parsing
  */
 
-const useNumberParser = (): any => {
-  const parser = (locale: string): any => {
-    const localeToUse = locale === 'gx' ? 'en' : locale;
+const getLocaleToUse = (locale?: string) => (locale === 'gx' || !locale ? 'en' : locale);
+
+export const useNumberParser = (): any => {
+  const parser = (locale?: string): any => {
+    const localeToUse = getLocaleToUse(locale);
     const parts = new Intl.NumberFormat(localeToUse).formatToParts(12345.6);
     const numerals = new Intl.NumberFormat(localeToUse, { useGrouping: false }).format(9876543210).split('').reverse();
     const index = new Map(numerals.map((d, i) => [d, i]));
@@ -27,4 +29,17 @@ const useNumberParser = (): any => {
   return useMemo(() => parser, []);
 };
 
-export default useNumberParser;
+/**
+ * formatter
+ */
+export const useNumberFormatter = (): any => {
+  const formatter = (locale?: string): any => {
+    const localeToUse = getLocaleToUse(locale);
+    const intlFormat = new Intl.NumberFormat(localeToUse);
+    const format = (num: number) => intlFormat.format(num);
+
+    return { format };
+  };
+
+  return useMemo(() => formatter, []);
+};

--- a/src/utils/useNumberParser.ts
+++ b/src/utils/useNumberParser.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react';
+
+/**
+ * See: https://observablehq.com/@mbostock/localized-number-parsing
+ */
+
+const useNumberParser = (): any => {
+  const parser = (locale: string): any => {
+    const localeToUse = locale === 'gx' ? 'en' : locale;
+    const parts = new Intl.NumberFormat(localeToUse).formatToParts(12345.6);
+    const numerals = new Intl.NumberFormat(localeToUse, { useGrouping: false }).format(9876543210).split('').reverse();
+    const index = new Map(numerals.map((d, i) => [d, i]));
+    const _group = new RegExp(`[${parts?.find((d) => d?.type === 'group')?.value}]`, 'g');
+    const _decimal = new RegExp(`[${parts?.find((d) => d?.type === 'decimal')?.value}]`);
+    const _numeral = new RegExp(`[${numerals.join('')}]`, 'g');
+    const _index = (d: any) => index.get(d) as unknown as string;
+
+    const parse = (numberStr: string): number | typeof NaN => {
+      const str = numberStr.trim().replace(_group, '').replace(_decimal, '.').replace(_numeral, _index);
+
+      return str ? +str : NaN;
+    };
+
+    return { parse };
+  };
+
+  return useMemo(() => parser, []);
+};
+
+export default useNumberParser;


### PR DESCRIPTION
- Add util to parse a number from a locale/formatted number-string. See https://observablehq.com/@mbostock/localized-number-parsing (there may be a better way to do this (npm package)? but i like the simple reverse-engineered approach in the above article)
- Add util to format a number using locale (leverage Intl.. not sure if this is totally correct for fixed precision)
- Inventory create/edit/withdraw flows had inconsistent display formatting, BE provided numbers were formatted correctly, UI generated numbers (running totals, etc.) were not formatted. Leverage above utils to render in correct format.
- UI allowed user to enter formatted numbers in the various quantity input elements - but was also sending this back to the BE as the number data, which generated format errors since BE was expecting a number (not a formatted string). Updated code to parse number from human input which could have been formatted
- UI validation functions were interpreting numbers using `Number(string)` or `+<number-string>` both of which won't work with formatted numbers. Updated code to do simper checks such as `number != '0'` and in other cases where we needed to check for `>`,, parse the number from formatted number, leveraging new utils
