### PR TITLE
SW-2941 / SW-2942 Sort inventory/withdrawals table using BE sort order

### DIFF
--- a/src/components/Inventory/InventoryTable.tsx
+++ b/src/components/Inventory/InventoryTable.tsx
@@ -10,6 +10,8 @@ import PageSnackbar from 'src/components/PageSnackbar';
 import { APP_PATHS } from 'src/constants';
 import Search from './Search';
 import Table from 'src/components/common/table';
+import { SortOrder } from 'src/components/common/table/sort';
+import { SearchSortOrder } from 'src/services/SearchService';
 
 interface InventoryTableProps {
   results: SearchResponseElement[];
@@ -17,10 +19,13 @@ interface InventoryTableProps {
   setTemporalSearchValue: React.Dispatch<React.SetStateAction<string>>;
   filters: InventoryFiltersType;
   setFilters: React.Dispatch<React.SetStateAction<InventoryFiltersType>>;
+  setSearchSortOrder: (sortOrder: SearchSortOrder) => void;
+  isPresorted: boolean;
 }
 
 export default function InventoryTable(props: InventoryTableProps): JSX.Element {
-  const { results, setTemporalSearchValue, temporalSearchValue, filters, setFilters } = props;
+  const { results, setTemporalSearchValue, temporalSearchValue, filters, setFilters, setSearchSortOrder, isPresorted } =
+    props;
   const [selectedRows, setSelectedRows] = useState<any[]>([]);
   const history = useHistory();
   const theme = useTheme();
@@ -71,6 +76,13 @@ export default function InventoryTable(props: InventoryTableProps): JSX.Element 
     return selectedRows.some((row) => row.species_id && row.totalQuantity !== '0');
   };
 
+  const onSortChange = (order: SortOrder, orderBy: string) => {
+    setSearchSortOrder({
+      field: orderBy as string,
+      direction: order === 'asc' ? 'Ascending' : 'Descending',
+    });
+  };
+
   return (
     <>
       <Grid item xs={12}>
@@ -107,6 +119,8 @@ export default function InventoryTable(props: InventoryTableProps): JSX.Element 
                     disabled: !isSelectionWithdrawable(),
                   },
                 ]}
+                sortHandler={onSortChange}
+                isPresorted={isPresorted}
               />
             </Grid>
           </Grid>

--- a/src/components/NurseryWithdrawals/NurseryReassignment.tsx
+++ b/src/components/NurseryWithdrawals/NurseryReassignment.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
-import { Box, CircularProgress, Grid, useTheme } from '@mui/material';
+import { Box, CircularProgress, Grid, Theme, useTheme } from '@mui/material';
 import { ErrorBox, TableColumnType } from '@terraware/web-components';
 import { Delivery } from 'src/types/Tracking';
 import { getDelivery } from 'src/api/tracking/deliveries';
@@ -23,8 +23,18 @@ import { useOrganization } from 'src/providers/hooks';
 import Table from 'src/components/common/table';
 import { useUser } from 'src/providers';
 import { useNumberParser, useNumberFormatter } from 'src/utils/useNumber';
