### PR TITLE
SW-3272 Include all English keys in JS strings

### DIFF
--- a/src/strings/export.js
+++ b/src/strings/export.js
@@ -83,8 +83,8 @@ async function convertCsvFile(csvPath, targetDir) {
   if (locale === 'en') {
     englishStringsMap = stringsMap;
   } else {
-    const englishPath = path.resolve(path.dirname(csvPath), "en.csv");
-    const englishCsvData = await fs.readFile(englishPath, { encoding: 'utf-8'});
+    const englishPath = path.resolve(path.dirname(csvPath), 'en.csv');
+    const englishCsvData = await fs.readFile(englishPath, { encoding: 'utf-8' });
     englishStringsMap = csvToStrings(englishCsvData);
   }
 

--- a/src/strings/export.js
+++ b/src/strings/export.js
@@ -41,7 +41,18 @@ function stringsToJS(stringsMap) {
   return `export const strings = ${json};\n`;
 }
 
-async function exportStrings(stringsMap, locale, targetDir) {
+async function exportStrings(englishStrings, localizedStrings, locale, targetDir) {
+  const stringsMap = {};
+  for (let key in englishStrings) {
+    if (key in localizedStrings) {
+      stringsMap[key] = localizedStrings[key];
+    } else {
+      // tslint:disable-next-line:no-console
+      console.warn(`Locale ${locale} has no translation for ${key}`);
+      stringsMap[key] = englishStrings[key];
+    }
+  }
+
   const javascript = stringsToJS(stringsMap);
 
   const exportPath = path.resolve(targetDir, `strings-${locale}.js`);
@@ -51,6 +62,8 @@ async function exportStrings(stringsMap, locale, targetDir) {
 
 /**
  * Converts a CSV strings file to a JavaScript source file that exports a constant called "strings".
+ * This will be an object that has the same keys as the English strings file; the English strings
+ * will be used for any keys that aren't translated yet.
  *
  * @param {string} [csvPath] - Location of CSV file. The filename is assumed to be the locale
  * code with a ".csv" suffix.
@@ -66,10 +79,19 @@ async function convertCsvFile(csvPath, targetDir) {
   const csvData = await fs.readFile(csvPath, { encoding: 'utf-8' });
   const stringsMap = csvToStrings(csvData);
 
-  await exportStrings(stringsMap, locale, targetDir);
+  let englishStringsMap;
+  if (locale === 'en') {
+    englishStringsMap = stringsMap;
+  } else {
+    const englishPath = path.resolve(path.dirname(csvPath), "en.csv");
+    const englishCsvData = await fs.readFile(englishPath, { encoding: 'utf-8'});
+    englishStringsMap = csvToStrings(englishCsvData);
+  }
+
+  await exportStrings(englishStringsMap, stringsMap, locale, targetDir);
 
   if (locale === 'en') {
-    await exportStrings(generateGibberish(stringsMap), 'gx', targetDir);
+    await exportStrings(englishStringsMap, generateGibberish(englishStringsMap), 'gx', targetDir);
   }
 }
 


### PR DESCRIPTION
If we have CSV files for multiple locales, we generate a JavaScript source file
with the strings for each locale. Previously, this was just an alternate rendering
locale's CSV file.

Unfortunately, that simple approach means that if you add or remove an English
string, the JS strings objects for the other locales won't have the same keys as
the English one. At best, this will cause a TypeScript error because the type
signatures don't match; at worst, it'll be a runtime error.

Instead, generate each locale's JS file using both the English and localized CSV
files. The list of keys will always be based on the English file. The values will
be the localized strings if available, or the original English strings if not,
such that the app effectively falls back to English for strings that aren't
translated yet.

Print a warning for each untranslated string; that'll let us easily check the CI
build logs before a release to see if we're missing any translations.
