### PR TITLE
Report Annual Validation

### DIFF
--- a/src/components/Reports/ReportEdit.tsx
+++ b/src/components/Reports/ReportEdit.tsx
@@ -146,6 +146,7 @@ export default function ReportEdit({ organization }: ReportEditProps): JSX.Eleme
     if (report) {
       const saveResult = await ReportService.updateReport(report);
       setShowAnnual(true);
+      setValidateFields(false);
       if (!saveResult.requestSucceeded) {
         snackbar.toastError(strings.GENERIC_ERROR, strings.REPORT_COULD_NOT_SAVE);
       } else {
@@ -159,6 +160,7 @@ export default function ReportEdit({ organization }: ReportEditProps): JSX.Eleme
     if (report) {
       const saveResult = await ReportService.updateReport(report);
       setShowAnnual(false);
+      setValidateFields(false);
       if (!saveResult.requestSucceeded) {
         snackbar.toastError(strings.GENERIC_ERROR, strings.REPORT_COULD_NOT_SAVE);
       }
@@ -183,16 +185,41 @@ export default function ReportEdit({ organization }: ReportEditProps): JSX.Eleme
         !plantingSite.mortalityRate
       );
     });
-    return emptySeedbankFields || emptyNurseryFields || emptyPlantingSitesFields;
+    return !iReport.summaryOfProgress || emptySeedbankFields || emptyNurseryFields || emptyPlantingSitesFields;
   };
+
+  const hasEmptyRequiredAnnualFields = (iReport: Report) => {
+    if (!iReport.isAnnual) {
+      return false;
+    }
+    return (
+      !iReport.annualDetails?.projectSummary ||
+      !iReport.annualDetails.projectImpact ||
+      !iReport.annualDetails.budgetNarrativeSummary ||
+      !iReport.annualDetails.socialImpact ||
+      !iReport.annualDetails.challenges ||
+      !iReport.annualDetails.keyLessons ||
+      !iReport.annualDetails.successStories ||
+      !iReport.annualDetails.opportunities ||
+      !iReport.annualDetails.nextSteps ||
+      (iReport.annualDetails.isCatalytic && !iReport.annualDetails.catalyticDetail) ||
+      iReport.annualDetails.sustainableDevelopmentGoals.some((sdg) => !sdg.progress)
+    );
+  };
+
   const submitReport = async () => {
     if (report) {
       if (hasEmptyRequiredFields(report)) {
         setConfirmSubmitDialogOpen(false);
-        setValidateFields(true);
         if (showAnnual) {
           handleBack();
         }
+        setValidateFields(true);
+        return;
+      }
+      if (hasEmptyRequiredAnnualFields(report)) {
+        setConfirmSubmitDialogOpen(false);
+        setValidateFields(true);
         return;
       }
       const saveResult = await ReportService.updateReport(report);
@@ -367,6 +394,7 @@ export default function ReportEdit({ organization }: ReportEditProps): JSX.Eleme
                 initialReportFiles={initialReportFiles ?? []}
                 onNewFilesChanged={onNewFilesChanged}
                 onExistingFilesChanged={onExistingFilesChanged}
+                validate={validateFields}
               />
             ) : (
               <ReportForm

--- a/src/components/Reports/ReportEdit.tsx
+++ b/src/components/Reports/ReportEdit.tsx
@@ -194,16 +194,16 @@ export default function ReportEdit({ organization }: ReportEditProps): JSX.Eleme
     }
     return (
       !iReport.annualDetails?.projectSummary ||
-      !iReport.annualDetails.projectImpact ||
-      !iReport.annualDetails.budgetNarrativeSummary ||
-      !iReport.annualDetails.socialImpact ||
-      !iReport.annualDetails.challenges ||
-      !iReport.annualDetails.keyLessons ||
-      !iReport.annualDetails.successStories ||
-      !iReport.annualDetails.opportunities ||
-      !iReport.annualDetails.nextSteps ||
-      (iReport.annualDetails.isCatalytic && !iReport.annualDetails.catalyticDetail) ||
-      iReport.annualDetails.sustainableDevelopmentGoals.some((sdg) => !sdg.progress)
+      !iReport.annualDetails?.projectImpact ||
+      !iReport.annualDetails?.budgetNarrativeSummary ||
+      !iReport.annualDetails?.socialImpact ||
+      !iReport.annualDetails?.challenges ||
+      !iReport.annualDetails?.keyLessons ||
+      !iReport.annualDetails?.successStories ||
+      !iReport.annualDetails?.opportunities ||
+      !iReport.annualDetails?.nextSteps ||
+      (iReport.annualDetails?.isCatalytic && !iReport.annualDetails?.catalyticDetail) ||
+      iReport.annualDetails?.sustainableDevelopmentGoals.some((sdg) => !sdg?.progress)
     );
   };
 

--- a/src/components/Reports/ReportForm.tsx
+++ b/src/components/Reports/ReportForm.tsx
@@ -143,6 +143,7 @@ export default function ReportForm(props: ReportFormProps): JSX.Element {
               onUpdateReport('summaryOfProgress', value);
             }
           }}
+          errorText={validate && !draftReport.summaryOfProgress ? strings.REQUIRED_FIELD : ''}
         />
       </Grid>
       <Grid item xs={mediumItemGridWidth()}>

