### PR TITLE
SW-3152 Dashboard status filters should stick with pre-exposed-filter setup

### DIFF
--- a/src/components/seeds/database/Filters.tsx
+++ b/src/components/seeds/database/Filters.tsx
@@ -99,6 +99,7 @@ export default function Filters(props: Props): JSX.Element {
   const { columns, searchColumns, preExpFilterColumn, filters, availableValues, allValues, onChange } = props;
   const { isMobile, isDesktop } = useDeviceInfo();
   const classes = useStyles({ isMobile, isDesktop });
+  const preExpFilterKey = preExpFilterColumn.key;
   const [searchTerm, setSearchTerm] = React.useState(getSearchTermFromFilters(filters));
   const searchTermCallback = useCallback(
     (value: string) => {
@@ -133,10 +134,10 @@ export default function Filters(props: Props): JSX.Element {
 
   const filterPillItems = useMemo(() => {
     const result: PillListItem<string>[] = [];
-    const preExpFilterPill: PillListItem<string> = filters.preExpFilter && {
-      id: 'preExpFilter',
+    const preExpFilterPill: PillListItem<string> = filters[preExpFilterKey] && {
+      id: preExpFilterKey,
       label: preExpFilterColumn.name,
-      value: filters.preExpFilter.values.join(', '),
+      value: filters[preExpFilterKey].values.join(', '),
     };
     if (preExpFilterPill) {
       result.push(preExpFilterPill);
@@ -152,13 +153,13 @@ export default function Filters(props: Props): JSX.Element {
       }
     }
     return result;
-  }, [filters, columns, preExpFilterColumn.name]);
+  }, [filters, columns, preExpFilterColumn.name, preExpFilterKey]);
 
   const onChangePreExpFilter = (selectedValues: string[]) => {
     let newFilters;
     if (selectedValues.length === 0) {
       newFilters = { ...filters };
-      delete newFilters.preExpFilter;
+      delete newFilters[preExpFilterKey];
     } else {
       newFilters = { ...filters, ...getPreExpFilter(preExpFilterColumn, selectedValues) };
     }
@@ -167,7 +168,7 @@ export default function Filters(props: Props): JSX.Element {
 
   const onUpdateFilters = (newFilters: Record<string, SearchNodePayload>) => {
     const keepFilters = Object.entries(filters).filter(
-      (ent) => ent[0] === 'searchTermFilter' || ent[0] === 'preExpFilter'
+      (ent) => ent[0] === 'searchTermFilter' || ent[0] === preExpFilterKey
     );
     onChange({ ...Object.fromEntries(keepFilters), ...newFilters });
   };
@@ -317,7 +318,7 @@ function getSearchTermFilter(searchCols: DatabaseColumn[], searchTerm: string): 
 
 function getPreExpFilter(col: DatabaseColumn, values: string[]): Record<string, SearchNodePayload> {
   return {
-    preExpFilter: {
+    [col.key]: {
       operation: 'field',
       field: col.key,
       type: 'Exact',
@@ -327,7 +328,7 @@ function getPreExpFilter(col: DatabaseColumn, values: string[]): Record<string, 
 }
 
 function getCurrentPreExpFilterValues(col: DatabaseColumn, filters: Record<string, SearchNodePayload>): string[] {
-  return filters.preExpFilter?.values ?? [];
+  return filters[col.key]?.values ?? [];
 }
 
 function getOptions(col: DatabaseColumn, availableValues: FieldValuesPayload, allValues: FieldValuesPayload): Option[] {

--- a/src/components/seeds/database/Filters.tsx
+++ b/src/components/seeds/database/Filters.tsx
@@ -135,7 +135,7 @@ export default function Filters(props: Props): JSX.Element {
     const result: PillListItem<string>[] = [];
     const preExpFilterPill: PillListItem<string> = filters.preExpFilter && {
       id: 'preExpFilter',
-      label: strings.STATUS,
+      label: preExpFilterColumn.name,
       value: filters.preExpFilter.values.join(', '),
     };
     if (preExpFilterPill) {
@@ -151,9 +151,8 @@ export default function Filters(props: Props): JSX.Element {
         } as PillListItem<string>);
       }
     }
-
     return result;
-  }, [filters, columns]);
+  }, [filters, columns, preExpFilterColumn.name]);
 
   const onChangePreExpFilter = (selectedValues: string[]) => {
     let newFilters;

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -290,13 +290,13 @@ export default function Database(props: DatabaseProps): JSX.Element {
     const storageLocationName = query.get('storageLocationName');
     let newSearchCriteria = searchCriteria || {};
     if (stage.length || query.has('stage')) {
-      delete newSearchCriteria.state;
+      delete newSearchCriteria.preExpFilter;
       const stageNames = ACCESSION_2_STATES.map((name) => stateName(name));
       const stages = (stage || []).filter((stageName) => stageNames.indexOf(stageName) !== -1);
       if (stages.length) {
         newSearchCriteria = {
           ...newSearchCriteria,
-          state: {
+          preExpFilter: {
             field: 'state',
             values: stages,
             type: 'Exact',

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -290,13 +290,13 @@ export default function Database(props: DatabaseProps): JSX.Element {
     const storageLocationName = query.get('storageLocationName');
     let newSearchCriteria = searchCriteria || {};
     if (stage.length || query.has('stage')) {
-      delete newSearchCriteria.preExpFilter;
+      delete newSearchCriteria.state;
       const stageNames = ACCESSION_2_STATES.map((name) => stateName(name));
       const stages = (stage || []).filter((stageName) => stageNames.indexOf(stageName) !== -1);
       if (stages.length) {
         newSearchCriteria = {
           ...newSearchCriteria,
-          preExpFilter: {
+          state: {
             field: 'state',
             values: stages,
             type: 'Exact',


### PR DESCRIPTION
- when going from a dashboard quick filter to accessions table, the status does not stick with the pre-exposed filter
- update code such that it sticks, previously the filters were keyed off different names `state` and `preExpFilter`.. converge them all to use `state`


![screencast 2023-03-10 13-49-53](https://user-images.githubusercontent.com/1865174/224435756-fd9d238e-03e7-4f9f-838b-d8b43a6a52e8.gif)
