### PR TITLE
SW-2982 Fix error management for collected/received date

### DIFF
--- a/src/components/accession2/create/Accession2Create.tsx
+++ b/src/components/accession2/create/Accession2Create.tsx
@@ -46,6 +46,16 @@ export default function CreateAccession(): JSX.Element {
   const tz = useLocationTimeZone().get(selectedSeedBank);
   const [timeZone, setTimeZone] = useState<string>(tz.id);
   const { selectedOrganization } = useOrganization();
+  const [collectedDateError, setCollectedDateError] = useState<string>();
+  const [receivedDateError, setReceivedDateError] = useState<string>();
+
+  const onCollectedDateError = (error?: string) => {
+    setCollectedDateError(error);
+  };
+
+  const onReceivedDateError = (error?: string) => {
+    setReceivedDateError(error);
+  };
 
   const defaultAccession = (): AccessionPostRequestBody =>
     ({
@@ -89,7 +99,7 @@ export default function CreateAccession(): JSX.Element {
 
   const hasErrors = () => {
     const missingRequiredField = MANDATORY_FIELDS.some((field: MandatoryField) => !record[field]);
-    return missingRequiredField;
+    return missingRequiredField || collectedDateError || receivedDateError;
   };
 
   const saveAccession = async () => {
@@ -146,11 +156,14 @@ export default function CreateAccession(): JSX.Element {
               <Species2Dropdown record={record} setRecord={setRecord} validate={validateFields} />
             </Grid>
             <CollectedReceivedDate2
-              record={record}
               onChange={onChange}
-              type='collected'
               validate={validateFields}
               timeZone={timeZone}
+              id='collectedDate'
+              onDateError={onCollectedDateError}
+              label={strings.COLLECTION_DATE_REQUIRED}
+              maxDate={new Date()}
+              dateError={collectedDateError}
             />
             <Grid item xs={12} sx={marginTop}>
               <Collectors2 collectors={record.collectors} onChange={onChange} />
@@ -188,11 +201,14 @@ export default function CreateAccession(): JSX.Element {
           </Grid>
           <Grid container>
             <CollectedReceivedDate2
-              record={record}
               onChange={onChange}
-              type='received'
               validate={validateFields}
               timeZone={timeZone}
+              value={record.receivedDate}
+              id='receivedDate'
+              onDateError={onReceivedDateError}
+              label={strings.RECEIVING_DATE_REQUIRED}
+              dateError={receivedDateError}
             />
             <Grid item xs={12} sx={marginTop}>
               <Dropdown

--- a/src/components/accession2/edit/Accession2EditModal.tsx
+++ b/src/components/accession2/edit/Accession2EditModal.tsx
@@ -38,10 +38,15 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
   const selectedSeedBank = getSeedBank(selectedOrganization, record.facilityId);
   const tz = useLocationTimeZone().get(selectedSeedBank);
   const timeZone = tz.id;
+  const [collectedDateError, setCollectedDateError] = useState<string>();
+
+  const onCollectedDateError = (error?: string) => {
+    setCollectedDateError(error);
+  };
 
   const hasErrors = () => {
     const missingRequiredField = MANDATORY_FIELDS.some((field: MandatoryField) => !record || !record[field]);
-    return missingRequiredField;
+    return missingRequiredField || collectedDateError;
   };
 
   useEffect(() => {
@@ -107,11 +112,15 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
           validate={validateFields}
         />
         <CollectedReceivedDate2
-          record={record}
           onChange={onChange}
-          type='collected'
           validate={validateFields}
           timeZone={timeZone}
+          id='collectedDate'
+          onDateError={onCollectedDateError}
+          label={strings.COLLECTION_DATE_REQUIRED}
+          maxDate={new Date()}
+          dateError={collectedDateError}
+          value={record.collectedDate}
         />
         <Grid item xs={12}>
           <Collectors2 onChange={onChange} collectors={record.collectors} />

--- a/src/components/accession2/properties/CollectedReceivedDate2.tsx
+++ b/src/components/accession2/properties/CollectedReceivedDate2.tsx
@@ -43,13 +43,13 @@ export default function CollectedReceivedDate2({
   };
 
   const validateDate = useCallback(
-    (value?: string | undefined) => {
+    (newValue?: string | undefined) => {
       onDateError('');
-      if (!value) {
-        const required = validate && value === undefined;
+      if (!newValue) {
+        const required = validate && newValue === undefined;
         onDateError(required ? strings.REQUIRED_FIELD : strings.INVALID_DATE);
         return false;
-      } else if (isInTheFuture(value, timeZone)) {
+      } else if (isInTheFuture(newValue, timeZone)) {
         onDateError(strings.NO_FUTURE_DATES);
         return false;
       } else {
@@ -59,10 +59,10 @@ export default function CollectedReceivedDate2({
     [timeZone, validate, onDateError]
   );
 
-  const changeDate = (value?: any) => {
-    setDateValue(value);
+  const changeDate = (newValue?: any) => {
+    setDateValue(newValue);
 
-    const date = value ? getDateDisplayValue(value.getTime(), timeZone) : null;
+    const date = newValue ? getDateDisplayValue(newValue.getTime(), timeZone) : null;
     if (date) {
       onChange(id, date);
     }
@@ -72,8 +72,8 @@ export default function CollectedReceivedDate2({
     validateDate(dateValue);
   }, [validate, dateValue, validateDate]);
 
-  const onErrorHandler = (value: any) => {
-    setDateValue(value);
+  const onErrorHandler = (newValue: any) => {
+    setDateValue(newValue);
   };
 
   return (
@@ -83,11 +83,11 @@ export default function CollectedReceivedDate2({
         label={label}
         aria-label={label}
         value={dateValue}
-        onChange={(value) => changeDate(value)}
+        onChange={(newValue) => changeDate(newValue)}
         errorText={validate ? dateError : ''}
         maxDate={maxDate}
         defaultTimeZone={timeZone}
-        onError={(reason, value) => onErrorHandler(value)}
+        onError={(reason, newValue) => onErrorHandler(newValue)}
       />
     </Grid>
   );

--- a/src/components/accession2/properties/CollectedReceivedDate2.tsx
+++ b/src/components/accession2/properties/CollectedReceivedDate2.tsx
@@ -1,17 +1,19 @@
 import React, { useCallback, useState, useEffect } from 'react';
 import { useTheme, Grid } from '@mui/material';
 import DatePicker from 'src/components/common/DatePicker';
-import { Accession } from 'src/types/Accession';
-import { AccessionPostRequestBody } from 'src/services/SeedBankService';
 import getDateDisplayValue, { isInTheFuture } from '@terraware/web-components/utils/date';
 import strings from 'src/strings';
 
 interface Props {
   onChange: (id: string, value: string) => void;
-  record: Accession | AccessionPostRequestBody;
-  type: 'collected' | 'received';
+  id: string;
   validate?: boolean;
   timeZone: string;
+  label: string;
+  onDateError: (error: string) => void;
+  dateError?: string;
+  maxDate?: Date;
+  value?: string;
 }
 
 export type Dates = {
@@ -19,14 +21,19 @@ export type Dates = {
   receivedDate?: any;
 };
 
-export default function CollectedReceivedDate2({ onChange, record, type, validate, timeZone }: Props): JSX.Element {
+export default function CollectedReceivedDate2({
+  id,
+  label,
+  onChange,
+  validate,
+  timeZone,
+  dateError,
+  maxDate,
+  onDateError,
+  value,
+}: Props): JSX.Element {
   const theme = useTheme();
-
-  const [dateErrors, setDateErrors] = useState<{ [key: string]: string | undefined }>({});
-  const [dates, setDates] = useState<Dates>({
-    collectedDate: record.collectedDate,
-    receivedDate: record.receivedDate,
-  });
+  const [dateValue, setDateValue] = useState(value);
 
   const datePickerStyle = {
     '.MuiFormControl-root': {
@@ -35,32 +42,25 @@ export default function CollectedReceivedDate2({ onChange, record, type, validat
     marginTop: theme.spacing(2),
   };
 
-  const setDateError = (id: string, error?: string) => {
-    setDateErrors((prev) => ({
-      ...prev,
-      [id]: error,
-    }));
-  };
-
   const validateDate = useCallback(
-    (id: string, value?: string | undefined) => {
-      setDateError(id, '');
+    (value?: string | undefined) => {
+      onDateError('');
       if (!value) {
         const required = validate && value === undefined;
-        setDateError(id, required ? strings.REQUIRED_FIELD : strings.INVALID_DATE);
+        onDateError(required ? strings.REQUIRED_FIELD : strings.INVALID_DATE);
         return false;
       } else if (isInTheFuture(value, timeZone)) {
-        setDateError(id, strings.NO_FUTURE_DATES);
+        onDateError(strings.NO_FUTURE_DATES);
         return false;
       } else {
         return true;
       }
     },
-    [timeZone, validate]
+    [timeZone, validate, onDateError]
   );
 
-  const changeDate = (id: string, value?: any) => {
-    setDates((curr) => ({ ...curr, [id]: value }));
+  const changeDate = (value?: any) => {
+    setDateValue(value);
 
     const date = value ? getDateDisplayValue(value.getTime(), timeZone) : null;
     if (date) {
@@ -69,36 +69,26 @@ export default function CollectedReceivedDate2({ onChange, record, type, validat
   };
 
   useEffect(() => {
-    if (validate) {
-      validateDate('collectedDate', dates.collectedDate);
-      validateDate('receivedDate', dates.receivedDate);
-    }
-  }, [validate, dates.collectedDate, dates.receivedDate, validateDate]);
+    validateDate(dateValue);
+  }, [validate, dateValue, validateDate]);
+
+  const onErrorHandler = (value: any) => {
+    setDateValue(value);
+  };
 
   return (
     <Grid item xs={12} sx={datePickerStyle}>
-      {type === 'collected' ? (
-        <DatePicker
-          id='collectedDate'
-          label={strings.COLLECTION_DATE_REQUIRED}
-          aria-label={strings.COLLECTION_DATE_REQUIRED}
-          value={dates.collectedDate}
-          onChange={(value) => changeDate('collectedDate', value)}
-          errorText={dateErrors.collectedDate}
-          maxDate={new Date()}
-          defaultTimeZone={timeZone}
-        />
-      ) : (
-        <DatePicker
-          id='receivedDate'
-          label={strings.RECEIVING_DATE_REQUIRED}
-          aria-label={strings.RECEIVING_DATE_REQUIRED}
-          value={dates.receivedDate}
-          onChange={(value) => changeDate('receivedDate', value)}
-          errorText={dateErrors.receivedDate}
-          defaultTimeZone={timeZone}
-        />
-      )}
+      <DatePicker
+        id={id}
+        label={label}
+        aria-label={label}
+        value={dateValue}
+        onChange={(value) => changeDate(value)}
+        errorText={validate ? dateError : ''}
+        maxDate={maxDate}
+        defaultTimeZone={timeZone}
+        onError={(reason, value) => onErrorHandler(value)}
+      />
     </Grid>
   );
 }


### PR DESCRIPTION
Having a dateErrors object to manage both date errors (collected and received) was causing a lot of unwanted state changes/refreshes when one of the values changed. Some times collected error was overwrited with an empty error, when received error changed. So, to fix this, the component will render only one datepicker for each and manage its own value/error

This also fix the date validation not stopping the save action, when it was the only error in the form.
