### PR TITLE
Redo table columns for i18n in terraware-web

### DIFF
--- a/src/components/Inventory/InventoryTable.tsx
+++ b/src/components/Inventory/InventoryTable.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import strings from 'src/strings';
 import { TableColumnType } from '@terraware/web-components';
@@ -11,7 +11,6 @@ import Search from './Search';
 import Table from 'src/components/common/table';
 import { SortOrder } from 'src/components/common/table/sort';
 import { SearchSortOrder } from 'src/types/Search';
-import { useLocalization } from 'src/providers';
 
 interface InventoryTableProps {
   results: SearchResponseElement[];
@@ -23,48 +22,41 @@ interface InventoryTableProps {
   isPresorted: boolean;
 }
 
+const columns = (): TableColumnType[] => [
+  {
+    key: 'species_scientificName',
+    name: strings.SPECIES,
+    type: 'string',
+    tooltipTitle: strings.TOOLTIP_SCIENTIFIC_NAME,
+  },
+  {
+    key: 'species_commonName',
+    name: strings.COMMON_NAME,
+    type: 'string',
+    tooltipTitle: strings.TOOLTIP_COMMON_NAME,
+  },
+  { key: 'facilityInventories', name: strings.NURSERIES, type: 'string' },
+  {
+    key: 'germinatingQuantity',
+    name: strings.GERMINATING,
+    type: 'string',
+    tooltipTitle: strings.TOOLTIP_GERMINATING_QUANTITY,
+  },
+  {
+    key: 'notReadyQuantity',
+    name: strings.NOT_READY,
+    type: 'string',
+    tooltipTitle: strings.TOOLTIP_NOT_READY_QUANTITY,
+  },
+  { key: 'readyQuantity', name: strings.READY, type: 'string', tooltipTitle: strings.TOOLTIP_READY_QUANTITY },
+  { key: 'totalQuantity', name: strings.TOTAL, type: 'string', tooltipTitle: strings.TOOLTIP_TOTAL_QUANTITY },
+];
+
 export default function InventoryTable(props: InventoryTableProps): JSX.Element {
-  const { activeLocale } = useLocalization();
   const { results, setTemporalSearchValue, temporalSearchValue, filters, setFilters, setSearchSortOrder, isPresorted } =
     props;
   const [selectedRows, setSelectedRows] = useState<any[]>([]);
   const history = useHistory();
-
-  const columns: TableColumnType[] = useMemo(
-    () =>
-      activeLocale
-        ? [
-            {
-              key: 'species_scientificName',
-              name: strings.SPECIES,
-              type: 'string',
-              tooltipTitle: strings.TOOLTIP_SCIENTIFIC_NAME,
-            },
-            {
-              key: 'species_commonName',
-              name: strings.COMMON_NAME,
-              type: 'string',
-              tooltipTitle: strings.TOOLTIP_COMMON_NAME,
-            },
-            { key: 'facilityInventories', name: strings.NURSERIES, type: 'string' },
-            {
-              key: 'germinatingQuantity',
-              name: strings.GERMINATING,
-              type: 'string',
-              tooltipTitle: strings.TOOLTIP_GERMINATING_QUANTITY,
-            },
-            {
-              key: 'notReadyQuantity',
-              name: strings.NOT_READY,
-              type: 'string',
-              tooltipTitle: strings.TOOLTIP_NOT_READY_QUANTITY,
-            },
-            { key: 'readyQuantity', name: strings.READY, type: 'string', tooltipTitle: strings.TOOLTIP_READY_QUANTITY },
-            { key: 'totalQuantity', name: strings.TOTAL, type: 'string', tooltipTitle: strings.TOOLTIP_TOTAL_QUANTITY },
-          ]
-        : [],
-    [activeLocale]
-  );
 
   const withdrawInventory = () => {
     const speciesIds = selectedRows.filter((row) => row.species_id).map((row) => `speciesId=${row.species_id}`);

--- a/src/components/Inventory/view/InventorySeedlingsTable.tsx
+++ b/src/components/Inventory/view/InventorySeedlingsTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Typography, Grid, Box, useTheme } from '@mui/material';
 import { Button, DropdownItem, TableColumnType } from '@terraware/web-components';
@@ -16,7 +16,7 @@ import BatchDetailsModal from './BatchDetailsModal';
 import Search from '../Search';
 import { APP_PATHS } from 'src/constants';
 import { TopBarButton } from '@terraware/web-components/components/table';
-import { useLocalization, useOrganization } from 'src/providers';
+import { useOrganization } from 'src/providers';
 import Table from 'src/components/common/table';
 import { SortOrder } from 'src/components/common/table/sort';
 import OptionsMenu from 'src/components/common/OptionsMenu';
@@ -30,8 +30,21 @@ interface InventorySeedslingsTableProps {
   onUpdateOpenBatch: (batchNum: string | null) => void;
 }
 
+const columns = (): TableColumnType[] => [
+  { key: 'batchNumber', name: strings.SEEDLING_BATCH, type: 'string' },
+  { key: 'germinatingQuantity', name: strings.GERMINATING, type: 'string' },
+  { key: 'notReadyQuantity', name: strings.NOT_READY, type: 'string' },
+  { key: 'readyQuantity', name: strings.READY, type: 'string' },
+  { key: 'totalQuantity', name: strings.TOTAL, type: 'string' },
+  { key: 'totalQuantityWithdrawn', name: strings.WITHDRAWN, type: 'string' },
+  { key: 'facility_name', name: strings.NURSERY, type: 'string' },
+  { key: 'readyByDate', name: strings.EST_READY_DATE, type: 'string' },
+  { key: 'addedDate', name: strings.DATE_ADDED, type: 'string' },
+  { key: 'withdraw', name: '', type: 'string' },
+  { key: 'quantitiesMenu', name: '', type: 'string' },
+];
+
 export default function InventorySeedslingsTable(props: InventorySeedslingsTableProps): JSX.Element {
-  const { activeLocale } = useLocalization();
   const { selectedOrganization } = useOrganization();
   const { speciesId, modified, setModified, openBatchNumber, onUpdateOpenBatch } = props;
   const { isMobile, isDesktop } = useDeviceInfo();
@@ -48,26 +61,6 @@ export default function InventorySeedslingsTable(props: InventorySeedslingsTable
   const debouncedSearchTerm = useDebounce(temporalSearchValue, 250);
   const snackbar = useSnackbar();
   const history = useHistory();
-
-  const columns: TableColumnType[] = useMemo(
-    () =>
-      activeLocale
-        ? [
-            { key: 'batchNumber', name: strings.SEEDLING_BATCH, type: 'string' },
-            { key: 'germinatingQuantity', name: strings.GERMINATING, type: 'string' },
-            { key: 'notReadyQuantity', name: strings.NOT_READY, type: 'string' },
-            { key: 'readyQuantity', name: strings.READY, type: 'string' },
-            { key: 'totalQuantity', name: strings.TOTAL, type: 'string' },
-            { key: 'totalQuantityWithdrawn', name: strings.WITHDRAWN, type: 'string' },
-            { key: 'facility_name', name: strings.NURSERY, type: 'string' },
-            { key: 'readyByDate', name: strings.EST_READY_DATE, type: 'string' },
-            { key: 'addedDate', name: strings.DATE_ADDED, type: 'string' },
-            { key: 'withdraw', name: '', type: 'string' },
-            { key: 'quantitiesMenu', name: '', type: 'string' },
-          ]
-        : [],
-    [activeLocale]
-  );
 
   const getSearchFields = useCallback(() => {
     // Skip fuzzy search on empty strings since the query will be

--- a/src/components/Inventory/withdraw/flow/SelectBatchesWithdrawnQuantity.tsx
+++ b/src/components/Inventory/withdraw/flow/SelectBatchesWithdrawnQuantity.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Box, Container, Grid, Typography, useTheme } from '@mui/material';
 import PageForm from 'src/components/common/PageForm';
 import { useDeviceInfo } from '@terraware/web-components/utils';
@@ -8,7 +8,7 @@ import { ErrorBox, TableColumnType } from '@terraware/web-components';
 import WithdrawalBatchesCellRenderer from './WithdrawalBatchesCellRenderer';
 import useForm from 'src/utils/useForm';
 import { makeStyles } from '@mui/styles';
-import { useLocalization, useOrganization } from 'src/providers';
+import { useOrganization } from 'src/providers';
 import Table from 'src/components/common/table';
 
 type SelectBatchesWithdrawnQuantityProps = {
@@ -42,8 +42,51 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+const tableColumns = (): TableColumnType[] => [
+  {
+    key: 'batchNumber',
+    name: strings.SEEDLING_BATCH,
+    type: 'string',
+  },
+  {
+    key: 'facilityName',
+    name: strings.NURSERY,
+    type: 'string',
+  },
+  {
+    key: 'notReadyQuantityWithdrawn',
+    name: strings.NOT_READY_QUANTITY,
+    type: 'string',
+  },
+  { key: 'readyQuantityWithdrawn', name: strings.READY_QUANTITY, type: 'string' },
+  { key: 'totalQuantity', name: strings.TOTAL_QUANTITY, type: 'string' },
+  {
+    key: 'totalWithdraw',
+    name: strings.TOTAL_WITHDRAW,
+    type: 'string',
+  },
+];
+
+const outplantTableColumns = (): TableColumnType[] => [
+  {
+    key: 'batchNumber',
+    name: strings.SEEDLING_BATCH,
+    type: 'string',
+  },
+  {
+    key: 'facilityName',
+    name: strings.NURSERY,
+    type: 'string',
+  },
+  {
+    key: 'readyQuantity',
+    name: strings.READY_QUANTITY,
+    type: 'string',
+  },
+  { key: 'outplantReadyQuantityWithdrawn', name: strings.WITHDRAW, type: 'string' },
+];
+
 export default function SelectBatches(props: SelectBatchesWithdrawnQuantityProps): JSX.Element {
-  const { activeLocale } = useLocalization();
   const { selectedOrganization } = useOrganization();
   const { onNext, onCancel, saveText, batches, nurseryWithdrawal } = props;
   const { OUTPLANT } = NurseryWithdrawalPurposes;
@@ -92,57 +135,6 @@ export default function SelectBatches(props: SelectBatchesWithdrawnQuantityProps
 
     transformBatchesForTable();
   }, [batches, nurseryWithdrawal, selectedOrganization, setRecord]);
-
-  const columns: TableColumnType[] = useMemo(() => {
-    const tableColumns: TableColumnType[] = [
-      {
-        key: 'batchNumber',
-        name: strings.SEEDLING_BATCH,
-        type: 'string',
-      },
-      {
-        key: 'facilityName',
-        name: strings.NURSERY,
-        type: 'string',
-      },
-      {
-        key: 'notReadyQuantityWithdrawn',
-        name: strings.NOT_READY_QUANTITY,
-        type: 'string',
-      },
-      { key: 'readyQuantityWithdrawn', name: strings.READY_QUANTITY, type: 'string' },
-      { key: 'totalQuantity', name: strings.TOTAL_QUANTITY, type: 'string' },
-      {
-        key: 'totalWithdraw',
-        name: strings.TOTAL_WITHDRAW,
-        type: 'string',
-      },
-    ];
-
-    const outplantTableColumns: TableColumnType[] = [
-      {
-        key: 'batchNumber',
-        name: strings.SEEDLING_BATCH,
-        type: 'string',
-      },
-      {
-        key: 'facilityName',
-        name: strings.NURSERY,
-        type: 'string',
-      },
-      {
-        key: 'readyQuantity',
-        name: strings.READY_QUANTITY,
-        type: 'string',
-      },
-      { key: 'outplantReadyQuantityWithdrawn', name: strings.WITHDRAW, type: 'string' },
-    ];
-    if (activeLocale) {
-      return nurseryWithdrawal.purpose === OUTPLANT ? outplantTableColumns : tableColumns;
-    } else {
-      return [];
-    }
-  }, [activeLocale, nurseryWithdrawal.purpose, OUTPLANT]);
 
   const onEditHandler = (batch: BatchWithdrawalForTable, fromColumn?: string, value?: string) => {
     setRecord((previousRecord: BatchWithdrawalForTable[]): BatchWithdrawalForTable[] => {
@@ -320,7 +312,7 @@ export default function SelectBatches(props: SelectBatchesWithdrawnQuantityProps
                     {record.length > 0 && (
                       <Table
                         id={`batch-withdraw-quantity-table${nurseryWithdrawal.purpose === OUTPLANT ? '-outplant' : ''}`}
-                        columns={columns}
+                        columns={nurseryWithdrawal.purpose === OUTPLANT ? outplantTableColumns : tableColumns}
                         rows={record.filter((rec) => rec.speciesId === iSpecies.id)}
                         Renderer={WithdrawalBatchesCellRenderer}
                         orderBy={'batchId'}

--- a/src/components/MyAccount/index.tsx
+++ b/src/components/MyAccount/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Button, DropdownItem } from '@terraware/web-components';
 import { OrganizationUserService, OrganizationService, PreferencesService, UserService } from 'src/services';
@@ -73,6 +73,13 @@ function addRoleNames(organizations: Organization[]): PersonOrganization[] {
   return organizations.map(addRoleName);
 }
 
+const columns = (): TableColumnType[] => [
+  { key: 'name', name: strings.ORGANIZATION_NAME, type: 'string' },
+  { key: 'description', name: strings.DESCRIPTION, type: 'string' },
+  { key: 'totalUsers', name: strings.PEOPLE, type: 'string' },
+  { key: 'roleName', name: strings.ROLE, type: 'string' },
+];
+
 const MyAccountContent = ({
   user,
   organizations,
@@ -105,19 +112,6 @@ const MyAccountContent = ({
     (userPreferences?.preferredWeightSystem as string) || 'metric'
   );
   const loadedStringsForLocale = useLocalization().activeLocale;
-
-  const columns: TableColumnType[] = useMemo(
-    () =>
-      loadedStringsForLocale
-        ? [
-            { key: 'name', name: strings.ORGANIZATION_NAME, type: 'string' },
-            { key: 'description', name: strings.DESCRIPTION, type: 'string' },
-            { key: 'totalUsers', name: strings.PEOPLE, type: 'string' },
-            { key: 'roleName', name: strings.ROLE, type: 'string' },
-          ]
-        : [],
-    [loadedStringsForLocale]
-  );
 
   const [localeSelected, setLocaleSelected] = useState(selectedLocale);
 

--- a/src/components/Nurseries/index.tsx
+++ b/src/components/Nurseries/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button, TableColumnType } from '@terraware/web-components';
 import TextField from '@terraware/web-components/components/Textfield/Textfield';
@@ -16,8 +16,14 @@ import PageSnackbar from '../PageSnackbar';
 import NurseriesCellRenderer from './TableCellRenderer';
 import PageHeaderWrapper from '../common/PageHeaderWrapper';
 import Table from 'src/components/common/table';
-import { useLocalization, useTimeZones } from 'src/providers';
+import { useTimeZones } from 'src/providers';
 import { setTimeZone, useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
+
+const columns = (): TableColumnType[] => [
+  { key: 'name', name: strings.NAME, type: 'string' },
+  { key: 'description', name: strings.DESCRIPTION, type: 'string' },
+  { key: 'timeZone', name: strings.TIME_ZONE, type: 'string' },
+];
 
 type NurseriesListProps = {
   organization: Organization;
@@ -26,7 +32,6 @@ type NurseriesListProps = {
 export default function NurseriesList({ organization }: NurseriesListProps): JSX.Element {
   const theme = useTheme();
   const timeZones = useTimeZones();
-  const { activeLocale } = useLocalization();
   const defaultTimeZone = useDefaultTimeZone().get();
   const { isMobile } = useDeviceInfo();
   const history = useHistory();
@@ -34,18 +39,6 @@ export default function NurseriesList({ organization }: NurseriesListProps): JSX
   const debouncedSearchTerm = useDebounce(temporalSearchValue, 250);
   const [results, setResults] = useState<Facility[]>();
   const contentRef = useRef(null);
-
-  const columns: TableColumnType[] = useMemo(
-    () =>
-      activeLocale
-        ? [
-            { key: 'name', name: strings.NAME, type: 'string' },
-            { key: 'description', name: strings.DESCRIPTION, type: 'string' },
-            { key: 'timeZone', name: strings.TIME_ZONE, type: 'string' },
-          ]
-        : [],
-    [activeLocale]
-  );
 
   const goToNewNursery = () => {
     const newNurseryLocation = {

--- a/src/components/NurseryWithdrawals/NurseryReassignment.tsx
+++ b/src/components/NurseryWithdrawals/NurseryReassignment.tsx
@@ -16,7 +16,7 @@ import PageForm from 'src/components/common/PageForm';
 import ReassignmentRenderer, { Reassignment, SubzoneInfo } from './ReassignmentRenderer';
 import PageSnackbar from 'src/components/PageSnackbar';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
-import { useLocalization, useOrganization } from 'src/providers';
+import { useOrganization } from 'src/providers';
 import Table from 'src/components/common/table';
 import { useUser } from 'src/providers';
 import { useNumberFormatter } from 'src/utils/useNumber';
@@ -30,13 +30,22 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
+const columns = (): TableColumnType[] => [
+  { key: 'species', name: strings.SPECIES, type: 'string' },
+  { key: 'siteName', name: strings.PLANTING_SITE, type: 'string' },
+  { key: 'zoneName', name: strings.ZONE, type: 'string' },
+  { key: 'originalSubzone', name: strings.ORIGINAL_SUBZONE, type: 'string' },
+  { key: 'newSubzone', name: strings.NEW_SUBZONE, type: 'string' },
+  { key: 'reassign', name: strings.REASSIGN, type: 'string' },
+  { key: 'notes', name: strings.NOTES, type: 'string' },
+];
+
 export default function NurseryReassignment(): JSX.Element {
   const classes = useStyles();
   const query = useQuery();
   const { user } = useUser();
   const numberFormatter = useNumberFormatter();
   const { selectedOrganization } = useOrganization();
-  const { activeLocale } = useLocalization();
   const theme = useTheme();
   const history = useHistory();
   const { isMobile } = useDeviceInfo();
@@ -50,22 +59,6 @@ export default function NurseryReassignment(): JSX.Element {
   const [reassignments, setReassignments] = useState<{ [subzoneId: string]: Reassignment }>({});
   const [noReassignments, setNoReassignments] = useState<boolean>(false);
   const contentRef = useRef(null);
-
-  const columns: TableColumnType[] = useMemo(
-    () =>
-      activeLocale
-        ? [
-            { key: 'species', name: strings.SPECIES, type: 'string' },
-            { key: 'siteName', name: strings.PLANTING_SITE, type: 'string' },
-            { key: 'zoneName', name: strings.ZONE, type: 'string' },
-            { key: 'originalSubzone', name: strings.ORIGINAL_SUBZONE, type: 'string' },
-            { key: 'newSubzone', name: strings.NEW_SUBZONE, type: 'string' },
-            { key: 'reassign', name: strings.REASSIGN, type: 'string' },
-            { key: 'notes', name: strings.NOTES, type: 'string' },
-          ]
-        : [],
-    [activeLocale]
-  );
 
   const numericFormatter = useMemo(() => numberFormatter(user?.locale), [numberFormatter, user?.locale]);
 

--- a/src/components/NurseryWithdrawals/NurseryWithdrawals.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawals.tsx
@@ -35,6 +35,17 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
+const columns = (): TableColumnType[] => [
+  { key: 'withdrawnDate', name: strings.DATE, type: 'string' },
+  { key: 'purpose', name: strings.PURPOSE, type: 'string' },
+  { key: 'facility_name', name: strings.FROM_NURSERY, type: 'string' },
+  { key: 'destinationName', name: strings.DESTINATION, type: 'string' },
+  { key: 'plantingSubzoneNames', name: strings.TO_SUBZONE, type: 'string' },
+  { key: 'speciesScientificNames', name: strings.SPECIES, type: 'string' },
+  { key: 'totalWithdrawn', name: strings.TOTAL_QUANTITY, type: 'number' },
+  { key: 'hasReassignments', name: '', type: 'string' },
+];
+
 export default function NurseryWithdrawals(): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const { activeLocale } = useLocalization();
@@ -59,23 +70,6 @@ export default function NurseryWithdrawals(): JSX.Element {
     field: 'withdrawnDate',
     direction: 'Descending',
   } as SearchSortOrder);
-
-  const columns: TableColumnType[] = useMemo(
-    () =>
-      activeLocale
-        ? [
-            { key: 'withdrawnDate', name: strings.DATE, type: 'string' },
-            { key: 'purpose', name: strings.PURPOSE, type: 'string' },
-            { key: 'facility_name', name: strings.FROM_NURSERY, type: 'string' },
-            { key: 'destinationName', name: strings.DESTINATION, type: 'string' },
-            { key: 'plantingSubzoneNames', name: strings.TO_SUBZONE, type: 'string' },
-            { key: 'speciesScientificNames', name: strings.SPECIES, type: 'string' },
-            { key: 'totalWithdrawn', name: strings.TOTAL_QUANTITY, type: 'number' },
-            { key: 'hasReassignments', name: '', type: 'string' },
-          ]
-        : [],
-    [activeLocale]
-  );
 
   const filterColumns = useMemo<FilterField[]>(
     () =>

--- a/src/components/NurseryWithdrawals/WithdrawalDetails/sections/NonOutplantWithdrawalTable.tsx
+++ b/src/components/NurseryWithdrawals/WithdrawalDetails/sections/NonOutplantWithdrawalTable.tsx
@@ -4,7 +4,7 @@ import strings from 'src/strings';
 import { Batch, NurseryWithdrawal } from 'src/types/Batch';
 import { Species } from 'src/types/Species';
 import Table from 'src/components/common/table';
-import { useLocalization, useUser } from 'src/providers';
+import { useUser } from 'src/providers';
 import { useNumberFormatter } from 'src/utils/useNumber';
 
 type SpeciesWithdrawal = {
@@ -22,30 +22,23 @@ type NonOutplantWithdrawalTableProps = {
   batches?: Batch[];
 };
 
+const columns = (): TableColumnType[] => [
+  { key: 'name', name: strings.SPECIES, type: 'string' },
+  { key: 'notReady', name: strings.NOT_READY, type: 'number' },
+  { key: 'ready', name: strings.READY, type: 'number' },
+  { key: 'total', name: strings.TOTAL, type: 'number' },
+];
+
 export default function NonOutplantWithdrawalTable({
   species,
   withdrawal,
   batches,
 }: NonOutplantWithdrawalTableProps): JSX.Element {
   const { user } = useUser();
-  const { activeLocale } = useLocalization();
   const numberFormatter = useNumberFormatter();
   const numericFormatter = useMemo(() => numberFormatter(user?.locale), [numberFormatter, user?.locale]);
 
   const [rowData, setRowData] = useState<SpeciesWithdrawal[]>([]);
-
-  const columns: TableColumnType[] = useMemo(
-    () =>
-      activeLocale
-        ? [
-            { key: 'name', name: strings.SPECIES, type: 'string' },
-            { key: 'notReady', name: strings.NOT_READY, type: 'number' },
-            { key: 'ready', name: strings.READY, type: 'number' },
-            { key: 'total', name: strings.TOTAL, type: 'number' },
-          ]
-        : [],
-    [activeLocale]
-  );
 
   useEffect(() => {
     // get map of batch id to species id - for correlation

--- a/src/components/NurseryWithdrawals/WithdrawalDetails/sections/OutplantReassignmentTable.tsx
+++ b/src/components/NurseryWithdrawals/WithdrawalDetails/sections/OutplantReassignmentTable.tsx
@@ -4,7 +4,7 @@ import { Delivery } from 'src/types/Tracking';
 import { TableColumnType } from '@terraware/web-components';
 import strings from 'src/strings';
 import Table from 'src/components/common/table';
-import { useLocalization, useUser } from 'src/providers';
+import { useUser } from 'src/providers';
 import { useNumberFormatter } from 'src/utils/useNumber';
 
 type OutplantReassignmentTableProps = {
@@ -14,6 +14,15 @@ type OutplantReassignmentTableProps = {
   withdrawalNotes?: string;
 };
 
+const columns = (): TableColumnType[] => [
+  { key: 'species', name: strings.SPECIES, type: 'string' },
+  { key: 'from_subzone', name: strings.FROM_SUBZONE, type: 'string' },
+  { key: 'to_subzone', name: strings.TO_SUBZONE, type: 'string' },
+  { key: 'original_qty', name: strings.ORIGINAL_QTY, type: 'string' },
+  { key: 'final_qty', name: strings.FINAL_QTY, type: 'string' },
+  { key: 'notes', name: strings.NOTES, type: 'string' },
+];
+
 export default function OutplantReassignmentTable({
   delivery,
   species,
@@ -21,26 +30,10 @@ export default function OutplantReassignmentTable({
   withdrawalNotes,
 }: OutplantReassignmentTableProps): JSX.Element {
   const { user } = useUser();
-  const { activeLocale } = useLocalization();
   const numberFormatter = useNumberFormatter();
   const numericFormatter = useMemo(() => numberFormatter(user?.locale), [numberFormatter, user?.locale]);
 
   const [rowData, setRowData] = useState<{ [p: string]: unknown }[]>([]);
-
-  const columns: TableColumnType[] = useMemo(
-    () =>
-      activeLocale
-        ? [
-            { key: 'species', name: strings.SPECIES, type: 'string' },
-            { key: 'from_subzone', name: strings.FROM_SUBZONE, type: 'string' },
-            { key: 'to_subzone', name: strings.TO_SUBZONE, type: 'string' },
-            { key: 'original_qty', name: strings.ORIGINAL_QTY, type: 'string' },
-            { key: 'final_qty', name: strings.FINAL_QTY, type: 'string' },
-            { key: 'notes', name: strings.NOTES, type: 'string' },
-          ]
-        : [],
-    [activeLocale]
-  );
 
   useEffect(() => {
     // get list of distinct species

--- a/src/components/NurseryWithdrawals/WithdrawalDetails/sections/OutplantWithdrawalTable.tsx
+++ b/src/components/NurseryWithdrawals/WithdrawalDetails/sections/OutplantWithdrawalTable.tsx
@@ -4,7 +4,7 @@ import strings from 'src/strings';
 import { Delivery } from 'src/types/Tracking';
 import { Species } from 'src/types/Species';
 import Table from 'src/components/common/table';
-import { useLocalization, useUser } from 'src/providers';
+import { useUser } from 'src/providers';
 import { useNumberFormatter } from 'src/utils/useNumber';
 
 type OutplantWithdrawalTableProps = {
@@ -13,29 +13,22 @@ type OutplantWithdrawalTableProps = {
   delivery?: Delivery;
 };
 
+const columns = (): TableColumnType[] => [
+  { key: 'species', name: strings.SPECIES, type: 'string' },
+  { key: 'to_subzone', name: strings.TO_SUBZONE, type: 'string' },
+  { key: 'quantity', name: strings.QUANTITY, type: 'string' },
+];
+
 export default function OutplantWithdrawalTable({
   species,
   subzoneNames,
   delivery,
 }: OutplantWithdrawalTableProps): JSX.Element {
   const { user } = useUser();
-  const { activeLocale } = useLocalization();
   const numberFormatter = useNumberFormatter();
   const numericFormatter = useMemo(() => numberFormatter(user?.locale), [numberFormatter, user?.locale]);
 
   const [rowData, setRowData] = useState<{ [p: string]: unknown }[]>([]);
-
-  const columns: TableColumnType[] = useMemo(
-    () =>
-      activeLocale
-        ? [
-            { key: 'species', name: strings.SPECIES, type: 'string' },
-            { key: 'to_subzone', name: strings.TO_SUBZONE, type: 'string' },
-            { key: 'quantity', name: strings.QUANTITY, type: 'string' },
-          ]
-        : [],
-    [activeLocale]
-  );
 
   useEffect(() => {
     // get list of distinct species

--- a/src/components/Observations/org/OrgObservationsListView.tsx
+++ b/src/components/Observations/org/OrgObservationsListView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { makeStyles } from '@mui/styles';
 import { Box, useTheme } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
@@ -24,6 +24,49 @@ const useStyles = makeStyles(() => ({
 export type OrgObservationsListViewProps = {
   observationsResults?: ObservationResults[];
 };
+
+const columns = (): TableColumnType[] => [
+  {
+    key: 'completedTime',
+    name: strings.DATE,
+    type: 'string',
+  },
+  {
+    key: 'state',
+    name: strings.STATUS,
+    type: 'string',
+  },
+  {
+    key: 'plantingZones',
+    name: strings.ZONES,
+    type: 'string',
+  },
+  {
+    key: 'plantingSubzones',
+    name: strings.SUBZONES,
+    type: 'string',
+  },
+  {
+    key: 'totalPlants',
+    name: strings.PLANTS,
+    type: 'number',
+  },
+  {
+    key: 'totalSpecies',
+    name: strings.SPECIES,
+    type: 'number',
+  },
+  {
+    key: 'plantingDensity',
+    name: strings.PLANTING_DENSITY,
+    type: 'number',
+  },
+  {
+    key: 'mortalityRate',
+    name: strings.MORTALITY_RATE,
+    type: 'number',
+  },
+];
 
 export default function OrgObservationsListView({ observationsResults }: OrgObservationsListViewProps): JSX.Element {
   const { activeLocale } = useLocalization();
@@ -52,55 +95,6 @@ export default function OrgObservationsListView({ observationsResults }: OrgObse
       })
     );
   }, [observationsResults]);
-
-  const columns: TableColumnType[] = useMemo(
-    () =>
-      activeLocale
-        ? [
-            {
-              key: 'completedTime',
-              name: strings.DATE,
-              type: 'string',
-            },
-            {
-              key: 'state',
-              name: strings.STATUS,
-              type: 'string',
-            },
-            {
-              key: 'plantingZones',
-              name: strings.ZONES,
-              type: 'string',
-            },
-            {
-              key: 'plantingSubzones',
-              name: strings.SUBZONES,
-              type: 'string',
-            },
-            {
-              key: 'totalPlants',
-              name: strings.PLANTS,
-              type: 'number',
-            },
-            {
-              key: 'totalSpecies',
-              name: strings.SPECIES,
-              type: 'number',
-            },
-            {
-              key: 'plantingDensity',
-              name: strings.PLANTING_DENSITY,
-              type: 'number',
-            },
-            {
-              key: 'mortalityRate',
-              name: strings.MORTALITY_RATE,
-              type: 'number',
-            },
-          ]
-        : [],
-    [activeLocale]
-  );
 
   return (
     <Box>

--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import Button from 'src/components/common/button/Button';
 import Table from 'src/components/common/table';
@@ -50,6 +50,14 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
+const columns = (): TableColumnType[] => [
+  { key: 'email', name: strings.EMAIL, type: 'string' },
+  { key: 'firstName', name: strings.FIRST_NAME, type: 'string' },
+  { key: 'lastName', name: strings.LAST_NAME, type: 'string' },
+  { key: 'role', name: strings.ROLE, type: 'string' },
+  { key: 'addedTime', name: strings.DATE_ADDED, type: 'date' },
+];
+
 export default function PeopleList(): JSX.Element {
   const { selectedOrganization, reloadOrganizations } = useOrganization();
   const { user } = useUser();
@@ -70,20 +78,6 @@ export default function PeopleList(): JSX.Element {
   const { isMobile } = useDeviceInfo();
   const contentRef = useRef(null);
   const { activeLocale } = useLocalization();
-
-  const columns: TableColumnType[] = useMemo(
-    () =>
-      activeLocale
-        ? [
-            { key: 'email', name: strings.EMAIL, type: 'string' },
-            { key: 'firstName', name: strings.FIRST_NAME, type: 'string' },
-            { key: 'lastName', name: strings.LAST_NAME, type: 'string' },
-            { key: 'role', name: strings.ROLE, type: 'string' },
-            { key: 'addedTime', name: strings.DATE_ADDED, type: 'date' },
-          ]
-        : [],
-    [activeLocale]
-  );
 
   useEffect(() => {
     const refreshSearch = async () => {

--- a/src/components/PlantingSites/PlantingSitesTable.tsx
+++ b/src/components/PlantingSites/PlantingSitesTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { Box, Grid, useTheme } from '@mui/material';
 import { TableColumnType, Textfield } from '@terraware/web-components';
 import { SearchResponseElement } from 'src/types/Search';
@@ -7,7 +7,6 @@ import PlantingSitesCellRenderer from './PlantingSitesCellRenderer';
 import Table from 'src/components/common/table';
 import { SortOrder } from 'src/components/common/table/sort';
 import { SearchSortOrder } from 'src/types/Search';
-import { useLocalization } from 'src/providers';
 
 interface PlantingSitesTableProps {
   results: SearchResponseElement[];
@@ -16,33 +15,26 @@ interface PlantingSitesTableProps {
   setSearchSortOrder: (sortOrder: SearchSortOrder) => void;
 }
 
+const columns = (): TableColumnType[] => [
+  {
+    key: 'name',
+    name: strings.NAME,
+    type: 'string',
+  },
+  {
+    key: 'description',
+    name: strings.DESCRIPTION,
+    type: 'string',
+  },
+  { key: 'numPlantingZones', name: strings.PLANTING_ZONES, type: 'string' },
+  { key: 'numPlantingSubzones', name: strings.SUBZONES, type: 'string' },
+  { key: 'timeZone', name: strings.TIME_ZONE, type: 'string' },
+];
+
 export default function PlantingSitesTable(props: PlantingSitesTableProps): JSX.Element {
   const { results, setTemporalSearchValue, temporalSearchValue, setSearchSortOrder } = props;
   const [isPresorted, setIsPresorted] = useState<boolean>(false);
   const theme = useTheme();
-  const { activeLocale } = useLocalization();
-
-  const columns: TableColumnType[] = useMemo(
-    () =>
-      activeLocale
-        ? [
-            {
-              key: 'name',
-              name: strings.NAME,
-              type: 'string',
-            },
-            {
-              key: 'description',
-              name: strings.DESCRIPTION,
-              type: 'string',
-            },
-            { key: 'numPlantingZones', name: strings.PLANTING_ZONES, type: 'string' },
-            { key: 'numPlantingSubzones', name: strings.SUBZONES, type: 'string' },
-            { key: 'timeZone', name: strings.TIME_ZONE, type: 'string' },
-          ]
-        : [],
-    [activeLocale]
-  );
 
   const onSortChange = (order: SortOrder, orderBy: string) => {
     const isTimeZone = orderBy === 'timeZone';

--- a/src/components/Reports/LocationSection.tsx
+++ b/src/components/Reports/LocationSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import { Grid, Theme, Typography, useTheme } from '@mui/material';
 import { DatePicker, TableColumnType, Textfield } from '@terraware/web-components';
@@ -8,7 +8,7 @@ import { makeStyles } from '@mui/styles';
 import { ReportNursery, ReportPlantingSite, ReportSeedBank } from 'src/types/Report';
 import PlantingSiteSpeciesCellRenderer from './PlantingSitesSpeciesCellRenderer';
 import Table from '../common/table';
-import { useLocalization, useOrganization } from 'src/providers';
+import { useOrganization } from 'src/providers';
 import { SpeciesService } from 'src/services';
 import { Species } from 'src/types/Species';
 
@@ -30,13 +30,31 @@ export type LocationSectionProps = {
   validate?: boolean;
 };
 
+const columns = (): TableColumnType[] => [
+  {
+    key: 'name',
+    name: strings.SPECIES,
+    type: 'string',
+  },
+  {
+    key: 'growthForm',
+    name: strings.GROWTH_FORM,
+    type: 'string',
+  },
+  {
+    key: 'totalPlanted',
+    name: strings.TOTAL_PLANTED_REQUIRED,
+    type: 'string',
+  },
+  { key: 'mortalityRateInField', name: strings.MORTALITY_RATE_IN_FIELD_REQUIRED, type: 'string' },
+];
+
 export default function LocationSection(props: LocationSectionProps): JSX.Element {
   const { editable, location, onUpdateLocation, onUpdateWorkers, locationType, validate } = props;
   const { isMobile, isTablet } = useDeviceInfo();
   const theme = useTheme();
   const classes = useStyles();
   const { selectedOrganization } = useOrganization();
-  const { activeLocale } = useLocalization();
 
   const isSeedBank = locationType === 'seedBank';
   const isNursery = locationType === 'nursery';
@@ -95,31 +113,6 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
       setPlantingSiteSpecies(psSpecies);
     }
   }, [allSpecies, isPlantingSite, location]);
-
-  const columns: TableColumnType[] = useMemo(
-    () =>
-      activeLocale
-        ? [
-            {
-              key: 'name',
-              name: strings.SPECIES,
-              type: 'string',
-            },
-            {
-              key: 'growthForm',
-              name: strings.GROWTH_FORM,
-              type: 'string',
-            },
-            {
-              key: 'totalPlanted',
-              name: strings.TOTAL_PLANTED_REQUIRED,
-              type: 'string',
-            },
-            { key: 'mortalityRateInField', name: strings.MORTALITY_RATE_IN_FIELD_REQUIRED, type: 'string' },
-          ]
-        : [],
-    [activeLocale]
-  );
 
   const onEditPlantingSiteReport = (species: PlantingSiteSpecies, fromColumn?: string, value?: any) => {
     if (fromColumn) {

--- a/src/components/Reports/ReportList.tsx
+++ b/src/components/Reports/ReportList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Container, Grid, Typography, useTheme } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
 import Table from 'src/components/common/table';
@@ -8,28 +8,21 @@ import strings from 'src/strings';
 import { ListReport } from 'src/types/Report';
 import PageHeaderWrapper from '../common/PageHeaderWrapper';
 import ReportsCellRenderer from './TableCellRenderer';
-import { useLocalization, useOrganization } from 'src/providers';
+import { useOrganization } from 'src/providers';
+
+const columns = (): TableColumnType[] => [
+  { key: 'name', name: strings.REPORT, type: 'string' },
+  { key: 'status', name: strings.STATUS, type: 'string' },
+  { key: 'modifiedByName', name: strings.LAST_EDITED_BY, type: 'string' },
+  { key: 'submittedByName', name: strings.SUBMITTED_BY, type: 'string' },
+  { key: 'submittedTime', name: strings.DATE_SUBMITTED, type: 'string' },
+];
 
 export default function ReportList(): JSX.Element {
   const contentRef = useRef(null);
   const [results, setResults] = useState<ListReport[]>([]);
   const { selectedOrganization } = useOrganization();
-  const { activeLocale } = useLocalization();
   const theme = useTheme();
-
-  const columns: TableColumnType[] = useMemo(
-    () =>
-      activeLocale
-        ? [
-            { key: 'name', name: strings.REPORT, type: 'string' },
-            { key: 'status', name: strings.STATUS, type: 'string' },
-            { key: 'modifiedByName', name: strings.LAST_EDITED_BY, type: 'string' },
-            { key: 'submittedByName', name: strings.SUBMITTED_BY, type: 'string' },
-            { key: 'submittedTime', name: strings.DATE_SUBMITTED, type: 'string' },
-          ]
-        : [],
-    [activeLocale]
-  );
 
   useEffect(() => {
     const refreshSearch = async () => {

--- a/src/components/SeedBank/StorageLocations.tsx
+++ b/src/components/SeedBank/StorageLocations.tsx
@@ -25,6 +25,11 @@ const storageLocationWith = (name: string, id: number) => ({
   activeAccessions: 0,
 });
 
+const columns = (): TableColumnType[] => [
+  { key: 'name', name: strings.NAME, type: 'string' },
+  { key: 'activeAccessions', name: strings.ACTIVE_ACCESSIONS, type: 'number' },
+];
+
 export default function StorageLocations({ seedBankId, onEdit }: StorageLocationsProps): JSX.Element | null {
   const { activeLocale } = useLocalization();
   const { isMobile } = useDeviceInfo();
@@ -34,17 +39,6 @@ export default function StorageLocations({ seedBankId, onEdit }: StorageLocation
   const [storageLocations, setStorageLocations] = useState<PartialStorageLocation[]>([]);
   const [openStorageLocationModal, setOpenStorageLocationModal] = useState<boolean>(false);
   const numericFormatter = useMemo(() => numberFormatter(activeLocale), [numberFormatter, activeLocale]);
-
-  const columns: TableColumnType[] = useMemo(
-    () =>
-      activeLocale
-        ? [
-            { key: 'name', name: strings.NAME, type: 'string' },
-            { key: 'activeAccessions', name: strings.ACTIVE_ACCESSIONS, type: 'number' },
-          ]
-        : [],
-    [activeLocale]
-  );
 
   useEffect(() => {
     const fetchStorageLocations = async () => {

--- a/src/components/SeedBanks/index.tsx
+++ b/src/components/SeedBanks/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import Button from 'src/components/common/button/Button';
 import Table from 'src/components/common/table';
@@ -18,7 +18,7 @@ import { Box, Grid, Theme, useTheme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import PageHeaderWrapper from '../common/PageHeaderWrapper';
-import { useLocalization, useTimeZones } from 'src/providers';
+import { useTimeZones } from 'src/providers';
 import { setTimeZone, useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -53,9 +53,14 @@ type SeedBanksListProps = {
   organization: Organization;
 };
 
+const columns = (): TableColumnType[] => [
+  { key: 'name', name: strings.NAME, type: 'string' },
+  { key: 'description', name: strings.DESCRIPTION, type: 'string' },
+  { key: 'timeZone', name: strings.TIME_ZONE, type: 'string' },
+];
+
 export default function SeedBanksList({ organization }: SeedBanksListProps): JSX.Element {
   const timeZones = useTimeZones();
-  const { activeLocale } = useLocalization();
   const defaultTimeZone = useDefaultTimeZone().get();
   const classes = useStyles();
   const theme = useTheme();
@@ -65,18 +70,6 @@ export default function SeedBanksList({ organization }: SeedBanksListProps): JSX
   const [results, setResults] = useState<Facility[]>([]);
   const { isMobile } = useDeviceInfo();
   const contentRef = useRef(null);
-
-  const columns: TableColumnType[] = useMemo(
-    () =>
-      activeLocale
-        ? [
-            { key: 'name', name: strings.NAME, type: 'string' },
-            { key: 'description', name: strings.DESCRIPTION, type: 'string' },
-            { key: 'timeZone', name: strings.TIME_ZONE, type: 'string' },
-          ]
-        : [],
-    [activeLocale]
-  );
 
   const goToNewSeedBank = () => {
     const newSeedBankLocation = {

--- a/src/components/accession2/viabilityTesting/ViabilityTestingDatabase.tsx
+++ b/src/components/accession2/viabilityTesting/ViabilityTestingDatabase.tsx
@@ -15,14 +15,14 @@ interface ViabilityTestingDatabaseProps {
   onSelectViabilityTest: (test: ViabilityTest) => void;
 }
 
-const columns: TableColumnType[] = [
+const columns = (): TableColumnType[] => [
   { key: 'id', name: '', type: 'number' },
   { key: 'startDate', name: '', type: 'string' },
   { key: 'testType', name: '', type: 'string' },
   { key: 'viabilityPercent', name: '', type: 'number' },
 ];
 
-const mobileColumns: TableColumnType[] = [
+const mobileColumns = (): TableColumnType[] => [
   { key: 'id', name: '', type: 'number' },
   { key: 'viabilityPercent', name: '', type: 'number' },
 ];


### PR DESCRIPTION
- wasn't too thrilled about the last fix
- extracted out changed-locale semantics and moved it into the table wrapper
- now each component supplies a function that returns the table names, function has to be outside scope of the component so it doesn't change on every render
- this will scale more easily without bugs, etc.