### PR TITLE
SW-2681 Show withdrawal notes in accession history

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -355,6 +355,8 @@ export interface components {
       description: string;
       /** @description Full name of the person responsible for the event, if known. */
       fullName?: string;
+      /** @description User-entered notes about the event, if any. */
+      notes?: string;
       type:
         | "Created"
         | "QuantityUpdated"
@@ -1820,6 +1822,8 @@ export interface components {
       storageCondition: "Refrigerator" | "Freezer";
     };
     StorageLocationPayload: {
+      /** Format: int32 */
+      activeAccessions: number;
       /** Format: int64 */
       facilityId: number;
       /** Format: int64 */

--- a/src/components/accession2/history/Accession2History.tsx
+++ b/src/components/accession2/history/Accession2History.tsx
@@ -62,6 +62,11 @@ export default function Accession2History(props: Accession2HistoryProps): JSX.El
           </Typography>
           <Typography fontWeight={500}>
             {item.fullName || strings.NAME_UNKNOWN}&nbsp;{item.description}
+            {item.notes && (
+              <Typography fontSize={'14px'} fontWeight={300}>
+                {item.notes}
+              </Typography>
+            )}
           </Typography>
         </Box>
       ))}


### PR DESCRIPTION
If an accession withdrawal has notes, show them below the system-generated
description of the history event.
