### PR TITLE
SW-3151 Fix add inventory manually entered dates

### DIFF
--- a/src/components/Inventory/InventoryCreate.tsx
+++ b/src/components/Inventory/InventoryCreate.tsx
@@ -236,6 +236,7 @@ export default function CreateInventory(): JSX.Element {
                   aria-label={strings.ESTIMATED_READY_DATE}
                   value={record.readyByDate}
                   onChange={(value) => changeDate('readyByDate', value)}
+                  defaultTimeZone={timeZone}
                 />
               </Grid>
               <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>


### PR DESCRIPTION
Timezone was not set correctly, so when manually entering dates, they were off by one