### PR TITLE
Set map/view selector icon order based on initial/default view

### DIFF
--- a/src/components/ListMapView/index.tsx
+++ b/src/components/ListMapView/index.tsx
@@ -37,7 +37,7 @@ export default function ListMapView({ search, list, map, onView, initialView }: 
     >
       <Box display='flex' flexDirection='row' justifyContent='space-between' alignItems='center'>
         {search}
-        <ListMapSelector view={view} onView={updateView} />
+        <ListMapSelector defaultView={initialView} view={view} onView={updateView} />
       </Box>
       <Box display='flex' flexGrow={1} marginTop={theme.spacing(2)}>
         <Box display={view === 'list' ? 'flex' : 'none'}>{list}</Box>

--- a/src/components/common/ListMapSelector.tsx
+++ b/src/components/common/ListMapSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Box, Theme, Typography, useTheme } from '@mui/material';
 import hexRgb from 'hex-rgb';
 import strings from 'src/strings';

--- a/src/components/common/ListMapSelector.tsx
+++ b/src/components/common/ListMapSelector.tsx
@@ -23,12 +23,12 @@ const useStyles = makeStyles((theme: Theme) => ({
 export type View = 'list' | 'map';
 
 export type ListMapSelectorProps = {
+  defaultView: View;
   view: View;
   onView: (view: View) => void;
 };
 
-export default function ListMapSelector({ view, onView }: ListMapSelectorProps): JSX.Element {
-  const [initialView] = useState<View>(view);
+export default function ListMapSelector({ defaultView, view, onView }: ListMapSelectorProps): JSX.Element {
   const classes = useStyles();
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
@@ -80,8 +80,8 @@ export default function ListMapSelector({ view, onView }: ListMapSelectorProps):
       gap={theme.spacing(0.5)}
       style={{ backgroundColor: theme.palette.TwClrBgSecondary }}
     >
-      {renderSelector(initialView === 'list' ? 'list' : 'map')}
-      {renderSelector(initialView !== 'list' ? 'list' : 'map')}
+      {renderSelector(defaultView === 'list' ? 'list' : 'map')}
+      {renderSelector(defaultView !== 'list' ? 'list' : 'map')}
     </Box>
   );
 }

--- a/src/components/common/ListMapSelector.tsx
+++ b/src/components/common/ListMapSelector.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Box, Theme, Typography, useTheme } from '@mui/material';
 import hexRgb from 'hex-rgb';
 import strings from 'src/strings';
@@ -28,11 +28,14 @@ export type ListMapSelectorProps = {
 };
 
 export default function ListMapSelector({ view, onView }: ListMapSelectorProps): JSX.Element {
+  const [initialView] = useState<View>(view);
   const classes = useStyles();
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
 
-  const renderSelector = (iconName: IconName, title: string, selectorView: View) => {
+  const renderSelector = (selectorView: View) => {
+    const iconName: IconName = selectorView === 'list' ? 'iconList' : 'iconTreasureMap';
+    const title: string = selectorView === 'list' ? strings.LIST : strings.MAP;
     const isSelected = view === selectorView;
     return (
       <Box
@@ -77,8 +80,8 @@ export default function ListMapSelector({ view, onView }: ListMapSelectorProps):
       gap={theme.spacing(0.5)}
       style={{ backgroundColor: theme.palette.TwClrBgSecondary }}
     >
-      {renderSelector('iconList', strings.LIST, 'list')}
-      {renderSelector('iconTreasureMap', strings.MAP, 'map')}
+      {renderSelector(initialView === 'list' ? 'list' : 'map')}
+      {renderSelector(initialView !== 'list' ? 'list' : 'map')}
     </Box>
   );
 }

--- a/src/stories/ListMapSelector.stories.tsx
+++ b/src/stories/ListMapSelector.stories.tsx
@@ -3,9 +3,9 @@ import { Story } from '@storybook/react';
 import ListMapSelector, { View, ListMapSelectorProps } from 'src/components/common/ListMapSelector';
 
 const ListMapSelectorTemplate: Story<ListMapSelectorProps> = (args) => {
-  const [view, setView] = useState<View>(args.view);
+  const [view, setView] = useState<View>(args.defaultView);
 
-  return <ListMapSelector view={view} onView={setView} />;
+  return <ListMapSelector {...args} view={view} onView={setView} />;
 };
 
 export default {
@@ -16,11 +16,11 @@ export default {
 export const DefaultList = ListMapSelectorTemplate.bind({});
 
 DefaultList.args = {
-  view: 'list',
+  defaultView: 'list',
 };
 
 export const DefaultMap = ListMapSelectorTemplate.bind({});
 
 DefaultMap.args = {
-  view: 'map',
+  defaultView: 'map',
 };

--- a/src/stories/ListMapSelector.stories.tsx
+++ b/src/stories/ListMapSelector.stories.tsx
@@ -13,8 +13,14 @@ export default {
   component: ListMapSelector,
 };
 
-export const Default = ListMapSelectorTemplate.bind({});
+export const DefaultList = ListMapSelectorTemplate.bind({});
 
-Default.args = {
+DefaultList.args = {
   view: 'list',
+};
+
+export const DefaultMap = ListMapSelectorTemplate.bind({});
+
+DefaultMap.args = {
+  view: 'map',
 };


### PR DESCRIPTION
- as per Chudo's request
- we have views where the default view is a map, and the selector needs to show map first in those cases

<img width="338" alt="ListMapSelector - Default Map ⋅ Storybook 2023-06-05 09-29-58" src="https://github.com/terraware/terraware-web/assets/1865174/2fb98220-cdc6-4fc5-b8c1-988a78d859d1">

<img width="349" alt="ListMapSelector - Default List ⋅ Storybook 2023-06-05 09-29-33" src="https://github.com/terraware/terraware-web/assets/1865174/233d1a77-d079-46cd-80c2-597701f57692">
