### PR TITLE
SW-3350 SW-3354 Lots of Report Field Validation Fixes

### DIFF
--- a/src/components/Reports/LocationSection.tsx
+++ b/src/components/Reports/LocationSection.tsx
@@ -41,9 +41,11 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
   const isNursery = locationType === 'nursery';
   const isPlantingSite = locationType === 'plantingSite';
 
-  const [paidWorkers, setPaidWorkers] = useState<number | undefined>(location.workers?.paidWorkers);
-  const [femalePaidWorkers, setFemalePaidWorkers] = useState<number | undefined>(location.workers?.femalePaidWorkers);
-  const [volunteers, setVolunteers] = useState<number | undefined>(location.workers?.volunteers);
+  const [paidWorkers, setPaidWorkers] = useState<number | null>(location.workers?.paidWorkers ?? null);
+  const [femalePaidWorkers, setFemalePaidWorkers] = useState<number | null>(
+    location.workers?.femalePaidWorkers ?? null
+  );
+  const [volunteers, setVolunteers] = useState<number | null>(location.workers?.volunteers ?? null);
   const [locationNotes, setLocationNotes] = useState(location.notes ?? '');
 
   const smallItemGridWidth = () => (isMobile ? 12 : 4);
@@ -114,7 +116,7 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
   ];
 
   const onEditPlantingSiteReport = (species: PlantingSiteSpecies, fromColumn?: string, value?: any) => {
-    if (fromColumn && value) {
+    if (fromColumn) {
       const speciesToEditIndex = (location as ReportPlantingSite).species.findIndex(
         (iSpecies) => iSpecies.id === species.id
       );
@@ -224,9 +226,11 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
               value={(location as ReportNursery).capacity ?? ''}
               minNum={0}
               editable={editable}
-              onChange={(value) => onUpdateLocation('capacity', Math.floor(value as number))}
+              onChange={(value) =>
+                onUpdateLocation('capacity', value === '' ? null : Math.max(0, Math.floor(value as number)))
+              }
               type='text'
-              errorText={validate && !(location as ReportNursery).capacity ? strings.REQUIRED_FIELD : ''}
+              errorText={validate && (location as ReportNursery).capacity === null ? strings.REQUIRED_FIELD : ''}
               tooltipTitle={strings.REPORT_NURSERY_CAPACITY_INFO}
             />
           </Grid>
@@ -257,10 +261,17 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
               value={(location as ReportPlantingSite).totalPlantingSiteArea ?? ''}
               minNum={0}
               editable={editable}
-              onChange={(value) => onUpdateLocation('totalPlantingSiteArea', Math.floor(value as number))}
+              onChange={(value) =>
+                onUpdateLocation(
+                  'totalPlantingSiteArea',
+                  value === '' ? null : Math.max(0, Math.floor(value as number))
+                )
+              }
               type='text'
               errorText={
-                validate && !(location as ReportPlantingSite).totalPlantingSiteArea ? strings.REQUIRED_FIELD : ''
+                validate && (location as ReportPlantingSite).totalPlantingSiteArea === null
+                  ? strings.REQUIRED_FIELD
+                  : ''
               }
               tooltipTitle={strings.REPORT_TOTAL_PLANTING_SITE_AREA_INFO}
             />
@@ -272,9 +283,13 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
               value={(location as ReportPlantingSite).totalPlantedArea ?? ''}
               minNum={0}
               editable={editable}
-              onChange={(value) => onUpdateLocation('totalPlantedArea', Math.floor(value as number))}
+              onChange={(value) =>
+                onUpdateLocation('totalPlantedArea', value === '' ? null : Math.max(0, Math.floor(value as number)))
+              }
               type='text'
-              errorText={validate && !(location as ReportPlantingSite).totalPlantedArea ? strings.REQUIRED_FIELD : ''}
+              errorText={
+                validate && (location as ReportPlantingSite).totalPlantedArea === null ? strings.REQUIRED_FIELD : ''
+              }
               tooltipTitle={strings.REPORT_TOTAL_PLANTED_AREA_INFO}
             />
           </Grid>
@@ -286,10 +301,14 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
               value={(location as ReportPlantingSite).totalTreesPlanted ?? ''}
               minNum={0}
               editable={editable}
-              onChange={(value) => onUpdateLocation('totalTreesPlanted', Math.floor(value as number))}
+              onChange={(value) =>
+                onUpdateLocation('totalTreesPlanted', value === '' ? null : Math.max(0, Math.floor(value as number)))
+              }
               type='text'
               helper={strings.TOTAL_TREES_PLANTED_HELPER_TEXT}
-              errorText={validate && !(location as ReportPlantingSite).totalTreesPlanted ? strings.REQUIRED_FIELD : ''}
+              errorText={
+                validate && (location as ReportPlantingSite).totalTreesPlanted === null ? strings.REQUIRED_FIELD : ''
+              }
               tooltipTitle={strings.REPORT_TOTAL_TREES_PLANTED_INFO}
             />
           </Grid>
@@ -300,10 +319,14 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
               value={(location as ReportPlantingSite).totalPlantsPlanted ?? ''}
               minNum={0}
               editable={editable}
-              onChange={(value) => onUpdateLocation('totalPlantsPlanted', Math.floor(value as number))}
+              onChange={(value) =>
+                onUpdateLocation('totalPlantsPlanted', value === '' ? null : Math.max(0, Math.floor(value as number)))
+              }
               type='text'
               helper={strings.TOTAL_PLANTS_PLANTED_HELPER_TEXT}
-              errorText={validate && !(location as ReportPlantingSite).totalPlantsPlanted ? strings.REQUIRED_FIELD : ''}
+              errorText={
+                validate && (location as ReportPlantingSite).totalPlantsPlanted === null ? strings.REQUIRED_FIELD : ''
+              }
               tooltipTitle={strings.REPORT_TOTAL_NON_TREES_PLANTED_INFO}
             />
           </Grid>
@@ -321,9 +344,16 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
               minNum={0}
               maxNum={100}
               editable={editable}
-              onChange={(value) => onUpdateLocation('mortalityRate', Math.min(100, Math.floor(value as number)))}
+              onChange={(value) =>
+                onUpdateLocation(
+                  'mortalityRate',
+                  value === '' ? null : Math.min(100, Math.max(0, Math.floor(value as number)))
+                )
+              }
               type='text'
-              errorText={validate && !(location as ReportPlantingSite).mortalityRate ? strings.REQUIRED_FIELD : ''}
+              errorText={
+                validate && (location as ReportPlantingSite).mortalityRate === null ? strings.REQUIRED_FIELD : ''
+              }
               tooltipTitle={strings.REPORT_MORTALITY_RATE_INFO}
             />
           </Grid>
@@ -352,12 +382,13 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
           value={editable ? paidWorkers ?? '' : location.workers.paidWorkers?.toString() ?? ''}
           minNum={0}
           onChange={(value) => {
-            const newValue = Math.floor(value as number);
+            const newValue = value === '' ? null : Math.max(0, Math.floor(value as number));
             setPaidWorkers(newValue);
             onUpdateWorkers('paidWorkers', newValue);
           }}
           type='text'
           tooltipTitle={strings.REPORT_TOTAL_PAID_WORKERS_INFO}
+          errorText={validate && location.workers.paidWorkers === null ? strings.REQUIRED_FIELD : ''}
         />
       </Grid>
       <Grid item xs={smallItemGridWidth()}>
@@ -368,12 +399,13 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
           value={editable ? femalePaidWorkers ?? '' : location.workers.femalePaidWorkers?.toString() ?? ''}
           minNum={0}
           onChange={(value) => {
-            const newValue = Math.floor(value as number);
+            const newValue = value === '' ? null : Math.max(0, Math.floor(value as number));
             setFemalePaidWorkers(newValue);
             onUpdateWorkers('femalePaidWorkers', newValue);
           }}
           type='text'
           tooltipTitle={strings.REPORT_TOTAL_WOMEN_PAID_WORKERS_INFO}
+          errorText={validate && location.workers.femalePaidWorkers === null ? strings.REQUIRED_FIELD : ''}
         />
       </Grid>
       <Grid item xs={smallItemGridWidth()}>
@@ -384,12 +416,13 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
           value={editable ? volunteers ?? '' : location.workers.volunteers?.toString() ?? ''}
           minNum={0}
           onChange={(value) => {
-            const newValue = Math.floor(value as number);
+            const newValue = value === '' ? null : Math.max(0, Math.floor(value as number));
             setVolunteers(newValue);
             onUpdateWorkers('volunteers', newValue);
           }}
           type='text'
           tooltipTitle={strings.REPORT_TOTAL_VOLUNTEERS_INFO}
+          errorText={validate && location.workers.volunteers === null ? strings.REQUIRED_FIELD : ''}
         />
       </Grid>
       <Grid item xs={mediumItemGridWidth()}>

--- a/src/components/Reports/PlantingSitesSpeciesCellRenderer.tsx
+++ b/src/components/Reports/PlantingSitesSpeciesCellRenderer.tsx
@@ -67,7 +67,7 @@ type TableCellInputProps = {
   id: string;
   initialValue: string;
   isPercentage?: boolean;
-  onConfirmEdit: (value: string) => void;
+  onConfirmEdit: (value: string | undefined) => void;
   className: string;
   validate?: boolean;
 };
@@ -75,6 +75,7 @@ type TableCellInputProps = {
 function TableCellInput(props: TableCellInputProps): JSX.Element {
   const { id, initialValue, isPercentage, onConfirmEdit, className, validate } = props;
   const [inputValue, setInputValue] = useState(initialValue);
+  const inputInvalid = inputValue === null || inputValue === undefined || inputValue === '';
 
   return (
     <Textfield
@@ -82,7 +83,13 @@ function TableCellInput(props: TableCellInputProps): JSX.Element {
       type='number'
       onChange={(newValue) =>
         setInputValue(
-          `${isPercentage ? Math.min(100, Math.floor(newValue as number)) : Math.floor(newValue as number)}`
+          `${
+            newValue === ''
+              ? ''
+              : isPercentage
+              ? Math.max(0, Math.min(100, Math.floor(newValue as number)))
+              : Math.max(0, Math.floor(newValue as number))
+          }`
         )
       }
       onBlur={() => onConfirmEdit(inputValue)}
@@ -91,7 +98,7 @@ function TableCellInput(props: TableCellInputProps): JSX.Element {
       className={className}
       min={0}
       max={isPercentage ? 100 : undefined}
-      errorText={validate && !inputValue ? strings.REQUIRED_FIELD : ''}
+      errorText={validate && inputInvalid ? strings.REQUIRED_FIELD : ''}
     />
   );
 }

--- a/src/components/Reports/ReportEdit.tsx
+++ b/src/components/Reports/ReportEdit.tsx
@@ -193,8 +193,14 @@ export default function ReportEdit({ organization }: ReportEditProps): JSX.Eleme
       snackbar.toastWarning(strings.REPORT_BACK_WARNING);
     });
   }, [snackbar]);
-
   const hasEmptyRequiredFields = (iReport: Report) => {
+    const emptyWorkerField = (location: any) => {
+      return (
+        location.workers.paidWorkers === null ||
+        location.workers.femalePaidWorkers === null ||
+        location.workers.volunteers === null
+      );
+    };
     const emptySeedbankFields = iReport.seedBanks?.some((sb) => {
       return (
         sb.selected &&
@@ -203,7 +209,8 @@ export default function ReportEdit({ organization }: ReportEditProps): JSX.Eleme
           !sb.operationStartedDate ||
           !buildStartedDateValid(sb) ||
           !buildCompletedDateValid(sb) ||
-          !operationStartedDateValid(sb))
+          !operationStartedDateValid(sb) ||
+          emptyWorkerField(sb))
       );
     });
     const emptyNurseryFields = iReport.nurseries?.some((nursery) => {
@@ -212,23 +219,25 @@ export default function ReportEdit({ organization }: ReportEditProps): JSX.Eleme
         (!nursery.buildStartedDate ||
           !nursery.buildCompletedDate ||
           !nursery.operationStartedDate ||
-          !nursery.capacity ||
+          nursery.capacity === null ||
           !buildStartedDateValid(nursery) ||
           !buildCompletedDateValid(nursery) ||
-          !operationStartedDateValid(nursery))
+          !operationStartedDateValid(nursery) ||
+          emptyWorkerField(nursery))
       );
     });
     const emptyPlantingSitesFields = iReport.plantingSites?.some((plantingSite) => {
       const speciesDataMissing =
-        plantingSite.species?.some((sp) => !sp.totalPlanted || !sp.mortalityRateInField) ?? false;
+        plantingSite.species?.some((sp) => sp.totalPlanted === null || sp.mortalityRateInField === null) ?? false;
       return (
         plantingSite.selected &&
-        (!plantingSite.totalPlantingSiteArea ||
-          !plantingSite.totalPlantedArea ||
-          !plantingSite.totalTreesPlanted ||
-          !plantingSite.totalPlantsPlanted ||
-          !plantingSite.mortalityRate ||
-          speciesDataMissing)
+        (plantingSite.totalPlantingSiteArea === null ||
+          plantingSite.totalPlantedArea === null ||
+          plantingSite.totalTreesPlanted === null ||
+          plantingSite.totalPlantsPlanted === null ||
+          plantingSite.mortalityRate === null ||
+          speciesDataMissing ||
+          emptyWorkerField(plantingSite))
       );
     });
     return !iReport.summaryOfProgress || emptySeedbankFields || emptyNurseryFields || emptyPlantingSitesFields;


### PR DESCRIPTION
- fix numeric fields to not allow a negative number to be input
- allow numeric fields to be cleared out all the way
- validate species table fields and worker fields correctly
- check for null instead of falsey (problems with zeros)