### PR TITLE
SW-3667 list/map selector component with a grouped view

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@mui/styled-engine-sc": "^5.12.0",
     "@mui/styles": "^5.11.9",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^2.3.43",
+    "@terraware/web-components": "^2.3.45",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^14.4.3",

--- a/src/components/ListMapView/index.tsx
+++ b/src/components/ListMapView/index.tsx
@@ -1,0 +1,62 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Box } from '@mui/material';
+import Card from 'src/components/common/Card';
+import ListMapSelector, { View } from 'src/components/common/ListMapSelector';
+
+/**
+ * Props include an optional search component for the top left.
+ * List and map components are optional, absence of either will
+ * disable corresponding selector. 
+ */
+export type ListMapViewProps = {
+  search?: React.ReactNode;
+  list?: React.ReactNode;
+  map?: React.ReactNode;
+  onView?: (view: View) => void;
+  initialView: View;
+};
+
+export default function ListMapView({ search, list, map, onView, initialView }: ListMapViewProps): JSX.Element {
+  const [view, setView] = useState<View>(initialView);
+
+  const updateView = useCallback((nextView: View) => {
+    setView(nextView);
+    if (onView) {
+      onView(nextView);
+    }
+  }, [onView]);
+
+  useEffect(() => {
+    let nextView;
+
+    if (list && map && !view) {
+      nextView = initialView || 'list';
+    } else if (list && !map) {
+      nextView = 'list'; 
+    } else if (map && !list) {
+      nextView = 'map'; 
+    }
+
+    if (view !== nextView) {
+      updateView(nextView);
+    }
+  }, [list, map, initialView, updateView]);
+
+  return (
+    <Card>
+      <Box display='flex' justifyContent='space-between' flexDirection='row'>
+        {search}
+        <ListMapSelector
+          view={view}
+          onView={updateView}
+          listDisabled={!list}
+          mapDisabled={!map}
+        />
+      </Box>
+      <Box>
+        {view === 'map' && map}
+        {view === 'list' && list}
+      </Box>
+    </Card>
+  );
+}

--- a/src/components/ListMapView/index.tsx
+++ b/src/components/ListMapView/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Box } from '@mui/material';
 import Card from 'src/components/common/Card';
 import ListMapSelector, { View } from 'src/components/common/ListMapSelector';
@@ -6,56 +6,41 @@ import ListMapSelector, { View } from 'src/components/common/ListMapSelector';
 /**
  * Props include an optional search component for the top left.
  * List and map components are optional, absence of either will
- * disable corresponding selector. 
+ * disable corresponding selector.
  */
 export type ListMapViewProps = {
-  search?: React.ReactNode;
-  list?: React.ReactNode;
-  map?: React.ReactNode;
-  onView?: (view: View) => void;
+  search: React.ReactNode;
+  list: React.ReactNode;
+  map: React.ReactNode;
   initialView: View;
+  onView?: (view: View) => void;
 };
 
 export default function ListMapView({ search, list, map, onView, initialView }: ListMapViewProps): JSX.Element {
   const [view, setView] = useState<View>(initialView);
 
-  const updateView = useCallback((nextView: View) => {
+  const updateView = (nextView: View) => {
     setView(nextView);
     if (onView) {
       onView(nextView);
     }
-  }, [onView]);
-
-  useEffect(() => {
-    let nextView;
-
-    if (list && map && !view) {
-      nextView = initialView || 'list';
-    } else if (list && !map) {
-      nextView = 'list'; 
-    } else if (map && !list) {
-      nextView = 'map'; 
-    }
-
-    if (view !== nextView) {
-      updateView(nextView);
-    }
-  }, [list, map, initialView, updateView]);
+  };
 
   return (
-    <Card>
-      <Box display='flex' justifyContent='space-between' flexDirection='row'>
+    <Card
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        flexGrow: 1,
+      }}
+    >
+      <Box display='flex' flexDirection='row' justifyContent='space-between' alignItems='center'>
         {search}
-        <ListMapSelector
-          view={view}
-          onView={updateView}
-          listDisabled={!list}
-          mapDisabled={!map}
-        />
+        <ListMapSelector view={view} onView={updateView} />
       </Box>
