### PR TITLE
SW-2961 / SW-2979 Show seed-bank/sub-location columns when going from seed bank details to accessions table

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -172,6 +172,15 @@ function AppContent() {
   const [plotNames, setPlotNames] = useState<Record<number, string>>({});
   const [showNavBar, setShowNavBar] = useState(true);
 
+  const setDefaults = useCallback(() => {
+    if (!isPlaceholderOrg(selectedOrganization.id)) {
+      const savedColumns = orgPreferences.accessionsColumns ? (orgPreferences.accessionsColumns as string[]) : [];
+      const defaultColumns = savedColumns.length ? savedColumns : DefaultColumns(preferredWeightSystem).fields;
+      setAccessionsDisplayColumns(defaultColumns);
+      setWithdrawalCreated(false);
+    }
+  }, [selectedOrganization.id, preferredWeightSystem, orgPreferences.accessionsColumns]);
+
   const reloadSpecies = useCallback(() => {
     const populateSpecies = async () => {
       if (!isPlaceholderOrg(selectedOrganization.id)) {
@@ -184,10 +193,6 @@ function AppContent() {
     populateSpecies();
   }, [selectedOrganization]);
 
-  useEffect(() => {
-    reloadSpecies();
-  }, [reloadSpecies]);
-
   const reloadTracking = useCallback(() => {
     const populatePlantingSites = async () => {
       if (!isPlaceholderOrg(selectedOrganization.id)) {
@@ -199,6 +204,14 @@ function AppContent() {
     };
     populatePlantingSites();
   }, [selectedOrganization]);
+
+  useEffect(() => {
+    setDefaults();
+  }, [setDefaults]);
+
+  useEffect(() => {
+    reloadSpecies();
+  }, [reloadSpecies]);
 
   useEffect(() => {
     reloadTracking();
@@ -216,17 +229,6 @@ function AppContent() {
 
     setPlotNames(plots);
   }, [plantingSites]);
-
-  const setDefaults = useCallback(() => {
-    if (!isPlaceholderOrg(selectedOrganization.id)) {
-      setAccessionsDisplayColumns(DefaultColumns(preferredWeightSystem).fields);
-      setWithdrawalCreated(false);
-    }
-  }, [selectedOrganization.id, preferredWeightSystem]);
-
-  useEffect(() => {
-    setDefaults();
-  }, [setDefaults]);
 
   useEffect(() => {
     if (organizations?.length === 0 && MINIMAL_USER_ROUTES.indexOf(location.pathname) === -1) {
@@ -369,7 +371,6 @@ function AppContent() {
                 hasSeedBanks={selectedOrgHasSeedBanks()}
                 hasSpecies={selectedOrgHasSpecies()}
                 reloadData={reloadOrganizations}
-                orgScopedPreferences={orgPreferences}
               />
             </Route>
             <Route exact path={APP_PATHS.ACCESSIONS2_NEW}>

--- a/src/providers/DataTypes.ts
+++ b/src/providers/DataTypes.ts
@@ -20,6 +20,7 @@ export type ProvidedOrganizationData = {
   organizations: Organization[];
   orgPreferences: PreferencesType;
   reloadOrganizations: (selectedOrgId?: number) => void;
+  reloadOrgPreferences: () => void;
   bootstrapped: boolean;
   orgPreferenceForId: number;
 };

--- a/src/providers/OrganizationProvider.tsx
+++ b/src/providers/OrganizationProvider.tsx
@@ -61,31 +61,6 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
     await populateOrganizations();
   }, []);
 
-  const [organizationData, setOrganizationData] = useState<ProvidedOrganizationData>({
-    selectedOrganization: selectedOrganization || defaultSelectedOrg,
-    setSelectedOrganization,
-    organizations,
-    orgPreferences,
-    reloadOrganizations,
-    bootstrapped,
-    orgPreferenceForId,
-  });
-
-  useEffect(() => {
-    reloadOrganizations();
-  }, [reloadOrganizations]);
-
-  useEffect(() => {
-    setOrganizationData((prev) => ({
-      ...prev,
-      selectedOrganization: selectedOrganization || defaultSelectedOrg,
-      organizations,
-      orgPreferences,
-      bootstrapped,
-      orgPreferenceForId,
-    }));
-  }, [selectedOrganization, organizations, orgPreferences, bootstrapped, orgPreferenceForId]);
-
   const reloadOrgPreferences = useCallback(() => {
     const getOrgPreferences = async () => {
       if (selectedOrganization) {
@@ -103,8 +78,24 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
   }, [selectedOrganization]);
 
   useEffect(() => {
+    reloadOrganizations();
+  }, [reloadOrganizations]);
+
+  useEffect(() => {
+    setOrganizationData((prev) => ({
+      ...prev,
+      selectedOrganization: selectedOrganization || defaultSelectedOrg,
+      organizations,
+      orgPreferences,
+      bootstrapped,
+      orgPreferenceForId,
+      reloadOrgPreferences,
+    }));
+  }, [selectedOrganization, organizations, orgPreferences, bootstrapped, orgPreferenceForId, reloadOrgPreferences]);
+
+  useEffect(() => {
     reloadOrgPreferences();
-  }, [reloadOrgPreferences, selectedOrganization]);
+  }, [reloadOrgPreferences]);
 
   useEffect(() => {
     if (userBootstrapped && organizations.length && userPreferences) {
@@ -137,6 +128,17 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
   if (orgAPIRequestStatus === APIRequestStatus.FAILED) {
     history.push(APP_PATHS.ERROR_FAILED_TO_FETCH_ORG_DATA);
   }
+
+  const [organizationData, setOrganizationData] = useState<ProvidedOrganizationData>({
+    selectedOrganization: selectedOrganization || defaultSelectedOrg,
+    setSelectedOrganization,
+    organizations,
+    orgPreferences,
+    reloadOrganizations,
+    reloadOrgPreferences,
+    bootstrapped,
+    orgPreferenceForId,
+  });
 
   return <OrganizationContext.Provider value={organizationData}>{children}</OrganizationContext.Provider>;
 }

--- a/src/providers/contexts.ts
+++ b/src/providers/contexts.ts
@@ -30,6 +30,10 @@ export const OrganizationContext = createContext<ProvidedOrganizationData>({
     // default no-op implementation
     return;
   },
+  reloadOrgPreferences: () => {
+    // default no-op implementation
+    return;
+  },
   setSelectedOrganization: (org) => {
     // no-op
     return;


### PR DESCRIPTION
- also fix case where we restoring defaults for an org
- refactored code a bit to set the useEffect order correctly
- we will be saving the columns to preferences for now, for any changes to this we can talk with product

<img width="754" alt="Terraware App 2023-02-16 10-18-00" src="https://user-images.githubusercontent.com/1865174/219462254-c0dd62e9-16d5-40ee-976b-460299618129.png">
