### PR TITLE
SW-3010 Use AND Logic Across Different Filters

### DIFF
--- a/src/components/NurseryWithdrawals/NurseryWithdrawals.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawals.tsx
@@ -163,7 +163,7 @@ export default function NurseryWithdrawals(): JSX.Element {
 
       if (filterValueChildren.length) {
         const filterValueNodes: FieldNodePayload = {
-          operation: 'or',
+          operation: 'and',
           children: filterValueChildren,
         };
 
@@ -176,7 +176,7 @@ export default function NurseryWithdrawals(): JSX.Element {
       }
     } else if (filterValueChildren.length) {
       const filterValueNodes: FieldNodePayload = {
-        operation: 'or',
+        operation: 'and',
         children: filterValueChildren,
       };
       finalSearchValueChildren.push(filterValueNodes);


### PR DESCRIPTION
It seems like we're currently using the "or" logic across different filters but we should be using the "and" logic. In other words, if a user filters by the species Koa and the destination Site A on the withdrawal log page, then the results should show all withdrawals with Koa as the species AND Site A as the destination.

The only time we use the "or" logic should be within a single filter. For example, if a user filters by the status Awaiting Check-In, Drying, and In Storage then we should show all results whose status is any of those options.

* This has been fixed on the Withdrawal Log filters. It was already being done correctly in the Species and Accessions filters