### PR TITLE
SW-2929 / SW-2999 Fix locations icon, fix total-active-accessions tootip

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -198,7 +198,7 @@ export default function NavBar({
             }}
             id='people'
           />
-          <NavItem label={strings.LOCATIONS} icon='seedbankNav' id='locations'>
+          <NavItem label={strings.LOCATIONS} icon='iconMyLocation' id='locations'>
             <SubNavbar>
               <NavItem
                 label={strings.SEED_BANKS}

--- a/src/strings/strings-en.ts
+++ b/src/strings/strings-en.ts
@@ -934,7 +934,7 @@ export const strings = {
   TOOLTIP_ACCESSIONS_SUBLOCATION: 'Specific area within the place where seeds are being processed.',
   TOOLTIP_COMMON_NAME: 'The name an organism is known by to the general public, rather than its scientific name.',
   TOOLTIP_DASHBOARD_TOTAL_ACTIVE_ACCESSIONS:
-    'This number represents all accessions with the statuses awaiting processing, cleaning, drying, and in storage.',
+    'This number represents all accessions with the statuses awaiting processing, processing, drying, and in storage.',
   TOOLTIP_ECOSYSTEM_TYPE:
     'Relatively large units of land or water containing a distinct assemblage of natural communities sharing a large majority of species, dynamics, and environmental conditions.',
   TOOLTIP_GERMINATING_QUANTITY:


### PR DESCRIPTION
- as per jira suggestions (renamed cleaning as processing)

<img width="314" alt="Screen Shot 2023-02-20 at 4 36 41 PM" src="https://user-images.githubusercontent.com/1865174/220219011-032c497e-cd1e-4af1-b3d6-24d4ea57574c.png">

<img width="1099" alt="Screen Shot 2023-02-20 at 4 36 32 PM" src="https://user-images.githubusercontent.com/1865174/220219018-65c32059-595a-4e9e-bcf8-f8c17f026a81.png">
