### PR TITLE
SW-3430 Fix species template download and species import resolutions

### DIFF
--- a/src/components/Species/ImportSpeciesModal.tsx
+++ b/src/components/Species/ImportSpeciesModal.tsx
@@ -12,7 +12,7 @@ export type ImportSpeciesModalProps = {
 
 export const downloadCsvTemplate = async () => {
   const apiResponse = await SpeciesService.downloadSpeciesTemplate();
-  const csvContent = 'data:text/csv;charset=utf-8,' + apiResponse;
+  const csvContent = 'data:text/csv;charset=utf-8,' + apiResponse.template;
   const encodedUri = encodeURI(csvContent);
   const link = document.createElement('a');
   link.setAttribute('href', encodedUri);

--- a/src/services/SpeciesService.ts
+++ b/src/services/SpeciesService.ts
@@ -215,7 +215,7 @@ const resolveSpeciesUpload = async (uploadId: number, overwriteExisting: boolean
     urlReplacements: {
       '{uploadId}': uploadId.toString(),
     },
-    params: { overwriteExisting: overwriteExisting.toString() },
+    entity: { overwriteExisting: overwriteExisting.toString() },
   });
 };
 


### PR DESCRIPTION
- the response needed to be parsed for csv template
- the payload for import resolutions needed to be an entity instead of search param