### PR TITLE
yarn script to generate build collateral (for vercel)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "build-version-file": "echo $(git rev-parse --short HEAD) > public/build-version.txt",
     "test": "TZ=America/Los_Angeles craco test",
     "eject": "craco eject",
+    "generate-collateral": "yarn build-version-file",
     "generate-types": "node -r esm scripts/openapi-typescript-formatter.js",
     "cy:run": "TZ=UTC cypress run",
     "cy": "TZ=UTC cypress open",


### PR DESCRIPTION
- we can use this as an entry point to add more commands without having to update vercel build settings