### PR TITLE
SW-2994 Limit Jira transitions on production releases

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -144,4 +144,4 @@ jobs:
         uses: terraware/gajira-transition-multiple@master
         with:
           issueList: ./docs/jiralist.txt
-          transition: 'Released to Production'
+          transition: 'Released to Production from Done'


### PR DESCRIPTION
Only transition to "Released to Production" if the Jira is already marked as "Done"