### PR TITLE
E2e Cypress Test Improvements

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -87,6 +87,13 @@ jobs:
           REACT_APP_SNACKBAR_TIMEOUT: 1000
           REACT_APP_TERRAWARE_FE_BUILD_VERSION: ${{ env.APP_VERSION }}
 
+      - name: save screenshots of e2e test failures
+        uses: actions/upload-artifact@latest
+        if: failure()
+        with:
+          name: cypress-snapshots
+          path: cypress/snapshots
+
       - name: build
         run: yarn build
         env:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -88,7 +88,7 @@ jobs:
           REACT_APP_TERRAWARE_FE_BUILD_VERSION: ${{ env.APP_VERSION }}
 
       - name: save screenshots of e2e test failures
-        uses: actions/upload-artifact@latest
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-snapshots

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -91,8 +91,8 @@ jobs:
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: cypress-snapshots
-          path: cypress/snapshots
+          name: cypress-screenshots
+          path: cypress/screenshots
 
       - name: build
         run: yarn build

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -12,5 +12,7 @@ export default defineConfig({
       return require('./cypress/plugins/index.js')(on, config);
     },
     baseUrl: 'http://localhost:3000',
+    pageLoadTimeout: 120000,
+    responseTimeout: 60000,
   },
 });

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
-  screenshotOnRunFailure: false,
+  screenshotOnRunFailure: true,
   video: false,
   watchForFileChanges: false,
   blockHosts: '*cookie-script.com',
@@ -12,7 +12,5 @@ export default defineConfig({
       return require('./cypress/plugins/index.js')(on, config);
     },
     baseUrl: 'http://localhost:3000',
-    pageLoadTimeout: 120000,
-    responseTimeout: 60000,
   },
 });

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -12,5 +12,7 @@ export default defineConfig({
       return require('./cypress/plugins/index.js')(on, config);
     },
     baseUrl: 'http://localhost:3000',
+    pageLoadTimeout: 90000,
+    responseTimeout: 60000,
   },
 });

--- a/cypress/e2e/10-database.cy.js
+++ b/cypress/e2e/10-database.cy.js
@@ -1,4 +1,8 @@
 describe('Database', () => {
+  it('visits accessions before running tests to clear network problems', () => {
+    cy.visit('/accessions');
+    cy.wait(5000);
+  });
   context('Customize columns', () => {
     it('should display the default columns', () => {
       cy.visit('/accessions');

--- a/cypress/e2e/10-database.cy.js
+++ b/cypress/e2e/10-database.cy.js
@@ -2,7 +2,7 @@ describe('Database', () => {
   it('visits accessions before running tests to clear network problems', () => {
     cy.on('uncaught:exception', () => {
       return false;
-    })
+    });
     cy.visit('/accessions');
     cy.wait(5000);
   });

--- a/cypress/e2e/10-database.cy.js
+++ b/cypress/e2e/10-database.cy.js
@@ -2,7 +2,6 @@ describe('Database', () => {
   context('Customize columns', () => {
     it('should display the default columns', () => {
       cy.visit('/accessions');
-      cy.wait(2000);
       cy.get('#table-header').children().should('have.length', 8);
       cy.get('#table-header-accessionNumber').contains('ACCESSION');
       cy.get('#table-header-state').contains('STATUS');

--- a/cypress/e2e/10-database.cy.js
+++ b/cypress/e2e/10-database.cy.js
@@ -1,5 +1,8 @@
 describe('Database', () => {
   it('visits accessions before running tests to clear network problems', () => {
+    cy.on('uncaught:exception', () => {
+      return false;
+    })
     cy.visit('/accessions');
     cy.wait(5000);
   });

--- a/cypress/e2e/10-database.cy.js
+++ b/cypress/e2e/10-database.cy.js
@@ -2,6 +2,7 @@ describe('Database', () => {
   context('Customize columns', () => {
     it('should display the default columns', () => {
       cy.visit('/accessions');
+      cy.wait(2000);
       cy.get('#table-header').children().should('have.length', 8);
       cy.get('#table-header-accessionNumber').contains('ACCESSION');
       cy.get('#table-header-state').contains('STATUS');


### PR DESCRIPTION
Some changes to make the e2e cypress tests more robust and debuggable:
- Capture screenshots and store them in the event of a test failure
  - These can be found on the workflow summary page after the run completes
- Increase the `pageLoadTimeout` and `responseTimeout` ([ref](https://docs.cypress.io/guides/references/configuration#Timeouts))
  - Passing tests were sometimes running close to these limits, so increasing ought to help with the flakiness
- Add a dummy test to visit `/accessions` at the beginning of the `10-database` tests
  - Noticed that the first attempt to `cy.visit('/accessions')` often fails, with subsequent attempts succeeding
  - The dummy tests ignores exceptions thrown by the visit, so the idea is to clear any network issues before running the actual tests.