### PR TITLE
SW-3540 Auto save table columns order in all tables

### DIFF
--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRecoilState } from 'recoil';
 import Button from 'src/components/common/button/Button';
 import EmptyMessage from 'src/components/common/EmptyMessage';
-import Table from 'src/components/common/table';
+import { OrderPreserveableTable as Table } from 'src/components/common/table';
 import { TableColumnType } from 'src/components/common/table/types';
 import speciesAtom from 'src/state/species';
 import strings from 'src/strings';
@@ -48,6 +48,7 @@ import FilterGroup, { FilterField } from 'src/components/common/FilterGroup';
 import { FieldOptionsMap } from 'src/services/NurseryWithdrawalService';
 import { SpeciesService } from 'src/services';
 import OptionsMenu from 'src/components/common/OptionsMenu';
+import _ from 'lodash';
 
 type SpeciesListProps = {
   reloadData: () => void;
@@ -626,7 +627,7 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
       if (hasErrors?.length) {
         newColumns = [problemsColumn, ...columns];
       }
-      if (selectedColumns[0].key !== newColumns[0].key) {
+      if (!_.isEqual(selectedColumns, newColumns)) {
         setSelectedColumns(newColumns);
       }
       setHandleProblemsColumn(false);
@@ -819,6 +820,13 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
             <Grid item xs={12}>
               {results && (
                 <Table
+                  setColumns={(columnsToSet: TableColumnType[]) => {
+                    // show the check-data error column only if it was already exposed
+                    const showProblemsColumn = selectedColumns.find((column) => column.key === problemsColumn.key);
+                    setSelectedColumns(
+                      columnsToSet.filter((column) => showProblemsColumn || column.key !== problemsColumn.key)
+                    );
+                  }}
                   id='species-table'
                   columns={selectedColumns}
                   rows={results}

--- a/src/components/common/table/index.tsx
+++ b/src/components/common/table/index.tsx
@@ -1,6 +1,10 @@
-import { Table as WebComponentsTable, TableRowType } from '@terraware/web-components';
+import { useCallback, useEffect, useState } from 'react';
+import { Table as WebComponentsTable, TableColumnType, TableRowType } from '@terraware/web-components';
 import strings from 'src/strings';
 import { LocalizationProps, Props } from '@terraware/web-components/components/table';
+import { useOrganization } from 'src/providers/hooks';
+import { PreferencesService } from 'src/services';
+import _ from 'lodash';
 
 function renderPaginationText(from: number, to: number, total: number): string {
   if (total > 0) {
@@ -18,7 +22,7 @@ interface TableProps<T> extends Omit<Props<T>, keyof LocalizationProps> {
   showPagination?: boolean;
 }
 
-export default function Table<T extends TableRowType>(props: TableProps<T>): JSX.Element {
+export function BaseTable<T extends TableRowType>(props: TableProps<T>): JSX.Element {
   return WebComponentsTable({
     ...props,
     booleanFalseText: strings.NO,
@@ -26,5 +30,92 @@ export default function Table<T extends TableRowType>(props: TableProps<T>): JSX
     editText: strings.EDIT,
     renderNumSelectedText,
     ...(props.showPagination !== false ? { renderPaginationText } : {}),
+  });
+}
+
+/**
+ * Ordered columns component that preserves reordered columns using callback functions.
+ * This table fetches column names from preferences and sets them if available.
+ * Also saves new columns order upon reordering, into user preferences (for the org scope).
+ */
+
+export type OrderPreserveableTableProps = {
+  setColumns: (columns: TableColumnType[]) => void;
+};
+
+export function OrderPreserveableTable<T extends TableRowType>(
+  props: TableProps<T> & OrderPreserveableTableProps
+): JSX.Element {
+  const [initialized, setInitialized] = useState<boolean>(false);
+  const { setColumns, onReorderEnd, columns, id, ...tableProps } = props;
+  const { selectedOrganization, orgPreferences, reloadOrgPreferences } = useOrganization();
+
+  const getPreferenceName = useCallback(() => `${id}-columns`, [id]);
+
+  const getTableColumns = useCallback(
+    (columnNames: string[]): TableColumnType[] =>
+      columnNames.map((columnName) => columns.find((column) => column.key === columnName)) as TableColumnType[],
+    [columns]
+  );
+
+  const reorderHandler = async (reorderedColumns: string[]) => {
+    await PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
+      [getPreferenceName()]: reorderedColumns,
+    });
+    reloadOrgPreferences();
+    const columnsToSet = getTableColumns(reorderedColumns);
+    setColumns(columnsToSet);
+
+    if (onReorderEnd) {
+      onReorderEnd(reorderedColumns);
+    }
+  };
+
+  useEffect(() => {
+    const fetchSavedColumns = () => {
+      if (!orgPreferences) {
+        return;
+      }
+      setInitialized(true);
+      const columnNames: string[] | undefined = orgPreferences[getPreferenceName()] as string[] | undefined;
+      if (
+        columnNames?.length &&
+        columns.length === columnNames.length &&
+        !_.isEqual(
+          columns.map((column) => column.key),
+          columnNames
+        )
+      ) {
+        const columnsToSet = getTableColumns(columnNames);
+        setColumns(columnsToSet);
+      }
+    };
+
+    if (!initialized) {
+      fetchSavedColumns();
+    }
+  });
+
+  return BaseTable<T>({
+    ...tableProps,
+    id,
+    columns,
+    onReorderEnd: reorderHandler,
+  });
+}
+
+/**
+ * Ordered columns table with implementation to set columns - this handles the most common cases
+ * where client does not need extra semantics to filter columns.
+ * Species table is an example where this won't work, uses its own setColumns implementation.
+ */
+export default function OrderPreservedTable<T extends TableRowType>(props: TableProps<T>): JSX.Element {
+  const { columns, ...tableProps } = props;
+  const [tableColumns, setTableColumns] = useState<TableColumnType[]>(columns);
+
+  return OrderPreserveableTable<T>({
+    ...tableProps,
+    columns: tableColumns,
+    setColumns: (columnsToSet: TableColumnType[]) => setTableColumns(columnsToSet),
   });
 }

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -11,7 +11,7 @@ import SeedBankService, {
 } from 'src/services/SeedBankService';
 import { SearchNodePayload, SearchResponseElement, SearchCriteria, SearchSortOrder } from 'src/types/Search';
 import Button from 'src/components/common/button/Button';
-import Table from 'src/components/common/table';
+import { BaseTable as Table } from 'src/components/common/table';
 import { SortOrder as Order } from 'src/components/common/table/sort';
 import strings from 'src/strings';
 import useStateLocation, { getLocation } from 'src/utils/useStateLocation';


### PR DESCRIPTION
- tables in terraware-web can be reshuffled
- added a wrapper component around the base table to save the order of columns upon reshuffling, in user preferences for the specific org
- added another wrapper with some default implementation,this wrapper component is now the default table as it is the most common use-case
- the species table uses a the original wrapper with some overridden implementation
- the accessions table does not use these wrapper, it has its own extended/customized behavior