### PR TITLE
SW-3140 Make spacing between table headers and search/filters consistent

### DIFF
--- a/src/components/Inventory/InventoryTable.tsx
+++ b/src/components/Inventory/InventoryTable.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import strings from 'src/strings';
 import { TableColumnType } from '@terraware/web-components';
-import { Box, Grid, useTheme } from '@mui/material';
+import { Box, Grid } from '@mui/material';
 import { SearchResponseElement } from 'src/types/Search';
 import InventoryCellRenderer from './InventoryCellRenderer';
 import { InventoryFiltersType } from './InventoryFiltersPopover';
@@ -27,7 +27,6 @@ export default function InventoryTable(props: InventoryTableProps): JSX.Element 
     props;
   const [selectedRows, setSelectedRows] = useState<any[]>([]);
   const history = useHistory();
-  const theme = useTheme();
   const columns: TableColumnType[] = [
     {
       key: 'species_scientificName',
@@ -84,7 +83,7 @@ export default function InventoryTable(props: InventoryTableProps): JSX.Element 
 
   return (
     <>
-      <Box marginBottom={theme.spacing(2)}>
+      <Box>
         <Search
           searchValue={temporalSearchValue}
           onSearch={(val) => setTemporalSearchValue(val)}

--- a/src/components/Inventory/Search.tsx
+++ b/src/components/Inventory/Search.tsx
@@ -35,7 +35,7 @@ export default function Search(props: SearchProps): JSX.Element {
 
   return (
     <>
-      <Box display='flex' flexDirection='row' alignItems='center' marginBottom={filters.facilityIds?.length ? 2 : 0}>
+      <Box display='flex' flexDirection='row' alignItems='center' marginBottom='16px'>
         <Box width='300px'>
           <Textfield
             placeholder={strings.SEARCH}

--- a/src/components/NurseryWithdrawals/NurseryWithdrawals.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawals.tsx
@@ -277,7 +277,7 @@ export default function NurseryWithdrawals(): JSX.Element {
                 />
               </Popover>
             </Grid>
-            <Grid xs={12} display='flex' sx={{ marginBottom: 2 }}>
+            <Grid xs={12} display='flex'>
               <PillList data={filterPillData} />
             </Grid>
 

--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -33,12 +33,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontSize: '24px',
     fontWeight: 600,
   },
-  mainContent: {
-    padding: theme.spacing(3),
-    backgroundColor: theme.palette.TwClrBg,
-    borderRadius: '32px',
-    minWidth: 'fit-content',
-  },
   contentContainer: {
     backgroundColor: theme.palette.TwClrBg,
     padding: theme.spacing(3),
@@ -315,7 +309,7 @@ export default function PeopleList(): JSX.Element {
         </Grid>
       </PageHeaderWrapper>
       <Grid container className={classes.contentContainer} ref={contentRef}>
-        <Grid item xs={12}>
+        <Grid item xs={12} marginBottom='16px'>
           <TextField
             placeholder={strings.SEARCH}
             iconLeft='search'
@@ -331,7 +325,7 @@ export default function PeopleList(): JSX.Element {
         </Grid>
 
         <Grid item xs={12}>
-          <div className={classes.mainContent}>
+          <div>
             <Grid container spacing={4}>
               <Grid item xs={12}>
                 {results && (

--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -93,7 +93,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   searchBar: {
     display: 'flex',
     alignItems: 'center',
-    marginBottom: '16px',
+  },
+  pillList: {
+    display: 'flex',
+    alightItems: 'center',
+    marginTop: '16px',
   },
   icon: {
     fill: theme.palette.TwClrIcnSecondary,
@@ -835,7 +839,7 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
               />
             </Tooltip>
           </Grid>
-          <Grid item xs={12} className={classes.searchBar}>
+          <Grid item xs={12} className={classes.pillList}>
             <PillList data={getFilterPillData()} />
           </Grid>
           {species && species.length ? (

--- a/src/components/seeds/database/Filters.tsx
+++ b/src/components/seeds/database/Filters.tsx
@@ -1,4 +1,4 @@
-import { Container, Popover, Theme, Typography } from '@mui/material';
+import { Box, Container, Popover, Theme, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import React, { useCallback, useMemo, useState } from 'react';
 import { FieldValuesPayload, SearchNodePayload } from 'src/types/Search';
@@ -19,7 +19,7 @@ interface StyleProps {
 
 const useStyles = makeStyles((theme: Theme) => ({
   mainContainer: {
-    margin: theme.spacing(2, 0, 2, 0),
+    margin: theme.spacing(2, 0, 0, 0),
     padding: theme.spacing(0),
     display: 'flex',
     flexDirection: 'column',
@@ -33,6 +33,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     alignItems: (props: StyleProps) => (props.isMobile ? 'flex-start' : 'center'),
     gap: theme.spacing(1),
     marginTop: `-${theme.spacing(1)}`,
+    marginBottom: '8px',
   },
   searchField: {
     width: '300px',
@@ -210,7 +211,7 @@ export default function Filters(props: Props): JSX.Element {
 
   return (
     <Container maxWidth={false} className={classes.mainContainer}>
-      <div className={classes.filtersContainer}>
+      <Box className={classes.filtersContainer}>
         <TextField
           placeholder={strings.SEARCH}
           iconLeft='search'
@@ -296,7 +297,7 @@ export default function Filters(props: Props): JSX.Element {
             }}
           />
         </Popover>
-      </div>
+      </Box>
       <PillList data={filterPillItems} onRemove={removeFilter} />
     </Container>
   );


### PR DESCRIPTION

<img width="620" alt="Screen Shot 2023-03-28 at 10 54 15 AM" src="https://user-images.githubusercontent.com/104874529/228326810-0d5eec1d-39ce-438d-8c76-5d6d4554fabf.png">
<img width="603" alt="Screen Shot 2023-03-28 at 10 55 39 AM" src="https://user-images.githubusercontent.com/104874529/228326816-e8876cdb-e5ec-4671-82a8-1c2ef5a9d2ec.png">
<img width="551" alt="Screen Shot 2023-03-28 at 10 55 44 AM" src="https://user-images.githubusercontent.com/104874529/228326817-08c1a4c6-ec47-435b-ae96-0a9822b2f920.png">
<img width="571" alt="Screen Shot 2023-03-28 at 10 55 50 AM" src="https://user-images.githubusercontent.com/104874529/228326818-4d63caac-dab8-4850-aba4-9aa37032351c.png">
<img width="595" alt="Screen Shot 2023-03-28 at 10 56 04 AM" src="https://user-images.githubusercontent.com/104874529/228326821-bf1078f4-97a0-49f8-b6fe-c3419103b5bc.png">
<img width="456" alt="Screen Shot 2023-03-28 at 10 56 13 AM" src="https://user-images.githubusercontent.com/104874529/228326822-6a779b30-32a4-4d36-bee3-5e97e58e9d94.png">
<img width="640" alt="Screen Shot 2023-03-28 at 10 56 24 AM" src="https://user-images.githubusercontent.com/104874529/228326824-d0d1e751-16d2-42de-b7cb-e0fd0523cb60.png">
<img width="509" alt="Screen Shot 2023-03-28 at 10 56 34 AM" src="https://user-images.githubusercontent.com/104874529/228326825-28fa7b24-5826-4c62-b233-b7305c4f60e7.png">
Various tweaks to make spacing consistent across pages.