### PR TITLE
SW-3368, SW-3369 Report Mobile Style Fixes

### DIFF
--- a/src/components/Reports/ReportEdit.tsx
+++ b/src/components/Reports/ReportEdit.tsx
@@ -23,6 +23,13 @@ import {
   operationStartedDateValid,
 } from 'src/components/Reports/LocationSection';
 import { overWordLimit } from 'src/utils/text';
+import { makeStyles } from '@mui/styles';
+
+const useStyles = makeStyles((theme) => ({
+  form: {
+    paddingBottom: '250px',
+  },
+}));
 
 export type ReportEditProps = {
   organization: Organization;
@@ -34,6 +41,8 @@ export default function ReportEdit({ organization }: ReportEditProps): JSX.Eleme
   const { user } = useUser();
 
   const theme = useTheme();
+
+  const classes = useStyles();
 
   const history = useHistory();
 
@@ -439,6 +448,7 @@ export default function ReportEdit({ organization }: ReportEditProps): JSX.Eleme
       </Box>
       {report && (
         <PageForm
+          className={classes.form}
           cancelID='cancelEdits'
           saveID='submitReport'
           onCancel={() => gotoReportView(false)}

--- a/src/components/Reports/ReportForm.tsx
+++ b/src/components/Reports/ReportForm.tsx
@@ -105,7 +105,7 @@ export default function ReportForm(props: ReportFormProps): JSX.Element {
       borderRadius={theme.spacing(3)}
       padding={theme.spacing(0, 3, 3, 0)}
       margin={0}
-      width='100%'
+      width='fit-content'
       sx={{
         backgroundColor: theme.palette.TwClrBg,
       }}

--- a/src/components/Reports/ReportView.tsx
+++ b/src/components/Reports/ReportView.tsx
@@ -13,6 +13,7 @@ import ReportFormAnnual from 'src/components/Reports/ReportFormAnnual';
 import useSnackbar from 'src/utils/useSnackbar';
 import ConcurrentEditorWarningDialog from 'src/components/Reports/ConcurrentEditorWarningDialog';
 import useReportFiles from 'src/components/Reports/useReportFiles';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
 
 export default function ReportView(): JSX.Element {
   const { reportId } = useParams<{ reportId: string }>();
@@ -20,6 +21,8 @@ export default function ReportView(): JSX.Element {
   const reportIdInt = parseInt(reportId, 10);
 
   const theme = useTheme();
+
+  const { isMobile } = useDeviceInfo();
 
   const history = useHistory();
 
@@ -93,11 +96,21 @@ export default function ReportView(): JSX.Element {
         <Box paddingLeft={theme.spacing(3)}>
           <BackToLink id='backToReports' name={strings.REPORTS} to={APP_PATHS.REPORTS} />
         </Box>
-        <Box display='flex' justifyContent='space-between' padding={theme.spacing(4, 3)}>
+        <Box
+          display='flex'
+          flexDirection={isMobile ? 'column' : 'row'}
+          justifyContent='space-between'
+          padding={theme.spacing(4, 3)}
+        >
           <Typography fontSize='24px' fontWeight={600}>
             {report ? `Report (${report?.year}-Q${report?.quarter})` : ''}
           </Typography>
-          <Box gap={theme.spacing(1)}>
+          <Box
+            display='flex'
+            gap={isMobile ? 0 : theme.spacing(1)}
+            flexDirection={isMobile ? 'column' : 'row'}
+            marginTop={isMobile ? theme.spacing(1) : theme.spacing(0)}
+          >
             {report?.isAnnual &&
               (showAnnual ? (
                 <Button
@@ -132,7 +145,12 @@ export default function ReportView(): JSX.Element {
             allPlantingSites={report.plantingSites}
           />
         ))}
-      <Box display='flex' justifyContent='flex-end' padding={theme.spacing(3)}>
+      <Box
+        display='flex'
+        flexDirection={isMobile ? 'column' : 'row'}
+        justifyContent='flex-end'
+        padding={theme.spacing(3)}
+      >
         {report?.isAnnual &&
           (showAnnual ? (
             <Button

--- a/src/components/common/PageForm.tsx
+++ b/src/components/common/PageForm.tsx
@@ -12,6 +12,6 @@ export default function WrappedPageForm(props: PageFormProps): JSX.Element {
   return PageForm({
     ...formProps,
     saveButtonText: saveButtonText || strings.SAVE,
-    cancelButtonText: saveButtonText || strings.CANCEL,
+    cancelButtonText: cancelButtonText || strings.CANCEL,
   });
 }


### PR DESCRIPTION
- Container width should be fit-content to ensure table displays
  within the container properly
- Add more bottom padding to accomidate buttons
- Rearrange 'Show Quarterly/Annual' and 'Edit Report' buttons

<img width="516" alt="image" src="https://user-images.githubusercontent.com/114949086/229588943-861e55f0-60c4-4fc7-af50-29fc4f55127d.png">
<img width="515" alt="image" src="https://user-images.githubusercontent.com/114949086/229589020-989a3144-a3ce-4545-9764-ec9987ff93c4.png">
<img width="518" alt="image" src="https://user-images.githubusercontent.com/114949086/229589127-4de9b0fe-b874-4827-94c9-afb3d4235696.png">
<img width="518" alt="image" src="https://user-images.githubusercontent.com/114949086/229589187-de9230da-79b3-40a2-9503-6839b2566e30.png">
