### PR TITLE
SW-3057 Show reload-app banner outside the inventory table container

### DIFF
--- a/src/components/Inventory/InventoryTable.tsx
+++ b/src/components/Inventory/InventoryTable.tsx
@@ -6,7 +6,6 @@ import { Box, Grid, useTheme } from '@mui/material';
 import { SearchResponseElement } from 'src/types/Search';
 import InventoryCellRenderer from './InventoryCellRenderer';
 import { InventoryFiltersType } from './InventoryFiltersPopover';
-import PageSnackbar from 'src/components/PageSnackbar';
 import { APP_PATHS } from 'src/constants';
 import Search from './Search';
 import Table from 'src/components/common/table';
@@ -85,9 +84,6 @@ export default function InventoryTable(props: InventoryTableProps): JSX.Element 
 
   return (
     <>
-      <Grid item xs={12}>
-        <PageSnackbar />
-      </Grid>
       <Box marginBottom={theme.spacing(2)}>
         <Search
           searchValue={temporalSearchValue}

--- a/src/components/Inventory/index.tsx
+++ b/src/components/Inventory/index.tsx
@@ -250,6 +250,7 @@ export default function Inventory(props: InventoryProps): JSX.Element {
           </Grid>
         </Box>
       </PageHeaderWrapper>
+      <PageSnackbar />
       <Box
         ref={contentRef}
         sx={{
@@ -281,7 +282,6 @@ export default function Inventory(props: InventoryProps): JSX.Element {
           )
         ) : (
           <Container maxWidth={false} className={classes.mainContainer}>
-            <PageSnackbar />
             {isAdmin(selectedOrganization) ? (
               <EmptyMessage
                 className={classes.message}


### PR DESCRIPTION
- keep one banner for all inventory views

<img width="818" alt="Terraware App 2023-02-24 15-07-48" src="https://user-images.githubusercontent.com/1865174/221319094-e828e0ad-6451-4624-b3cc-4f63672f3ee8.png">

<img width="823" alt="Terraware App 2023-02-24 15-07-27" src="https://user-images.githubusercontent.com/1865174/221319096-4e964915-e4a9-48da-9edc-ca339fdca5c2.png">
