### PR TITLE
SW-2918 Format numeric chart axes in gibberish

### DIFF
--- a/src/components/common/Chart/index.tsx
+++ b/src/components/common/Chart/index.tsx
@@ -1,7 +1,8 @@
-import { Chart, ChartType, DefaultDataPoint, ScaleOptionsByType } from 'chart.js/auto';
+import { Chart, ChartType, DefaultDataPoint, ScaleOptionsByType, TooltipItem } from 'chart.js/auto';
 import { ChartConfiguration, ChartConfigurationCustomTypesPerDataset, ChartItem } from 'chart.js/dist/types';
 import 'chartjs-adapter-date-fns';
 import { Locale } from 'date-fns';
+import { formatGibberish } from 'src/utils/useNumber';
 
 type DateFnsModule = {
   default: Locale;
@@ -22,28 +23,78 @@ function importDateFuncsForLocale(locale: string): Promise<DateFnsModule> {
   return loadModule();
 }
 
+function formatGibberishTick(tickValue: number | string, index: number): string {
+  if (typeof tickValue === 'number') {
+    return formatGibberish(tickValue);
+  } else {
+    return tickValue;
+  }
+}
+
+function formatGibberishTooltipValue<TType extends ChartType>(context: TooltipItem<TType>): string {
+  // @ts-ignore
+  const value = context.parsed.y;
+  if (typeof value === 'number') {
+    return formatGibberish(value);
+  } else if (value === null || value === undefined) {
+    return '';
+  } else {
+    return value.toString();
+  }
+}
+
 export async function newChart<TType extends ChartType = ChartType, TData = DefaultDataPoint<TType>, TLabel = unknown>(
   locale: string,
   item: ChartItem,
   config: ChartConfiguration<TType, TData, TLabel> | ChartConfigurationCustomTypesPerDataset<TType, TData, TLabel>
 ): Promise<Chart<TType, TData, TLabel>> {
-  // @ts-ignore
-  if (typeof config.options === 'object' && 'scales' in config.options) {
-    config.options.locale = locale === 'gx' ? 'ko' : locale;
-    const scales = config.options.scales as { [name: string]: ScaleOptionsByType };
+  if (typeof config.options === 'object') {
+    if ('scales' in config.options) {
+      config.options.locale = locale === 'gx' ? 'ko' : locale;
+      const scales = config.options.scales as { [name: string]: ScaleOptionsByType };
 
-    for (const scaleOptions of Object.values(scales)) {
-      if (scaleOptions.type === 'time') {
-        const existingDateOptions = scaleOptions.adapters?.date as object | undefined;
-        const dateFuncsLocale = (await importDateFuncsForLocale(locale)).default;
-        scaleOptions.adapters = {
-          ...scaleOptions.adapters,
-          date: {
-            ...existingDateOptions,
-            locale: dateFuncsLocale,
-          },
-        };
+      for (const scaleOptions of Object.values(scales)) {
+        if (scaleOptions.type === 'time') {
+          const existingDateOptions = scaleOptions.adapters?.date as object | undefined;
+          const dateFuncsLocale = (await importDateFuncsForLocale(locale)).default;
+          scaleOptions.adapters = {
+            ...scaleOptions.adapters,
+            date: {
+              ...existingDateOptions,
+              locale: dateFuncsLocale,
+            },
+          };
+        }
+
+        if (
+          locale === 'gx' &&
+          !scaleOptions.ticks?.callback &&
+          (!scaleOptions.type || scaleOptions.type === 'linear' || scaleOptions.type === 'logarithmic')
+        ) {
+          scaleOptions.ticks = {
+            ...scaleOptions.ticks,
+            callback: formatGibberishTick,
+          };
+        }
       }
+    }
+
+    // @ts-ignore
+    if (locale === 'gx' && !config.options.plugins?.tooltip?.callbacks?.label && config.options.scales?.y) {
+      // @ts-ignore
+      config.options.plugins = {
+        // @ts-ignore
+        ...config.options.plugins,
+        tooltip: {
+          // @ts-ignore
+          ...config.options.plugins?.tooltip,
+          callbacks: {
+            // @ts-ignore
+            ...config.options.plugins?.tooltip?.callbacks,
+            label: formatGibberishTooltipValue,
+          },
+        },
+      };
     }
   }
 

--- a/src/utils/useNumber.ts
+++ b/src/utils/useNumber.ts
@@ -4,11 +4,23 @@ import { useMemo } from 'react';
  * See: https://observablehq.com/@mbostock/localized-number-parsing
  */
 
-const getLocaleToUse = (locale?: string) => (locale === 'gx' || !locale ? 'en' : locale);
+function parseGibberish(numberStr: string): number {
+  const str = numberStr.replace(',', '.').replace(/&/g, '');
+  return str ? +str : NaN;
+}
+
+export function formatGibberish(num: number): string {
+  const english = new Intl.NumberFormat('en').format(num);
+  return english.replace(/,/g, '&').replace('.', ',');
+}
 
 export const useNumberParser = (): any => {
   const parser = (locale?: string): any => {
-    const localeToUse = getLocaleToUse(locale);
+    if (locale === 'gx') {
+      return { parse: parseGibberish };
+    }
+
+    const localeToUse = locale || 'en';
     const parts = new Intl.NumberFormat(localeToUse).formatToParts(12345.6);
     const numerals = new Intl.NumberFormat(localeToUse, { useGrouping: false }).format(9876543210).split('').reverse();
     const index = new Map(numerals.map((d, i) => [d, i]));
@@ -34,8 +46,11 @@ export const useNumberParser = (): any => {
  */
 export const useNumberFormatter = (): any => {
   const formatter = (locale?: string): any => {
-    const localeToUse = getLocaleToUse(locale);
-    const intlFormat = new Intl.NumberFormat(localeToUse);
+    if (locale === 'gx') {
+      return { format: formatGibberish };
+    }
+
+    const intlFormat = new Intl.NumberFormat(locale || 'en');
     const format = (num: number) => intlFormat.format(num);
 
     return { format };


### PR DESCRIPTION
On the plants dashboard, the bar graph of number of plants by species wasn't using
localized numbers. We want localized numbers on all our charts, so extend our
custom Chart.js wrapper to add render functions for gibberish numbers on Y axis
labels and in tooltips.

The locale-aware number formatter wasn't using the formatting rules for the
gibberish locale; extract that logic out into a couple of helper functions.
