### PR TITLE
Updates to Report Seedbanks

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -1221,6 +1221,7 @@ export interface components {
       /** Format: date */
       operationStartedDate?: string;
       operationStartedDateEditable: boolean;
+      selected: boolean;
       /** Format: int64 */
       totalPlantsPropagated: number;
       workers: components["schemas"]["WorkersPayloadV1"];
@@ -1261,6 +1262,7 @@ export interface components {
       mortalityRate?: number;
       name: string;
       notes?: string;
+      selected: boolean;
       species: components["schemas"]["GetPlantingSiteSpeciesV1"][];
       /** Format: int32 */
       totalPlantedArea?: number;
@@ -1282,6 +1284,10 @@ export interface components {
       quarter: number;
       /** Format: date-time */
       modifiedTime?: string;
+      /** Format: date-time */
+      lockedTime?: string;
+      /** Format: date-time */
+      submittedTime?: string;
       lockedByName?: string;
       /** Format: int64 */
       lockedByUserId?: number;
@@ -1291,10 +1297,6 @@ export interface components {
       submittedByName?: string;
       /** Format: int64 */
       submittedByUserId?: number;
-      /** Format: date-time */
-      lockedTime?: string;
-      /** Format: date-time */
-      submittedTime?: string;
       version: string;
     };
     GetReportPayloadV1: components["schemas"]["GetReportPayload"] & {
@@ -1344,6 +1346,7 @@ export interface components {
       /** Format: date */
       operationStartedDate?: string;
       operationStartedDateEditable: boolean;
+      selected: boolean;
       /** Format: int64 */
       totalSeedsStored: number;
       workers: components["schemas"]["WorkersPayloadV1"];
@@ -1853,6 +1856,7 @@ export interface components {
       notes?: string;
       /** Format: date */
       operationStartedDate?: string;
+      selected: boolean;
       workers: components["schemas"]["WorkersPayloadV1"];
     };
     PutPlantingSiteSpeciesV1: {
@@ -1869,6 +1873,7 @@ export interface components {
       /** Format: int64 */
       id: number;
       notes?: string;
+      selected: boolean;
       species: components["schemas"]["PutPlantingSiteSpeciesV1"][];
       /** Format: int32 */
       mortalityRate?: number;
@@ -1910,6 +1915,7 @@ export interface components {
       notes?: string;
       /** Format: date */
       operationStartedDate?: string;
+      selected: boolean;
       workers: components["schemas"]["WorkersPayloadV1"];
     };
     ReassignDeliveryRequestPayload: {
@@ -2567,7 +2573,7 @@ export interface components {
     };
     UploadReportFileResponsePayload: {
       /** Format: int64 */
-      fileId: number;
+      id: number;
       status: components["schemas"]["SuccessOrError"];
     };
     UserProfilePayload: {

--- a/src/components/Reports/ReportForm.tsx
+++ b/src/components/Reports/ReportForm.tsx
@@ -53,19 +53,9 @@ export default function ReportForm(props: ReportFormProps): JSX.Element {
     }
   });
 
-  const handleAddRemoveSeedbank = (add: boolean, seedbank: ReportSeedBank) => {
-    const newSeedbanks = structuredClone(draftReport.seedBanks ?? []);
-    if (add) {
-      // add the seedbank
-      newSeedbanks.push(seedbank);
-    } else {
-      // remove the seedbank
-      const index = newSeedbanks.findIndex((sb: ReportSeedBank) => sb.id === seedbank.id);
-      newSeedbanks.splice(index, 1);
-    }
-    // call update
-    if (onUpdateReport) {
-      onUpdateReport('seedBanks', newSeedbanks);
+  const handleAddRemoveSeedbank = (selected: boolean, index: number) => {
+    if (onUpdateSeedbank) {
+      onUpdateSeedbank(index, 'selected', selected);
     }
   };
 
@@ -165,11 +155,11 @@ export default function ReportForm(props: ReportFormProps): JSX.Element {
                   disabled={!editable}
                   name={seedbank.name}
                   label={seedbank.name}
-                  value={!!draftReport.seedBanks?.find((sb) => sb.id === seedbank.id) ?? false}
-                  onChange={(value) => handleAddRemoveSeedbank(value, seedbank)}
+                  value={seedbank.selected}
+                  onChange={(value) => handleAddRemoveSeedbank(value, index)}
                 />
               </Grid>
-              {(!!draftReport.seedBanks?.find((sb) => sb.id === seedbank.id) ?? false) && (
+              {seedbank.selected && (
                 <SeedbankSection
                   editable={editable}
                   seedbank={seedbank}

--- a/src/components/Reports/ReportView.tsx
+++ b/src/components/Reports/ReportView.tsx
@@ -36,7 +36,9 @@ export default function ReportView(): JSX.Element {
       }
     };
 
-    getReport();
+    if (reportIdInt) {
+      getReport();
+    }
   }, [reportIdInt, snackbar]);
 
   const [showAnnual, setShowAnnual] = useState(false);
@@ -44,7 +46,7 @@ export default function ReportView(): JSX.Element {
   const [confirmEditDialogOpen, setConfirmEditDialogOpen] = useState(false);
 
   const startEdit = () => {
-    if (report?.lockedByName) {
+    if (report?.lockedByUserId) {
       setConfirmEditDialogOpen(true);
     } else {
       confirmEdit();

--- a/src/components/Reports/SeedbankSection.tsx
+++ b/src/components/Reports/SeedbankSection.tsx
@@ -10,12 +10,6 @@ import { ReportSeedBank } from 'src/types/Report';
 
 const DEBOUNCE_TIME_MS = 500;
 
-const useStyles = makeStyles((theme: Theme) => ({
-  infoCardStyle: {
-    padding: 0,
-  },
-}));
-
 export type SeedbankSectionProps = {
   editable: boolean;
   seedbank: ReportSeedBank;
@@ -27,7 +21,6 @@ export default function SeedbankSection(props: SeedbankSectionProps): JSX.Elemen
   const { editable, seedbank, onUpdateSeedbank, onUpdateSeedbankWorkers } = props;
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
-  const classes = useStyles();
 
   const [workersPaidEngaged, setWorkersPaidEngaged] = useState<number>(seedbank.workers?.paidWorkers ?? 0);
   const [workersPaidFemale, setWorkersPaidFemale] = useState<number>(seedbank.workers?.femalePaidWorkers ?? 0);
@@ -59,7 +52,6 @@ export default function SeedbankSection(props: SeedbankSectionProps): JSX.Elemen
           editable={editable && seedbank.buildStartedDateEditable}
           value={seedbank.buildStartedDate ?? ''}
           onChange={(value) => onUpdateSeedbank('buildStartedDate', value)}
-          className={classes.infoCardStyle}
           type='date'
         />
       </Grid>
@@ -70,7 +62,6 @@ export default function SeedbankSection(props: SeedbankSectionProps): JSX.Elemen
           editable={editable && seedbank.buildCompletedDateEditable}
           value={seedbank.buildCompletedDate ?? ''}
           onChange={(value) => onUpdateSeedbank('buildCompletedDate', value)}
-          className={classes.infoCardStyle}
           type='date'
         />
       </Grid>
@@ -81,7 +72,6 @@ export default function SeedbankSection(props: SeedbankSectionProps): JSX.Elemen
           editable={editable && seedbank.buildCompletedDateEditable}
           value={seedbank.operationStartedDate ?? ''}
           onChange={(value) => onUpdateSeedbank('operationStartedDate', value)}
-          className={classes.infoCardStyle}
           type='date'
         />
       </Grid>
@@ -90,7 +80,6 @@ export default function SeedbankSection(props: SeedbankSectionProps): JSX.Elemen
           isEditable={false}
           title={strings.TOTAL_SEEDS_STORED}
           contents={seedbank.totalSeedsStored.toString() ?? '0'}
-          className={classes.infoCardStyle}
         />
       </Grid>
       <Grid item xs={smallItemGridWidth()}>
@@ -100,7 +89,6 @@ export default function SeedbankSection(props: SeedbankSectionProps): JSX.Elemen
           editable={editable}
           value={editable ? workersPaidEngaged : seedbank.workers.paidWorkers?.toString() ?? '0'}
           onChange={(value) => setWorkersPaidEngaged(value as number)}
-          className={classes.infoCardStyle}
           type='text'
         />
       </Grid>
@@ -111,7 +99,6 @@ export default function SeedbankSection(props: SeedbankSectionProps): JSX.Elemen
           editable={editable}
           value={editable ? workersPaidFemale : seedbank.workers.femalePaidWorkers?.toString() ?? '0'}
           onChange={(value) => setWorkersPaidFemale(value as number)}
-          className={classes.infoCardStyle}
           type='text'
         />
       </Grid>
@@ -122,7 +109,6 @@ export default function SeedbankSection(props: SeedbankSectionProps): JSX.Elemen
           editable={editable}
           value={editable ? workersVolunteer : seedbank.workers.volunteers?.toString() ?? '0'}
           onChange={(value) => setWorkersVolunteer(value as number)}
-          className={classes.infoCardStyle}
           type='text'
         />
       </Grid>
@@ -148,18 +134,24 @@ export default function SeedbankSection(props: SeedbankSectionProps): JSX.Elemen
   );
 }
 
+const useStyles = makeStyles((theme: Theme) => ({
+  infoCardStyle: {
+    padding: 0,
+  },
+}));
+
 type InfoFieldProps = {
   id: string;
   label: string;
   editable: boolean;
   value: string | number;
   onChange: (value: any) => void;
-  className: string;
   type: 'text' | 'date';
 };
 
 function InfoField(props: InfoFieldProps): JSX.Element {
-  const { id, label, editable, value, onChange, className, type } = props;
+  const { id, label, editable, value, onChange, type } = props;
+  const classes = useStyles();
   return editable ? (
     type === 'text' ? (
       <Textfield label={label} id={id} type='number' value={value} readonly={!editable} onChange={onChange} />
@@ -169,6 +161,11 @@ function InfoField(props: InfoFieldProps): JSX.Element {
       <></>
     )
   ) : (
-    <OverviewItemCard isEditable={false} title={label} contents={value.toString() ?? '0'} className={className} />
+    <OverviewItemCard
+      isEditable={false}
+      title={label}
+      contents={value.toString() ?? '0'}
+      className={classes.infoCardStyle}
+    />
   );
 }

--- a/src/services/ReportService.ts
+++ b/src/services/ReportService.ts
@@ -1,7 +1,6 @@
 import { paths } from 'src/api/types/generated-schema';
-import { ListReport, Report, ReportFile, ReportPhoto, ReportSeedBank } from 'src/types/Report';
+import { ListReport, Report, ReportFile, ReportPhoto } from 'src/types/Report';
 import HttpService, { Response } from './HttpService';
-import { Facility } from 'src/types/Facility';
 
 /**
  * Report related services
@@ -179,7 +178,7 @@ const uploadReportFile = async (file: string): Promise<UploadReportFileResponse>
 
   if (response.requestSucceeded) {
     const data: UploadReportFileResponsePayload = response.data;
-    response.fileId = data?.fileId;
+    response.fileId = data?.id;
   }
 
   return response;
@@ -294,7 +293,7 @@ const uploadReportPhoto = async (file: string): Promise<UploadReportPhotoRespons
 
   if (response.requestSucceeded) {
     const data: UploadReportPhotoResponsePayload = response.data;
-    response.fileId = data?.fileId;
+    response.fileId = data?.id;
   }
 
   return response;
@@ -343,26 +342,6 @@ const deleteReportPhoto = async (reportId: number, fileId: number): Promise<Resp
 };
 
 /**
- * Convert Facility to ReportSeedBank
- */
-const seedbankFromFacility = (facility: Facility, originalReport: Report): ReportSeedBank => {
-  const existingSeedbank = originalReport.seedBanks?.find((sb) => sb.id === facility.id);
-  if (existingSeedbank) {
-    return existingSeedbank;
-  }
-
-  return {
-    id: facility.id,
-    name: facility.name,
-    buildCompletedDateEditable: true,
-    buildStartedDateEditable: true,
-    operationStartedDateEditable: true,
-    totalSeedsStored: 0,
-    workers: {},
-  };
-};
-
-/**
  * Exported functions
  */
 const ReportService = {
@@ -382,7 +361,6 @@ const ReportService = {
   getReportPhoto,
   updateReportPhoto,
   deleteReportPhoto,
-  seedbankFromFacility,
 };
 
 export default ReportService;

--- a/src/strings/strings-en.ts
+++ b/src/strings/strings-en.ts
@@ -732,6 +732,7 @@ export const strings = {
   REPORT_COULD_NOT_OPEN: 'Could not open report',
   REPORT_COULD_NOT_SAVE: 'Could not save report',
   REPORT_COULD_NOT_SUBMIT: 'Could not submit report',
+  REPORT_COULD_NOT_UNLOCK: 'Could not unlock report',
   REPORT_EDIT: 'Edit Report',
   REPORT_NAME: 'Report Name',
   REPORT_NO_SEEDBANKS: 'No seed banks included in report.',


### PR DESCRIPTION
- Seedbanks have the "selected" field, which we toggle to show whether a
  seedbank is included in the report or not
- Let the seedbank InfoField component use the useStyles hook directly
  instead of passing the className through props
- No longer need two copies, report and draftReport, in ReportEdit
- Do not let the polling for lock status change the report data out from
  under the ReportEdit component