### PR TITLE
SW-2816 encode user provided data before sticking in accessions table url query param

### DIFF
--- a/src/components/SeedBank/StorageLocationsCellRenderer.tsx
+++ b/src/components/SeedBank/StorageLocationsCellRenderer.tsx
@@ -29,7 +29,7 @@ export default function StorageLocationsCellRenderer({
     const createLinkToAccessions = (locationName: string, data: string) => {
       const to = [
         `${APP_PATHS.ACCESSIONS}/?`,
-        `storageLocationName=${locationName}`,
+        `storageLocationName=${encodeURIComponent(locationName)}`,
         `facilityId=${seedBankId}`,
         ...ActiveStatuses().map((status) => `stage=${status}`),
       ].join('&');


### PR DESCRIPTION
the content was not being encoded correctly, fixed that

<img width="744" alt="Screen Shot 2023-02-17 at 7 53 28 AM" src="https://user-images.githubusercontent.com/1865174/219702589-cb5ae43f-fb33-4aa4-8d54-629d9a068584.png">
