### PR TITLE
Rename locale properties

### DIFF
--- a/src/AppBootstrap.tsx
+++ b/src/AppBootstrap.tsx
@@ -56,17 +56,17 @@ export type AppBootstrapProps = {
 };
 
 export default function AppBootstrap({ children }: AppBootstrapProps): JSX.Element {
-  const [locale, setLocale] = useState('en');
-  const [loadedStringsForLocale, setLoadedStringsForLocale] = useState<string | null>(null);
+  const [selectedLocale, setSelectedLocale] = useState('en');
+  const [activeLocale, setActiveLocale] = useState<string | null>(null);
 
   return (
     <UserProvider>
       <OrganizationProvider>
         <LocalizationProvider
-          locale={locale}
-          setLocale={setLocale}
-          loadedStringsForLocale={loadedStringsForLocale}
-          setLoadedStringsForLocale={setLoadedStringsForLocale}
+          selectedLocale={selectedLocale}
+          setSelectedLocale={setSelectedLocale}
+          activeLocale={activeLocale}
+          setActiveLocale={setActiveLocale}
         >
           <BlockingBootstrap>{children}</BlockingBootstrap>
         </LocalizationProvider>

--- a/src/components/LocaleSelector.tsx
+++ b/src/components/LocaleSelector.tsx
@@ -12,7 +12,7 @@ import strings from 'src/strings';
 type LocaleSelectorProps = {
   transparent?: boolean;
   onChangeLocale?: (newValue: string) => void;
-  selectedLocale?: string;
+  localeSelected?: string;
 };
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -39,7 +39,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 export default function LocaleSelector({
   transparent,
   onChangeLocale,
-  selectedLocale,
+  localeSelected,
 }: LocaleSelectorProps): JSX.Element {
   const { user, reloadUser } = useUser();
   const localeItems: DropdownItem[] = supportedLocales.map((supportedLocale) => ({
@@ -58,11 +58,11 @@ export default function LocaleSelector({
 
   return (
     <LocalizationContext.Consumer>
-      {({ locale, setLocale }) => {
+      {({ selectedLocale, setSelectedLocale }) => {
         const onChange = (selectedItem: DropdownItem) => {
           const newValue = selectedItem.value;
-          if (locale !== newValue) {
-            setLocale(newValue);
+          if (selectedLocale !== newValue) {
+            setSelectedLocale(newValue);
           }
 
           if (user && user.locale !== newValue) {
@@ -82,7 +82,7 @@ export default function LocaleSelector({
               <div>
                 <IconButton onClick={handleClick} size='small' className={classes.iconContainer}>
                   <span className={classes.selected}>
-                    {localeItems.find((iLocale) => iLocale.value === locale)?.label}
+                    {localeItems.find((iLocale) => iLocale.value === selectedLocale)?.label}
                   </span>
                   <Icon name='chevronDown' size='medium' className={classes.chevronDown} />
                 </IconButton>

--- a/src/components/Monitoring/dashboard/PVBatteryChart.tsx
+++ b/src/components/Monitoring/dashboard/PVBatteryChart.tsx
@@ -90,12 +90,9 @@ export default function PVBatteryChart(props: PVBatteryChartProps): JSX.Element 
   const classes = useStyles({ isMobile, isDesktop });
   const { BMU, defaultTimePeriod, updateTimePeriodPreferences, timeZone } = props;
   const [selectedPVBatteryPeriod, setSelectedPVBatteryPeriod] = useState<string>();
-  const { loadedStringsForLocale } = useLocalization();
+  const { activeLocale } = useLocalization();
   const numberFormatter = useNumberFormatter();
-  const numericFormatter = useMemo(
-    () => numberFormatter(loadedStringsForLocale),
-    [loadedStringsForLocale, numberFormatter]
-  );
+  const numericFormatter = useMemo(() => numberFormatter(activeLocale), [activeLocale, numberFormatter]);
 
   useEffect(() => {
     if (defaultTimePeriod) {
@@ -110,9 +107,9 @@ export default function PVBatteryChart(props: PVBatteryChartProps): JSX.Element 
       chartReference: React.RefObject<HTMLCanvasElement>
     ) => {
       const ctx = chartReference?.current?.getContext('2d');
-      if (ctx && selectedPVBatteryPeriod && loadedStringsForLocale) {
+      if (ctx && selectedPVBatteryPeriod && activeLocale) {
         const timePeriodParams = getTimePeriodParams(selectedPVBatteryPeriod, timeZone);
-        window.pvBatteryChart = await newChart(loadedStringsForLocale, ctx, {
+        window.pvBatteryChart = await newChart(activeLocale, ctx, {
           type: 'scatter',
           data: {
             datasets: [
@@ -239,7 +236,7 @@ export default function PVBatteryChart(props: PVBatteryChartProps): JSX.Element 
     if (selectedPVBatteryPeriod) {
       getChartData();
     }
-  }, [BMU, loadedStringsForLocale, numericFormatter, selectedPVBatteryPeriod, timeZone]);
+  }, [BMU, activeLocale, numericFormatter, selectedPVBatteryPeriod, timeZone]);
 
   const onChangePVBatterySelectedPeriod = (newValue: string) => {
     setSelectedPVBatteryPeriod(newValue);

--- a/src/components/Monitoring/dashboard/TemperatureHumidityChart.tsx
+++ b/src/components/Monitoring/dashboard/TemperatureHumidityChart.tsx
@@ -106,12 +106,9 @@ export default function TemperatureHumidityChart(props: TemperatureHumidityChart
   } = props;
   const [selectedLocation, setSelectedLocation] = useState<Device>();
   const [selectedPeriod, setSelectedPeriod] = useState<string>();
-  const { loadedStringsForLocale } = useLocalization();
+  const { activeLocale } = useLocalization();
   const numberFormatter = useNumberFormatter();
-  const numericFormatter = useMemo(
-    () => numberFormatter(loadedStringsForLocale),
-    [loadedStringsForLocale, numberFormatter]
-  );
+  const numericFormatter = useMemo(() => numberFormatter(activeLocale), [activeLocale, numberFormatter]);
 
   useEffect(() => {
     if (defaultSensor) {
@@ -144,7 +141,7 @@ export default function TemperatureHumidityChart(props: TemperatureHumidityChart
       chartReference: React.RefObject<HTMLCanvasElement>
     ) => {
       const ctx = chartReference?.current?.getContext('2d');
-      if (ctx && selectedLocation && selectedPeriod && loadedStringsForLocale) {
+      if (ctx && selectedLocation && selectedPeriod && activeLocale) {
         const commonDatasets = [
           {
             data: temperatureValues?.map((entry) => {
@@ -295,7 +292,7 @@ export default function TemperatureHumidityChart(props: TemperatureHumidityChart
         }
 
         const timePeriodParams = getTimePeriodParams(selectedPeriod, timeZone);
-        window.temperatureHumidityChart = await newChart(loadedStringsForLocale, ctx, {
+        window.temperatureHumidityChart = await newChart(activeLocale, ctx, {
           type: 'scatter',
           data: {
             datasets: datasetsToUse,
@@ -409,7 +406,7 @@ export default function TemperatureHumidityChart(props: TemperatureHumidityChart
     ) {
       getChartData();
     }
-  }, [availableLocations, loadedStringsForLocale, numericFormatter, selectedPeriod, selectedLocation, timeZone]);
+  }, [availableLocations, activeLocale, numericFormatter, selectedPeriod, selectedLocation, timeZone]);
 
   const onChangeLocation = (newValue: string) => {
     const location = availableLocations?.find((aL) => aL.name === newValue);

--- a/src/components/MyAccount/index.tsx
+++ b/src/components/MyAccount/index.tsx
@@ -97,24 +97,24 @@ const MyAccountContent = ({
   const timeZonesEnabled = isEnabled('Timezones');
   const weightUnitsEnabled = isEnabled('Weight units');
   const localeSelectionEnabled = isEnabled('Locale selection');
-  const { locale } = useLocalization();
+  const { selectedLocale } = useLocalization();
   const timeZones = useTimeZones();
   const tz = timeZones.find((timeZone) => timeZone.id === record.timeZone) || getUTC(timeZones);
   const [preferredWeightSystemSelected, setPreferredWeightSystemSelected] = useState(
     (userPreferences?.preferredWeightSystem as string) || 'metric'
   );
-  const loadedStringsForLocale = useLocalization().loadedStringsForLocale;
+  const loadedStringsForLocale = useLocalization().activeLocale;
   const columns: TableColumnType[] = [
     { key: 'name', name: strings.ORGANIZATION_NAME, type: 'string' },
     { key: 'description', name: strings.DESCRIPTION, type: 'string' },
     { key: 'totalUsers', name: strings.PEOPLE, type: 'string' },
     { key: 'roleName', name: strings.ROLE, type: 'string' },
   ];
-  const [localeSelected, setLocaleSelected] = useState(locale);
+  const [localeSelected, setLocaleSelected] = useState(selectedLocale);
 
   useEffect(() => {
-    setLocaleSelected(locale);
-  }, [locale]);
+    setLocaleSelected(selectedLocale);
+  }, [selectedLocale]);
 
   useEffect(() => {
     if (organizations && loadedStringsForLocale) {
@@ -165,7 +165,7 @@ const MyAccountContent = ({
     }
     setRemovedOrg(undefined);
     setPreferredWeightSystemSelected((userPreferences?.preferredWeightSystem as string) || 'metric');
-    setLocaleSelected(locale);
+    setLocaleSelected(selectedLocale);
     setSelectedRows([]);
     history.push(APP_PATHS.MY_ACCOUNT);
   };
@@ -393,14 +393,14 @@ const MyAccountContent = ({
                 {edit ? (
                   <LocaleSelector
                     onChangeLocale={(newValue) => setLocaleSelected(newValue)}
-                    selectedLocale={localeSelected}
+                    localeSelected={localeSelected}
                   />
                 ) : (
                   <TextField
                     label={strings.LANGUAGE}
                     id='locale'
                     type='text'
-                    value={supportedLocales.find((sLocale) => sLocale.id === locale)?.name}
+                    value={supportedLocales.find((sLocale) => sLocale.id === selectedLocale)?.name}
                     display={true}
                   />
                 )}

--- a/src/components/Organization/index.tsx
+++ b/src/components/Organization/index.tsx
@@ -26,14 +26,14 @@ export default function OrganizationView(): JSX.Element {
   const [countries, setCountries] = useState<Country[]>();
   const [people, setPeople] = useState<OrganizationUser[]>();
   const { isMobile } = useDeviceInfo();
-  const { loadedStringsForLocale } = useLocalization();
+  const { activeLocale } = useLocalization();
   const timeZones = useTimeZones();
   const utcTimeZone = getUTC(timeZones);
   const timeZoneFeatureEnabled = isEnabled('Timezones');
   const currentTimeZone = timeZones.find((tz) => tz.id === selectedOrganization.timeZone)?.longName;
 
   useEffect(() => {
-    if (loadedStringsForLocale) {
+    if (activeLocale) {
       const populateCountries = async () => {
         const response = await searchCountries();
         if (response) {
@@ -43,7 +43,7 @@ export default function OrganizationView(): JSX.Element {
 
       populateCountries();
     }
-  }, [loadedStringsForLocale]);
+  }, [activeLocale]);
 
   useEffect(() => {
     const populatePeople = async () => {

--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -74,7 +74,7 @@ export default function PeopleList(): JSX.Element {
   const snackbar = useSnackbar();
   const { isMobile } = useDeviceInfo();
   const contentRef = useRef(null);
-  const { loadedStringsForLocale } = useLocalization();
+  const { activeLocale } = useLocalization();
   const columns: TableColumnType[] = [
     { key: 'email', name: strings.EMAIL, type: 'string' },
     { key: 'firstName', name: strings.FIRST_NAME, type: 'string' },
@@ -140,10 +140,10 @@ export default function PeopleList(): JSX.Element {
       }
     };
 
-    if (loadedStringsForLocale) {
+    if (activeLocale) {
       refreshSearch();
     }
-  }, [debouncedSearchTerm, selectedOrganization, loadedStringsForLocale]);
+  }, [debouncedSearchTerm, selectedOrganization, activeLocale]);
 
   const goToNewPerson = () => {
     const newPersonLocation = {

--- a/src/components/Plants/DashboardChart.tsx
+++ b/src/components/Plants/DashboardChart.tsx
@@ -25,12 +25,12 @@ export interface DashboardChartProps {
 
 export default function DashboardChart(props: DashboardChartProps): JSX.Element | null {
   const { chartLabels, chartValues } = props;
-  const { loadedStringsForLocale } = useLocalization();
+  const { activeLocale } = useLocalization();
   const [locale, setLocale] = useState<string | null>(null);
 
   useEffect(() => {
-    setLocale(loadedStringsForLocale);
-  }, [loadedStringsForLocale]);
+    setLocale(activeLocale);
+  }, [activeLocale]);
 
   if (!locale || !chartLabels || !chartValues) {
     return null;

--- a/src/components/RegionSelector/index.tsx
+++ b/src/components/RegionSelector/index.tsx
@@ -29,11 +29,11 @@ export default function RegionSelector({
 }: RegionSelectorProps): JSX.Element {
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
-  const { loadedStringsForLocale } = useLocalization();
+  const { activeLocale } = useLocalization();
   const [countries, setCountries] = useState<Country[]>();
 
   useEffect(() => {
-    if (loadedStringsForLocale) {
+    if (activeLocale) {
       const populateCountries = async () => {
         const response = await searchCountries();
         if (response) {
@@ -42,7 +42,7 @@ export default function RegionSelector({
       };
       populateCountries();
     }
-  }, [loadedStringsForLocale]);
+  }, [activeLocale]);
 
   const onChangeCountry = (newValue: string) => {
     const found = countries?.find((country) => country.code.toString() === newValue);

--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -144,7 +144,7 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
   const [results, setResults] = useState<SpeciesSearchResultRow[]>();
   const [record, setRecord] = useForm<SpeciesFiltersType>({});
   const contentRef = useRef(null);
-  const { loadedStringsForLocale } = useLocalization();
+  const { activeLocale } = useLocalization();
   const [searchSortOrder, setSearchSortOrder] = useState<SearchSortOrder | undefined>({
     field: 'scientificName',
     direction: 'Descending',
@@ -179,7 +179,7 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
 
   const columns: TableColumnType[] = React.useMemo(() => {
     // No-op to make lint happy so it doesn't think the dependency is unused.
-    if (!loadedStringsForLocale) {
+    if (!activeLocale) {
       return [];
     }
 
@@ -274,7 +274,7 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
         ),
       },
     ];
-  }, [loadedStringsForLocale]);
+  }, [activeLocale]);
 
   const [selectedColumns, setSelectedColumns] = useForm(columns);
   const [handleProblemsColumn, setHandleProblemsColumn] = useState<boolean>(false);
@@ -429,11 +429,11 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
   // When the user switches locales, we need to update the state value that contains the list of
   // column definitions as well as reset the search filters.
   useEffect(() => {
-    if (loadedStringsForLocale) {
+    if (activeLocale) {
       setRecord({});
       setSelectedColumns(columns);
     }
-  }, [columns, setRecord, setSelectedColumns, loadedStringsForLocale]);
+  }, [columns, setRecord, setSelectedColumns, activeLocale]);
 
   useEffect(() => {
     if (speciesState?.checkData) {

--- a/src/components/accession2/edit/EditLocationModal.tsx
+++ b/src/components/accession2/edit/EditLocationModal.tsx
@@ -23,7 +23,7 @@ export interface EditLocationModalProps {
 
 export default function EditLocationModal(props: EditLocationModalProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
-  const { loadedStringsForLocale } = useLocalization();
+  const { activeLocale } = useLocalization();
   const { onClose, open, accession, reload } = props;
   const seedBanks: Facility[] = (getAllSeedBanks(selectedOrganization).filter((sb) => !!sb) as Facility[]) || [];
   const [storageLocations, setStorageLocations] = useState<StorageLocationPayload[]>([]);
@@ -42,10 +42,10 @@ export default function EditLocationModal(props: EditLocationModalProps): JSX.El
 
   useEffect(() => {
     const setLocations = async () => {
-      if (record.facilityId && loadedStringsForLocale) {
+      if (record.facilityId && activeLocale) {
         const response = await SeedBankService.getStorageLocations(record.facilityId);
         if (response.requestSucceeded) {
-          const collator = new Intl.Collator(loadedStringsForLocale);
+          const collator = new Intl.Collator(activeLocale);
           setStorageLocations(response.locations.sort((a, b) => collator.compare(a.name, b.name)));
         } else {
           setStorageLocations([]);
@@ -53,7 +53,7 @@ export default function EditLocationModal(props: EditLocationModalProps): JSX.El
       }
     };
     setLocations();
-  }, [loadedStringsForLocale, record.facilityId]);
+  }, [activeLocale, record.facilityId]);
 
   const saveLocation = async () => {
     const response = await AccessionService.updateAccession({

--- a/src/components/accession2/properties/Accession2Address.tsx
+++ b/src/components/accession2/properties/Accession2Address.tsx
@@ -23,12 +23,12 @@ export default function Accession2Address(props: Accession2AddressProps): JSX.El
   const [countries, setCountries] = useState<Country[]>();
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
-  const { loadedStringsForLocale } = useLocalization();
+  const { activeLocale } = useLocalization();
   const [temporalCountryValue, setTemporalCountryValue] = useState('');
   const [temporalSubValue, setTemporalSubValue] = useState('');
 
   useEffect(() => {
-    if (loadedStringsForLocale) {
+    if (activeLocale) {
       const populateCountries = async () => {
         const response = await searchCountries();
         if (response) {
@@ -37,7 +37,7 @@ export default function Accession2Address(props: Accession2AddressProps): JSX.El
       };
       populateCountries();
     }
-  }, [loadedStringsForLocale]);
+  }, [activeLocale]);
 
   const gridSize = () => (isMobile ? 12 : 6);
 

--- a/src/components/accession2/properties/SeedBank2Selector.tsx
+++ b/src/components/accession2/properties/SeedBank2Selector.tsx
@@ -17,7 +17,7 @@ type SeedBank2SelectorProps = {
 
 export default function SeedBank2Selector(props: SeedBank2SelectorProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
-  const { loadedStringsForLocale } = useLocalization();
+  const { activeLocale } = useLocalization();
   const { record, onChange, validate } = props;
   const [storageLocations, setStorageLocations] = useState<StorageLocationPayload[]>([]);
   const { isMobile } = useDeviceInfo();
@@ -34,10 +34,10 @@ export default function SeedBank2Selector(props: SeedBank2SelectorProps): JSX.El
 
   useEffect(() => {
     const setLocation = async () => {
-      if (record.facilityId && loadedStringsForLocale) {
+      if (record.facilityId && activeLocale) {
         const response = await SeedBankService.getStorageLocations(record.facilityId);
         if (response.requestSucceeded) {
-          const collator = new Intl.Collator(loadedStringsForLocale);
+          const collator = new Intl.Collator(activeLocale);
           setStorageLocations(response.locations.sort((a, b) => collator.compare(a.name, b.name)));
           return;
         }
@@ -45,7 +45,7 @@ export default function SeedBank2Selector(props: SeedBank2SelectorProps): JSX.El
       setStorageLocations([]);
     };
     setLocation();
-  }, [loadedStringsForLocale, record.facilityId]);
+  }, [activeLocale, record.facilityId]);
 
   return (
     <Grid item xs={12} display='flex' flexDirection={isMobile ? 'column' : 'row'} justifyContent='space-between'>

--- a/src/components/accession2/viabilityTesting/ObservationsChart.tsx
+++ b/src/components/accession2/viabilityTesting/ObservationsChart.tsx
@@ -21,13 +21,13 @@ export default function ObservationsChart({ observations }: Props): JSX.Element 
   const classes = useStyles();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const chartRef = useRef<Chart | null>(null);
-  const { loadedStringsForLocale } = useLocalization();
+  const { activeLocale } = useLocalization();
   const theme = useTheme();
 
   useEffect(() => {
     const createChart = async () => {
       const ctx = canvasRef?.current?.getContext('2d');
-      if (ctx && loadedStringsForLocale) {
+      if (ctx && activeLocale) {
         if (chartRef.current) {
           chartRef.current?.destroy();
           chartRef.current = null;
@@ -45,7 +45,7 @@ export default function ObservationsChart({ observations }: Props): JSX.Element 
           y: entry.seedsGerminated,
         }));
 
-        chartRef.current = await newChart(loadedStringsForLocale, ctx, {
+        chartRef.current = await newChart(activeLocale, ctx, {
           type: 'line',
           data: {
             datasets: [
@@ -121,7 +121,7 @@ export default function ObservationsChart({ observations }: Props): JSX.Element 
 
     return () => chartRef.current?.destroy();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loadedStringsForLocale, observations]);
+  }, [activeLocale, observations]);
 
   return <canvas id='myChart' ref={canvasRef} className={classes.chart} />;
 }

--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -108,7 +108,7 @@ export default function Accession2View(): JSX.Element {
   const themeObj = useTheme();
   const contentRef = useRef(null);
   const weightUnitsEnabled = isEnabled('Weight units');
-  const { loadedStringsForLocale } = useLocalization();
+  const { activeLocale } = useLocalization();
 
   const reloadData = useCallback(() => {
     const populateAccession = async () => {
@@ -137,7 +137,7 @@ export default function Accession2View(): JSX.Element {
   }, [accessionId, reloadData]);
 
   useEffect(() => {
-    if (loadedStringsForLocale) {
+    if (activeLocale) {
       const today = moment();
       const seedCollectionDate = accession?.collectedDate ? moment(accession?.collectedDate, 'YYYY-MM-DD') : undefined;
       const accessionAge = seedCollectionDate ? today.diff(seedCollectionDate, 'months') : undefined;
@@ -151,20 +151,20 @@ export default function Accession2View(): JSX.Element {
         setAge(strings.formatString(strings.AGE_VALUE_MONTHS, accessionAge) as string);
       }
     }
-  }, [accession, loadedStringsForLocale]);
+  }, [accession, activeLocale]);
 
   useEffect(() => {
-    if (loadedStringsForLocale) {
+    if (activeLocale) {
       if (accession?.dryingEndDate) {
         // MomentJS has its own version of a "gibberish" locale, but with a different name.
-        const momentLocale = loadedStringsForLocale === 'gx' ? 'x-pseudo' : loadedStringsForLocale;
+        const momentLocale = activeLocale === 'gx' ? 'x-pseudo' : activeLocale;
         const dryingMoment = moment(accession.dryingEndDate).locale(momentLocale);
         setDryingRelativeDate(dryingMoment.fromNow());
       } else {
         setDryingRelativeDate(null);
       }
     }
-  }, [accession, loadedStringsForLocale]);
+  }, [accession, activeLocale]);
 
   useEffect(() => {
     setSelectedTab((query.get('tab') || 'detail') as string);

--- a/src/components/accession2/view/DetailPanel.tsx
+++ b/src/components/accession2/view/DetailPanel.tsx
@@ -19,7 +19,7 @@ type DetailPanelProps = {
 };
 export default function DetailPanel(props: DetailPanelProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
-  const { loadedStringsForLocale } = useLocalization();
+  const { activeLocale } = useLocalization();
   const { accession, reload } = props;
   const userCanEdit = !isContributor(selectedOrganization);
   const theme = useTheme();
@@ -64,7 +64,7 @@ export default function DetailPanel(props: DetailPanelProps): JSX.Element {
   const classes = useStyles();
 
   useEffect(() => {
-    if (loadedStringsForLocale) {
+    if (activeLocale) {
       const populateCountries = async () => {
         const response = await searchCountries();
         if (response) {
@@ -73,7 +73,7 @@ export default function DetailPanel(props: DetailPanelProps): JSX.Element {
       };
       populateCountries();
     }
-  }, [loadedStringsForLocale]);
+  }, [activeLocale]);
 
   const getCollectionSource = () => {
     const source = accession?.collectionSource;

--- a/src/components/common/DatePicker.tsx
+++ b/src/components/common/DatePicker.tsx
@@ -4,17 +4,17 @@ import { useLocalization } from 'src/providers';
 import { useEffect, useState } from 'react';
 
 export default function DatePicker(props: Props): JSX.Element {
-  const { loadedStringsForLocale } = useLocalization();
+  const { activeLocale } = useLocalization();
   const [propsWithLocale, setPropsWithLocale] = useState(props);
 
   useEffect(() => {
-    if (loadedStringsForLocale) {
+    if (activeLocale) {
       // Adding a custom gibberish locale to MUI's date picker is nontrivial; show French dates
       // in the gibberish locale to support testing that the date picker is localized.
-      const effectiveLocale = loadedStringsForLocale === 'gx' ? 'fr' : loadedStringsForLocale;
+      const effectiveLocale = activeLocale === 'gx' ? 'fr' : activeLocale;
       setPropsWithLocale({ ...props, locale: effectiveLocale });
     }
-  }, [loadedStringsForLocale, props, setPropsWithLocale]);
+  }, [activeLocale, props, setPropsWithLocale]);
 
   return WebComponentsDatePicker(propsWithLocale);
 }

--- a/src/components/common/Timestamp.tsx
+++ b/src/components/common/Timestamp.tsx
@@ -21,12 +21,12 @@ function newDateTimeFormat(locale?: string, timeZone?: string) {
 /** Renders a timestamp using the current locale and the user's time zone. */
 export default function Timestamp({ className, isoString }: TimestampProps): JSX.Element | null {
   const timeZone = useUserTimeZone()?.id;
-  const { locale } = useLocalization();
+  const { selectedLocale } = useLocalization();
   const [formattedDate, setFormattedDate] = useState<string | null>(null);
 
   useEffect(() => {
-    setFormattedDate(newDateTimeFormat(locale, timeZone).format(new Date(isoString)));
-  }, [isoString, locale, timeZone, setFormattedDate]);
+    setFormattedDate(newDateTimeFormat(selectedLocale, timeZone).format(new Date(isoString)));
+  }, [isoString, selectedLocale, timeZone, setFormattedDate]);
 
   return <span className={className}>{formattedDate}</span>;
 }

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -149,7 +149,7 @@ type DatabaseProps = {
 
 export default function Database(props: DatabaseProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
-  const { loadedStringsForLocale } = useLocalization();
+  const { activeLocale } = useLocalization();
   const { reloadUserPreferences } = useUser();
   const { isMobile } = useDeviceInfo();
   const classes = useStyles({ isMobile });
@@ -190,7 +190,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
   const [pendingAccessions, setPendingAccessions] = useState<SearchResponseElement[] | null>();
   const [selectedOrgInfo, setSelectedOrgInfo] = useRecoilState(seedsDatabaseSelectedOrgInfo);
   const contentRef = useRef(null);
-  const searchedLocaleRef = useRef<string | null>(loadedStringsForLocale);
+  const searchedLocaleRef = useRef<string | null>(activeLocale);
 
   /*
    * fieldOptions is a list of records
@@ -403,15 +403,15 @@ export default function Database(props: DatabaseProps): JSX.Element {
   }, [orgScopedPreferences, updateSearchColumns]);
 
   useEffect(() => {
-    if (searchedLocaleRef.current && loadedStringsForLocale && searchedLocaleRef.current !== loadedStringsForLocale) {
+    if (searchedLocaleRef.current && activeLocale && searchedLocaleRef.current !== activeLocale) {
       // If we've already done a search with a different locale, throw away search criteria since
       // they might contain localized values. Copy the default filters so React sees this as a
       // modification even if the existing search was also using the default.
       setSearchCriteria({ ...DEFAULT_SEED_SEARCH_FILTERS });
     }
 
-    searchedLocaleRef.current = loadedStringsForLocale;
-  }, [loadedStringsForLocale, setSearchCriteria]);
+    searchedLocaleRef.current = activeLocale;
+  }, [activeLocale, setSearchCriteria]);
 
   const onSelect = (row: SearchResponseElement) => {
     if (row.id) {

--- a/src/providers/DataTypes.ts
+++ b/src/providers/DataTypes.ts
@@ -25,9 +25,18 @@ export type ProvidedOrganizationData = {
 };
 
 export type ProvidedLocalizationData = {
-  locale: string;
+  /**
+   * Which locale's strings are currently available from the "strings" module. This is usually what
+   * you'll want to use if you need to reference the user's current locale.
+   */
+  activeLocale: string | null;
+  /**
+   * Which locale has been selected in the locale selector. Strings for this locale may not be
+   * available yet if the user has just changed locales or if the page is still loading; only use
+   * this if you don't need to look up anything from the "strings" module.
+   */
+  selectedLocale: string;
+  setSelectedLocale: (locale: string) => void;
   supportedTimeZones: TimeZoneDescription[];
-  setLocale: (locale: string) => void;
-  loadedStringsForLocale: string | null;
   bootstrapped: boolean;
 };

--- a/src/providers/LocalizationProvider.tsx
+++ b/src/providers/LocalizationProvider.tsx
@@ -8,43 +8,43 @@ import { HttpService, I18nService } from 'src/services';
 
 export type LocalizationProviderProps = {
   children?: React.ReactNode;
-  locale: string;
-  setLocale: (locale: string) => void;
-  loadedStringsForLocale: string | null;
-  setLoadedStringsForLocale: (locale: string) => void;
+  selectedLocale: string;
+  setSelectedLocale: (locale: string) => void;
+  activeLocale: string | null;
+  setActiveLocale: (locale: string) => void;
 };
 
 export default function LocalizationProvider({
   children,
-  locale,
-  setLocale,
-  loadedStringsForLocale,
-  setLoadedStringsForLocale,
+  selectedLocale,
+  setSelectedLocale,
+  activeLocale,
+  setActiveLocale,
 }: LocalizationProviderProps): JSX.Element | null {
   const [timeZones, setTimeZones] = useState<TimeZoneDescription[]>([]);
   const { user } = useUser();
 
   useEffect(() => {
     if (user?.locale) {
-      setLocale(user.locale);
+      setSelectedLocale(user.locale);
     }
-  }, [user?.locale, setLocale]);
+  }, [user?.locale, setSelectedLocale]);
 
   useEffect(() => {
-    HttpService.setDefaultHeaders({ 'Accept-Language': locale });
-  }, [locale]);
+    HttpService.setDefaultHeaders({ 'Accept-Language': selectedLocale });
+  }, [selectedLocale]);
 
   // This must come after the effect that configures the Accept-Language header.
   useEffect(() => {
     const fetchTimeZones = async () => {
       const timeZoneResponse = await I18nService.getTimeZones();
       if (!timeZoneResponse.error && timeZoneResponse.timeZones) {
-        setTimeZones(timeZoneResponse.timeZones.sort((a, b) => a.longName.localeCompare(b.longName, locale)));
+        setTimeZones(timeZoneResponse.timeZones.sort((a, b) => a.longName.localeCompare(b.longName, selectedLocale)));
       }
     };
 
     fetchTimeZones();
-  }, [locale]);
+  }, [selectedLocale]);
 
   useEffect(() => {
     // Switch locales on the cookie consent UI, if enabled. This is an undocumented internal API of
@@ -52,37 +52,37 @@ export default function LocalizationProvider({
     const func = (window as any).CookieScript?.instance?.applyTranslationByCode;
     if (typeof func === 'function') {
       try {
-        func(locale);
+        func(selectedLocale);
       } catch (e) {
         // Swallow it rather than surfacing an error to the user.
       }
     }
-  }, [locale]);
+  }, [selectedLocale]);
 
   useEffect(() => {
     const fetchStrings = async () => {
-      const language = locale.replace(/[-_].*/, ''); // 'en-US' => 'en'
+      const language = selectedLocale.replace(/[-_].*/, ''); // 'en-US' => 'en'
       const localeDetails =
-        supportedLocales.find((details) => details.id === locale) ||
+        supportedLocales.find((details) => details.id === selectedLocale) ||
         supportedLocales.find((details) => details.id === language) ||
         supportedLocales[0];
 
       const localeMap: ILocalizedStringsMap = {};
-      localeMap[locale] = (await localeDetails.loadModule()).strings;
+      localeMap[selectedLocale] = (await localeDetails.loadModule()).strings;
       strings.setContent(localeMap);
-      strings.setLanguage(locale);
+      strings.setLanguage(selectedLocale);
 
-      setLoadedStringsForLocale(locale);
+      setActiveLocale(selectedLocale);
     };
 
     fetchStrings();
-  }, [locale, setLoadedStringsForLocale]);
+  }, [selectedLocale, setActiveLocale]);
 
   const context: ProvidedLocalizationData = {
-    bootstrapped: !!loadedStringsForLocale,
-    locale,
-    setLocale,
-    loadedStringsForLocale,
+    activeLocale,
+    bootstrapped: !!activeLocale,
+    selectedLocale,
+    setSelectedLocale,
     supportedTimeZones: timeZones,
   };
 

--- a/src/providers/contexts.ts
+++ b/src/providers/contexts.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import { ProvidedUserData, ProvidedOrganizationData, ProvidedLocalizationData } from './DataTypes';
+import { ProvidedLocalizationData, ProvidedOrganizationData, ProvidedUserData } from './DataTypes';
 import { Organization } from '../types/Organization';
 
 export const UserContext = createContext<ProvidedUserData>({
@@ -40,9 +40,9 @@ export const OrganizationContext = createContext<ProvidedOrganizationData>({
 });
 
 export const LocalizationContext = createContext<ProvidedLocalizationData>({
-  loadedStringsForLocale: null,
-  locale: 'en',
-  setLocale: () => undefined,
+  activeLocale: null,
+  selectedLocale: 'en',
+  setSelectedLocale: () => undefined,
   supportedTimeZones: [],
   bootstrapped: false,
 });


### PR DESCRIPTION
The names of the locale context properties were not very clear. Rename them to
make their meanings more obvious.
