### PR TITLE
SW-3002 Fix back to link effective area

### DIFF
--- a/src/components/common/BackToLink.tsx
+++ b/src/components/common/BackToLink.tsx
@@ -9,8 +9,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginRight: theme.spacing(1),
   },
   back: {
-    display: 'flex',
     alignItems: 'center',
+    display: 'flex',
+    width: 'fit-content',
   },
 }));
 


### PR DESCRIPTION
- content alone should be link-able
- was using a flex property that gave it full width, mostly for the align items property
- inline-flex was giving it a bit more height, not suitable
- fix width to fit content