### PR TITLE
Fix button height on accession detail

### DIFF
--- a/src/components/accession2/view/DetailPanel.tsx
+++ b/src/components/accession2/view/DetailPanel.tsx
@@ -230,14 +230,16 @@ export default function DetailPanel(props: DetailPanelProps): JSX.Element {
         </Grid>
 
         <Grid />
-        <Grid item xs={3} sx={{ display: 'flex', justifyContent: 'end' }}>
+        <Grid item xs={3} sx={{ display: 'flex', justifyContent: 'end', alignItems: 'center' }}>
           {userCanEdit ? (
-            <Button
-              onClick={() => setOpenEditAccessionModal(true)}
-              icon='iconEdit'
-              label={isMobile ? '' : strings.EDIT}
-              priority='secondary'
-            />
+            <Box height='32px'>
+              <Button
+                onClick={() => setOpenEditAccessionModal(true)}
+                icon='iconEdit'
+                label={isMobile ? '' : strings.EDIT}
+                priority='secondary'
+              />
+            </Box>
           ) : (
             spaceFiller()
           )}


### PR DESCRIPTION
- Buttons will take all the space of their container now (because of web-components change). 
- Add a container with height to edit button in accession detail to limit its height