### PR TITLE
SW-3025 fix edit accession view stickiness upon cancel

### DIFF
--- a/src/components/accession2/view/DetailPanel.tsx
+++ b/src/components/accession2/view/DetailPanel.tsx
@@ -115,12 +115,14 @@ export default function DetailPanel(props: DetailPanelProps): JSX.Element {
 
   return accession ? (
     <>
-      <Accession2EditModal
-        accession={accession}
-        open={openEditAccessionModal}
-        onClose={() => setOpenEditAccessionModal(false)}
-        reload={reload}
-      />
+      {openEditAccessionModal && (
+        <Accession2EditModal
+          accession={accession}
+          open={openEditAccessionModal}
+          onClose={() => setOpenEditAccessionModal(false)}
+          reload={reload}
+        />
+      )}
       <ViewPhotosModal
         photosUrls={
           accession.photoFilenames?.map((file) => `/api/v1/seedbank/accessions/${accession.id}/photos/${file}`) || []


### PR DESCRIPTION
- pretty much all editable fields were sticking
- the open property on the modal is not working to our advantage here
- also using open for conditional rendering which is really the best solution here
- i propose we do similar conditional rendering in other places where we have stickiness instead of so much cleanup code with little ROI