### PR TITLE
Don't update collected/received value when changing other field

### DIFF
--- a/src/components/accession2/properties/CollectedReceivedDate2.tsx
+++ b/src/components/accession2/properties/CollectedReceivedDate2.tsx
@@ -28,13 +28,6 @@ export default function CollectedReceivedDate2({ onChange, record, type, validat
     receivedDate: record.receivedDate,
   });
 
-  useEffect(() => {
-    setDates({
-      collectedDate: record.collectedDate,
-      receivedDate: record.receivedDate,
-    });
-  }, [record]);
-
   const datePickerStyle = {
     '.MuiFormControl-root': {
       width: '100%',


### PR DESCRIPTION
Now when setting an invalid value on the datepicker of accession / collected date or received date, and then changing focus to other field, the value of the datepicker is reset. 
This was happening because when the record changed one of its fields, the collected date and received date where set to the record value that is null (because the invalid value doesn't change the record value) 
So the fix to avoid "reseting" the value, is not refreshing the temporal values when the record changes.