### PR TITLE
SW-2965 Add bottom padding to feature notifications

### DIFF
--- a/src/components/NotificationsDropdown.tsx
+++ b/src/components/NotificationsDropdown.tsx
@@ -365,6 +365,7 @@ function NotificationItem(props: NotificationItemProps): JSX.Element {
       <ListItemText
         className={classes.notificationContent}
         primary={<span className={classes.notificationTitle}>{title}</span>}
+        sx={{ paddingBottom: hideDate ? 1 : 0 }}
         secondary={
           <>
             <span className={classes.notificationBody}>{body}</span>


### PR DESCRIPTION
The bottom padding is given by the notification date, so add padding when no date 

<img width="520" alt="Screenshot 2023-02-14 at 15 58 19" src="https://user-images.githubusercontent.com/5919083/218831726-b12f7045-d55a-43fe-a1a0-eece5ccb59f1.png">
