### PR TITLE
SW-3070 Update Exact Matching in Accessions Search

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@mui/styled-engine-sc": "^5.12.0",
     "@mui/styles": "^5.11.9",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^2.3.34",
+    "@terraware/web-components": "^2.3.36",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^14.4.3",

--- a/src/components/seeds/database/Filters.tsx
+++ b/src/components/seeds/database/Filters.tsx
@@ -308,7 +308,7 @@ function getSearchTermFilter(searchCols: DatabaseColumn[], searchTerm: string): 
     children: searchCols.map((col) => ({
       operation: 'field',
       field: col.key,
-      type: col.key === 'accessionNumber' ? 'ExactOrFuzzy' : 'Fuzzy',
+      type: col.searchType ?? 'Fuzzy',
       values: [searchTerm],
     })),
     operation: 'or',

--- a/src/components/seeds/database/columns.ts
+++ b/src/components/seeds/database/columns.ts
@@ -8,6 +8,7 @@ function columns(): DatabaseColumn[] {
       name: strings.ACCESSION,
       type: 'string',
       filter: { type: 'search' },
+      searchType: 'ExactOrFuzzy',
     },
     {
       key: 'state',
@@ -56,6 +57,7 @@ function columns(): DatabaseColumn[] {
       name: strings.COLLECTING_SITE,
       type: 'string',
       filter: { type: 'search' },
+      searchType: 'ExactOrFuzzy',
     },
     {
       key: 'collectionSiteLandowner',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2315,10 +2315,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^2.3.34":
-  version "2.3.34"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.3.34.tgz#e98095096788eda8eb0393ce4d81df0a67700f5f"
-  integrity sha512-nZ/IlF6Ml4ch1/KhJzHGK/m+QWz+zXyHXuisBChtCsbUPK3PZZ966VVXaMcWJbCs4v9df7CnQ8YrKtNJW+sFrg==
+"@terraware/web-components@^2.3.36":
+  version "2.3.36"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.3.36.tgz#ac2844207af1b08e685c048eaba17e643be19470"
+  integrity sha512-W2DAN+CD9CgbIEJbZyHU8TfmB5O2vVjx3pBX7Ow3yrWn0wsTvRlqj6cY1pEHrhqzQuGoEcIZ5qYUF+2LmvRwDQ==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.16.1"


### PR DESCRIPTION
Set "exact or fuzzy" search for accessions table "Accession Number" and "Collection Site Name" columns.
Exact search now matches exact substrings.

<img width="1258" alt="image" src="https://github.com/terraware/terraware-web/assets/114949086/d68f3667-9939-458d-8a2f-dee12681300e">
<img width="1267" alt="image" src="https://github.com/terraware/terraware-web/assets/114949086/8ffdab64-e21b-43c4-bbcc-9aa3fb882fdc">
