### PR TITLE
SW-2925 Handle localized booleans in search results

### DIFF
--- a/src/components/NurseryWithdrawals/NurseryWithdrawalsDetails.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawalsDetails.tsx
@@ -23,6 +23,7 @@ import { Species } from 'src/types/Species';
 import { NurseryWithdrawalPurposes } from 'src/types/Batch';
 import BackToLink from 'src/components/common/BackToLink';
 import { useOrganization } from 'src/providers/hooks';
+import { isTrue } from 'src/utils/boolean';
 
 const useStyles = makeStyles((theme: Theme) => ({
   backToWithdrawals: {
@@ -106,7 +107,7 @@ export default function NurseryWithdrawalsDetails({ species, plotNames }: Nurser
           plotNames: withdrawalSummaryRecord.plotNames as string,
           scientificNames: withdrawalSummaryRecord.speciesScientificNames as string[],
           totalWithdrawn: Number(withdrawalSummaryRecord.totalWithdrawn),
-          hasReassignments: withdrawalSummaryRecord.hasReassignments === 'true',
+          hasReassignments: isTrue(withdrawalSummaryRecord.hasReassignments),
         });
       }
     };

--- a/src/components/NurseryWithdrawals/WithdrawalLogRenderer.tsx
+++ b/src/components/NurseryWithdrawals/WithdrawalLogRenderer.tsx
@@ -8,6 +8,7 @@ import { Theme, useTheme } from '@mui/material';
 import { Button, TextTruncated } from '@terraware/web-components';
 import strings from 'src/strings';
 import { NurseryWithdrawalPurposes } from 'src/types/Batch';
+import { isTrue } from 'src/utils/boolean';
 
 const useStyles = makeStyles((theme: Theme) => ({
   link: {
@@ -86,7 +87,7 @@ export default function WithdrawalLogRenderer(props: RendererProps<TableRowType>
                 size='small'
                 priority='secondary'
                 className={classes.text}
-                disabled={row.hasReassignments === 'true'}
+                disabled={isTrue(row.hasReassignments)}
               />
             }
           />

--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -46,6 +46,7 @@ import PopoverMenu from '../common/PopoverMenu';
 import { DropdownItem } from '@terraware/web-components';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
 import { PillList, PillListItem } from '@terraware/web-components';
+import { isTrue } from 'src/utils/boolean';
 
 type SpeciesListProps = {
   reloadData: () => void;
@@ -156,11 +157,14 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
   };
 
   const getConservationStatusString = (result: { [key: string]: unknown }) => {
-    if (result.endangered && result.rare) {
+    const endangered = isTrue(result.endangered);
+    const rare = isTrue(result.rare);
+
+    if (endangered && rare) {
       return strings.RARE_ENDANGERED;
-    } else if (result.endangered) {
+    } else if (endangered) {
       return strings.ENDANGERED;
-    } else if (result.rare) {
+    } else if (rare) {
       return strings.RARE;
     } else {
       return '';
@@ -338,7 +342,7 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
         operation: 'field',
         field: 'endangered',
         type: 'Exact',
-        values: [record.endangered],
+        values: [record.endangered ? strings.BOOLEAN_TRUE : strings.BOOLEAN_FALSE],
       };
       params.search.children.push(newNode);
     }
@@ -348,7 +352,7 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
         operation: 'field',
         field: 'rare',
         type: 'Exact',
-        values: [record.rare],
+        values: [record.rare ? strings.BOOLEAN_TRUE : strings.BOOLEAN_FALSE],
       };
       params.search.children.push(newNode);
     }
@@ -420,8 +424,8 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
               growthForm: result.growthForm as any,
               seedStorageBehavior: result.seedStorageBehavior as any,
               ecosystemTypes: (result.ecosystemTypes as Record<string, EcosystemType>[])?.map((r) => r.ecosystemType),
-              rare: result.rare as boolean,
-              endangered: result.endangered as boolean,
+              rare: isTrue(result.rare),
+              endangered: isTrue(result.endangered),
               conservationStatus: getConservationStatusString(result),
             });
           });

--- a/src/strings/strings-en.ts
+++ b/src/strings/strings-en.ts
@@ -109,6 +109,8 @@ export const strings = {
   BATCH_WITHDRAW_SUCCESS: '{0} {1} for a total of {2} {3} withdrawn.',
   BATCHES_PLURAL: 'batches',
   BATCHES_SINGULAR: 'batch',
+  BOOLEAN_FALSE: 'false',
+  BOOLEAN_TRUE: 'true',
   BOTH_WITHDRAWS_DESCRIPTION:
     'You have withdrawn seeds by both count and weight. As a result, the app has calculated the amount of seeds withdrawn for you by weight.',
   BOUNDARIES_AND_PLOTS: 'Boundaries and Plots',

--- a/src/utils/boolean.ts
+++ b/src/utils/boolean.ts
@@ -1,0 +1,9 @@
+import strings from 'src/strings';
+
+/**
+ * Returns true if a value is either a boolean true value or a string that equals the word for
+ * "true" in the current locale.
+ */
+export function isTrue(value: unknown): boolean {
+  return (typeof value === 'boolean' && value) || value === strings.BOOLEAN_TRUE;
+}


### PR DESCRIPTION
Boolean search fields, like all search fields, return string values. Currently,
these are assumed to be the English words `'true'` and `'false'`.

Update the application code to handle booleans being rendered as localized
strings.

This fixes a bug in the species list UI in English: if you had a search filter,
it could erroneously show species as rare and/or endangered because the string
`'false'` evaluates as true in JavaScript.
