### PR TITLE
SW-2933 Use French date/number formatting for gibberish

### DIFF
--- a/src/components/Monitoring/dashboard/PVBatteryChart.tsx
+++ b/src/components/Monitoring/dashboard/PVBatteryChart.tsx
@@ -1,6 +1,6 @@
 import { Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import strings from 'src/strings';
 import { Chart } from 'chart.js';
 import { Device } from 'src/types/Device';
@@ -21,6 +21,7 @@ import Icon from '../../common/icon/Icon';
 import { Dropdown } from '@terraware/web-components';
 import { useLocalization } from 'src/providers';
 import { newChart } from '../../common/Chart';
+import { useNumberFormatter } from 'src/utils/useNumber';
 
 declare global {
   interface Window {
@@ -90,6 +91,11 @@ export default function PVBatteryChart(props: PVBatteryChartProps): JSX.Element 
   const { BMU, defaultTimePeriod, updateTimePeriodPreferences, timeZone } = props;
   const [selectedPVBatteryPeriod, setSelectedPVBatteryPeriod] = useState<string>();
   const { loadedStringsForLocale } = useLocalization();
+  const numberFormatter = useNumberFormatter();
+  const numericFormatter = useMemo(
+    () => numberFormatter(loadedStringsForLocale),
+    [loadedStringsForLocale, numberFormatter]
+  );
 
   useEffect(() => {
     if (defaultTimePeriod) {
@@ -170,7 +176,7 @@ export default function PVBatteryChart(props: PVBatteryChartProps): JSX.Element 
                 },
                 ticks: {
                   callback: (value, index, ticks) => {
-                    return strings.formatString(strings.WATTS_VALUE, value) as string;
+                    return strings.formatString(strings.WATTS_VALUE, numericFormatter.format(value)) as string;
                   },
                 },
               },
@@ -233,7 +239,7 @@ export default function PVBatteryChart(props: PVBatteryChartProps): JSX.Element 
     if (selectedPVBatteryPeriod) {
       getChartData();
     }
-  }, [BMU, loadedStringsForLocale, selectedPVBatteryPeriod, timeZone]);
+  }, [BMU, loadedStringsForLocale, numericFormatter, selectedPVBatteryPeriod, timeZone]);
 
   const onChangePVBatterySelectedPeriod = (newValue: string) => {
     setSelectedPVBatteryPeriod(newValue);

--- a/src/components/Monitoring/dashboard/TemperatureHumidityChart.tsx
+++ b/src/components/Monitoring/dashboard/TemperatureHumidityChart.tsx
@@ -1,5 +1,5 @@
 import { makeStyles } from '@mui/styles';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import strings from 'src/strings';
 import Select from '../../common/Select/Select';
 import Icon from '../../common/icon/Icon';
@@ -23,6 +23,7 @@ import useDeviceInfo from 'src/utils/useDeviceInfo';
 import { Dropdown } from '@terraware/web-components';
 import { useLocalization } from 'src/providers';
 import { newChart } from '../../common/Chart';
+import { useNumberFormatter } from 'src/utils/useNumber';
 
 declare global {
   interface Window {
@@ -106,6 +107,11 @@ export default function TemperatureHumidityChart(props: TemperatureHumidityChart
   const [selectedLocation, setSelectedLocation] = useState<Device>();
   const [selectedPeriod, setSelectedPeriod] = useState<string>();
   const { loadedStringsForLocale } = useLocalization();
+  const numberFormatter = useNumberFormatter();
+  const numericFormatter = useMemo(
+    () => numberFormatter(loadedStringsForLocale),
+    [loadedStringsForLocale, numberFormatter]
+  );
 
   useEffect(() => {
     if (defaultSensor) {
@@ -299,7 +305,10 @@ export default function TemperatureHumidityChart(props: TemperatureHumidityChart
               y: {
                 ticks: {
                   callback: (value, index, ticks) => {
-                    return strings.formatString(strings.DEGREES_CELSIUS_VALUE, value) as string;
+                    return strings.formatString(
+                      strings.DEGREES_CELSIUS_VALUE,
+                      numericFormatter.format(value)
+                    ) as string;
                   },
                 },
                 suggestedMax: Number(getMaxValue(temperatureValues)) + 10,
@@ -332,7 +341,7 @@ export default function TemperatureHumidityChart(props: TemperatureHumidityChart
                 },
                 ticks: {
                   callback: (value, index, ticks) => {
-                    return strings.formatString(strings.PERCENTAGE_VALUE, value) as string;
+                    return strings.formatString(strings.PERCENTAGE_VALUE, numericFormatter.format(value)) as string;
                   },
                 },
               },
@@ -400,7 +409,7 @@ export default function TemperatureHumidityChart(props: TemperatureHumidityChart
     ) {
       getChartData();
     }
-  }, [availableLocations, loadedStringsForLocale, selectedPeriod, selectedLocation, timeZone]);
+  }, [availableLocations, loadedStringsForLocale, numericFormatter, selectedPeriod, selectedLocation, timeZone]);
 
   const onChangeLocation = (newValue: string) => {
     const location = availableLocations?.find((aL) => aL.name === newValue);

--- a/src/components/common/Chart/index.tsx
+++ b/src/components/common/Chart/index.tsx
@@ -11,8 +11,8 @@ const availableDateModules: { [locale: string]: () => Promise<DateFnsModule> } =
   // The default locale if there isn't a better match.
   '': () => import('date-fns/locale/en-US'),
   es: () => import('date-fns/locale/es'),
-  // Render dates in Korean in the gibberish locale so they look visually distinct from English.
-  gx: () => import('date-fns/locale/ko'),
+  // Render dates in French in the gibberish locale so they look visually distinct from English.
+  gx: () => import('date-fns/locale/fr'),
 };
 
 function importDateFuncsForLocale(locale: string): Promise<DateFnsModule> {
@@ -29,7 +29,7 @@ export async function newChart<TType extends ChartType = ChartType, TData = Defa
 ): Promise<Chart<TType, TData, TLabel>> {
   // @ts-ignore
   if (typeof config.options === 'object' && 'scales' in config.options) {
-    config.options.locale = locale === 'gx' ? 'ko' : locale;
+    config.options.locale = locale === 'gx' ? 'fr' : locale;
     const scales = config.options.scales as { [name: string]: ScaleOptionsByType };
 
     for (const scaleOptions of Object.values(scales)) {

--- a/src/components/common/DatePicker.tsx
+++ b/src/components/common/DatePicker.tsx
@@ -9,9 +9,9 @@ export default function DatePicker(props: Props): JSX.Element {
 
   useEffect(() => {
     if (loadedStringsForLocale) {
-      // Adding a custom gibberish locale to MUI's date picker is nontrivial; show Korean dates
+      // Adding a custom gibberish locale to MUI's date picker is nontrivial; show French dates
       // in the gibberish locale to support testing that the date picker is localized.
-      const effectiveLocale = loadedStringsForLocale === 'gx' ? 'ko' : loadedStringsForLocale;
+      const effectiveLocale = loadedStringsForLocale === 'gx' ? 'fr' : loadedStringsForLocale;
       setPropsWithLocale({ ...props, locale: effectiveLocale });
     }
   }, [loadedStringsForLocale, props, setPropsWithLocale]);

--- a/src/components/common/Timestamp.tsx
+++ b/src/components/common/Timestamp.tsx
@@ -1,5 +1,5 @@
-import { useLocalization } from '../../providers';
-import { useUserTimeZone } from '../../utils/useTimeZoneUtils';
+import { useLocalization } from 'src/providers';
+import { useUserTimeZone } from 'src/utils/useTimeZoneUtils';
 import { useEffect, useState } from 'react';
 
 export interface TimestampProps {
@@ -10,11 +10,11 @@ export interface TimestampProps {
 
 /** Returns a DateTimeFormat object for a locale and time zone. */
 function newDateTimeFormat(locale?: string, timeZone?: string) {
-  return new Intl.DateTimeFormat(locale, {
+  const localeToUse = locale === 'gx' ? 'fr' : locale || 'en';
+  return new Intl.DateTimeFormat(localeToUse, {
     dateStyle: 'long',
     timeStyle: 'medium',
     timeZone,
-    hourCycle: locale === 'gx' ? 'h24' : undefined,
   });
 }
 
@@ -22,20 +22,11 @@ function newDateTimeFormat(locale?: string, timeZone?: string) {
 export default function Timestamp({ className, isoString }: TimestampProps): JSX.Element | null {
   const timeZone = useUserTimeZone()?.id;
   const { locale } = useLocalization();
-  const [dateTimeFormat, setDateTimeFormat] = useState<Intl.DateTimeFormat>(newDateTimeFormat(locale, timeZone));
+  const [formattedDate, setFormattedDate] = useState<string | null>(null);
 
   useEffect(() => {
-    setDateTimeFormat(newDateTimeFormat(locale, timeZone));
-  }, [locale, timeZone, setDateTimeFormat]);
+    setFormattedDate(newDateTimeFormat(locale, timeZone).format(new Date(isoString)));
+  }, [isoString, locale, timeZone, setFormattedDate]);
 
-  const format = () => {
-    const formatted = dateTimeFormat.format(new Date(isoString));
-    if (locale === 'gx') {
-      return formatted?.replace(/[A-Za-z]/g, 'XY');
-    } else {
-      return formatted;
-    }
-  };
-
-  return <span className={className}>{format()}</span>;
+  return <span className={className}>{formattedDate}</span>;
 }

--- a/src/utils/useNumber.ts
+++ b/src/utils/useNumber.ts
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
  * See: https://observablehq.com/@mbostock/localized-number-parsing
  */
 
-const getLocaleToUse = (locale?: string) => (locale === 'gx' || !locale ? 'en' : locale);
+const getLocaleToUse = (locale?: string) => (locale === 'gx' ? 'fr' : locale || 'en');
 
 export const useNumberParser = (): any => {
   const parser = (locale?: string): any => {


### PR DESCRIPTION
The goal of the gibberish locale is to be visually distinct from English so we
can spot places in the UI that we haven't localized. Initially, that included
using custom formatting rules for numbers and dates, but that has turned out to
be annoying to implement in practice. Update the code to use French formatting
instead; it serves the purpose of being distinct from English but requires less
special-case code.

Also fixes SW-2918.
