### PR TITLE
Planting Site Map Data

### DIFF
--- a/src/components/Map/PlantingSiteMap.tsx
+++ b/src/components/Map/PlantingSiteMap.tsx
@@ -3,12 +3,19 @@ import { Box, CircularProgress, Theme, useTheme } from '@mui/material';
 import hexRgb from 'hex-rgb';
 import useSnackbar from 'src/utils/useSnackbar';
 import GenericMap from './GenericMap';
-import { MapEntityId, MapEntityOptions, MapOptions, MapPopupRenderer, MapSource } from 'src/types/Map';
+import {
+  MapData,
+  MapEntityId,
+  MapEntityOptions,
+  MapObject,
+  MapOptions,
+  MapPopupRenderer,
+  MapSource,
+} from 'src/types/Map';
 import { MapService } from 'src/services';
 import _ from 'lodash';
 import { MapLayer } from 'src/components/common/MapLayerSelect';
 import { makeStyles } from '@mui/styles';
-import { MapData, MapObject } from 'src/services/MapService';
 
 const useStyles = makeStyles((theme: Theme) => ({
   bottomLeftControl: {

--- a/src/components/PlantingSites/BoundariesAndZones.tsx
+++ b/src/components/PlantingSites/BoundariesAndZones.tsx
@@ -5,6 +5,7 @@ import { PlantingSite } from 'src/types/Tracking';
 import { PlantingSiteMap } from '../Map';
 import React, { useState } from 'react';
 import MapLayerSelect, { MapLayer } from 'src/components/common/MapLayerSelect';
+import { MapService } from 'src/services';
 
 type BoundariesAndZonesProps = {
   plantingSite: PlantingSite;
@@ -35,7 +36,7 @@ export default function BoundariesAndZones(props: BoundariesAndZonesProps): JSX.
           <>
             {plantingSite.boundary ? (
               <PlantingSiteMap
-                plantingSite={plantingSite}
+                mapData={MapService.getMapDataFromPlantingSite(plantingSite)}
                 style={{ borderRadius: '24px' }}
                 layers={includedLayers}
                 topRightMapControl={

--- a/src/components/Plants/PlantingSiteDashboardMap.tsx
+++ b/src/components/Plants/PlantingSiteDashboardMap.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Box } from '@mui/material';
 import { PlantingSite } from 'src/types/Tracking';
-import { TrackingService } from 'src/services';
+import { MapService, TrackingService } from 'src/services';
 import useSnackbar from 'src/utils/useSnackbar';
 import { PlantingSiteSubzone } from 'src/types/PlantingSite';
 import { GenericMap, PlantingSiteMap, useSpeciesPlantsRenderer } from 'src/components/Map';
@@ -59,7 +59,7 @@ export default function PlantingSiteDashboardMap(props: PlantingSiteDashboardMap
     <Box display='flex' height='100%'>
       {hasPolygons ? (
         <PlantingSiteMap
-          plantingSite={plantingSite}
+          mapData={MapService.getMapDataFromPlantingSite(plantingSite)}
           key={plantingSite?.id}
           style={MAP_STYLE}
           contextRenderer={contextRenderer}

--- a/src/services/MapService.ts
+++ b/src/services/MapService.ts
@@ -107,11 +107,15 @@ const getPlantingSiteBoundingBox = (mapData: MapData): MapBoundingBox => {
   const site: MapSourceBaseData = mapData.site ?? { id: 'site', entities: [] };
   const zones: MapSourceBaseData = mapData.zone ?? { id: 'zone', entities: [] };
   const subzones: MapSourceBaseData = mapData.subzone ?? { id: 'subzone', entities: [] };
+  const permanentPlots: MapSourceBaseData = mapData.permanentPlot ?? { id: 'permanentPlot', entities: [] };
+  const temporaryPlots: MapSourceBaseData = mapData.temporaryPlot ?? { id: 'temporaryPlot', entities: [] };
 
   const geometries: MapGeometry[] = [
     site.entities[0]?.boundary,
     ...(zones?.entities.map((s) => s.boundary) || []),
     ...(subzones?.entities.map((s) => s.boundary) || []),
+    ...(permanentPlots?.entities.map((s) => s.boundary) || []),
+    ...(temporaryPlots?.entities.map((s) => s.boundary) || []),
   ].filter((g) => g) as MapGeometry[];
 
   return getBoundingBox(geometries);

--- a/src/services/MapService.ts
+++ b/src/services/MapService.ts
@@ -1,6 +1,6 @@
 import { paths } from 'src/api/types/generated-schema';
 import { MultiPolygon, PlantingSite } from 'src/types/Tracking';
-import { MapBoundingBox, MapEntity, MapGeometry, MapSourceBaseData } from 'src/types/Map';
+import { MapBoundingBox, MapData, MapEntity, MapGeometry, MapSourceBaseData } from 'src/types/Map';
 import HttpService, { Response } from './HttpService';
 
 /**
@@ -20,9 +20,6 @@ export type MapboxTokenResponse = Response & MapboxToken;
 const MAPBOX_TOKEN_ENDPOINT = '/api/v1/tracking/mapbox/token';
 type MapboxTokenServerResponse =
   paths[typeof MAPBOX_TOKEN_ENDPOINT]['get']['responses'][200]['content']['application/json'];
-
-export type MapObject = 'site' | 'zone' | 'subzone' | 'permanentPlot' | 'temporaryPlot';
-export type MapData = Record<MapObject, MapSourceBaseData | undefined>;
 
 /**
  * Fetch a mapbox api token.

--- a/src/services/MapService.ts
+++ b/src/services/MapService.ts
@@ -21,6 +21,9 @@ const MAPBOX_TOKEN_ENDPOINT = '/api/v1/tracking/mapbox/token';
 type MapboxTokenServerResponse =
   paths[typeof MAPBOX_TOKEN_ENDPOINT]['get']['responses'][200]['content']['application/json'];
 
+export type MapObject = 'site' | 'zone' | 'subzone' | 'permanentPlot' | 'temporaryPlot';
+export type MapData = Record<MapObject, MapSourceBaseData | undefined>;
+
 /**
  * Fetch a mapbox api token.
  */
@@ -100,10 +103,10 @@ const getBoundingBox = (geometries: MapGeometry[]): MapBoundingBox => {
 /**
  * Get planting site bounding box
  */
-const getPlantingSiteBoundingBox = (plantingSite: PlantingSite): MapBoundingBox => {
-  const site: MapSourceBaseData = extractPlantingSite(plantingSite);
-  const zones: MapSourceBaseData = extractPlantingZones(plantingSite);
-  const subzones: MapSourceBaseData = extractSubzones(plantingSite);
+const getPlantingSiteBoundingBox = (mapData: MapData): MapBoundingBox => {
+  const site: MapSourceBaseData = mapData.site ?? { id: 'site', entities: [] };
+  const zones: MapSourceBaseData = mapData.zone ?? { id: 'zone', entities: [] };
+  const subzones: MapSourceBaseData = mapData.subzone ?? { id: 'subzone', entities: [] };
 
   const geometries: MapGeometry[] = [
     site.entities[0]?.boundary,
@@ -206,11 +209,25 @@ const getMapEntityGeometry = (entity: MapEntity): MapGeometry => {
 };
 
 /**
+ * Extract Planting Site, Zones, Subzones from planting site data
+ */
+const getMapDataFromPlantingSite = (plantingSite: PlantingSite): MapData => {
+  return {
+    site: extractPlantingSite(plantingSite),
+    zone: extractPlantingZones(plantingSite),
+    subzone: extractSubzones(plantingSite),
+    permanentPlot: undefined,
+    temporaryPlot: undefined,
+  };
+};
+
+/**
  * Exported functions
  */
 const MapService = {
   getMapboxToken,
   getBoundingBox,
+  getMapDataFromPlantingSite,
   getPlantingSiteBoundingBox,
   getMapEntityGeometry,
   extractPlantingSite,

--- a/src/services/test/MapService.test.ts
+++ b/src/services/test/MapService.test.ts
@@ -16,7 +16,8 @@ describe('Map service', () => {
 
     it('should calcualte the bounding box from planting sites data', () => {
       const data = readData('plantingSite.json');
-      const observedBbox = MapService.getPlantingSiteBoundingBox(data);
+      const mapData = MapService.getMapDataFromPlantingSite(data);
+      const observedBbox = MapService.getPlantingSiteBoundingBox(mapData);
       const expectedBbox = {
         lowerLeft: [-138.12211603, 26.89432882],
         upperRight: [-138.10623684, 26.90304444],

--- a/src/types/Map.ts
+++ b/src/types/Map.ts
@@ -105,3 +105,13 @@ export type MapEntityOptions = {
   highlight?: MapEntityId;
   focus?: MapEntityId;
 };
+
+/**
+ * Types of objects that can be added to MapData
+ */
+export type MapObject = 'site' | 'zone' | 'subzone' | 'permanentPlot' | 'temporaryPlot';
+
+/**
+ * Sources for a map
+ */
+export type MapData = Record<MapObject, MapSourceBaseData | undefined>;


### PR DESCRIPTION
We change the way that map data flows into the PlantingSiteMap. Instead of
passing in the planting site, we pass in a more generic MapData object, which
contains data for the various map objects (site, zone, subzone, permanentPlot,
temporaryPlot). This will help make the component more reusable where, for
instance, one does not have a planting site object, but observation results
from which the map data object may be created. Behavior for existing maps, such
as the ones in the Planting Site or Plants Dashboard pages, is unchanged.