### PR TITLE
SW-3022 / SW-3023 Add/edit for inventory and reassign should send use…

### DIFF
--- a/src/components/Inventory/InventoryCreate.tsx
+++ b/src/components/Inventory/InventoryCreate.tsx
@@ -125,7 +125,7 @@ export default function CreateInventory(): JSX.Element {
     if (response.requestSucceeded) {
       history.replace(inventoryLocation);
       history.push({
-        pathname: APP_PATHS.INVENTORY,
+        pathname: `${APP_PATHS.INVENTORY}/${record.speciesId}`,
       });
     } else {
       snackbar.toastError();

--- a/src/components/NurseryWithdrawals/NurseryWithdrawalsDetails.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawalsDetails.tsx
@@ -144,6 +144,7 @@ export default function NurseryWithdrawalsDetails({ species, plotNames }: Nurser
     if (delivery) {
       history.push({
         pathname: APP_PATHS.NURSERY_REASSIGNMENT.replace(':deliveryId', delivery.id.toString()),
+        search: '?fromWithdrawal',
       });
     }
   };


### PR DESCRIPTION
…r back to context

- add inventory takes user to species view after new batch is addded
- cancel on add inventory goes back to inventory list
- reassign cancel/save will take user back to originating view, which could be the withdrawal log or the withdrawal detail
- leveraging a url query param for the reassign redirect