### PR TITLE
SW-3440 Fix change status/quantities modal in seedlings batches when the numbers are large

### DIFF
--- a/src/components/Inventory/view/BatchesCellRenderer.tsx
+++ b/src/components/Inventory/view/BatchesCellRenderer.tsx
@@ -75,13 +75,14 @@ export default function BatchesCellRenderer(props: RendererProps<TableRowType>):
         row={row}
         value={
           <>
-            <ChangeQuantityModal
-              open={modalValues.openChangeQuantityModal}
-              onClose={() => setModalValues({ openChangeQuantityModal: false, type: 'germinating' })}
-              modalValues={modalValues}
-              row={row as Batch}
-              reload={onRowClick}
-            />
+            {modalValues.openChangeQuantityModal && (
+              <ChangeQuantityModal
+                onClose={() => setModalValues({ openChangeQuantityModal: false, type: 'germinating' })}
+                modalValues={modalValues}
+                row={row as Batch}
+                reload={onRowClick}
+              />
+            )}
             <QuantitiesMenu setModalValues={setModalValues} batch={row} />
           </>
         }


### PR DESCRIPTION
- code was using the localized display value (with commas) for math instead of the raw values..
- switched to raw
- also fixed some UX issues like error validation and spinner