--- a/src/components/Reports/ReportFormAnnual.tsx
+++ b/src/components/Reports/ReportFormAnnual.tsx
@@ -23,6 +23,7 @@ export type ReportFormAnnualProps = {
   initialReportFiles: ReportFile[];
   onNewFilesChanged?: (files: File[]) => void;
   onExistingFilesChanged?: (files: ReportFile[]) => void;
+  validate?: boolean;
 };
 
 export default function ReportFormAnnual(props: ReportFormAnnualProps): JSX.Element {
@@ -34,6 +35,7 @@ export default function ReportFormAnnual(props: ReportFormAnnualProps): JSX.Elem
     initialReportFiles,
     onNewFilesChanged,
     onExistingFilesChanged,
+    validate,
   } = props;
   const classes = useStyles();
   const theme = useTheme();
@@ -224,6 +226,7 @@ export default function ReportFormAnnual(props: ReportFormAnnualProps): JSX.Elem
               updateDetails('projectSummary', value);
             }
           }}
+          errorText={validate && !report.annualDetails?.projectSummary ? strings.REQUIRED_FIELD : ''}
         />
       </Grid>
       <Grid item xs={mediumItemGridWidth()}>
@@ -238,6 +241,7 @@ export default function ReportFormAnnual(props: ReportFormAnnualProps): JSX.Elem
               updateDetails('projectImpact', value);
             }
           }}
+          errorText={validate && !report.annualDetails?.projectImpact ? strings.REQUIRED_FIELD : ''}
         />
       </Grid>
       <Grid item xs={mediumItemGridWidth()}>
@@ -252,6 +256,7 @@ export default function ReportFormAnnual(props: ReportFormAnnualProps): JSX.Elem
               updateDetails('budgetNarrativeSummary', value);
             }
           }}
+          errorText={validate && !report.annualDetails?.budgetNarrativeSummary ? strings.REQUIRED_FIELD : ''}
         />
       </Grid>
       <Grid item xs={12} ref={divRef}>
@@ -303,6 +308,7 @@ export default function ReportFormAnnual(props: ReportFormAnnualProps): JSX.Elem
               updateDetails('socialImpact', value);
             }
           }}
+          errorText={validate && !report.annualDetails?.socialImpact ? strings.REQUIRED_FIELD : ''}
         />
       </Grid>
       <Grid item xs={12}>
@@ -334,6 +340,14 @@ export default function ReportFormAnnual(props: ReportFormAnnualProps): JSX.Elem
                   updateSDGProgress(index, value as string);
                 }
               }}
+              errorText={
+                validate &&
+                !report.annualDetails?.sustainableDevelopmentGoals[
+                  report.annualDetails?.sustainableDevelopmentGoals?.findIndex((s) => s.goal === key)
+                ].progress
+                  ? strings.REQUIRED_FIELD
+                  : ''
+              }
             />
           )}
         </Grid>
@@ -351,6 +365,7 @@ export default function ReportFormAnnual(props: ReportFormAnnualProps): JSX.Elem
               updateDetails('challenges', value);
             }
           }}
+          errorText={validate && !report.annualDetails?.challenges ? strings.REQUIRED_FIELD : ''}
         />
       </Grid>
       <Grid item xs={mediumItemGridWidth()}>
@@ -365,6 +380,7 @@ export default function ReportFormAnnual(props: ReportFormAnnualProps): JSX.Elem
               updateDetails('keyLessons', value);
             }
           }}
+          errorText={validate && !report.annualDetails?.keyLessons ? strings.REQUIRED_FIELD : ''}
         />
       </Grid>
       <Grid item xs={mediumItemGridWidth()}>
@@ -379,6 +395,7 @@ export default function ReportFormAnnual(props: ReportFormAnnualProps): JSX.Elem
               updateDetails('successStories', value);
             }
           }}
+          errorText={validate && !report.annualDetails?.successStories ? strings.REQUIRED_FIELD : ''}
         />
       </Grid>
       <Grid item xs={12}>
@@ -407,6 +424,11 @@ export default function ReportFormAnnual(props: ReportFormAnnualProps): JSX.Elem
             }
           }}
           value={catalyticDetail}
+          errorText={
+            validate && report.annualDetails?.isCatalytic && !report.annualDetails?.catalyticDetail
+              ? strings.REQUIRED_FIELD
+              : ''
+          }
         />
       </Grid>
       <Grid item xs={mediumItemGridWidth()}>
@@ -421,6 +443,7 @@ export default function ReportFormAnnual(props: ReportFormAnnualProps): JSX.Elem
               updateDetails('opportunities', value);
             }
           }}
+          errorText={validate && !report.annualDetails?.opportunities ? strings.REQUIRED_FIELD : ''}
         />
       </Grid>
       <Grid item xs={mediumItemGridWidth()}>
@@ -435,6 +458,7 @@ export default function ReportFormAnnual(props: ReportFormAnnualProps): JSX.Elem
               updateDetails('nextSteps', value);
             }
           }}
+          errorText={validate && !report.annualDetails?.nextSteps ? strings.REQUIRED_FIELD : ''}
         />
       </Grid>
     </Grid>
@@ -447,10 +471,11 @@ type ReportFieldProps = {
   editable: boolean;
   value: string;
   onChange: (value: string) => void;
+  errorText?: string;
 };
 
 function ReportField(props: ReportFieldProps): JSX.Element {
-  const { title, instructions, editable, value, onChange } = props;
+  const { title, instructions, editable, value, onChange, errorText } = props;
   const theme = useTheme();
   return (
     <>
@@ -464,6 +489,7 @@ function ReportField(props: ReportFieldProps): JSX.Element {
         readonly={!editable}
         onChange={(v) => onChange(v as string)}
         value={value}
+        errorText={errorText}
       />
     </>
   );


### PR DESCRIPTION
- quarterly section is validated first and navigated to if there are problems
- then the annual section is validated
- added quarterly project summary to required fields
- turn off validation when switching pages until submit retry