### PR TITLE
SW-3671 Org level observations table

### DIFF
--- a/src/components/ListMapView/index.tsx
+++ b/src/components/ListMapView/index.tsx
@@ -40,8 +40,12 @@ export default function ListMapView({ search, list, map, onView, initialView }: 
         <ListMapSelector defaultView={initialView} view={view} onView={updateView} />
       </Box>
       <Box display='flex' flexGrow={1} marginTop={theme.spacing(2)}>
-        <Box display={view === 'list' ? 'flex' : 'none'}>{list}</Box>
-        <Box display={view === 'map' ? 'flex' : 'none'}>{map}</Box>
+        <Box flexGrow={1} flexDirection='column' display={view === 'list' ? 'flex' : 'none'}>
+          {list}
+        </Box>
+        <Box flexGrow={1} flexDirection='column' display={view === 'map' ? 'flex' : 'none'}>
+          {map}
+        </Box>
       </Box>
     </Card>
   );

--- a/src/components/Observations/index.tsx
+++ b/src/components/Observations/index.tsx
@@ -58,12 +58,7 @@ export default function Observations(): JSX.Element {
   }, [snackbar, observationsResultsError, speciesError, plantingSitesError]);
 
   // show spinner while initializing data
-  if (
-    observationsResults === undefined &&
-    observationsResultsError === undefined &&
-    speciesError === undefined &&
-    plantingSitesError === undefined
-  ) {
+  if (observationsResults === undefined && !(observationsResultsError || speciesError || plantingSitesError)) {
     return <CircularProgress sx={{ margin: 'auto' }} />;
   }
 

--- a/src/components/Observations/org/OrgObservationsListView.tsx
+++ b/src/components/Observations/org/OrgObservationsListView.tsx
@@ -1,9 +1,105 @@
-import { ObservationResults } from 'src/types/Observations';
+import { useEffect, useState } from 'react';
+import { makeStyles } from '@mui/styles';
+import { Box, useTheme } from '@mui/material';
+import { TableColumnType } from '@terraware/web-components';
+import strings from 'src/strings';
+import Table from 'src/components/common/table';
+import { useLocalization } from 'src/providers';
+import {
+  ObservationResults,
+  ObservationPlantingZoneResults,
+  ObservationPlantingSubzoneResults,
+} from 'src/types/Observations';
+import OrgObservationsRenderer from './OrgObservationsRenderer';
+
+const useStyles = makeStyles(() => ({
+  text: {
+    fontSize: '14px',
+    '& > p': {
+      fontSize: '14px',
+    },
+  },
+}));
 
 export type OrgObservationsListViewProps = {
   observationsResults?: ObservationResults[];
 };
 
 export default function OrgObservationsListView({ observationsResults }: OrgObservationsListViewProps): JSX.Element {
-  return <div>Placeholder for list view of observations results. Total count: {observationsResults?.length}</div>;
+  const { selectedLocale } = useLocalization();
+  const [results, setResults] = useState<any>([]);
+  const classes = useStyles();
+  const theme = useTheme();
+
+  useEffect(() => {
+    setResults(
+      (observationsResults ?? []).map((observation: ObservationResults) => {
+        return {
+          ...observation,
+          plantingZones: observation.plantingZones
+            .map((zone: ObservationPlantingZoneResults) => zone.plantingZoneName)
+            .join('\r'),
+          plantingSubzones: Array.from(
+            new Set(
+              observation.plantingZones.flatMap((zone: ObservationPlantingZoneResults) =>
+                zone.plantingSubzones.flatMap(
+                  (subzone: ObservationPlantingSubzoneResults) => subzone.plantingSubzoneName
+                )
+              )
+            )
+          ).join('\r'),
+        };
+      })
+    );
+  }, [observationsResults]);
+
+  const columns = (): TableColumnType[] => [
+    {
+      key: 'completedTime',
+      name: strings.DATE,
+      type: 'string',
+    },
+    {
+      key: 'state',
+      name: strings.STATUS,
+      type: 'string',
+    },
+    {
+      key: 'plantingZones',
+      name: strings.ZONES,
+      type: 'string',
+    },
+    {
+      key: 'plantingSubzones',
+      name: strings.SUBZONES,
+      type: 'string',
+    },
+    {
+      key: 'totalPlants',
+      name: strings.PLANTS,
+      type: 'number',
+    },
+    {
+      key: 'totalSpecies',
+      name: strings.SPECIES,
+      type: 'number',
+    },
+    {
+      key: 'mortalityRate',
+      name: strings.MORTALITY_RATE,
+      type: 'number',
+    },
+  ];
+
+  return (
+    <Box>
+      <Table
+        id='org-observations-table'
+        columns={columns()}
+        rows={results}
+        orderBy='completionTime'
+        Renderer={OrgObservationsRenderer(selectedLocale, theme, classes)}
+      />
+    </Box>
+  );
 }

--- a/src/components/Observations/org/OrgObservationsRenderer.tsx
+++ b/src/components/Observations/org/OrgObservationsRenderer.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Theme } from '@mui/material';
+import { APP_PATHS } from 'src/constants';
+import CellRenderer, { TableRowType } from 'src/components/common/table/TableCellRenderer';
+import { RendererProps } from 'src/components/common/table/types';
+import Link from 'src/components/common/Link';
+import { TextTruncated } from '@terraware/web-components';
+import { getShortDate } from 'src/utils/dateFormatter';
+import { ObservationState, getStatus } from 'src/types/Observations';
+import strings from 'src/strings';
+
+const COLUMN_WIDTH = 250;
+
+const OrgObservationsRenderer =
+  (locale: string, theme: Theme, classes: any) =>
+  (props: RendererProps<TableRowType>): JSX.Element => {
+    const { column, row, value } = props;
+
+    const getTruncatedNames = (inputNames: string) => {
+      const names = inputNames.split('\r');
+      return (
+        <TextTruncated
+          stringList={names}
+          maxLengthPx={COLUMN_WIDTH}
+          textStyle={{ fontSize: 14 }}
+          showAllStyle={{ padding: theme.spacing(2), fontSize: 14 }}
+          listSeparator={strings.LIST_SEPARATOR}
+          moreSeparator={strings.TRUNCATED_TEXT_MORE_SEPARATOR}
+          moreText={strings.TRUNCATED_TEXT_MORE_LINK}
+        />
+      );
+    };
+
+    const createLinkToSiteObservation = (date: string) => {
+      const url = APP_PATHS.OBSERVATIONS_SITE.replace(':plantingSiteId', row.plantingSiteId.toString()).replace(
+        ':observationId',
+        row.observationId.toString()
+      );
+      return <Link to={url}>{date as React.ReactNode}</Link>;
+    };
+
+    if (column.key === 'plantingZones' || column.key === 'plantingSubzones') {
+      return <CellRenderer {...props} value={getTruncatedNames(value as string)} className={classes.text} />;
+    }
+
+    if (column.key === 'completedTime') {
+      return <CellRenderer {...props} value={createLinkToSiteObservation(getShortDate(value as string, locale))} />;
+    }
+
+    if (column.key === 'state') {
+      return <CellRenderer {...props} value={getStatus(value as ObservationState)} />;
+    }
+
+    return <CellRenderer {...props} />;
+  };
+
+export default OrgObservationsRenderer;

