### PR TITLE
SW-3102 query param to bust cache when requesting app version data

### DIFF
--- a/src/services/SystemService.ts
+++ b/src/services/SystemService.ts
@@ -46,7 +46,8 @@ const getClock = async (): Promise<ClockResponse> => {
  * get app version
  */
 const getLatestAppVersion = async (): Promise<AppVersionResponse> => {
-  const response: AppVersionResponse = await httpAppVersion.get<any, AppVersion>({}, (version) => ({
+  const params = { timestamp: Date.now().toString() };
+  const response: AppVersionResponse = await httpAppVersion.get<any, AppVersion>({ params }, (version) => ({
     version: version ?? '',
   }));
 


### PR DESCRIPTION
- this was accidentally removed as part of the service refactor 😿 