-      <Box>
-        {view === 'map' && map}
-        {view === 'list' && list}
+      <Box display='flex' flexGrow={1} marginTop='20px'>
+        <Box display={view === 'list' ? 'flex' : 'none'}>{list}</Box>
+        <Box display={view === 'map' ? 'flex' : 'none'}>{map}</Box>
       </Box>
     </Card>
   );

--- a/src/components/common/ListMapSelector.tsx
+++ b/src/components/common/ListMapSelector.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Box, Theme, Typography, useTheme } from '@mui/material';
+import strings from 'src/strings';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
+import Icon from './icon/Icon';
+import { IconName } from './icon/icons';
+import Button from 'src/components/common/button/Button';
+import { makeStyles } from '@mui/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  selected: {
+  },
+  deselected: {
+  },
+  disabled: {
+  },
+}));
+
+export type View = 'list' | 'map' | undefined;
+
+export type ListMapSelectorProps = {
+  view: View;
+  onView: (view: View) => void;
+  listDisabled?: boolean;
+  mapDisabled?: boolean;
+};
+
+export default function ListMapSelector({
+  view,
+  onView,
+  listDisabled,
+  mapDisabled,
+}: ListMapSelectorProps): JSX.Element {
+  const classes = useStyles();
+  const { isMobile } = useDeviceInfo();
+
+  return (
+    <Box
+      display='flex'
+    >
+      <Box>
+      </Box>   
+      <Box>
+      </Box>   
+    </Box>
+  );
+}

--- a/src/components/common/ListMapSelector.tsx
+++ b/src/components/common/ListMapSelector.tsx
@@ -4,44 +4,73 @@ import strings from 'src/strings';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import Icon from './icon/Icon';
 import { IconName } from './icon/icons';
-import Button from 'src/components/common/button/Button';
 import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  selected: {
+  icon: {
+    '& path': {
+      fill: theme.palette.TwClrBaseGray500,
+    },
   },
-  deselected: {
-  },
-  disabled: {
+  box: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'flex-start',
   },
 }));
 
-export type View = 'list' | 'map' | undefined;
+export type View = 'list' | 'map';
 
 export type ListMapSelectorProps = {
   view: View;
   onView: (view: View) => void;
-  listDisabled?: boolean;
-  mapDisabled?: boolean;
 };
 
