### PR TITLE
SW-2989 restore accessions search bar value when user navigates back

### DIFF
--- a/src/components/seeds/database/Filters.tsx
+++ b/src/components/seeds/database/Filters.tsx
@@ -80,6 +80,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
+const getSearchTermFromFilters = (filters: Record<string, SearchNodePayload>): string => {
+  const filterValues = filters.searchTermFilter;
+  return filterValues?.children[0]?.values[0] ?? '';
+};
+
 interface Props {
   columns: DatabaseColumn[];
   searchColumns: DatabaseColumn[];
@@ -94,7 +99,7 @@ export default function Filters(props: Props): JSX.Element {
   const { columns, searchColumns, preExpFilterColumn, filters, availableValues, allValues, onChange } = props;
   const { isMobile, isDesktop } = useDeviceInfo();
   const classes = useStyles({ isMobile, isDesktop });
-  const [searchTerm, setSearchTerm] = React.useState('');
+  const [searchTerm, setSearchTerm] = React.useState(getSearchTermFromFilters(filters));
   const searchTermCallback = useCallback(
     (value: string) => {
       let newFilters;


### PR DESCRIPTION
- currently clears the input search bar but the results show last search term applied
- fixed the default state of search term to be initialized from the filters

<img width="1263" alt="Screen Shot 2023-02-17 at 3 24 03 PM" src="https://user-images.githubusercontent.com/1865174/219815911-b69045ce-a7c6-469b-bfbe-6f29e8662e0d.png">
