### PR TITLE
SW-3675 bread crumbs navigation wrapper component

### DIFF
--- a/src/components/BreadCrumbs/index.tsx
+++ b/src/components/BreadCrumbs/index.tsx
@@ -1,0 +1,49 @@
+import { Box, Typography, useTheme } from '@mui/material';
+import BackToLink from 'src/components/common/BackToLink';
+import Link from 'src/components/common/Link';
+
+export type Crumb = {
+  name: string; // name of crumb
+  to: string; // link to url/path
+};
+
+export type BreadCrumbsProps = {
+  hierarchical?: boolean; // if true, the 'to' paths are hierarchical and concantenated, default is false (each 'to' is a fully qualified path)
+  crumbs: Crumb[];
+};
+
+export default function BreadCrumbs({ hierarchical, crumbs }: BreadCrumbsProps): JSX.Element {
+  const theme = useTheme();
+  const breadCrumbs: Crumb[] =
+    hierarchical !== true
+      ? crumbs
+      : // construct the absolute paths using concatenation of previous paths
+        crumbs.reduce((acc, curr) => {
+          const crumb = {
+            name: curr.name,
+            to: [...acc.map((_, i) => crumbs[i].to), curr.to].join(''),
+          };
+          return [...acc, crumb];
+        }, [] as Crumb[]);
+
+  return (
+    <Box display='inline-flex' alignItems='center'>
+      {breadCrumbs.map((crumb: Crumb, index: number) => (
+        <>
+          {index === 0 ? (
+            <BackToLink id={`crumb_${index}`} to={crumb.to} name={crumb.name} />
+          ) : (
+            <Link id={`crumb_${index}`} to={crumb.to}>
+              {crumb.name}
+            </Link>
+          )}
+          {index + 1 !== breadCrumbs.length && (
+            <Typography fontSize='16px' fontWeight={500} lineHeight='24px' color={theme.palette.TwClrTxtTertiary}>
+              &nbsp;/&nbsp;
+            </Typography>
+          )}
+        </>
+      ))}
+    </Box>
+  );
+}

--- a/src/stories/BreadCrumbs.stories.tsx
+++ b/src/stories/BreadCrumbs.stories.tsx
@@ -1,0 +1,56 @@
+import { Story } from '@storybook/react';
+import BreadCrumbs, { BreadCrumbsProps } from 'src/components/BreadCrumbs';
+
+const BreadCrumbsTemplate: Story<BreadCrumbsProps> = (args: BreadCrumbsProps) => {
+  return <BreadCrumbs {...args} />;
+};
+
+export default {
+  title: 'BreadCrumbs',
+  component: BreadCrumbs,
+};
+
+export const SingleCrumb = BreadCrumbsTemplate.bind({});
+
+SingleCrumb.args = {
+  crumbs: [{ name: 'Hansel', to: '/hansel' }],
+};
+
+export const HierarchicalCrumbs = BreadCrumbsTemplate.bind({});
+
+HierarchicalCrumbs.args = {
+  hierarchical: true,
+  crumbs: [
+    {
+      name: 'Forest',
+      to: '/forest',
+    },
+    {
+      name: 'Road',
+      to: '/road',
+    },
+    {
+      name: 'Gretel',
+      to: '/gretel',
+    },
+  ],
+};
+
+export const NonHierarchicalCrumbs = BreadCrumbsTemplate.bind({});
+
+NonHierarchicalCrumbs.args = {
+  crumbs: [
+    {
+      name: 'Evil Witch',
+      to: '/abc/evil-witch',
+    },
+    {
+      name: 'GingerBread',
+      to: '/def/gingerbread',
+    },
+    {
+      name: 'House',
+      to: '/xyz/house',
+    },
+  ],
+};


### PR DESCRIPTION
- simple component built over existing `BackTo` and `Link` components
- added an option `hierarchical` if we want to build the hieararchical url paths for each crumb
- defaults to false => each path specific with crumb is absolute
- stories

<img width="327" alt="BreadCrumbs - Single Crumb ⋅ Storybook 2023-05-31 15-58-06" src="https://github.com/terraware/terraware-web/assets/1865174/b7d35f60-8b1f-4111-8d39-a659e05400dd">

<img width="310" alt="BreadCrumbs - Non Hierarchical Crumbs ⋅ Storybook 2023-05-31 15-58-29" src="https://github.com/terraware/terraware-web/assets/1865174/38dfd38a-41c8-4f34-a100-af439fae4710">