-export default function ListMapSelector({
-  view,
-  onView,
-  listDisabled,
-  mapDisabled,
-}: ListMapSelectorProps): JSX.Element {
+export default function ListMapSelector({ view, onView }: ListMapSelectorProps): JSX.Element {
   const classes = useStyles();
   const { isMobile } = useDeviceInfo();
+  const theme = useTheme();
+
+  const renderSelector = (iconName: IconName, title: string, selectorView: View) => (
+    <Box
+      className={classes.box}
+      width={isMobile ? '32px' : '67px'}
+      borderRadius='6px'
+      padding='4px'
+      gap='6px'
+      sx={{
+        background: view === selectorView ? theme.palette.TwClrBaseWhite : 'transparent',
+        cursor: 'pointer',
+      }}
+      onClick={() => onView(selectorView)}
+    >
+      <Icon name={iconName} size='medium' className={classes.icon} />
+      {!isMobile && (
+        <Typography
+          fontSize='16px'
+          fontWeight={400}
+          lineHeight='24px'
+          textAlign='center'
+          color={theme.palette.TwClrTxt}
+        >
+          {title}
+        </Typography>
+      )}
+    </Box>
+  );
 
   return (
     <Box
-      display='flex'
+      className={classes.box}
+      justifyContent='space-between'
+      width={isMobile ? '76px' : '152px'}
+      borderRadius='8px'
+      padding='4px'
+      gap='4px'
+      style={{ backgroundColor: theme.palette.TwClrBgSecondary }}
     >
-      <Box>
-      </Box>   
-      <Box>
-      </Box>   
+      {renderSelector('iconList', strings.LIST, 'list')}
+      {renderSelector('iconTreasureMap', strings.MAP, 'map')}
     </Box>
   );
 }

--- a/src/stories/ListMapSelector.stories.tsx
+++ b/src/stories/ListMapSelector.stories.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import { Story } from '@storybook/react';
+import ListMapSelector, { View, ListMapSelectorProps } from 'src/components/common/ListMapSelector';
+
+const ListMapSelectorTemplate: Story<ListMapSelectorProps> = (args) => {
+  const [view, setView] = useState<View>(args.view);
+
+  return <ListMapSelector view={view} onView={setView} />;
+};
+
+export default {
+  title: 'ListMapSelector',
+  component: ListMapSelector,
+};
+
+export const Default = ListMapSelectorTemplate.bind({});
+
+Default.args = {
+  view: 'list',
+};

--- a/src/stories/ListMapView.stories.tsx
+++ b/src/stories/ListMapView.stories.tsx
@@ -1,0 +1,39 @@
+import { Story } from '@storybook/react';
+import { Box, Typography } from '@mui/material';
+import ListMapView, { ListMapViewProps } from 'src/components/ListMapView';
+
+const ListMapViewTemplate: Story<ListMapViewProps> = (args) => {
+  return (
+    <Box display='flex' height='300px' padding='16px' style={{ backgroundColor: 'gray' }}>
+      <ListMapView
+        {...args}
+        search={
+          <Box width='50px'>
+            <input type='text' placeholder='search' style={{ fontSize: '16px', padding: '4px', borderRadius: '8px' }} />
+          </Box>
+        }
+        list={
+          <Box>
+            <Typography fontSize='20px'>This is the list view</Typography>
+          </Box>
+        }
+        map={
+          <Box>
+            <Typography fontSize='20px'>This is the map view</Typography>
+          </Box>
+        }
+      />
+    </Box>
+  );
+};
+
+export default {
+  title: 'ListMapView',
+  component: ListMapView,
+};
+
+export const Default = ListMapViewTemplate.bind({});
+
+Default.args = {
+  initialView: 'list',
+};

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -459,6 +459,7 @@ LEAVE_AND_SAVE,Leave and Save
 LEAVE_ORGANIZATION,Leave Organization
 LICHEN,Lichen
 LIGHT,Light
+LIST,List
 LOADING,Loading...
 LOCATION,Location
 LOCATION_REQUIRED,Location *
@@ -468,6 +469,7 @@ LOG_OUT,Log Out
 LOSS_RATE,Loss Rate
 MANAGER,Manager
 MANAGER_INFO,"A manager can do the above as well as edit data entries for seeds and manage outplant withdrawals, planting sites and species."
+MAP,Map
 MARK_ALL_AS_READ,Mark All As Read
 MARK_AS_COMPLETE,Mark as Complete
 MARK_AS_READ,Mark As Read

--- a/yarn.lock
+++ b/yarn.lock
@@ -3813,10 +3813,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^2.3.43":
-  version "2.3.43"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.3.43.tgz#aa02a6f68fd7c33a987b9fdebfbfeace98b76558"
-  integrity sha512-rg6guurEhpgBs4bzUdcQVE2HDgq80ivG0oMbR/WlaS+c9LSjIJKrBVD81dmyLm+GDeEN743qnRffQt3+rrCBSQ==
+"@terraware/web-components@^2.3.45":
+  version "2.3.45"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.3.45.tgz#0497a8a848e7b3904a82b0eb6c7dc12df0c9022f"
+  integrity sha512-KnTvBKAs9whgDvqXzmEiFQ1Qd1t2t9VQBvafzWNEjQPiqd4yBMPkY90/oHgLPe2/J87+CDcRFz13oMZ489XRJQ==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.16.1"


### PR DESCRIPTION
- selector to switch between list/map
- a search/selector/list/map grouped view/pane (used in observations page and planting site details page)
- added stories

### list/map view

<img width="898" alt="ListMapView - Default ⋅ Storybook 2023-05-31 10-08-46" src="https://github.com/terraware/terraware-web/assets/1865174/da3942e8-6b55-4f37-aeb2-ff6f6c41235e">

<img width="181" alt="ListMapView - Default ⋅ Storybook 2023-05-31 10-08-25" src="https://github.com/terraware/terraware-web/assets/1865174/2cbed99e-2042-4d77-8794-c089d38a7f5f">

### list/map selector

<img width="312" alt="ListMapSelector - Default ⋅ Storybook 2023-05-31 09-47-35" src="https://github.com/terraware/terraware-web/assets/1865174/649c7f92-bfed-4d82-a372-1d69fe204ab8">

<img width="432" alt="ListMapSelector - Default ⋅ Storybook 2023-05-31 09-47-06" src="https://github.com/terraware/terraware-web/assets/1865174/4edbdb34-ab15-42d4-a1fd-0a1777a1b489">
