### PR TITLE
SW-2604 Hide zone/plot selectors if no zones

### DIFF
--- a/src/components/Inventory/withdraw/flow/SelectPurposeForm.tsx
+++ b/src/components/Inventory/withdraw/flow/SelectPurposeForm.tsx
@@ -614,15 +614,17 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
                     }
                   />
                 </Grid>
-                <PlotSelector
-                  zones={zones}
-                  onZoneSelected={onChangePlantingZone}
-                  onPlotSelected={onChangePlot}
-                  zoneError={fieldsErrors.zoneId}
-                  plotError={fieldsErrors.plotId}
-                  selectedPlot={selectedPlot}
-                  selectedZone={selectedZone}
-                />
+                {!!zones.length && (
+                  <PlotSelector
+                    zones={zones}
+                    onZoneSelected={onChangePlantingZone}
+                    onPlotSelected={onChangePlot}
+                    zoneError={fieldsErrors.zoneId}
+                    plotError={fieldsErrors.plotId}
+                    selectedPlot={selectedPlot}
+                    selectedZone={selectedZone}
+                  />
+                )}
               </>
             )}
             <Grid display='flex' flexDirection={isMobile ? 'column' : 'row'}>


### PR DESCRIPTION
On the seedling batch withdrawal form, only show the zone/plot selectors if the
user has selected a planting site that has planting zones.
