### PR TITLE
SW-3666 Add planting site selector to observations page

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,5 +1,9 @@
 import type { Preview } from '@storybook/react';
 import { StyledEngineProvider, ThemeProvider } from '@mui/material';
+import { MemoryRouter } from 'react-router';
+import { RecoilRoot } from 'recoil';
+import { Provider } from 'react-redux';
+import { store } from 'src/redux/store';
 
 const preview: Preview = {
   parameters: {
@@ -33,7 +37,13 @@ export const decorators = [
           setActiveLocale={setActiveLocale}
         >
           <StyledEngineProvider injectFirst>
-            <Story />
+            <MemoryRouter initialEntries={['/']}>
+              <RecoilRoot>
+                <Provider store={store}>
+                  <Story />
+                </Provider>
+              </RecoilRoot>
+            </MemoryRouter>
           </StyledEngineProvider>
         </LocalizationProvider>
       </ThemeProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -264,6 +264,8 @@ function AppContent() {
 
   const selectedOrgHasPlantingSites = (): boolean => plantingSites.length > 0;
 
+  const selectedOrgHasObservations = (): boolean => false;
+
   const getSeedBanksView = (): JSX.Element => {
     if (!isPlaceholderOrg(selectedOrganization.id) && selectedOrgHasSeedBanks()) {
       return <SeedBanks organization={selectedOrganization} />;
@@ -288,6 +290,7 @@ function AppContent() {
       (location.pathname.startsWith(APP_PATHS.INVENTORY) && (!selectedOrgHasNurseries() || !selectedOrgHasSpecies())) ||
       (location.pathname.startsWith(APP_PATHS.SEED_BANKS) && !selectedOrgHasSeedBanks()) ||
       (location.pathname.startsWith(APP_PATHS.NURSERIES) && !selectedOrgHasNurseries()) ||
+      (location.pathname.startsWith(APP_PATHS.OBSERVATIONS) && !selectedOrgHasObservations()) ||
       (location.pathname.startsWith(APP_PATHS.PLANTING_SITES) && !selectedOrgHasPlantingSites())
     ) {
       return true;

--- a/src/components/Observations/index.tsx
+++ b/src/components/Observations/index.tsx
@@ -5,24 +5,31 @@ import { APP_PATHS } from 'src/constants';
 import PlantsPrimaryPage from 'src/components/PlantsPrimaryPage';
 
 export default function PlantsDashboard(): JSX.Element {
+  const [plantingSites, setPlantingSites] = useState<PlantingSite[]>();
   const [selectedPlantingSite, setSelectedPlantingSite] = useState<PlantingSite>();
   const [plantsSitePreferences, setPlantsSitePreferences] = useState<Record<string, unknown>>();
+  const hasObservations = false;
 
   const onSelect = useCallback((site: PlantingSite) => setSelectedPlantingSite(site), [setSelectedPlantingSite]);
+
   const onPreferences = useCallback(
     (preferences: Record<string, unknown>) => setPlantsSitePreferences(preferences),
     [setPlantsSitePreferences]
   );
+
+  const onPlantingSites = useCallback((sites: PlantingSite[]) => setPlantingSites(sites), [setPlantingSites]);
 
   return (
     <PlantsPrimaryPage
       title={strings.OBSERVATIONS}
       onSelect={onSelect}
       pagePath={APP_PATHS.PLANTING_SITE_OBSERVATIONS}
-      lastVisitedPreferenceName='lastObservationsPlantingSite'
+      lastVisitedPreferenceName='plants.observations.lastVisitedPlantingSite'
       plantsSitePreferences={plantsSitePreferences}
       setPlantsSitePreferences={onPreferences}
       allowAllAsSiteSelection={true}
+      onPlantingSites={onPlantingSites}
+      isEmptyState={!plantingSites?.length || !hasObservations}
     >
       <div>placeholder for selected planting site {selectedPlantingSite?.id}</div>
     </PlantsPrimaryPage>

--- a/src/components/Observations/index.tsx
+++ b/src/components/Observations/index.tsx
@@ -1,3 +1,30 @@
-export default function Observations(): JSX.Element {
-  return <div>placeholder</div>;
+import { useCallback, useState } from 'react';
+import strings from 'src/strings';
+import { PlantingSite } from 'src/types/Tracking';
+import { APP_PATHS } from 'src/constants';
+import PlantsPrimaryPage from 'src/components/PlantsPrimaryPage';
+
+export default function PlantsDashboard(): JSX.Element {
+  const [selectedPlantingSite, setSelectedPlantingSite] = useState<PlantingSite>();
+  const [plantsSitePreferences, setPlantsSitePreferences] = useState<Record<string, unknown>>();
+
+  const onSelect = useCallback((site: PlantingSite) => setSelectedPlantingSite(site), [setSelectedPlantingSite]);
+  const onPreferences = useCallback(
+    (preferences: Record<string, unknown>) => setPlantsSitePreferences(preferences),
+    [setPlantsSitePreferences]
+  );
+
+  return (
+    <PlantsPrimaryPage
+      title={strings.OBSERVATIONS}
+      onSelect={onSelect}
+      pagePath={APP_PATHS.PLANTING_SITE_OBSERVATIONS}
+      lastVisitedPreferenceName='lastObservationsPlantingSite'
+      plantsSitePreferences={plantsSitePreferences}
+      setPlantsSitePreferences={onPreferences}
+      allowAllAsSiteSelection={true}
+    >
+      <div>placeholder for selected planting site {selectedPlantingSite?.id}</div>
+    </PlantsPrimaryPage>
+  );
 }

--- a/src/components/Plants/index.tsx
+++ b/src/components/Plants/index.tsx
@@ -1,153 +1,36 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import strings from 'src/strings';
-import TfMain from 'src/components/common/TfMain';
-import { Box, CircularProgress, Grid, Typography, useTheme } from '@mui/material';
-import { Select } from '@terraware/web-components';
 import { PlantingSite } from 'src/types/Tracking';
-import { useDeviceInfo } from '@terraware/web-components/utils';
-import { useHistory, useParams } from 'react-router-dom';
-import useSnackbar from 'src/utils/useSnackbar';
 import { APP_PATHS } from 'src/constants';
 import PlantingSiteDetails from './PlantingSiteDetails';
-import { PreferencesService, TrackingService } from 'src/services';
-import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
-import PageSnackbar from 'src/components/PageSnackbar';
-import { useOrganization } from 'src/providers/hooks';
+import PlantsPrimaryPage from 'src/components/PlantsPrimaryPage';
 
 export default function PlantsDashboard(): JSX.Element {
-  const { selectedOrganization } = useOrganization();
   const [selectedPlantingSite, setSelectedPlantingSite] = useState<PlantingSite>();
-  const [plantingSites, setPlantingSites] = useState<PlantingSite[]>();
-  const theme = useTheme();
-  const { isMobile } = useDeviceInfo();
-  const { plantingSiteId } = useParams<{ plantingSiteId: string }>();
-  const history = useHistory();
-  const snackbar = useSnackbar();
-  const [plantsDashboardPreferences, setPlantsDashboardPreferences] = useState<{ [key: string]: unknown }>();
-  const contentRef = useRef(null);
+  const [plantsDashboardPreferences, setPlantsDashboardPreferences] = useState<Record<string, unknown>>();
 
-  useEffect(() => {
-    if (plantsDashboardPreferences) {
-      PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
-        lastDashboardPlantingSite: plantsDashboardPreferences,
-      });
-    }
-  }, [plantsDashboardPreferences, selectedOrganization]);
-
-  useEffect(() => {
-    const populatePlantingSites = async () => {
-      const serverResponse = await TrackingService.listPlantingSites(selectedOrganization.id);
-      if (serverResponse.requestSucceeded) {
-        setPlantingSites(serverResponse.sites ?? []);
-      } else {
-        snackbar.toastError();
-      }
-    };
-    populatePlantingSites();
-  }, [selectedOrganization, snackbar]);
-
-  const setActivePlantingSite = useCallback(
-    (site: PlantingSite | undefined) => {
-      if (site) {
-        history.push(APP_PATHS.PLANTING_SITE_DASHBOARD.replace(':plantingSiteId', site.id.toString()));
-      }
-    },
-    [history]
+  const onSelect = useCallback((site: PlantingSite) => setSelectedPlantingSite(site), [setSelectedPlantingSite]);
+  const onPreferences = useCallback(
+    (preferences: Record<string, unknown>) => setPlantsDashboardPreferences(preferences),
+    [setPlantsDashboardPreferences]
   );
 
-  useEffect(() => {
-    const initializePlantingSite = async () => {
-      if (plantingSites && plantingSites.length) {
-        let lastDashboardPlantingSite: any = {};
-        const response = await PreferencesService.getUserOrgPreferences(selectedOrganization.id);
-        if (response.requestSucceeded && response.preferences?.lastDashboardPlantingSite) {
-          lastDashboardPlantingSite = response.preferences.lastDashboardPlantingSite;
-        }
-        const plantingSiteIdToUse = plantingSiteId || lastDashboardPlantingSite.plantingSiteId;
-        const requestedPlantingSite = plantingSites.find(
-          (plantingSite) => plantingSite?.id === parseInt(plantingSiteIdToUse, 10)
-        );
-        const plantingSiteToUse = requestedPlantingSite || plantingSites[0];
-
-        if (plantingSiteToUse.id !== lastDashboardPlantingSite.plantingSiteId) {
-          lastDashboardPlantingSite = { plantingSiteId: plantingSiteToUse.id };
-          PreferencesService.updateUserOrgPreferences(selectedOrganization.id, { lastDashboardPlantingSite });
-        }
-        setPlantsDashboardPreferences(lastDashboardPlantingSite);
-        if (plantingSiteToUse.id.toString() === plantingSiteId) {
-          setSelectedPlantingSite(plantingSiteToUse);
-        } else {
-          setActivePlantingSite(plantingSiteToUse);
-        }
-      }
-    };
-    initializePlantingSite();
-  }, [plantingSites, plantingSiteId, setActivePlantingSite, selectedOrganization]);
-
-  const onChangePlantingSite = (newValue: string) => {
-    if (plantingSites) {
-      setActivePlantingSite(plantingSites.find((ps) => ps.name === newValue));
-    }
-  };
-
-  if (!plantingSites || (plantingSites.length && !selectedPlantingSite)) {
-    return (
-      <TfMain>
-        <CircularProgress sx={{ margin: 'auto' }} />
-      </TfMain>
-    );
-  }
-
   return (
-    <TfMain>
-      <PageHeaderWrapper nextElement={contentRef.current}>
-        <Grid
-          item
-          xs={12}
-          display={isMobile ? 'block' : 'flex'}
-          paddingLeft={theme.spacing(3)}
-          marginBottom={theme.spacing(4)}
-        >
-          <Typography sx={{ fontSize: '24px', fontWeight: 600, alignItems: 'center' }}>{strings.DASHBOARD}</Typography>
-          {plantingSites.length > 0 && (
-            <>
-              {!isMobile && (
-                <Box
-                  sx={{
-                    margin: theme.spacing(0, 2),
-                    width: '1px',
-                    height: '32px',
-                    backgroundColor: theme.palette.TwClrBgTertiary,
-                  }}
-                />
-              )}
-              <Box display='flex' alignItems='center' paddingTop={isMobile ? 2 : 0}>
-                <Typography sx={{ paddingRight: 1, fontSize: '16px', fontWeight: 500 }}>
-                  {strings.PLANTING_SITE}
-                </Typography>
-                <Select
-                  options={plantingSites.map((ps) => ps?.name || '')}
-                  onChange={onChangePlantingSite}
-                  selectedValue={selectedPlantingSite?.name}
-                  placeholder={strings.SELECT}
-                />
-              </Box>
-            </>
-          )}
-        </Grid>
-      </PageHeaderWrapper>
-      <Grid item xs={12}>
-        <PageSnackbar />
-      </Grid>
-      <Box ref={contentRef} display='flex' flexGrow={1}>
-        <PlantingSiteDetails
-          plantingSite={selectedPlantingSite}
-          plantsDashboardPreferences={plantsDashboardPreferences}
-          setPlantsDashboardPreferences={(newPreferences) => {
-            setPlantsDashboardPreferences((oldPreferences) => ({ ...oldPreferences, ...newPreferences }));
-          }}
-        />
-      </Box>
-    </TfMain>
+    <PlantsPrimaryPage
+      title={strings.DASHBOARD}
+      onSelect={onSelect}
+      pagePath={APP_PATHS.PLANTING_SITE_DASHBOARD}
+      lastVisitedPreferenceName='lastDashboardPlantingSite'
+      plantsSitePreferences={plantsDashboardPreferences}
+      setPlantsSitePreferences={onPreferences}
+    >
+      <PlantingSiteDetails
+        plantingSite={selectedPlantingSite}
+        plantsDashboardPreferences={plantsDashboardPreferences}
+        setPlantsDashboardPreferences={(newPreferences) => {
+          setPlantsDashboardPreferences((oldPreferences) => ({ ...oldPreferences, ...newPreferences }));
+        }}
+      />
+    </PlantsPrimaryPage>
   );
 }

--- a/src/components/Plants/index.tsx
+++ b/src/components/Plants/index.tsx
@@ -20,7 +20,7 @@ export default function PlantsDashboard(): JSX.Element {
       title={strings.DASHBOARD}
       onSelect={onSelect}
       pagePath={APP_PATHS.PLANTING_SITE_DASHBOARD}
-      lastVisitedPreferenceName='lastDashboardPlantingSite'
+      lastVisitedPreferenceName='plants.dashboard.lastVisitedPlantingSite'
       plantsSitePreferences={plantsDashboardPreferences}
       setPlantsSitePreferences={onPreferences}
     >

--- a/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
+++ b/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
@@ -1,0 +1,99 @@
+import React, { useMemo, useRef } from 'react';
+import strings from 'src/strings';
+import TfMain from 'src/components/common/TfMain';
+import { Box, CircularProgress, Grid, Typography, useTheme } from '@mui/material';
+import { Dropdown } from '@terraware/web-components';
+import { PlantingSite } from 'src/types/Tracking';
+import { useDeviceInfo } from '@terraware/web-components/utils';
+import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
+import PageSnackbar from 'src/components/PageSnackbar';
+
+export type PlantsPrimaryPageViewProps = {
+  title: string;
+  children: React.ReactNode; // primary content for this page
+  plantingSites: PlantingSite[] | undefined;
+  selectedPlantingSiteId?: number;
+  onSelect: (plantingSite: PlantingSite) => void; // planting site selected, id of -1 refers to All
+  isEmptyState?: boolean; // optional boolean to indicate this is an empty state view
+};
+
+export default function PlantsPrimaryPageView({
+  title,
+  children,
+  plantingSites,
+  selectedPlantingSiteId,
+  onSelect,
+  isEmptyState,
+}: PlantsPrimaryPageViewProps): JSX.Element {
+  const theme = useTheme();
+  const { isMobile } = useDeviceInfo();
+  const contentRef = useRef(null);
+
+  const onChangePlantingSite = (siteId: any) => {
+    const selectedPlantingSite = plantingSites?.find((ps) => ps.id === siteId);
+    if (selectedPlantingSite) {
+      onSelect(selectedPlantingSite);
+    }
+  };
+
+  const options = useMemo(
+    () => plantingSites?.map((site) => ({ label: site.name, value: site.id })) ?? [],
+    [plantingSites]
+  );
+
+  if (!plantingSites || (plantingSites.length && !selectedPlantingSiteId)) {
+    return (
+      <TfMain>
+        <CircularProgress sx={{ margin: 'auto' }} />
+      </TfMain>
+    );
+  }
+
+  return (
+    <TfMain backgroundImageVisible={isEmptyState}>
+      <PageHeaderWrapper nextElement={contentRef.current}>
+        <Grid
+          item
+          xs={12}
+          display={isMobile ? 'block' : 'flex'}
+          paddingLeft={theme.spacing(3)}
+          marginBottom={theme.spacing(4)}
+        >
+          <Typography sx={{ fontSize: '24px', fontWeight: 600, alignItems: 'center' }}>{title}</Typography>
+          {plantingSites.length > 0 && (
+            <>
+              {!isMobile && (
+                <Box
+                  sx={{
+                    margin: theme.spacing(0, 2),
+                    width: '1px',
+                    height: '32px',
+                    backgroundColor: theme.palette.TwClrBgTertiary,
+                  }}
+                />
+              )}
+              <Box display='flex' alignItems='center' paddingTop={isMobile ? 2 : 0}>
+                <Typography sx={{ paddingRight: 1, fontSize: '16px', fontWeight: 500 }}>
+                  {strings.PLANTING_SITE}
+                </Typography>
+                <Dropdown
+                  placeholder={strings.SELECT}
+                  id='planting-site-selector'
+                  onChange={onChangePlantingSite}
+                  options={options}
+                  selectedValue={selectedPlantingSiteId}
+                />
+              </Box>
+            </>
+          )}
+        </Grid>
+      </PageHeaderWrapper>
+      <Grid item xs={12}>
+        <PageSnackbar />
+      </Grid>
+      <Box ref={contentRef} display='flex' flexGrow={1}>
+        {children}
+      </Box>
+    </TfMain>
+  );
+}

--- a/src/components/PlantsPrimaryPage/index.tsx
+++ b/src/components/PlantsPrimaryPage/index.tsx
@@ -1,0 +1,184 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import strings from 'src/strings';
+import TfMain from 'src/components/common/TfMain';
+import { Box, CircularProgress, Grid, Typography, useTheme } from '@mui/material';
+import { Select } from '@terraware/web-components';
+import { PlantingSite } from 'src/types/Tracking';
+import { useDeviceInfo } from '@terraware/web-components/utils';
+import { useHistory, useParams } from 'react-router-dom';
+import useSnackbar from 'src/utils/useSnackbar';
+import { PreferencesService, TrackingService } from 'src/services';
+import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
+import PageSnackbar from 'src/components/PageSnackbar';
+import { useOrganization } from 'src/providers/hooks';
+
+export type PlantsPrimaryPageProps = {
+  title: string;
+  children: React.ReactNode; // primary content for this page
+  onSelect: (plantingSite: PlantingSite) => void; // planting site selected, id of -1 refers to All
+  pagePath: string;
+  lastVisitedPreferenceName: string;
+  plantsSitePreferences?: Record<string, unknown>;
+  setPlantsSitePreferences: (preferences: Record<string, unknown>) => void;
+  allowAllAsSiteSelection?: boolean; // whether to support 'All' as a planting site selection
+};
+
+const allSitesOption = () => ({
+  name: strings.ALL,
+  id: -1,
+});
+
+export default function PlantsPrimaryPage({
+  title,
+  children,
+  onSelect,
+  pagePath,
+  lastVisitedPreferenceName,
+  plantsSitePreferences,
+  setPlantsSitePreferences,
+  allowAllAsSiteSelection,
+}: PlantsPrimaryPageProps): JSX.Element {
+  const { selectedOrganization } = useOrganization();
+  const [selectedPlantingSite, setSelectedPlantingSite] = useState<PlantingSite>();
+  const [plantingSites, setPlantingSites] = useState<PlantingSite[]>();
+  const theme = useTheme();
+  const { isMobile } = useDeviceInfo();
+  const { plantingSiteId } = useParams<{ plantingSiteId: string }>();
+  const history = useHistory();
+  const snackbar = useSnackbar();
+  const contentRef = useRef(null);
+
+  useEffect(() => {
+    if (plantsSitePreferences) {
+      PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
+        [lastVisitedPreferenceName]: plantsSitePreferences,
+      });
+    }
+  }, [plantsSitePreferences, lastVisitedPreferenceName, selectedOrganization.id]);
+
+  useEffect(() => {
+    const populatePlantingSites = async () => {
+      const serverResponse = await TrackingService.listPlantingSites(selectedOrganization.id);
+      if (serverResponse.requestSucceeded) {
+        if (allowAllAsSiteSelection && serverResponse.sites?.length) {
+          setPlantingSites([allSitesOption(), ...serverResponse.sites]);
+        } else {
+          setPlantingSites(serverResponse.sites ?? []);
+        }
+      } else {
+        snackbar.toastError();
+      }
+    };
+    populatePlantingSites();
+  }, [selectedOrganization.id, snackbar, allowAllAsSiteSelection]);
+
+  const setActivePlantingSite = useCallback(
+    (site: PlantingSite | undefined) => {
+      if (site) {
+        history.push(pagePath.replace(':plantingSiteId', site.id.toString()));
+      }
+    },
+    [history, pagePath]
+  );
+
+  useEffect(() => {
+    const initializePlantingSite = async () => {
+      if (plantingSites && plantingSites.length) {
+        let lastVisitedPlantingSite: any = {};
+        const response = await PreferencesService.getUserOrgPreferences(selectedOrganization.id);
+        if (response.requestSucceeded && response.preferences && response.preferences[lastVisitedPreferenceName]) {
+          lastVisitedPlantingSite = response.preferences[lastVisitedPreferenceName];
+        }
+        const plantingSiteIdToUse = plantingSiteId || lastVisitedPlantingSite.plantingSiteId;
+        const requestedPlantingSite = plantingSites.find(
+          (plantingSite) => plantingSite?.id === parseInt(plantingSiteIdToUse, 10)
+        );
+        const plantingSiteToUse = requestedPlantingSite || plantingSites[0];
+
+        if (plantingSiteToUse.id !== lastVisitedPlantingSite.plantingSiteId) {
+          lastVisitedPlantingSite = { plantingSiteId: plantingSiteToUse.id };
+          PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
+            [lastVisitedPreferenceName]: lastVisitedPlantingSite,
+          });
+        }
+        setPlantsSitePreferences(lastVisitedPlantingSite);
+        if (plantingSiteToUse.id.toString() === plantingSiteId) {
+          setSelectedPlantingSite(plantingSiteToUse);
+          onSelect(plantingSiteToUse);
+        } else {
+          setActivePlantingSite(plantingSiteToUse);
+        }
+      }
+    };
+    initializePlantingSite();
+  }, [
+    onSelect,
+    plantingSites,
+    plantingSiteId,
+    setActivePlantingSite,
+    selectedOrganization.id,
+    lastVisitedPreferenceName,
+    setPlantsSitePreferences,
+  ]);
+
+  const onChangePlantingSite = (newValue: string) => {
+    if (plantingSites) {
+      setActivePlantingSite(plantingSites.find((ps) => ps.name === newValue));
+    }
+  };
+
+  if (!plantingSites || (plantingSites.length && !selectedPlantingSite)) {
+    return (
+      <TfMain>
+        <CircularProgress sx={{ margin: 'auto' }} />
+      </TfMain>
+    );
+  }
+
+  return (
+    <TfMain>
+      <PageHeaderWrapper nextElement={contentRef.current}>
+        <Grid
+          item
+          xs={12}
+          display={isMobile ? 'block' : 'flex'}
+          paddingLeft={theme.spacing(3)}
+          marginBottom={theme.spacing(4)}
+        >
+          <Typography sx={{ fontSize: '24px', fontWeight: 600, alignItems: 'center' }}>{title}</Typography>
+          {plantingSites.length > 0 && (
+            <>
+              {!isMobile && (
+                <Box
+                  sx={{
+                    margin: theme.spacing(0, 2),
+                    width: '1px',
+                    height: '32px',
+                    backgroundColor: theme.palette.TwClrBgTertiary,
+                  }}
+                />
+              )}
+              <Box display='flex' alignItems='center' paddingTop={isMobile ? 2 : 0}>
+                <Typography sx={{ paddingRight: 1, fontSize: '16px', fontWeight: 500 }}>
+                  {strings.PLANTING_SITE}
+                </Typography>
+                <Select
+                  options={plantingSites.map((ps) => ps?.name || '')}
+                  onChange={onChangePlantingSite}
+                  selectedValue={selectedPlantingSite?.name}
+                  placeholder={strings.SELECT}
+                />
+              </Box>
+            </>
+          )}
+        </Grid>
+      </PageHeaderWrapper>
+      <Grid item xs={12}>
+        <PageSnackbar />
+      </Grid>
+      <Box ref={contentRef} display='flex' flexGrow={1}>
+        {children}
+      </Box>
+    </TfMain>
+  );
+}

--- a/src/stories/PlantsPrimaryPage.stories.tsx
+++ b/src/stories/PlantsPrimaryPage.stories.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { Story } from '@storybook/react';
+import PlantsPrimaryPageView, {
+  PlantsPrimaryPageViewProps,
+} from 'src/components/PlantsPrimaryPage/PlantsPrimaryPageView';
+
+const PlantsPrimaryPageViewTemplate: Story<Omit<PlantsPrimaryPageViewProps, 'onSelect'>> = (args) => {
+  const [id, setId] = useState<number | undefined>(args.selectedPlantingSiteId);
+
+  return (
+    <PlantsPrimaryPageView {...args} onSelect={(site) => setId(site.id)} selectedPlantingSiteId={id}>
+      <div>Selected {id}</div>
+    </PlantsPrimaryPageView>
+  );
+};
+
+export default {
+  title: 'PlantsPrimaryPageView',
+  component: PlantsPrimaryPageView,
+};
+
+export const Default = PlantsPrimaryPageViewTemplate.bind({});
+
+Default.args = {
+  title: 'Cloudforest Sites',
+  isEmptyState: true,
+  plantingSites: [
+    { name: 'Monteverde', id: 5 },
+    { name: 'Amazon', id: 99 },
+    { name: 'Congo', id: 3 },
+  ],
+  selectedPlantingSiteId: 99,
+};

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -79,6 +79,7 @@ AGE_VALUE_MONTHS,{0} Months
 AGE_YEARS,Age (yr)
 AGROFORESTRY,Agroforestry
 ALERTS,Alerts
+ALL,All
 ALL_SEEDS_WITHDRAWN_MSG,"As all seeds have been withdrawn, new withdrawals are disabled, the accession's stage has been set to Withdrawn, and the accession itself marked as Inactive"
 ALL_SENSORS_FOUND,All sensors found.
 ALREADY_INVITED_PERSON_ERROR,It looks like you have already added or invited this person. Please enter a unique email address or go to the existing person’s profile.


### PR DESCRIPTION
- Plants dashboard and plants observations have the same page structure
- extracted out plants dashboard page into a wrapper page component
- reused that for observations
- added a concept of 'All' as a selection
- added a story for the page view

<img width="769" alt="PlantsPrimaryPageView - Default ⋅ Storybook 2023-05-26 10-09-10" src="https://github.com/terraware/terraware-web/assets/1865174/f2dd7584-936d-46e7-9642-9ac154e5b6b8">

<img width="764" alt="PlantsPrimaryPageView - Default ⋅ Storybook 2023-05-26 10-08-54" src="https://github.com/terraware/terraware-web/assets/1865174/565cc067-0e36-44a4-bb8e-522a30c2c3fd">

<img width="775" alt="Terraware App 2023-05-26 09-50-54" src="https://github.com/terraware/terraware-web/assets/1865174/c323f1d3-d373-48df-917f-af66e7910226">

