### PR TITLE
Remove popstate Event Handler

### DIFF
--- a/src/components/Reports/ReportEdit.tsx
+++ b/src/components/Reports/ReportEdit.tsx
@@ -187,12 +187,18 @@ export default function ReportEdit({ organization }: ReportEditProps): JSX.Eleme
   };
 
   useEffect(() => {
-    window.history.pushState(null, document.title, window.location.href);
-    window.addEventListener('popstate', (event) => {
+    const popStateEventHandler = (event: PopStateEvent) => {
       window.history.pushState(null, document.title, window.location.href);
       snackbar.toastWarning(strings.REPORT_BACK_WARNING);
-    });
+    };
+
+    window.history.pushState(null, document.title, window.location.href);
+    window.addEventListener('popstate', popStateEventHandler);
+    return () => {
+      window.removeEventListener('popstate', popStateEventHandler);
+    };
   }, [snackbar]);
+
   const hasEmptyRequiredFields = (iReport: Report) => {
     const emptyWorkerField = (location: any) => {
       return (


### PR DESCRIPTION
Forgot to remove the popstate event handler when ReportEdit unmounts.
Remove it so that it does not affect other pages.