### PR TITLE
SW-3071 Fix Can't upload species list

### DIFF
--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -14,7 +14,6 @@ import {
   getGrowthFormString,
   getSeedStorageBehaviorString,
   Species,
-  SpeciesProblemElement,
 } from 'src/types/Species';
 import TfMain from 'src/components/common/TfMain';
 import PageSnackbar from 'src/components/PageSnackbar';
@@ -455,7 +454,7 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
           searchResults?.forEach((result) => {
             speciesResults.push({
               id: result.id as number,
-              problems: result.problems as SpeciesProblemElement[],
+              problems: species.find((sp) => sp.id.toString() === (result.id as string))?.problems,
               scientificName: result.scientificName as string,
               commonName: result.commonName as string,
               familyName: result.familyName as string,

--- a/src/services/SpeciesService.ts
+++ b/src/services/SpeciesService.ts
@@ -173,9 +173,9 @@ const downloadSpeciesTemplate = async (): Promise<Response & SpeciesUploadTempla
 /**
  * upload species
  */
-const uploadSpecies = async (file: File, seedbankId: string): Promise<UploadFileResponse> => {
+const uploadSpecies = async (file: File, organizationId: string): Promise<UploadFileResponse> => {
   const entity = new FormData();
-  entity.append('facilityId', seedbankId);
+  entity.append('organizationId', organizationId);
   entity.append('file', file);
   const headers = { 'content-type': 'multipart/form-data' };
 


### PR DESCRIPTION
This bug was introduced with the new species service. Species upload file api uses organizationId instead of faciityId. This was causing the error