### PR TITLE
SW-2883 Error page copy is missing

### DIFF
--- a/src/AppError.tsx
+++ b/src/AppError.tsx
@@ -3,17 +3,24 @@ import { Route, Switch } from 'react-router-dom';
 import { APP_PATHS } from 'src/constants';
 import useQuery from './utils/useQuery';
 import ErrorContent from './ErrorContent';
+import { Provider } from 'react-redux';
+import AppBootstrap from './AppBootstrap';
+import { store } from './redux/store';
 
 export default function AppError() {
   return (
-    <Switch>
-      <Route exact path={APP_PATHS.ERROR_FAILED_TO_FETCH_ORG_DATA}>
-        <ErrorContent />
-      </Route>
-      <Route path={APP_PATHS.ERROR}>
-        <QueryParamsError />
-      </Route>
-    </Switch>
+    <AppBootstrap>
+      <Provider store={store}>
+        <Switch>
+          <Route exact path={APP_PATHS.ERROR_FAILED_TO_FETCH_ORG_DATA}>
+            <ErrorContent />
+          </Route>
+          <Route path={APP_PATHS.ERROR}>
+            <QueryParamsError />
+          </Route>
+        </Switch>
+      </Provider>
+    </AppBootstrap>
   );
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,9 @@ import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import theme from './theme';
 import { APP_PATHS } from './constants';
 import { ThemeProvider } from '@mui/material';
+import { Provider } from 'react-redux';
+import { store } from './redux/store';
+import AppBootstrap from './AppBootstrap';
 
 ReactDOM.render(
   <React.StrictMode>
@@ -19,7 +22,11 @@ ReactDOM.render(
           <Switch>
             <Route path={APP_PATHS.ERROR}>
               <ThemeProvider theme={theme}>
-                <AppError />
+                <AppBootstrap>
+                  <Provider store={store}>
+                    <AppError />
+                  </Provider>
+                </AppBootstrap>
               </ThemeProvider>
             </Route>
             <Route path={'*'}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,9 +10,6 @@ import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import theme from './theme';
 import { APP_PATHS } from './constants';
 import { ThemeProvider } from '@mui/material';
-import { Provider } from 'react-redux';
-import { store } from './redux/store';
-import AppBootstrap from './AppBootstrap';
 
 ReactDOM.render(
   <React.StrictMode>
@@ -22,11 +19,7 @@ ReactDOM.render(
           <Switch>
             <Route path={APP_PATHS.ERROR}>
               <ThemeProvider theme={theme}>
-                <AppBootstrap>
-                  <Provider store={store}>
-                    <AppError />
-                  </Provider>
-                </AppBootstrap>
+                <AppError />
               </ThemeProvider>
             </Route>
             <Route path={'*'}>


### PR DESCRIPTION
The error page was not showing the labels, this was because locale was not set for the error page.
Adding AppBootstrap to error page to allow setting the locale