### PR TITLE
SW-3070 Apply ExactOrFuzzy Search to Accession Number Only

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -1131,7 +1131,7 @@ export interface components {
       field?: string;
       /** @description List of values to match. For exact and fuzzy searches, a list of at least one value to search for; the list may include null to match accessions where the field does not have a value. For range searches, the list must contain exactly two values, the minimum and maximum; one of the values may be null to search for all values above a minimum or below a maximum. */
       values?: (string | null)[];
-      type?: "Exact" | "Fuzzy" | "Range";
+      type?: "Exact" | "ExactOrFuzzy" | "Fuzzy" | "Range";
     } & {
       field: unknown;
       type: unknown;
@@ -1277,6 +1277,11 @@ export interface components {
       id: number;
       /** Format: int32 */
       year: number;
+      status: "New" | "In Progress" | "Locked" | "Submitted";
+      /** Format: int32 */
+      quarter: number;
+      /** Format: date-time */
+      modifiedTime?: string;
       lockedByName?: string;
       /** Format: int64 */
       lockedByUserId?: number;
@@ -1286,11 +1291,6 @@ export interface components {
       submittedByName?: string;
       /** Format: int64 */
       submittedByUserId?: number;
-      status: "New" | "In Progress" | "Locked" | "Submitted";
-      /** Format: int32 */
-      quarter: number;
-      /** Format: date-time */
-      modifiedTime?: string;
       /** Format: date-time */
       lockedTime?: string;
       /** Format: date-time */

--- a/src/components/seeds/database/Filters.tsx
+++ b/src/components/seeds/database/Filters.tsx
@@ -305,7 +305,7 @@ function getSearchTermFilter(searchCols: DatabaseColumn[], searchTerm: string): 
     children: searchCols.map((col) => ({
       operation: 'field',
       field: col.key,
-      type: 'Fuzzy',
+      type: col.key === 'accessionNumber' ? 'ExactOrFuzzy' : 'Fuzzy',
       values: [searchTerm],
     })),
     operation: 'or',


### PR DESCRIPTION
- Now `Fuzzy` searches are always fuzzy, even if an exact match is found
- A new search type, `ExactOrFuzzy`, will show only an exact match if it
  exists, otherwise it will show fuzzy results
- In the Accessions list page apply `ExactOrFuzzy` to the Accession
  Number column only.