### PR TITLE
SW-3177 Fix Positioning of Skrim and Spinner

### DIFF
--- a/src/components/common/BusySpinner.tsx
+++ b/src/components/common/BusySpinner.tsx
@@ -11,7 +11,7 @@ export default function BusySpinner({ withSkrim }: BusySpinnerProps): JSX.Elemen
   return (
     <Box
       sx={{
-        position: 'absolute',
+        position: 'fixed',
         left: 0,
         right: 0,
         top: 0,


### PR DESCRIPTION
The skrim and spinner that are there when, e.g., uploading or deleting photos were stuck at the top of the page, even when scrolled. To fix this, and make them always visible and blocking interactions, change to `'fixed'` positioning.

<img width="1496" alt="image" src="https://user-images.githubusercontent.com/114949086/228628198-13669875-58ec-4acc-b6e0-c0ef653c1df1.png">