--- a/src/components/Reports/LocationSection.tsx
+++ b/src/components/Reports/LocationSection.tsx
@@ -319,7 +319,7 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
           <Grid item xs={smallItemGridWidth()}>
             <InfoField
               id={`${location.id}-mortality-rate`}
-              label={strings.MORTALITY_RATE}
+              label={strings.MORTALITY_RATE_PERCENT_REQUIRED}
               value={
                 editable
                   ? (location as ReportPlantingSite).mortalityRate ?? ''

--- a/src/components/common/MapDateSelect/index.tsx
+++ b/src/components/common/MapDateSelect/index.tsx
@@ -3,6 +3,7 @@ import { Box, Typography, useTheme } from '@mui/material';
 import { useMemo, useState } from 'react';
 import Card from 'src/components/common/Card';
 import { useLocalization } from 'src/providers';
+import { getShortDate } from 'src/utils/dateFormatter';
 
 type MapDateSelectProps = {
   dates: string[]; // date strings in the format 'YYYY-MM-DD'
@@ -42,11 +43,8 @@ export default function MapDateSelect({ dates, onChange }: MapDateSelectProps): 
     onChange(newDate);
   };
 
-  const getDateString = (date: string) => {
-    // TODO: Determine whether the dates input to this component are UTC or local to a planting site. This may influence
-    //       whether we need to localize them in the Intl.DateTimeFormatter
-    return new Intl.DateTimeFormat(locale, { month: 'short', year: 'numeric', timeZone: 'UTC' }).format(new Date(date));
-  };
+  const getDateString = (date: string) => getShortDate(date, locale);
+
   const getDateLabel = (date: string) => <Typography fontSize='12px'>{getDateString(date)}</Typography>;
 
   return (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,6 +22,7 @@ export enum APP_PATHS {
   INVENTORY_ITEM = '/inventory/:speciesId',
   INVENTORY_WITHDRAW = '/inventory/withdraw',
   OBSERVATIONS = '/observations',
+  OBSERVATIONS_SITE = '/observations/:plantingSiteId/:observationId',
   OPT_IN = '/opt-in',
   ORGANIZATION_EDIT = '/organization/edit',
   ORGANIZATION = '/organization',

--- a/src/redux/features/observations/observationsSelectors.ts
+++ b/src/redux/features/observations/observationsSelectors.ts
@@ -105,9 +105,11 @@ const subzonesReverseMap = (sites: PlantingSite[]): Record<number, Value> =>
 // reverse map of id to name, boundary (for planting site, zone, subzone), optionally just name for species
 const reverseMap = (ary: any[], type: string): Record<number, Value> =>
   ary.reduce((acc, curr) => {
-    const { id, name, boundary, timeZone } = curr;
+    const { id, name, fullName, boundary, timeZone } = curr;
     if (type === 'site') {
       acc[id] = { name, boundary, timeZone };
+    } else if (type === 'subzone') {
+      acc[id] = { name: fullName, boundary };
     } else {
       acc[id] = { name, boundary };
     }

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -165,6 +165,7 @@ COLLECTOR,Collector
 COLLECTORS,Collectors
 COMMON_NAME,Common Name
 COMPLETE,Complete
+COMPLETED,Completed
 COMPROMISED_SEEDS,Compromised Seeds
 CONNECT_FAILED,Connect failed
 CONNECTED,Connected
@@ -508,7 +509,8 @@ MONTH_10,October
 MONTH_11,November
 MONTH_12,December
 MORE_OPTIONS,More Options
-MORTALITY_RATE,Mortality Rate (%) *
+MORTALITY_RATE,Mortality Rate
+MORTALITY_RATE_PERCENT_REQUIRED,Mortality Rate (%) *
 MORTALITY_RATE_IN_FIELD,Mortality Rate in Field (%)
 MORTALITY_RATE_IN_FIELD_REQUIRED,Mortality Rate in Field (%) *
 MORTALITY_RATE_IN_NURSERY,Mortality Rate in Nursery (%)
@@ -642,6 +644,7 @@ OUT_PLANTING,Out-planting
 OUTPLANT,Outplant
 OUTPLANTS_REQUIRE_READY_SEEDLINGS,"Outplants require batches with seedlings that are ""ready."""
 OVER_WORD_LIMIT,Over word limit
+OVERDUE,Overdue
 OWNER,Owner
 OZ,oz
 OZ_OUNCES,oz (ounces)
@@ -672,6 +675,7 @@ PLANT_DETAIL,Plant Detail
 PLANT_ID,Plant ID
 PLANT_ID_TOOLTIP,It’s the ID of a plant for tracking or conservation purpose. Ideally seeds from a tracked plant do not mix with others in a same accession.
 PLANT_LABEL,Plant
+PLANTING_DENSITY,Planting Density
 PLANTING_SITE,Planting Site
 PLANTING_SITE_TYPE,Planting Site Type
 PLANTING_SITE_WITH_MAP_HELP,"If you are a Terraformation partner or accelerator participant, please [contact us] to create a site with a map."
@@ -1107,6 +1111,7 @@ UNITS_INITIALIZED_MESSAGE,Your Weight System was updated to {0}. You can edit th
 UNKNOWN,Unknown
 UNSPECIFIED,Unspecified
 UNSURE,Unsure
+UPCOMING,Upcoming
 UPDATE_STATUS_WARNING,You‘re about to update the status
 UPLOAD_PHOTO,Upload Photo...
 UPLOAD_PHOTO_DESCRIPTION,"Browse or drag and drop a file (JPG, PNG)."

--- a/src/types/Observations.ts
+++ b/src/types/Observations.ts
@@ -1,5 +1,6 @@
 import { components } from 'src/api/types/generated-schema';
 import { MultiPolygon } from './Tracking';
+import strings from 'src/strings';
 
 // basic information on a single observation (excluding observation results)
 export type Observation = components['schemas']['ObservationPayload'];
@@ -52,4 +53,17 @@ export type ObservationSpeciesResultsPayload = components['schemas']['Observatio
 export type ObservationSpeciesResults = ObservationSpeciesResultsPayload & {
   speciesCommonName?: string;
   speciesScientificName: string;
+};
+
+export const getStatus = (state: ObservationState): string => {
+  switch (state) {
+    case 'Completed':
+      return strings.COMPLETED;
+    case 'InProgress':
+      return strings.IN_PROGRESS;
+    case 'Overdue':
+      return strings.OVERDUE;
+    default:
+      return strings.UPCOMING;
+  }
 };

--- a/src/utils/dateFormatter.ts
+++ b/src/utils/dateFormatter.ts
@@ -1,0 +1,5 @@
+/**
+ * Returns <Month> <Year> (eg. July 2023) from yyyy-mm-dd format
+ */
+export const getShortDate = (date: string, locale: string): string =>
+  new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric', timeZone: 'UTC' }).format(new Date(date));


### PR DESCRIPTION
- added renderer
- extracted out date formatted for reuse
- renamed some strings, added some strings
- updated selector to populate the full name of subzone
- for empty columns in the screen shot, we didn't receive data from API

<img width="719" alt="Terraware App 2023-06-06 17-38-53" src="https://github.com/terraware/terraware-web/assets/1865174/3846f139-8cf2-46b6-95a5-794a8018862e">