+import { makeStyles } from '@mui/styles';
+import BackToLink from 'src/components/common/BackToLink';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  backToWithdrawals: {
+    marginLeft: 0,
+    marginTop: theme.spacing(2),
+  },
+}));
 
 export default function NurseryReassignment(): JSX.Element {
+  const classes = useStyles();
   const { user } = useUser();
   const numberFormatter = useNumberFormatter();
   const numberParser = useNumberParser();
@@ -216,7 +226,17 @@ export default function NurseryReassignment(): JSX.Element {
   return (
     <TfMain>
       <PageHeaderWrapper nextElement={contentRef.current}>
-        <TitleDescription title={strings.REASSIGN_SEEDLINGS} description={strings.REASSIGN_SEEDLINGS_DESCRIPTION} />
+        <Box>
+          <BackToLink
+            id='back'
+            to={APP_PATHS.NURSERY_WITHDRAWALS}
+            className={classes.backToWithdrawals}
+            name={strings.WITHDRAWAL_LOG}
+          />
+        </Box>
+        <Box marginTop={theme.spacing(3)}>
+          <TitleDescription title={strings.REASSIGN_SEEDLINGS} description={strings.REASSIGN_SEEDLINGS_DESCRIPTION} />
+        </Box>
       </PageHeaderWrapper>
       <Grid item xs={12}>
         <PageSnackbar />

--- a/src/components/NurseryWithdrawals/WithdrawalLogRenderer.tsx
+++ b/src/components/NurseryWithdrawals/WithdrawalLogRenderer.tsx
@@ -20,93 +20,83 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const WithdrawalLogRenderer = (formatter: { format: (num: number) => string }) => {
+export default function WithdrawalLogRenderer(props: RendererProps<TableRowType>): JSX.Element {
   const classes = useStyles();
   const theme = useTheme();
 
-  return (props: RendererProps<TableRowType>): JSX.Element => {
-    const { column, row, value, index, onRowClick } = props;
-    const { OUTPLANT } = NurseryWithdrawalPurposes;
-    const COLUMN_WIDTH = 250;
+  const { column, row, value, index, onRowClick } = props;
+  const { OUTPLANT } = NurseryWithdrawalPurposes;
+  const COLUMN_WIDTH = 250;
 
-    const rowClick = (event?: React.SyntheticEvent) => {
-      if (onRowClick) {
-        onRowClick();
-      }
-    };
-
-    const createLinkToNurseryWithdrawalDetail = (iValue: React.ReactNode | unknown[]) => {
-      const nurseryWithdrawalDetailLocation = APP_PATHS.NURSERY_WITHDRAWALS_DETAILS.replace(
-        ':withdrawalId',
-        row.id.toString()
-      );
-      return (
-        <Link to={nurseryWithdrawalDetailLocation} className={classes.link}>
-          {iValue as React.ReactNode}
-        </Link>
-      );
-    };
-
-    const getTruncated = (inputValues: any) => {
-      return (
-        <TextTruncated
-          stringList={inputValues}
-          maxLengthPx={COLUMN_WIDTH}
-          textStyle={{ fontSize: 14 }}
-          showAllStyle={{ padding: theme.spacing(2), fontSize: 14 }}
-          listSeparator={strings.LIST_SEPARATOR}
-          moreSeparator={strings.TRUNCATED_TEXT_MORE_SEPARATOR}
-          moreText={strings.TRUNCATED_TEXT_MORE_LINK}
-        />
-      );
-    };
-
-    if (column.key === 'speciesScientificNames') {
-      return <CellRenderer index={index} column={column} value={getTruncated(value)} row={row} />;
+  const rowClick = (event?: React.SyntheticEvent) => {
+    if (onRowClick) {
+      onRowClick();
     }
-
-    if (column.key === 'plotNames' && value) {
-      return <CellRenderer index={index} column={column} value={getTruncated([value])} row={row} />;
-    }
-
-    if (column.key === 'withdrawnDate') {
-      return (
-        <CellRenderer index={index} column={column} value={createLinkToNurseryWithdrawalDetail(value)} row={row} />
-      );
-    }
-
-    if (column.key === 'totalWithdrawn') {
-      return <CellRenderer index={index} column={column} value={formatter.format(value as number)} row={row} />;
-    }
-
-    if (column.key === 'hasReassignments') {
-      if (row.purpose === OUTPLANT && row.plotNames) {
-        return (
-          <>
-            <CellRenderer
-              index={index}
-              column={column}
-              row={row}
-              value={
-                <Button
-                  id='reassign'
-                  label={strings.REASSIGN}
-                  onClick={rowClick}
-                  size='small'
-                  priority='secondary'
-                  className={classes.text}
-                  disabled={isTrue(row.hasReassignments)}
-                />
-              }
-            />
-          </>
-        );
-      }
-      return <CellRenderer index={index} column={column} row={row} value='' />;
-    }
-
-    return <CellRenderer {...props} />;
   };
-};
 
-export default WithdrawalLogRenderer;
+  const createLinkToNurseryWithdrawalDetail = (iValue: React.ReactNode | unknown[]) => {
+    const nurseryWithdrawalDetailLocation = APP_PATHS.NURSERY_WITHDRAWALS_DETAILS.replace(
+      ':withdrawalId',
+      row.id.toString()
+    );
+    return (
+      <Link to={nurseryWithdrawalDetailLocation} className={classes.link}>
+        {iValue as React.ReactNode}
+      </Link>
+    );
+  };
+
+  const getTruncated = (inputValues: any) => {
+    return (
+      <TextTruncated
+        stringList={inputValues}
+        maxLengthPx={COLUMN_WIDTH}
+        textStyle={{ fontSize: 14 }}
+        showAllStyle={{ padding: theme.spacing(2), fontSize: 14 }}
+        listSeparator={strings.LIST_SEPARATOR}
+        moreSeparator={strings.TRUNCATED_TEXT_MORE_SEPARATOR}
+        moreText={strings.TRUNCATED_TEXT_MORE_LINK}
+      />
+    );
+  };
+
+  if (column.key === 'speciesScientificNames') {
+    return <CellRenderer index={index} column={column} value={getTruncated(value)} row={row} />;
+  }
+
+  if (column.key === 'plotNames' && value) {
+    return <CellRenderer index={index} column={column} value={getTruncated([value])} row={row} />;
+  }
+
+  if (column.key === 'withdrawnDate') {
+    return <CellRenderer index={index} column={column} value={createLinkToNurseryWithdrawalDetail(value)} row={row} />;
+  }
+
+  if (column.key === 'hasReassignments') {
+    if (row.purpose === OUTPLANT && row.plotNames) {
+      return (
+        <>
+          <CellRenderer
+            index={index}
+            column={column}
+            row={row}
+            value={
+              <Button
+                id='reassign'
+                label={strings.REASSIGN}
+                onClick={rowClick}
+                size='small'
+                priority='secondary'
+                className={classes.text}
+                disabled={isTrue(row.hasReassignments)}
+              />
+            }
+          />
+        </>
+      );
+    }
+    return <CellRenderer index={index} column={column} row={row} value='' />;
+  }
+
+  return <CellRenderer {...props} />;
+}


### PR DESCRIPTION
- also applies to batch details table
- nurseries columns is a client defined column and uses it's own sort mechanism
- common name is not working so using client side for now
- the detail views within withdrawal log are static and will use client side sorting for now