### PR TITLE
SW-3724 Make table columns i18n friendly, plus other i18n fixes

### DIFF
--- a/src/components/Inventory/InventoryTable.tsx
+++ b/src/components/Inventory/InventoryTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import strings from 'src/strings';
 import { TableColumnType } from '@terraware/web-components';
@@ -11,6 +11,7 @@ import Search from './Search';
 import Table from 'src/components/common/table';
 import { SortOrder } from 'src/components/common/table/sort';
 import { SearchSortOrder } from 'src/types/Search';
+import { useLocalization } from 'src/providers';
 
 interface InventoryTableProps {
   results: SearchResponseElement[];
@@ -23,39 +24,47 @@ interface InventoryTableProps {
 }
 
 export default function InventoryTable(props: InventoryTableProps): JSX.Element {
+  const { activeLocale } = useLocalization();
   const { results, setTemporalSearchValue, temporalSearchValue, filters, setFilters, setSearchSortOrder, isPresorted } =
     props;
   const [selectedRows, setSelectedRows] = useState<any[]>([]);
   const history = useHistory();
-  const columns: TableColumnType[] = [
-    {
-      key: 'species_scientificName',
-      name: strings.SPECIES,
-      type: 'string',
-      tooltipTitle: strings.TOOLTIP_SCIENTIFIC_NAME,
-    },
-    {
-      key: 'species_commonName',
-      name: strings.COMMON_NAME,
-      type: 'string',
-      tooltipTitle: strings.TOOLTIP_COMMON_NAME,
-    },
-    { key: 'facilityInventories', name: strings.NURSERIES, type: 'string' },
-    {
-      key: 'germinatingQuantity',
-      name: strings.GERMINATING,
-      type: 'string',
-      tooltipTitle: strings.TOOLTIP_GERMINATING_QUANTITY,
-    },
-    {
-      key: 'notReadyQuantity',
-      name: strings.NOT_READY,
-      type: 'string',
-      tooltipTitle: strings.TOOLTIP_NOT_READY_QUANTITY,
-    },
-    { key: 'readyQuantity', name: strings.READY, type: 'string', tooltipTitle: strings.TOOLTIP_READY_QUANTITY },
-    { key: 'totalQuantity', name: strings.TOTAL, type: 'string', tooltipTitle: strings.TOOLTIP_TOTAL_QUANTITY },
-  ];
+
+  const columns: TableColumnType[] = useMemo(
+    () =>
+      activeLocale
+        ? [
+            {
+              key: 'species_scientificName',
+              name: strings.SPECIES,
+              type: 'string',
+              tooltipTitle: strings.TOOLTIP_SCIENTIFIC_NAME,
+            },
+            {
+              key: 'species_commonName',
+              name: strings.COMMON_NAME,
+              type: 'string',
+              tooltipTitle: strings.TOOLTIP_COMMON_NAME,
+            },
+            { key: 'facilityInventories', name: strings.NURSERIES, type: 'string' },
+            {
+              key: 'germinatingQuantity',
+              name: strings.GERMINATING,
+              type: 'string',
+              tooltipTitle: strings.TOOLTIP_GERMINATING_QUANTITY,
+            },
+            {
+              key: 'notReadyQuantity',
+              name: strings.NOT_READY,
+              type: 'string',
+              tooltipTitle: strings.TOOLTIP_NOT_READY_QUANTITY,
+            },
+            { key: 'readyQuantity', name: strings.READY, type: 'string', tooltipTitle: strings.TOOLTIP_READY_QUANTITY },
+            { key: 'totalQuantity', name: strings.TOTAL, type: 'string', tooltipTitle: strings.TOOLTIP_TOTAL_QUANTITY },
+          ]
+        : [],
+    [activeLocale]
+  );
 
   const withdrawInventory = () => {
     const speciesIds = selectedRows.filter((row) => row.species_id).map((row) => `speciesId=${row.species_id}`);

--- a/src/components/Inventory/view/InventorySeedlingsTable.tsx
+++ b/src/components/Inventory/view/InventorySeedlingsTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Typography, Grid, Box, useTheme } from '@mui/material';
 import { Button, DropdownItem, TableColumnType } from '@terraware/web-components';
@@ -16,7 +16,7 @@ import BatchDetailsModal from './BatchDetailsModal';
 import Search from '../Search';
 import { APP_PATHS } from 'src/constants';
 import { TopBarButton } from '@terraware/web-components/components/table';
-import { useOrganization } from 'src/providers/hooks';
+import { useLocalization, useOrganization } from 'src/providers';
 import Table from 'src/components/common/table';
 import { SortOrder } from 'src/components/common/table/sort';
 import OptionsMenu from 'src/components/common/OptionsMenu';
@@ -31,6 +31,7 @@ interface InventorySeedslingsTableProps {
 }
 
 export default function InventorySeedslingsTable(props: InventorySeedslingsTableProps): JSX.Element {
+  const { activeLocale } = useLocalization();
   const { selectedOrganization } = useOrganization();
   const { speciesId, modified, setModified, openBatchNumber, onUpdateOpenBatch } = props;
   const { isMobile, isDesktop } = useDeviceInfo();
@@ -47,19 +48,26 @@ export default function InventorySeedslingsTable(props: InventorySeedslingsTable
   const debouncedSearchTerm = useDebounce(temporalSearchValue, 250);
   const snackbar = useSnackbar();
   const history = useHistory();
-  const columns: TableColumnType[] = [
-    { key: 'batchNumber', name: strings.SEEDLING_BATCH, type: 'string' },
-    { key: 'germinatingQuantity', name: strings.GERMINATING, type: 'string' },
-    { key: 'notReadyQuantity', name: strings.NOT_READY, type: 'string' },
-    { key: 'readyQuantity', name: strings.READY, type: 'string' },
-    { key: 'totalQuantity', name: strings.TOTAL, type: 'string' },
-    { key: 'totalQuantityWithdrawn', name: strings.WITHDRAWN, type: 'string' },
-    { key: 'facility_name', name: strings.NURSERY, type: 'string' },
-    { key: 'readyByDate', name: strings.EST_READY_DATE, type: 'string' },
-    { key: 'addedDate', name: strings.DATE_ADDED, type: 'string' },
-    { key: 'withdraw', name: '', type: 'string' },
-    { key: 'quantitiesMenu', name: '', type: 'string' },
-  ];
+
+  const columns: TableColumnType[] = useMemo(
+    () =>
+      activeLocale
+        ? [
+            { key: 'batchNumber', name: strings.SEEDLING_BATCH, type: 'string' },
+            { key: 'germinatingQuantity', name: strings.GERMINATING, type: 'string' },
+            { key: 'notReadyQuantity', name: strings.NOT_READY, type: 'string' },
+            { key: 'readyQuantity', name: strings.READY, type: 'string' },
+            { key: 'totalQuantity', name: strings.TOTAL, type: 'string' },
+            { key: 'totalQuantityWithdrawn', name: strings.WITHDRAWN, type: 'string' },
+            { key: 'facility_name', name: strings.NURSERY, type: 'string' },
+            { key: 'readyByDate', name: strings.EST_READY_DATE, type: 'string' },
+            { key: 'addedDate', name: strings.DATE_ADDED, type: 'string' },
+            { key: 'withdraw', name: '', type: 'string' },
+            { key: 'quantitiesMenu', name: '', type: 'string' },
+          ]
+        : [],
+    [activeLocale]
+  );
 
   const getSearchFields = useCallback(() => {
     // Skip fuzzy search on empty strings since the query will be

--- a/src/components/MyAccount/index.tsx
+++ b/src/components/MyAccount/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Button, DropdownItem } from '@terraware/web-components';
 import { OrganizationUserService, OrganizationService, PreferencesService, UserService } from 'src/services';
@@ -105,12 +105,20 @@ const MyAccountContent = ({
     (userPreferences?.preferredWeightSystem as string) || 'metric'
   );
   const loadedStringsForLocale = useLocalization().activeLocale;
-  const columns: TableColumnType[] = [
-    { key: 'name', name: strings.ORGANIZATION_NAME, type: 'string' },
-    { key: 'description', name: strings.DESCRIPTION, type: 'string' },
-    { key: 'totalUsers', name: strings.PEOPLE, type: 'string' },
-    { key: 'roleName', name: strings.ROLE, type: 'string' },
-  ];
+
+  const columns: TableColumnType[] = useMemo(
+    () =>
+      loadedStringsForLocale
+        ? [
+            { key: 'name', name: strings.ORGANIZATION_NAME, type: 'string' },
+            { key: 'description', name: strings.DESCRIPTION, type: 'string' },
+            { key: 'totalUsers', name: strings.PEOPLE, type: 'string' },
+            { key: 'roleName', name: strings.ROLE, type: 'string' },
+          ]
+        : [],
+    [loadedStringsForLocale]
+  );
+
   const [localeSelected, setLocaleSelected] = useState(selectedLocale);
 
   useEffect(() => {

--- a/src/components/Nurseries/index.tsx
+++ b/src/components/Nurseries/index.tsx
@@ -1,8 +1,8 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button, TableColumnType } from '@terraware/web-components';
 import TextField from '@terraware/web-components/components/Textfield/Textfield';
 import { useDeviceInfo } from '@terraware/web-components/utils';
-import { useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { FacilityService } from 'src/services';
 import { Facility } from 'src/types/Facility';
@@ -16,7 +16,7 @@ import PageSnackbar from '../PageSnackbar';
 import NurseriesCellRenderer from './TableCellRenderer';
 import PageHeaderWrapper from '../common/PageHeaderWrapper';
 import Table from 'src/components/common/table';
-import { useTimeZones } from 'src/providers/hooks';
+import { useLocalization, useTimeZones } from 'src/providers';
 import { setTimeZone, useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 
 type NurseriesListProps = {
@@ -26,6 +26,7 @@ type NurseriesListProps = {
 export default function NurseriesList({ organization }: NurseriesListProps): JSX.Element {
   const theme = useTheme();
   const timeZones = useTimeZones();
+  const { activeLocale } = useLocalization();
   const defaultTimeZone = useDefaultTimeZone().get();
   const { isMobile } = useDeviceInfo();
   const history = useHistory();
@@ -33,11 +34,18 @@ export default function NurseriesList({ organization }: NurseriesListProps): JSX
   const debouncedSearchTerm = useDebounce(temporalSearchValue, 250);
   const [results, setResults] = useState<Facility[]>();
   const contentRef = useRef(null);
-  const columns: TableColumnType[] = [
-    { key: 'name', name: strings.NAME, type: 'string' },
-    { key: 'description', name: strings.DESCRIPTION, type: 'string' },
-    { key: 'timeZone', name: strings.TIME_ZONE, type: 'string' },
-  ];
+
+  const columns: TableColumnType[] = useMemo(
+    () =>
+      activeLocale
+        ? [
+            { key: 'name', name: strings.NAME, type: 'string' },
+            { key: 'description', name: strings.DESCRIPTION, type: 'string' },
+            { key: 'timeZone', name: strings.TIME_ZONE, type: 'string' },
+          ]
+        : [],
+    [activeLocale]
+  );
 
   const goToNewNursery = () => {
     const newNurseryLocation = {

--- a/src/components/NurseryWithdrawals/NurseryReassignment.tsx
+++ b/src/components/NurseryWithdrawals/NurseryReassignment.tsx
@@ -16,7 +16,7 @@ import PageForm from 'src/components/common/PageForm';
 import ReassignmentRenderer, { Reassignment, SubzoneInfo } from './ReassignmentRenderer';
 import PageSnackbar from 'src/components/PageSnackbar';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
-import { useOrganization } from 'src/providers/hooks';
+import { useLocalization, useOrganization } from 'src/providers';
 import Table from 'src/components/common/table';
 import { useUser } from 'src/providers';
 import { useNumberFormatter } from 'src/utils/useNumber';
@@ -36,6 +36,7 @@ export default function NurseryReassignment(): JSX.Element {
   const { user } = useUser();
   const numberFormatter = useNumberFormatter();
   const { selectedOrganization } = useOrganization();
+  const { activeLocale } = useLocalization();
   const theme = useTheme();
   const history = useHistory();
   const { isMobile } = useDeviceInfo();
@@ -49,15 +50,22 @@ export default function NurseryReassignment(): JSX.Element {
   const [reassignments, setReassignments] = useState<{ [subzoneId: string]: Reassignment }>({});
   const [noReassignments, setNoReassignments] = useState<boolean>(false);
   const contentRef = useRef(null);
-  const columns: TableColumnType[] = [
-    { key: 'species', name: strings.SPECIES, type: 'string' },
-    { key: 'siteName', name: strings.PLANTING_SITE, type: 'string' },
-    { key: 'zoneName', name: strings.ZONE, type: 'string' },
-    { key: 'originalSubzone', name: strings.ORIGINAL_SUBZONE, type: 'string' },
-    { key: 'newSubzone', name: strings.NEW_SUBZONE, type: 'string' },
-    { key: 'reassign', name: strings.REASSIGN, type: 'string' },
-    { key: 'notes', name: strings.NOTES, type: 'string' },
-  ];
+
+  const columns: TableColumnType[] = useMemo(
+    () =>
+      activeLocale
+        ? [
+            { key: 'species', name: strings.SPECIES, type: 'string' },
+            { key: 'siteName', name: strings.PLANTING_SITE, type: 'string' },
+            { key: 'zoneName', name: strings.ZONE, type: 'string' },
+            { key: 'originalSubzone', name: strings.ORIGINAL_SUBZONE, type: 'string' },
+            { key: 'newSubzone', name: strings.NEW_SUBZONE, type: 'string' },
+            { key: 'reassign', name: strings.REASSIGN, type: 'string' },
+            { key: 'notes', name: strings.NOTES, type: 'string' },
+          ]
+        : [],
+    [activeLocale]
+  );
 
   const numericFormatter = useMemo(() => numberFormatter(user?.locale), [numberFormatter, user?.locale]);
 

--- a/src/components/NurseryWithdrawals/NurseryWithdrawals.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawals.tsx
@@ -1,6 +1,6 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Grid, Popover, Theme, Typography, useTheme } from '@mui/material';
 import TextField from '@terraware/web-components/components/Textfield/Textfield';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import strings from 'src/strings';
 import PageSnackbar from 'src/components/PageSnackbar';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
@@ -14,7 +14,7 @@ import { APP_PATHS } from 'src/constants';
 import { useHistory } from 'react-router-dom';
 import useDebounce from 'src/utils/useDebounce';
 import { getRequestId, setRequestId } from 'src/utils/requestsId';
-import { useOrganization } from 'src/providers/hooks';
+import { useLocalization, useOrganization } from 'src/providers';
 import { Button, PillList } from '@terraware/web-components';
 import Table from 'src/components/common/table';
 import { TableColumnType } from '@terraware/web-components/components/table/types';
@@ -37,6 +37,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export default function NurseryWithdrawals(): JSX.Element {
   const { selectedOrganization } = useOrganization();
+  const { activeLocale } = useLocalization();
   const theme = useTheme();
   const contentRef = useRef(null);
   const classes = useStyles();
@@ -58,26 +59,40 @@ export default function NurseryWithdrawals(): JSX.Element {
     field: 'withdrawnDate',
     direction: 'Descending',
   } as SearchSortOrder);
-  const columns: TableColumnType[] = [
-    { key: 'withdrawnDate', name: strings.DATE, type: 'string' },
-    { key: 'purpose', name: strings.PURPOSE, type: 'string' },
-    { key: 'facility_name', name: strings.FROM_NURSERY, type: 'string' },
-    { key: 'destinationName', name: strings.DESTINATION, type: 'string' },
-    { key: 'plantingSubzoneNames', name: strings.TO_SUBZONE, type: 'string' },
-    { key: 'speciesScientificNames', name: strings.SPECIES, type: 'string' },
-    { key: 'totalWithdrawn', name: strings.TOTAL_QUANTITY, type: 'number' },
-    { key: 'hasReassignments', name: '', type: 'string' },
-  ];
+
+  const columns: TableColumnType[] = useMemo(
+    () =>
+      activeLocale
+        ? [
+            { key: 'withdrawnDate', name: strings.DATE, type: 'string' },
+            { key: 'purpose', name: strings.PURPOSE, type: 'string' },
+            { key: 'facility_name', name: strings.FROM_NURSERY, type: 'string' },
+            { key: 'destinationName', name: strings.DESTINATION, type: 'string' },
+            { key: 'plantingSubzoneNames', name: strings.TO_SUBZONE, type: 'string' },
+            { key: 'speciesScientificNames', name: strings.SPECIES, type: 'string' },
+            { key: 'totalWithdrawn', name: strings.TOTAL_QUANTITY, type: 'number' },
+            { key: 'hasReassignments', name: '', type: 'string' },
+          ]
+        : [],
+    [activeLocale]
+  );
 
   const filterColumns = useMemo<FilterField[]>(
-    () => [
-      { name: 'purpose', label: strings.PURPOSE, type: 'multiple_selection' },
-      { name: 'facility_name', label: strings.FROM_NURSERY, type: 'multiple_selection' },
-      { name: 'destinationName', label: strings.DESTINATION, type: 'multiple_selection' },
-      { name: 'batchWithdrawals.batch_species_scientificName', label: strings.SPECIES, type: 'multiple_selection' },
-      { name: 'withdrawnDate', label: strings.WITHDRAWN_DATE, type: 'date_range' },
-    ],
-    []
+    () =>
+      activeLocale
+        ? [
+            { name: 'purpose', label: strings.PURPOSE, type: 'multiple_selection' },
+            { name: 'facility_name', label: strings.FROM_NURSERY, type: 'multiple_selection' },
+            { name: 'destinationName', label: strings.DESTINATION, type: 'multiple_selection' },
+            {
+              name: 'batchWithdrawals.batch_species_scientificName',
+              label: strings.SPECIES,
+              type: 'multiple_selection',
+            },
+            { name: 'withdrawnDate', label: strings.WITHDRAWN_DATE, type: 'date_range' },
+          ]
+        : [],
+    [activeLocale]
   );
 
   const [filterOptions, setFilterOptions] = useState<FieldOptionsMap>({});

--- a/src/components/NurseryWithdrawals/WithdrawalDetails/WithdrawalOverview.tsx
+++ b/src/components/NurseryWithdrawals/WithdrawalDetails/WithdrawalOverview.tsx
@@ -5,6 +5,7 @@ import useDeviceInfo from 'src/utils/useDeviceInfo';
 import OverviewItemCard from 'src/components/common/OverviewItemCard';
 import { WithdrawalSummary } from '../NurseryWithdrawalsDetails';
 import { useOrganization } from 'src/providers/hooks';
+import { NurseryWithdrawalPurpose, purposeLabel } from 'src/types/Batch';
 
 type WithdrawalOverviewProps = {
   withdrawal?: NurseryWithdrawal;
@@ -23,7 +24,7 @@ export default function WithdrawalOverview({ withdrawal, withdrawalSummary }: Wi
     },
     {
       title: strings.PURPOSE,
-      data: withdrawal?.purpose ?? '',
+      data: withdrawal?.purpose ? purposeLabel(withdrawal.purpose as NurseryWithdrawalPurpose) : '',
     },
     {
       title: strings.QUANTITY,

--- a/src/components/NurseryWithdrawals/WithdrawalDetails/sections/NonOutplantWithdrawalTable.tsx
+++ b/src/components/NurseryWithdrawals/WithdrawalDetails/sections/NonOutplantWithdrawalTable.tsx
@@ -4,7 +4,7 @@ import strings from 'src/strings';
 import { Batch, NurseryWithdrawal } from 'src/types/Batch';
 import { Species } from 'src/types/Species';
 import Table from 'src/components/common/table';
-import { useUser } from 'src/providers';
+import { useLocalization, useUser } from 'src/providers';
 import { useNumberFormatter } from 'src/utils/useNumber';
 
 type SpeciesWithdrawal = {
@@ -28,16 +28,24 @@ export default function NonOutplantWithdrawalTable({
   batches,
 }: NonOutplantWithdrawalTableProps): JSX.Element {
   const { user } = useUser();
+  const { activeLocale } = useLocalization();
   const numberFormatter = useNumberFormatter();
   const numericFormatter = useMemo(() => numberFormatter(user?.locale), [numberFormatter, user?.locale]);
 
   const [rowData, setRowData] = useState<SpeciesWithdrawal[]>([]);
-  const columns: TableColumnType[] = [
-    { key: 'name', name: strings.SPECIES, type: 'string' },
-    { key: 'notReady', name: strings.NOT_READY, type: 'number' },
-    { key: 'ready', name: strings.READY, type: 'number' },
-    { key: 'total', name: strings.TOTAL, type: 'number' },
-  ];
+
+  const columns: TableColumnType[] = useMemo(
+    () =>
+      activeLocale
+        ? [
+            { key: 'name', name: strings.SPECIES, type: 'string' },
+            { key: 'notReady', name: strings.NOT_READY, type: 'number' },
+            { key: 'ready', name: strings.READY, type: 'number' },
+            { key: 'total', name: strings.TOTAL, type: 'number' },
+          ]
+        : [],
+    [activeLocale]
+  );
 
   useEffect(() => {
     // get map of batch id to species id - for correlation

--- a/src/components/NurseryWithdrawals/WithdrawalDetails/sections/OutplantReassignmentTable.tsx
+++ b/src/components/NurseryWithdrawals/WithdrawalDetails/sections/OutplantReassignmentTable.tsx
@@ -4,7 +4,7 @@ import { Delivery } from 'src/types/Tracking';
 import { TableColumnType } from '@terraware/web-components';
 import strings from 'src/strings';
 import Table from 'src/components/common/table';
-import { useUser } from 'src/providers';
+import { useLocalization, useUser } from 'src/providers';
 import { useNumberFormatter } from 'src/utils/useNumber';
 
 type OutplantReassignmentTableProps = {
@@ -21,18 +21,26 @@ export default function OutplantReassignmentTable({
   withdrawalNotes,
 }: OutplantReassignmentTableProps): JSX.Element {
   const { user } = useUser();
+  const { activeLocale } = useLocalization();
   const numberFormatter = useNumberFormatter();
   const numericFormatter = useMemo(() => numberFormatter(user?.locale), [numberFormatter, user?.locale]);
 
   const [rowData, setRowData] = useState<{ [p: string]: unknown }[]>([]);
-  const columns: TableColumnType[] = [
-    { key: 'species', name: strings.SPECIES, type: 'string' },
-    { key: 'from_subzone', name: strings.FROM_SUBZONE, type: 'string' },
-    { key: 'to_subzone', name: strings.TO_SUBZONE, type: 'string' },
-    { key: 'original_qty', name: strings.ORIGINAL_QTY, type: 'string' },
-    { key: 'final_qty', name: strings.FINAL_QTY, type: 'string' },
-    { key: 'notes', name: strings.NOTES, type: 'string' },
-  ];
+
+  const columns: TableColumnType[] = useMemo(
+    () =>
+      activeLocale
+        ? [
+            { key: 'species', name: strings.SPECIES, type: 'string' },
+            { key: 'from_subzone', name: strings.FROM_SUBZONE, type: 'string' },
+            { key: 'to_subzone', name: strings.TO_SUBZONE, type: 'string' },
+            { key: 'original_qty', name: strings.ORIGINAL_QTY, type: 'string' },
+            { key: 'final_qty', name: strings.FINAL_QTY, type: 'string' },
+            { key: 'notes', name: strings.NOTES, type: 'string' },
+          ]
+        : [],
+    [activeLocale]
+  );
 
   useEffect(() => {
     // get list of distinct species

--- a/src/components/NurseryWithdrawals/WithdrawalDetails/sections/OutplantWithdrawalTable.tsx
+++ b/src/components/NurseryWithdrawals/WithdrawalDetails/sections/OutplantWithdrawalTable.tsx
@@ -4,7 +4,7 @@ import strings from 'src/strings';
 import { Delivery } from 'src/types/Tracking';
 import { Species } from 'src/types/Species';
 import Table from 'src/components/common/table';
-import { useUser } from 'src/providers';
+import { useLocalization, useUser } from 'src/providers';
 import { useNumberFormatter } from 'src/utils/useNumber';
 
 type OutplantWithdrawalTableProps = {
@@ -19,15 +19,23 @@ export default function OutplantWithdrawalTable({
   delivery,
 }: OutplantWithdrawalTableProps): JSX.Element {
   const { user } = useUser();
+  const { activeLocale } = useLocalization();
   const numberFormatter = useNumberFormatter();
   const numericFormatter = useMemo(() => numberFormatter(user?.locale), [numberFormatter, user?.locale]);
 
   const [rowData, setRowData] = useState<{ [p: string]: unknown }[]>([]);
-  const columns: TableColumnType[] = [
-    { key: 'species', name: strings.SPECIES, type: 'string' },
-    { key: 'to_subzone', name: strings.TO_SUBZONE, type: 'string' },
-    { key: 'quantity', name: strings.QUANTITY, type: 'string' },
-  ];
+
+  const columns: TableColumnType[] = useMemo(
+    () =>
+      activeLocale
+        ? [
+            { key: 'species', name: strings.SPECIES, type: 'string' },
+            { key: 'to_subzone', name: strings.TO_SUBZONE, type: 'string' },
+            { key: 'quantity', name: strings.QUANTITY, type: 'string' },
+          ]
+        : [],
+    [activeLocale]
+  );
 
   useEffect(() => {
     // get list of distinct species

--- a/src/components/NurseryWithdrawals/WithdrawalLogRenderer.tsx
+++ b/src/components/NurseryWithdrawals/WithdrawalLogRenderer.tsx
@@ -9,6 +9,7 @@ import { Button, TextTruncated } from '@terraware/web-components';
 import strings from 'src/strings';
 import { NurseryWithdrawalPurposes } from 'src/types/Batch';
 import { isTrue } from 'src/utils/boolean';
+import { NurseryWithdrawalPurpose, purposeLabel } from 'src/types/Batch';
 
 const useStyles = makeStyles((theme: Theme) => ({
   link: {
@@ -73,7 +74,7 @@ export default function WithdrawalLogRenderer(props: RendererProps<TableRowType>
   }
 
   if (column.key === 'hasReassignments') {
-    if (row.purpose === OUTPLANT && row.subzoneNames) {
+    if (row.purpose === OUTPLANT && row.plantingSubzoneNames) {
       return (
         <>
           <CellRenderer
@@ -96,6 +97,10 @@ export default function WithdrawalLogRenderer(props: RendererProps<TableRowType>
       );
     }
     return <CellRenderer index={index} column={column} row={row} value='' />;
+  }
+
+  if (column.key === 'purpose') {
+    return <CellRenderer {...props} value={purposeLabel(value as NurseryWithdrawalPurpose)} />;
   }
 
   return <CellRenderer {...props} />;

--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import Button from 'src/components/common/button/Button';
 import Table from 'src/components/common/table';
@@ -70,13 +70,20 @@ export default function PeopleList(): JSX.Element {
   const { isMobile } = useDeviceInfo();
   const contentRef = useRef(null);
   const { activeLocale } = useLocalization();
-  const columns: TableColumnType[] = [
-    { key: 'email', name: strings.EMAIL, type: 'string' },
-    { key: 'firstName', name: strings.FIRST_NAME, type: 'string' },
-    { key: 'lastName', name: strings.LAST_NAME, type: 'string' },
-    { key: 'role', name: strings.ROLE, type: 'string' },
-    { key: 'addedTime', name: strings.DATE_ADDED, type: 'date' },
-  ];
+
+  const columns: TableColumnType[] = useMemo(
+    () =>
+      activeLocale
+        ? [
+            { key: 'email', name: strings.EMAIL, type: 'string' },
+            { key: 'firstName', name: strings.FIRST_NAME, type: 'string' },
+            { key: 'lastName', name: strings.LAST_NAME, type: 'string' },
+            { key: 'role', name: strings.ROLE, type: 'string' },
+            { key: 'addedTime', name: strings.DATE_ADDED, type: 'date' },
+          ]
+        : [],
+    [activeLocale]
+  );
 
   useEffect(() => {
     const refreshSearch = async () => {

--- a/src/components/PlantingSites/PlantingSitesTable.tsx
+++ b/src/components/PlantingSites/PlantingSitesTable.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Box, Grid, useTheme } from '@mui/material';
 import { TableColumnType, Textfield } from '@terraware/web-components';
 import { SearchResponseElement } from 'src/types/Search';
@@ -7,6 +7,7 @@ import PlantingSitesCellRenderer from './PlantingSitesCellRenderer';
 import Table from 'src/components/common/table';
 import { SortOrder } from 'src/components/common/table/sort';
 import { SearchSortOrder } from 'src/types/Search';
+import { useLocalization } from 'src/providers';
 
 interface PlantingSitesTableProps {
   results: SearchResponseElement[];
@@ -19,21 +20,29 @@ export default function PlantingSitesTable(props: PlantingSitesTableProps): JSX.
   const { results, setTemporalSearchValue, temporalSearchValue, setSearchSortOrder } = props;
   const [isPresorted, setIsPresorted] = useState<boolean>(false);
   const theme = useTheme();
-  const columns: TableColumnType[] = [
-    {
-      key: 'name',
-      name: strings.NAME,
-      type: 'string',
-    },
-    {
-      key: 'description',
-      name: strings.DESCRIPTION,
-      type: 'string',
-    },
-    { key: 'numPlantingZones', name: strings.PLANTING_ZONES, type: 'string' },
-    { key: 'numPlantingSubzones', name: strings.SUBZONES, type: 'string' },
-    { key: 'timeZone', name: strings.TIME_ZONE, type: 'string' },
-  ];
+  const { activeLocale } = useLocalization();
+
+  const columns: TableColumnType[] = useMemo(
+    () =>
+      activeLocale
+        ? [
+            {
+              key: 'name',
+              name: strings.NAME,
+              type: 'string',
+            },
+            {
+              key: 'description',
+              name: strings.DESCRIPTION,
+              type: 'string',
+            },
+            { key: 'numPlantingZones', name: strings.PLANTING_ZONES, type: 'string' },
+            { key: 'numPlantingSubzones', name: strings.SUBZONES, type: 'string' },
+            { key: 'timeZone', name: strings.TIME_ZONE, type: 'string' },
+          ]
+        : [],
+    [activeLocale]
+  );
 
   const onSortChange = (order: SortOrder, orderBy: string) => {
     const isTimeZone = orderBy === 'timeZone';

--- a/src/components/Reports/LocationSection.tsx
+++ b/src/components/Reports/LocationSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import { Grid, Theme, Typography, useTheme } from '@mui/material';
 import { DatePicker, TableColumnType, Textfield } from '@terraware/web-components';
@@ -8,7 +8,7 @@ import { makeStyles } from '@mui/styles';
 import { ReportNursery, ReportPlantingSite, ReportSeedBank } from 'src/types/Report';
 import PlantingSiteSpeciesCellRenderer from './PlantingSitesSpeciesCellRenderer';
 import Table from '../common/table';
-import { useOrganization } from 'src/providers';
+import { useLocalization, useOrganization } from 'src/providers';
 import { SpeciesService } from 'src/services';
 import { Species } from 'src/types/Species';
 
@@ -36,6 +36,7 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
   const theme = useTheme();
   const classes = useStyles();
   const { selectedOrganization } = useOrganization();
+  const { activeLocale } = useLocalization();
 
   const isSeedBank = locationType === 'seedBank';
   const isNursery = locationType === 'nursery';
@@ -95,24 +96,30 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
     }
   }, [allSpecies, isPlantingSite, location]);
 
-  const columns: TableColumnType[] = [
-    {
-      key: 'name',
-      name: strings.SPECIES,
-      type: 'string',
-    },
-    {
-      key: 'growthForm',
-      name: strings.GROWTH_FORM,
-      type: 'string',
-    },
-    {
-      key: 'totalPlanted',
-      name: strings.TOTAL_PLANTED_REQUIRED,
-      type: 'string',
-    },
-    { key: 'mortalityRateInField', name: strings.MORTALITY_RATE_IN_FIELD_REQUIRED, type: 'string' },
-  ];
+  const columns: TableColumnType[] = useMemo(
+    () =>
+      activeLocale
+        ? [
+            {
+              key: 'name',
+              name: strings.SPECIES,
+              type: 'string',
+            },
+            {
+              key: 'growthForm',
+              name: strings.GROWTH_FORM,
+              type: 'string',
+            },
+            {
+              key: 'totalPlanted',
+              name: strings.TOTAL_PLANTED_REQUIRED,
+              type: 'string',
+            },
+            { key: 'mortalityRateInField', name: strings.MORTALITY_RATE_IN_FIELD_REQUIRED, type: 'string' },
+          ]
+        : [],
+    [activeLocale]
+  );
 
   const onEditPlantingSiteReport = (species: PlantingSiteSpecies, fromColumn?: string, value?: any) => {
     if (fromColumn) {

--- a/src/components/Reports/ReportList.tsx
+++ b/src/components/Reports/ReportList.tsx
@@ -1,28 +1,35 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Container, Grid, Typography, useTheme } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
 import Table from 'src/components/common/table';
-import React, { useEffect, useRef, useState } from 'react';
 import TfMain from 'src/components/common/TfMain';
 import ReportService from 'src/services/ReportService';
 import strings from 'src/strings';
 import { ListReport } from 'src/types/Report';
 import PageHeaderWrapper from '../common/PageHeaderWrapper';
 import ReportsCellRenderer from './TableCellRenderer';
-import { useOrganization } from 'src/providers';
+import { useLocalization, useOrganization } from 'src/providers';
 
 export default function ReportList(): JSX.Element {
   const contentRef = useRef(null);
   const [results, setResults] = useState<ListReport[]>([]);
   const { selectedOrganization } = useOrganization();
+  const { activeLocale } = useLocalization();
   const theme = useTheme();
 
-  const columns: TableColumnType[] = [
-    { key: 'name', name: strings.REPORT, type: 'string' },
-    { key: 'status', name: strings.STATUS, type: 'string' },
-    { key: 'modifiedByName', name: strings.LAST_EDITED_BY, type: 'string' },
-    { key: 'submittedByName', name: strings.SUBMITTED_BY, type: 'string' },
-    { key: 'submittedTime', name: strings.DATE_SUBMITTED, type: 'string' },
-  ];
+  const columns: TableColumnType[] = useMemo(
+    () =>
+      activeLocale
+        ? [
+            { key: 'name', name: strings.REPORT, type: 'string' },
+            { key: 'status', name: strings.STATUS, type: 'string' },
+            { key: 'modifiedByName', name: strings.LAST_EDITED_BY, type: 'string' },
+            { key: 'submittedByName', name: strings.SUBMITTED_BY, type: 'string' },
+            { key: 'submittedTime', name: strings.DATE_SUBMITTED, type: 'string' },
+          ]
+        : [],
+    [activeLocale]
+  );
 
   useEffect(() => {
     const refreshSearch = async () => {

--- a/src/components/SeedBank/StorageLocations.tsx
+++ b/src/components/SeedBank/StorageLocations.tsx
@@ -1,9 +1,9 @@
-import { Box, Grid, Typography } from '@mui/material';
 import { useEffect, useMemo, useState } from 'react';
+import { Box, Grid, Typography } from '@mui/material';
 import strings from 'src/strings';
 import { SeedBankService } from 'src/services';
 import { DEFAULT_STORAGE_LOCATIONS, PartialStorageLocation } from 'src/types/Facility';
-import { useLocalization } from 'src/providers/hooks';
+import { useLocalization } from 'src/providers';
 import Table from 'src/components/common/table';
 import { TableColumnType } from 'src/components/common/table/types';
 import { useNumberFormatter } from 'src/utils/useNumber';
@@ -27,17 +27,24 @@ const storageLocationWith = (name: string, id: number) => ({
 
 export default function StorageLocations({ seedBankId, onEdit }: StorageLocationsProps): JSX.Element | null {
   const { activeLocale } = useLocalization();
+  const { isMobile } = useDeviceInfo();
   const numberFormatter = useNumberFormatter();
   const [selectedRows, setSelectedRows] = useState<PartialStorageLocation[]>([]);
   const [selectedStorageLocation, setSelectedStorageLocation] = useState<PartialStorageLocation | undefined>();
   const [storageLocations, setStorageLocations] = useState<PartialStorageLocation[]>([]);
   const [openStorageLocationModal, setOpenStorageLocationModal] = useState<boolean>(false);
   const numericFormatter = useMemo(() => numberFormatter(activeLocale), [numberFormatter, activeLocale]);
-  const columns: TableColumnType[] = [
-    { key: 'name', name: strings.NAME, type: 'string' },
-    { key: 'activeAccessions', name: strings.ACTIVE_ACCESSIONS, type: 'number' },
-  ];
-  const { isMobile } = useDeviceInfo();
+
+  const columns: TableColumnType[] = useMemo(
+    () =>
+      activeLocale
+        ? [
+            { key: 'name', name: strings.NAME, type: 'string' },
+            { key: 'activeAccessions', name: strings.ACTIVE_ACCESSIONS, type: 'number' },
+          ]
+        : [],
+    [activeLocale]
+  );
 
   useEffect(() => {
     const fetchStorageLocations = async () => {

--- a/src/components/SeedBanks/index.tsx
+++ b/src/components/SeedBanks/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import Button from 'src/components/common/button/Button';
 import Table from 'src/components/common/table';
@@ -18,7 +18,7 @@ import { Box, Grid, Theme, useTheme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import PageHeaderWrapper from '../common/PageHeaderWrapper';
-import { useTimeZones } from 'src/providers/hooks';
+import { useLocalization, useTimeZones } from 'src/providers';
 import { setTimeZone, useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -55,6 +55,7 @@ type SeedBanksListProps = {
 
 export default function SeedBanksList({ organization }: SeedBanksListProps): JSX.Element {
   const timeZones = useTimeZones();
+  const { activeLocale } = useLocalization();
   const defaultTimeZone = useDefaultTimeZone().get();
   const classes = useStyles();
   const theme = useTheme();
@@ -64,11 +65,18 @@ export default function SeedBanksList({ organization }: SeedBanksListProps): JSX
   const [results, setResults] = useState<Facility[]>([]);
   const { isMobile } = useDeviceInfo();
   const contentRef = useRef(null);
-  const columns: TableColumnType[] = [
-    { key: 'name', name: strings.NAME, type: 'string' },
-    { key: 'description', name: strings.DESCRIPTION, type: 'string' },
-    { key: 'timeZone', name: strings.TIME_ZONE, type: 'string' },
-  ];
+
+  const columns: TableColumnType[] = useMemo(
+    () =>
+      activeLocale
+        ? [
+            { key: 'name', name: strings.NAME, type: 'string' },
+            { key: 'description', name: strings.DESCRIPTION, type: 'string' },
+            { key: 'timeZone', name: strings.TIME_ZONE, type: 'string' },
+          ]
+        : [],
+    [activeLocale]
+  );
 
   const goToNewSeedBank = () => {
     const newSeedBankLocation = {

--- a/src/components/common/table/index.tsx
+++ b/src/components/common/table/index.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Table as WebComponentsTable, TableColumnType, TableRowType } from '@terraware/web-components';
 import strings from 'src/strings';
 import { LocalizationProps, Props } from '@terraware/web-components/components/table';
-import { useOrganization } from 'src/providers/hooks';
+import { useOrganization } from 'src/providers';
 import { PreferencesService } from 'src/services';
 import _ from 'lodash';
 
@@ -114,6 +114,18 @@ export default function OrderPreservedTable<T extends TableRowType>(
 ): JSX.Element {
   const { columns, ...tableProps } = props;
   const [tableColumns, setTableColumns] = useState<TableColumnType[]>(columns);
+
+  useEffect(() => {
+    const refreshedColumns: TableColumnType[] = tableColumns
+      .map((tableColumn: TableColumnType) =>
+        columns.find((sourceColumn: TableColumnType) => sourceColumn.key === tableColumn.key)
+      )
+      .filter((tableColumn?: TableColumnType) => !!tableColumn) as TableColumnType[];
+
+    if (!_.isEqual(tableColumns, refreshedColumns)) {
+      setTableColumns(refreshedColumns);
+    }
+  }, [columns, tableColumns]);
 
   return OrderPreserveableTable<T>({
     ...tableProps,

--- a/src/types/Batch.ts
+++ b/src/types/Batch.ts
@@ -1,4 +1,5 @@
 import { components } from 'src/api/types/generated-schema';
+import strings from 'src/strings';
 
 export type Batch = components['schemas']['BatchResponsePayload']['batch'];
 export type CreateBatchRequestPayload = components['schemas']['CreateBatchRequestPayload'];
@@ -17,3 +18,16 @@ export const NurseryWithdrawalPurposesValues = Object.values(NurseryWithdrawalPu
 
 export type NurseryTransfer = components['schemas']['CreateNurseryTransferRequestPayload'];
 export type NurseryWithdrawalRequest = components['schemas']['CreateNurseryWithdrawalRequestPayload'];
+
+export const purposeLabel = (purpose: NurseryWithdrawalPurpose): string => {
+  switch (purpose) {
+    case 'Out Plant':
+      return strings.OUTPLANT;
+    case 'Nursery Transfer':
+      return strings.NURSERY_TRANSFER;
+    case 'Dead':
+      return strings.DEAD;
+    default:
+      return strings.OTHER;
+  }
+};


### PR DESCRIPTION
- table columns were not updating on locale change except for accessions and species tables
- render withdrawal purpose using strings
- withdrawal log filters update with locale
- fix reassign button not showing up in withdrawal table
- see changes in vercel