### PR TITLE
SW-3664 Empty state message for no observations in planting site(s)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -330,7 +330,11 @@ function AppContent() {
       {type !== 'desktop' ? (
         <Slide direction='right' in={showNavBar} mountOnEnter unmountOnExit>
           <div className={classes.navBarOpened}>
-            <NavBar setShowNavBar={setShowNavBar} withdrawalCreated={withdrawalCreated} />
+            <NavBar
+              setShowNavBar={setShowNavBar}
+              withdrawalCreated={withdrawalCreated}
+              hasPlantingSites={selectedOrgHasPlantingSites()}
+            />
           </div>
         </Slide>
       ) : (
@@ -338,6 +342,7 @@ function AppContent() {
           setShowNavBar={setShowNavBar}
           backgroundTransparent={viewHasBackgroundImage()}
           withdrawalCreated={withdrawalCreated}
+          hasPlantingSites={selectedOrgHasPlantingSites()}
         />
       )}
       <div

--- a/src/components/Monitoring/SeedBankMonitoring.tsx
+++ b/src/components/Monitoring/SeedBankMonitoring.tsx
@@ -5,7 +5,6 @@ import strings from 'src/strings';
 import { isAdmin } from 'src/utils/organization';
 import { Facility } from 'src/types/Facility';
 import EmptyStateContent from '../emptyStatePages/EmptyStateContent';
-import { EMPTY_STATE_CONTENT_STYLES } from '../emptyStatePages/EmptyStatePage';
 import SensorKitSetup from './SensorKitSetup';
 import SeedBankDashboard from './dashboard/SeedBankDashboard';
 import { Grid, Theme } from '@mui/material';
@@ -72,7 +71,6 @@ export default function Monitoring(props: SeedBankMonitoringProps): JSX.Element 
                   listItems={[{ icon: 'monitoring' }]}
                   buttonText={strings.SET_UP}
                   onClickButton={() => setOnboarding(true)}
-                  styles={EMPTY_STATE_CONTENT_STYLES}
                 />
               </div>
             </Grid>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -19,11 +19,13 @@ type NavBarProps = {
   setShowNavBar: React.Dispatch<React.SetStateAction<boolean>>;
   backgroundTransparent?: boolean;
   withdrawalCreated?: boolean;
+  hasPlantingSites?: boolean;
 };
 export default function NavBar({
   setShowNavBar,
   backgroundTransparent,
   withdrawalCreated,
+  hasPlantingSites,
 }: NavBarProps): JSX.Element | null {
   const { selectedOrganization } = useOrganization();
   const [role, setRole] = useState<OrganizationRole>();
@@ -189,7 +191,7 @@ export default function NavBar({
             }}
             id='plants-dashboard'
           />
-          {trackingV2 && (
+          {trackingV2 && hasPlantingSites === true && (
             <NavItem
               label={strings.OBSERVATIONS}
               selected={!!isObservationsRoute}

--- a/src/components/Observations/index.tsx
+++ b/src/components/Observations/index.tsx
@@ -2,6 +2,9 @@ import { useCallback, useState } from 'react';
 import strings from 'src/strings';
 import { PlantingSite } from 'src/types/Tracking';
 import { APP_PATHS } from 'src/constants';
+import EmptyStateContent from 'src/components/emptyStatePages/EmptyStateContent';
+import { EMPTY_STATE_CONTENT_STYLES } from 'src/components/emptyStatePages/EmptyStatePage';
+import Card from 'src/components/common/Card';
 import PlantsPrimaryPage from 'src/components/PlantsPrimaryPage';
 
 export default function PlantsDashboard(): JSX.Element {
@@ -31,7 +34,17 @@ export default function PlantsDashboard(): JSX.Element {
       onPlantingSites={onPlantingSites}
       isEmptyState={!plantingSites?.length || !hasObservations}
     >
-      <div>placeholder for selected planting site {selectedPlantingSite?.id}</div>
+      {hasObservations ? (
+        <div>placeholder for selected planting site {selectedPlantingSite?.id}</div>
+      ) : (
+        <Card style={{ margin: 'auto' }}>
+          <EmptyStateContent
+            title={strings.OBSERVATIONS_EMPTY_STATE_TITLE}
+            subtitle={[strings.OBSERVATIONS_EMPTY_STATE_MESSAGE_1, strings.OBSERVATIONS_EMPTY_STATE_MESSAGE_2]}
+            styles={EMPTY_STATE_CONTENT_STYLES}
+          />
+        </Card>
+      )}
     </PlantsPrimaryPage>
   );
 }

--- a/src/components/Observations/index.tsx
+++ b/src/components/Observations/index.tsx
@@ -3,7 +3,6 @@ import strings from 'src/strings';
 import { PlantingSite } from 'src/types/Tracking';
 import { APP_PATHS } from 'src/constants';
 import EmptyStateContent from 'src/components/emptyStatePages/EmptyStateContent';
-import { EMPTY_STATE_CONTENT_STYLES } from 'src/components/emptyStatePages/EmptyStatePage';
 import Card from 'src/components/common/Card';
 import PlantsPrimaryPage from 'src/components/PlantsPrimaryPage';
 
@@ -41,7 +40,6 @@ export default function PlantsDashboard(): JSX.Element {
           <EmptyStateContent
             title={strings.OBSERVATIONS_EMPTY_STATE_TITLE}
             subtitle={[strings.OBSERVATIONS_EMPTY_STATE_MESSAGE_1, strings.OBSERVATIONS_EMPTY_STATE_MESSAGE_2]}
-            styles={EMPTY_STATE_CONTENT_STYLES}
           />
         </Card>
       )}

--- a/src/components/Observations/index.tsx
+++ b/src/components/Observations/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import strings from 'src/strings';
 import { PlantingSite } from 'src/types/Tracking';
 import { APP_PATHS } from 'src/constants';
@@ -7,6 +8,7 @@ import Card from 'src/components/common/Card';
 import PlantsPrimaryPage from 'src/components/PlantsPrimaryPage';
 
 export default function PlantsDashboard(): JSX.Element {
+  const history = useHistory();
   const [plantingSites, setPlantingSites] = useState<PlantingSite[]>();
   const [selectedPlantingSite, setSelectedPlantingSite] = useState<PlantingSite>();
   const [plantsSitePreferences, setPlantsSitePreferences] = useState<Record<string, unknown>>();
@@ -19,7 +21,15 @@ export default function PlantsDashboard(): JSX.Element {
     [setPlantsSitePreferences]
   );
 
-  const onPlantingSites = useCallback((sites: PlantingSite[]) => setPlantingSites(sites), [setPlantingSites]);
+  const onPlantingSites = useCallback(
+    (sites: PlantingSite[]) => {
+      if (!sites.length) {
+        history.push(APP_PATHS.HOME);
+      }
+      setPlantingSites(sites);
+    },
+    [setPlantingSites, history]
+  );
 
   return (
     <PlantsPrimaryPage

--- a/src/components/emptyStatePages/EmptyStateContent.tsx
+++ b/src/components/emptyStatePages/EmptyStateContent.tsx
@@ -16,6 +16,14 @@ type EmptyStateStyleProps = {
   isMobile?: boolean;
 };
 
+const DEFAULT_EMPTY_STATE_CONTENT_STYLES = {
+  titleFontSize: '20px',
+  titleLineHeight: '28px',
+  subtitleFontSize: '16px',
+  subtitleLineHeight: '24px',
+  listContainerVerticalMargin: '24px',
+};
+
 const useStyles = makeStyles((theme: Theme) => ({
   container: {
     fontWeight: 400,
@@ -109,13 +117,13 @@ type EmptyStateContentProps = {
   buttonIcon?: IconName;
   onClickButton?: () => void;
   footnote?: string[];
-  styles: EmptyStateStyleProps;
+  styles?: EmptyStateStyleProps;
 };
 
 export default function EmptyStateContent(props: EmptyStateContentProps): JSX.Element {
   const { title, subtitle, listItems, buttonText, buttonIcon, onClickButton, footnote, styles } = props;
   const { isMobile } = useDeviceInfo();
-  const classes = useStyles({ ...styles, isMobile });
+  const classes = useStyles({ ...(styles || DEFAULT_EMPTY_STATE_CONTENT_STYLES), isMobile });
 
   const subtitleParagraphs: string[] = typeof subtitle === 'string' ? [subtitle] : subtitle;
 

--- a/src/components/emptyStatePages/EmptyStateContent.tsx
+++ b/src/components/emptyStatePages/EmptyStateContent.tsx
@@ -103,8 +103,8 @@ export type ListItemContent = {
 
 type EmptyStateContentProps = {
   title: string;
-  subtitle: string;
-  listItems: ListItemContent[];
+  subtitle: string | string[];
+  listItems?: ListItemContent[];
   buttonText?: string;
   buttonIcon?: IconName;
   onClickButton?: () => void;
@@ -117,6 +117,8 @@ export default function EmptyStateContent(props: EmptyStateContentProps): JSX.El
   const { isMobile } = useDeviceInfo();
   const classes = useStyles({ ...styles, isMobile });
 
+  const subtitleParagraphs: string[] = typeof subtitle === 'string' ? [subtitle] : subtitle;
+
   const gridSize = () => {
     if (isMobile) {
       return 12;
@@ -127,9 +129,13 @@ export default function EmptyStateContent(props: EmptyStateContentProps): JSX.El
   return (
     <Container className={classes.container}>
       <h1 className={classes.title}>{title}</h1>
-      <p className={classes.subtitle}>{subtitle}</p>
+      {subtitleParagraphs.map((para, index) => (
+        <p className={classes.subtitle} key={index}>
+          {para}
+        </p>
+      ))}
       <div className={classes.listContainer}>
-        {listItems.map((item, index) => {
+        {listItems?.map((item, index) => {
           return (
             <Grid item xs={gridSize()} key={`${item.title}-${index}`} className={`${classes.listItem}`}>
               <Icon name={item.icon} className={classes.listItemIcon} />

--- a/src/components/emptyStatePages/EmptyStatePage.tsx
+++ b/src/components/emptyStatePages/EmptyStatePage.tsx
@@ -48,14 +48,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-export const EMPTY_STATE_CONTENT_STYLES = {
-  titleFontSize: '20px',
-  titleLineHeight: '28px',
-  subtitleFontSize: '16px',
-  subtitleLineHeight: '24px',
-  listContainerVerticalMargin: '24px',
-};
-
 type PageContent = {
   title1?: string;
   title2: string;
@@ -310,7 +302,6 @@ export default function EmptyStatePage({
               buttonText={content.buttonText}
               buttonIcon={content.buttonIcon}
               onClickButton={goToNewLocation}
-              styles={EMPTY_STATE_CONTENT_STYLES}
             />
           </div>
         </Container>

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -610,6 +610,9 @@ NURSERY_MORTALITY_RATE,Nursery Mortality Rate
 NURSERY_REQUIRED,Nursery *
 NURSERY_TRANSFER,Nursery Transfer
 OBSERVATIONS,Observations
+OBSERVATIONS_EMPTY_STATE_TITLE,No Observations Yet
+OBSERVATIONS_EMPTY_STATE_MESSAGE_1,"Observations are when you record data from a sample of monitoring plots using our mobile app in the field. This allows us to calculate mortality rates, and eventually carbon sequestration."
+OBSERVATIONS_EMPTY_STATE_MESSAGE_2,"You will be notified when it is time to take your observations (typically, the next time you end a planting season). After you've completed your first observations, you'll see the records here."
 ONBOARDING_ADMIN_TITLE,"Just a moment, let’s complete setup first"
 OPPORTUNITIES,Opportunities
 OPPORTUNITIES_INSTRUCTIONS,"This may include opportunities for project expansion, new markets, referrals, training to other organizations, etc. (One-quarter page maximum.)"


### PR DESCRIPTION
- added empty state
- updated empty state content component to make some props optional
- for now no-observations flag is set to true
- once we have redux to fetch real observations, we will have different content
- i have an open question on figma regarding what to show if there are no planting sites (follow up)

<img width="770" alt="Terraware App 2023-05-30 11-35-51" src="https://github.com/terraware/terraware-web/assets/1865174/b760953b-c09f-4db9-994a-79ffb15b5fd4">

<img width="165" alt="Terraware App 2023-05-30 11-35-34" src="https://github.com/terraware/terraware-web/assets/1865174/3a726cd3-f167-42a5-bc07-ea99bbc70e7d">

<img width="773" alt="Terraware App 2023-05-30 11-37-08" src="https://github.com/terraware/terraware-web/assets/1865174/91fd7347-568b-45f6-80f3-70e4d279bb31">
