### PR TITLE
SW-3541 Preserve system order of accession columns where possible

### DIFF
--- a/cypress/e2e/10-database.cy.js
+++ b/cypress/e2e/10-database.cy.js
@@ -58,11 +58,11 @@ describe('Database', () => {
       cy.get('#table-header').children().should('have.length', 7);
       cy.get('#table-header > :nth-child(1)').contains('ACCESSION');
       cy.get('#table-header > :nth-child(2)').contains('STATUS');
-      cy.get('#table-header > :nth-child(7)').contains('SEED BANKS');
-      cy.get('#table-header > :nth-child(3)').contains('COLLECTING SITE');
-      cy.get('#table-header > :nth-child(4)').contains('AGE (MONTH');
-      cy.get('#table-header > :nth-child(5)').contains('WEIGHT (G)');
-      cy.get('#table-header > :nth-child(6)').contains('COUNT');
+      cy.get('#table-header > :nth-child(3)').contains('SEED BANKS');
+      cy.get('#table-header > :nth-child(4)').contains('COLLECTING SITE');
+      cy.get('#table-header > :nth-child(5)').contains('AGE (MONTH');
+      cy.get('#table-header > :nth-child(6)').contains('WEIGHT (G)');
+      cy.get('#table-header > :nth-child(7)').contains('COUNT');
     });
 
     it('should select ALL the columns', () => {
@@ -172,12 +172,12 @@ describe('Database', () => {
 
         cy.get('#table-header').children().should('have.length', 7);
         cy.get('#table-header > :nth-child(1)').contains('ACCESSION');
-        cy.get('#table-header > :nth-child(2)').contains('SPECIES');
-        cy.get('#table-header > :nth-child(3)').contains('STATUS');
-        cy.get('#table-header > :nth-child(4)').contains('COLLECTION DATE');
-        cy.get('#table-header > :nth-child(5)').contains('SEED BANKS');
-        cy.get('#table-header > :nth-child(6)').contains('SUB-LOCATION');
-        cy.get('#table-header > :nth-child(7)').contains('COMMON NAME');
+        cy.get('#table-header > :nth-child(2)').contains('STATUS');
+        cy.get('#table-header > :nth-child(3)').contains('SEED BANKS');
+        cy.get('#table-header > :nth-child(4)').contains('SUB-LOCATION');
+        cy.get('#table-header > :nth-child(5)').contains('SPECIES');
+        cy.get('#table-header > :nth-child(6)').contains('COMMON NAME');
+        cy.get('#table-header > :nth-child(7)').contains('COLLECTION DATE');
       });
     });
   });

--- a/src/components/seeds/database/columns.ts
+++ b/src/components/seeds/database/columns.ts
@@ -157,6 +157,10 @@ function columns(): DatabaseColumn[] {
   ];
 }
 
+export function orderedColumnNames(): string[] {
+  return columns().map((column) => column.key);
+}
+
 export function columnsIndexed(): Record<string, DatabaseColumn> {
   return columns().reduce((acum, value) => {
     acum[value.key] = value;

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -619,7 +619,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
         </>
       )}
       <TfMain backgroundImageVisible={!isOnboarded}>
-        <EditColumns open={editColumnsModalOpen} value={displayColumnNames} onClose={onCloseEditColumnsModal} />
+        {editColumnsModalOpen && <EditColumns value={displayColumnNames} onClose={onCloseEditColumnsModal} />}
         {selectedOrganization && (
           <DownloadReportModal
             searchCriteria={searchCriteria}


### PR DESCRIPTION
- in a previous commit, we added support to persist shuffled columns
- same commit introduced the new/updated preferred system order of column names
- in this commit, we try to preserve the shuffled columns and system order when columns are added/removed.. as much as possible using simple math
- approach is documented in the code
- a) when editing columns, preserve the current order (minus removed columns)
- b) determine which columns were shuffled and keep track of shuffled index
- b) sort new columns by order of appearance in the preferred system order, remove shuffled columns from this list
- c) re-insert shuffled columns at shuffled index
- this works well for most common cases without requiring us to persist any more information, after many attempts i like the latest version of the algorithm