### PR TITLE
SW-3437 Switch to selected locale on MyAccount save so confirmation reflects new locale

### DIFF
--- a/src/components/MyAccount/index.tsx
+++ b/src/components/MyAccount/index.tsx
@@ -193,11 +193,14 @@ const MyAccountContent = ({
       await PreferencesService.updateUserPreferences({ preferredWeightSystem: preferredWeightSystemSelected });
       reloadUserPreferences();
 
+      const lastLocale = selectedLocale;
+      setSelectedLocale(localeSelected);
       const updateUserResponse = await saveProfileChanges();
       if (updateUserResponse.requestSucceeded) {
         reloadUser();
         snackbar.toastSuccess(strings.CHANGES_SAVED);
       } else {
+        setSelectedLocale(lastLocale);
         snackbar.toastError();
       }
       history.push(APP_PATHS.MY_ACCOUNT);
@@ -207,7 +210,6 @@ const MyAccountContent = ({
   const saveProfileChanges = async () => {
     // Save the currently-selected locale, even if it differs from the locale in the profile data we
     // fetched from the server.
-    setSelectedLocale(localeSelected);
     const updateUserResponse = await UserService.updateUser({ ...record, locale: localeSelected });
     return updateUserResponse;
   };

--- a/src/components/MyAccount/index.tsx
+++ b/src/components/MyAccount/index.tsx
@@ -98,7 +98,7 @@ const MyAccountContent = ({
   const snackbar = useSnackbar();
   const contentRef = useRef(null);
   const localeSelectionEnabled = isEnabled('Locale selection');
-  const { selectedLocale } = useLocalization();
+  const { selectedLocale, setSelectedLocale } = useLocalization();
   const timeZones = useTimeZones();
   const tz = timeZones.find((timeZone) => timeZone.id === record.timeZone) || getUTC(timeZones);
   const [preferredWeightSystemSelected, setPreferredWeightSystemSelected] = useState(
@@ -207,6 +207,7 @@ const MyAccountContent = ({
   const saveProfileChanges = async () => {
     // Save the currently-selected locale, even if it differs from the locale in the profile data we
     // fetched from the server.
+    setSelectedLocale(localeSelected);
     const updateUserResponse = await UserService.updateUser({ ...record, locale: localeSelected });
     return updateUserResponse;
   };


### PR DESCRIPTION
- the locale was being applied post save
- apply it at the time of save
- if there's an error we switch back