### PR TITLE
SW-2936 Disable Removing Status Column from Accessions

### DIFF
--- a/src/components/seeds/database/EditColumns.tsx
+++ b/src/components/seeds/database/EditColumns.tsx
@@ -178,8 +178,8 @@ function sections(system?: string): Section[] {
       name: strings.GENERAL,
       options: [
         [{ ...columns.accessionNumber, disabled: true }],
+        [{ ...columns.state, disabled: true }],
         [columns.active],
-        [columns.state],
         [columns.facility_name],
       ],
     },


### PR DESCRIPTION
- The status column is used for the pre-exposed filter
- Removing it causes the filter values to not be loaded and also errors
- Don't allow it to be removed, as it is a "privileged" column because of the above properties

<img width="804" alt="image" src="https://user-images.githubusercontent.com/114949086/218862053-8748936f-af28-4de7-8b8a-167b745631c4.png">
