### PR TITLE
SW-3736 Replace hexRgb Calls with Utility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,6 @@ import { CssBaseline, Slide, StyledEngineProvider, Theme } from '@mui/material';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router';
 import { Redirect, Route, Switch } from 'react-router-dom';
-import hexRgb from 'hex-rgb';
 import useStateLocation from './utils/useStateLocation';
 import { DEFAULT_SEED_SEARCH_FILTERS, DEFAULT_SEED_SEARCH_SORT_ORDER } from 'src/services/SeedBankService';
 import { SearchSortOrder, SearchCriteria } from 'src/types/Search';
@@ -64,6 +63,7 @@ import { useAppVersion } from './hooks/useAppVersion';
 import { ReportList, ReportView, ReportEdit } from './components/Reports';
 import isEnabled from 'src/features';
 import Observations from 'src/components/Observations';
+import { getRgbaFromHex } from 'src/utils/color';
 
 interface StyleProps {
   isDesktop?: boolean;
@@ -74,8 +74,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     backgroundColor: theme.palette.TwClrBaseGray025,
     backgroundImage:
       'linear-gradient(180deg,' +
-      `${hexRgb(`${theme.palette.TwClrBaseGreen050}`, { alpha: 0, format: 'css' })} 0%,` +
-      `${hexRgb(`${theme.palette.TwClrBaseGreen050}`, { alpha: 0.4, format: 'css' })} 100%)`,
+      `${getRgbaFromHex(theme.palette.TwClrBaseGreen050 as string, 0)} 0%,` +
+      `${getRgbaFromHex(theme.palette.TwClrBaseGreen050 as string, 0.4)} 100%)`,
     backgroundAttachment: 'fixed',
     minHeight: '100vh',
     '& .navbar': {
@@ -84,8 +84,8 @@ const useStyles = makeStyles((theme: Theme) => ({
       backgroundImage: (props: StyleProps) =>
         props.isDesktop
           ? 'linear-gradient(180deg,' +
-            `${hexRgb(`${theme.palette.TwClrBaseGreen050}`, { alpha: 0, format: 'css' })} 0%,` +
-            `${hexRgb(`${theme.palette.TwClrBaseGreen050}`, { alpha: 0.4, format: 'css' })} 100%)`
+            `${getRgbaFromHex(theme.palette.TwClrBaseGreen050 as string, 0)} 0%,` +
+            `${getRgbaFromHex(theme.palette.TwClrBaseGreen050 as string, 0.4)} 100%)`
           : null,
       backgroundAttachment: 'fixed',
       paddingRight: (props: StyleProps) => (props.isDesktop ? '8px' : undefined),
@@ -116,7 +116,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   navBarOpened: {
     backdropFilter: 'blur(8px)',
-    background: hexRgb(`${theme.palette.TwClrBgSecondary}`, { alpha: 0.8, format: 'css' }),
+    background: getRgbaFromHex(theme.palette.TwClrBgSecondary as string, 0.8),
     height: '100%',
     alignItems: 'center',
     position: 'fixed',

--- a/src/components/OptInFeatures/index.tsx
+++ b/src/components/OptInFeatures/index.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { Box, LinearProgress, Switch, Stack, Grid, useTheme } from '@mui/material';
-import hexRgb from 'hex-rgb';
 import { PreferencesService } from 'src/services';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import useSnackbar from 'src/utils/useSnackbar';
 import PageSnackbar from 'src/components/PageSnackbar';
 import { Feature, OPT_IN_FEATURES } from 'src/features';
 import TfMain from 'src/components/common/TfMain';
+import { getRgbaFromHex } from 'src/utils/color';
 
 type OptInFeaturesProps = {
   refresh?: () => void;
@@ -126,7 +126,7 @@ export default function OptInFeatures({ refresh }: OptInFeaturesProps): JSX.Elem
                 border: `1px solid ${theme.palette.TwClrBrdrTertiary}`,
                 padding: '10px',
                 borderRadius: '5px',
-                backgroundColor: hexRgb(`${theme.palette.TwClrBg}`, { alpha: 0.8, format: 'css' }),
+                backgroundColor: getRgbaFromHex(theme.palette.TwClrBg as string, 0.8),
                 marginBottom: '10px',
               }}
               key={i}

--- a/src/components/SmallDeviceUserMenu.tsx
+++ b/src/components/SmallDeviceUserMenu.tsx
@@ -16,7 +16,6 @@ import { makeStyles } from '@mui/styles';
 import React, { useState } from 'react';
 import { useEffect, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
-import hexRgb from 'hex-rgb';
 import { APP_PATHS } from 'src/constants';
 import strings from 'src/strings';
 import { Organization } from 'src/types/Organization';
@@ -25,6 +24,7 @@ import Icon from './common/icon/Icon';
 import useEnvironment from 'src/utils/useEnvironment';
 import { useUser } from 'src/providers';
 import { useOrganization } from 'src/providers/hooks';
+import { getRgbaFromHex } from 'src/utils/color';
 
 const useStyles = makeStyles((theme: Theme) => ({
   icon: {
@@ -56,7 +56,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   userMenuOpened: {
     '& .blurred': {
       backdropFilter: 'blur(8px)',
-      background: hexRgb(`${theme.palette.TwClrBgSecondary}`, { alpha: 0.8, format: 'css' }),
+      background: getRgbaFromHex(theme.palette.TwClrBgSecondary as string, 0.8),
       height: '100%',
       alignItems: 'center',
       position: 'fixed',

--- a/src/components/Species/TableCellRenderer.tsx
+++ b/src/components/Species/TableCellRenderer.tsx
@@ -1,7 +1,6 @@
 import { ClickAwayListener, IconButton, Theme, Tooltip } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import React, { useState } from 'react';
-import hexRgb from 'hex-rgb';
 import { EcosystemType, ecosystemTypes, SpeciesProblemElement } from 'src/types/Species';
 import Icon from '../common/icon/Icon';
 import CellRenderer, { TableRowType } from '../common/table/TableCellRenderer';
@@ -9,6 +8,7 @@ import { RendererProps } from '../common/table/types';
 import ProblemTooltip from './ProblemTooltip';
 import { TextTruncated } from '@terraware/web-components';
 import strings from 'src/strings';
+import { getRgbaFromHex } from 'src/utils/color';
 
 const useStyles = makeStyles((theme: Theme) => ({
   icon: {
@@ -26,7 +26,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     padding: 0,
     background: theme.palette.TwClrBg,
     border: `1px solid ${theme.palette.TwClrBrdrTertiary}`,
-    boxShadow: `0px 4px 8px ${hexRgb(`${theme.palette.TwClrShdw}`, { alpha: 0.2, format: 'css' })}`,
+    boxShadow: `0px 4px 8px ${getRgbaFromHex(theme.palette.TwClrShdw as string, 0.2)}`,
     borderRadius: '7px',
     color: theme.palette.TwClrTxt,
     fontSize: '12px',

--- a/src/components/common/ListMapSelector.tsx
+++ b/src/components/common/ListMapSelector.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Box, Theme, Typography, useTheme } from '@mui/material';
-import hexRgb from 'hex-rgb';
 import strings from 'src/strings';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import Icon from './icon/Icon';
 import { IconName } from './icon/icons';
 import { makeStyles } from '@mui/styles';
+import { getRgbaFromHex } from 'src/utils/color';
 
 const useStyles = makeStyles((theme: Theme) => ({
   icon: {
@@ -48,7 +48,7 @@ export default function ListMapSelector({ defaultView, view, onView }: ListMapSe
         sx={{
           background: isSelected ? theme.palette.TwClrBaseWhite : 'transparent',
           boxShadow: isSelected
-            ? `0.0px 2.0px 4.0px 0px ${hexRgb(`${theme.palette.TwClrBaseGray800}`, { alpha: 0.2, format: 'css' })}`
+            ? `0.0px 2.0px 4.0px 0px ${getRgbaFromHex(theme.palette.TwClrBaseGray800 as string, 0.2)}`
             : 'none',
           cursor: 'pointer',
         }}


### PR DESCRIPTION
There were several places where hexRgb was being used to apply an opacity to
a color. Replace with the utility function, getRgbaFromHex.