### PR TITLE
observations plants stats info cards + charts

### DIFF
--- a/src/components/Observations/common/AggregatedPlantsStats.tsx
+++ b/src/components/Observations/common/AggregatedPlantsStats.tsx
@@ -1,0 +1,62 @@
+import { Box, Grid } from '@mui/material';
+import strings from 'src/strings';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
+import OverviewItemCard from 'src/components/common/OverviewItemCard';
+import Card from 'src/components/common/Card';
+
+export type SpeciesStats = {
+  totalDead: number;
+  totalExisting: number;
+  totalLive: number;
+  speciesName?: string;
+  speciesCommonName?: string;
+  speciesScientificName?: string;
+};
+
+export type AggregatedPlantsStatsProps = {
+  totalPlants?: number;
+  totalSpecies?: number;
+  plantingDensity?: number;
+  mortalityRate?: number;
+  species?: SpeciesStats[];
+};
+
+export default function AggregatedPlantsStats({
+  totalPlants,
+  totalSpecies,
+  plantingDensity,
+  mortalityRate,
+  species,
+}: AggregatedPlantsStatsProps): JSX.Element {
+  const { isMobile } = useDeviceInfo();
+
+  const infoCardGridSize = isMobile ? 12 : 3;
+  const chartGridSize = isMobile ? 12 : 6;
+
+  const getData = () => [
+    { label: strings.PLANTS, value: totalPlants },
+    { label: strings.SPECIES, value: totalSpecies },
+    { label: strings.PLANTING_DENSITY, value: plantingDensity },
+    { label: strings.MORTALITY_RATE, value: mortalityRate },
+  ];
+
+  return (
+    <Box display='flex' flexDirection='column'>
+      <Grid container spacing={3} marginBottom={3}>
+        {getData().map((data) => (
+          <Grid item xs={infoCardGridSize} key={data.label}>
+            <OverviewItemCard isEditable={false} title={data.label} contents={data.value?.toString() ?? null} />
+          </Grid>
+        ))}
+      </Grid>
+      <Grid container spacing={3}>
+        <Grid item xs={chartGridSize}>
+          <Card style={{ height: '240px' }}>add chart for {species?.length} species # plants</Card>
+        </Grid>
+        <Grid item xs={chartGridSize}>
+          <Card style={{ height: '240px' }}>add chart for {species?.length} species mortality rate</Card>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/src/components/Observations/common/AggregatedPlantsStats.tsx
+++ b/src/components/Observations/common/AggregatedPlantsStats.tsx
@@ -1,24 +1,18 @@
-import { Box, Grid } from '@mui/material';
+import { Box, Grid, Typography, useTheme } from '@mui/material';
 import strings from 'src/strings';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
+import { ObservationSpeciesResults } from 'src/types/Observations';
 import OverviewItemCard from 'src/components/common/OverviewItemCard';
 import Card from 'src/components/common/Card';
-
-export type SpeciesStats = {
-  totalDead: number;
-  totalExisting: number;
-  totalLive: number;
-  speciesName?: string;
-  speciesCommonName?: string;
-  speciesScientificName?: string;
-};
+import SpeciesTotalPlantsChart from './SpeciesTotalPlantsChart';
+import SpeciesMortalityRateChart from './SpeciesMortalityRateChart';
 
 export type AggregatedPlantsStatsProps = {
   totalPlants?: number;
   totalSpecies?: number;
   plantingDensity?: number;
   mortalityRate?: number;
-  species?: SpeciesStats[];
+  species?: ObservationSpeciesResults[];
 };
 
 export default function AggregatedPlantsStats({
@@ -29,7 +23,7 @@ export default function AggregatedPlantsStats({
   species,
 }: AggregatedPlantsStatsProps): JSX.Element {
   const { isMobile } = useDeviceInfo();
-
+  const theme = useTheme();
   const infoCardGridSize = isMobile ? 12 : 3;
   const chartGridSize = isMobile ? 12 : 6;
 
@@ -51,10 +45,36 @@ export default function AggregatedPlantsStats({
       </Grid>
       <Grid container spacing={3}>
         <Grid item xs={chartGridSize}>
-          <Card style={{ height: '240px' }}>add chart for {species?.length} species # plants</Card>
+          <Card style={{ height: '240px' }}>
+            <Box height='240px'>
+              <Typography
+                fontSize='14px'
+                lineHeight='20px'
+                fontWeight={400}
+                color={theme.palette.TwClrTxtSecondary}
+                marginBottom={2}
+              >
+                {strings.NUMBER_OF_PLANTS_BY_SPECIES}
+              </Typography>
+              <SpeciesTotalPlantsChart species={species} />
+            </Box>
+          </Card>
         </Grid>
         <Grid item xs={chartGridSize}>
-          <Card style={{ height: '240px' }}>add chart for {species?.length} species mortality rate</Card>
+          <Card style={{ height: '240px' }}>
+            <Box height='240px'>
+              <Typography
+                fontSize='14px'
+                lineHeight='20px'
+                fontWeight={400}
+                color={theme.palette.TwClrTxtSecondary}
+                marginBottom={1}
+              >
+                {strings.MORTALITY_RATE_BY_SPECIES}
+              </Typography>
+              <SpeciesMortalityRateChart species={species} />
+            </Box>
+          </Card>
         </Grid>
       </Grid>
     </Box>

--- a/src/components/Observations/common/AggregatedPlantsStats.tsx
+++ b/src/components/Observations/common/AggregatedPlantsStats.tsx
@@ -69,7 +69,7 @@ const ChartWrapper = ({ title, children }: ChartWrapperProps): JSX.Element => {
 
   return (
     <Card style={{ height: '240px', padding: 1 }}>
-      <Box height='185px' marginLeft={-0.5}>
+      <Box height='220px' marginLeft={-0.5} display='flex' flexDirection='column'>
         <Typography
           fontSize='14px'
           lineHeight='20px'
@@ -79,7 +79,9 @@ const ChartWrapper = ({ title, children }: ChartWrapperProps): JSX.Element => {
         >
           {title}
         </Typography>
-        {children}
+        <Box height='170px' display='flex' flexDirection='column'>
+          {children}
+        </Box>
       </Box>
     </Card>
   );

--- a/src/components/Observations/common/AggregatedPlantsStats.tsx
+++ b/src/components/Observations/common/AggregatedPlantsStats.tsx
@@ -79,7 +79,7 @@ const ChartWrapper = ({ title, children }: ChartWrapperProps): JSX.Element => {
         >
           {title}
         </Typography>
-        <Box height='170px' display='flex' flexDirection='column'>
+        <Box height='170px' display='flex' flexDirection='column' margin={theme.spacing(0, 1)}>
           {children}
         </Box>
       </Box>

--- a/src/components/Observations/common/AggregatedPlantsStats.tsx
+++ b/src/components/Observations/common/AggregatedPlantsStats.tsx
@@ -46,12 +46,12 @@ export default function AggregatedPlantsStats({
       <Grid container spacing={3}>
         <Grid item xs={chartGridSize}>
           <ChartWrapper title={strings.NUMBER_OF_PLANTS_BY_SPECIES}>
-            <SpeciesTotalPlantsChart species={species} />
+            <SpeciesTotalPlantsChart species={species} minHeight='170px' />
           </ChartWrapper>
         </Grid>
         <Grid item xs={chartGridSize}>
           <ChartWrapper title={strings.MORTALITY_RATE_BY_SPECIES}>
-            <SpeciesMortalityRateChart species={species} />
+            <SpeciesMortalityRateChart species={species} minHeight='170px' />
           </ChartWrapper>
         </Grid>
       </Grid>

--- a/src/components/Observations/common/AggregatedPlantsStats.tsx
+++ b/src/components/Observations/common/AggregatedPlantsStats.tsx
@@ -59,12 +59,12 @@ export default function AggregatedPlantsStats({
   );
 }
 
-type ChartWrapperType = {
+type ChartWrapperProps = {
   title: string;
   children: React.ReactNode;
 };
 
-const ChartWrapper = ({ title, children }: ChartWrapperType): JSX.Element => {
+const ChartWrapper = ({ title, children }: ChartWrapperProps): JSX.Element => {
   const theme = useTheme();
 
   return (

--- a/src/components/Observations/common/AggregatedPlantsStats.tsx
+++ b/src/components/Observations/common/AggregatedPlantsStats.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import strings from 'src/strings';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
@@ -23,7 +24,6 @@ export default function AggregatedPlantsStats({
   species,
 }: AggregatedPlantsStatsProps): JSX.Element {
   const { isMobile } = useDeviceInfo();
-  const theme = useTheme();
   const infoCardGridSize = isMobile ? 12 : 3;
   const chartGridSize = isMobile ? 12 : 6;
 
@@ -45,38 +45,42 @@ export default function AggregatedPlantsStats({
       </Grid>
       <Grid container spacing={3}>
         <Grid item xs={chartGridSize}>
-          <Card style={{ height: '240px' }}>
-            <Box height='240px'>
-              <Typography
-                fontSize='14px'
-                lineHeight='20px'
-                fontWeight={400}
-                color={theme.palette.TwClrTxtSecondary}
-                marginBottom={2}
-              >
-                {strings.NUMBER_OF_PLANTS_BY_SPECIES}
-              </Typography>
-              <SpeciesTotalPlantsChart species={species} />
-            </Box>
-          </Card>
+          <ChartWrapper title={strings.NUMBER_OF_PLANTS_BY_SPECIES}>
+            <SpeciesTotalPlantsChart species={species} />
+          </ChartWrapper>
         </Grid>
         <Grid item xs={chartGridSize}>
-          <Card style={{ height: '240px' }}>
-            <Box height='240px'>
-              <Typography
-                fontSize='14px'
-                lineHeight='20px'
-                fontWeight={400}
-                color={theme.palette.TwClrTxtSecondary}
-                marginBottom={1}
-              >
-                {strings.MORTALITY_RATE_BY_SPECIES}
-              </Typography>
-              <SpeciesMortalityRateChart species={species} />
-            </Box>
-          </Card>
+          <ChartWrapper title={strings.MORTALITY_RATE_BY_SPECIES}>
+            <SpeciesMortalityRateChart species={species} />
+          </ChartWrapper>
         </Grid>
       </Grid>
     </Box>
   );
 }
+
+type ChartWrapperType = {
+  title: string;
+  children: React.ReactNode;
+};
+
+const ChartWrapper = ({ title, children }: ChartWrapperType): JSX.Element => {
+  const theme = useTheme();
+
+  return (
+    <Card style={{ height: '240px', padding: 1 }}>
+      <Box height='185px' marginLeft={-0.5}>
+        <Typography
+          fontSize='14px'
+          lineHeight='20px'
+          fontWeight={400}
+          color={theme.palette.TwClrTxtSecondary}
+          margin={theme.spacing(2, 2, 2, 2.5)}
+        >
+          {title}
+        </Typography>
+        {children}
+      </Box>
+    </Card>
+  );
+};

--- a/src/components/Observations/common/SpeciesMortalityRateChart.tsx
+++ b/src/components/Observations/common/SpeciesMortalityRateChart.tsx
@@ -35,6 +35,7 @@ export default function SpeciesTotalPlantsChart({ species }: SpeciesTotalPlantsC
       chartLabels={mortalityRates.labels}
       chartValues={mortalityRates.values}
       barWidth={0}
+      minHeight='185px'
     />
   );
 }

--- a/src/components/Observations/common/SpeciesMortalityRateChart.tsx
+++ b/src/components/Observations/common/SpeciesMortalityRateChart.tsx
@@ -3,10 +3,11 @@ import { ObservationSpeciesResults } from 'src/types/Observations';
 import BarChart from 'src/components/common/Chart/BarChart';
 
 export type SpeciesTotalPlantsChartProps = {
+  minHeight?: string;
   species?: ObservationSpeciesResults[];
 };
 
-export default function SpeciesTotalPlantsChart({ species }: SpeciesTotalPlantsChartProps): JSX.Element {
+export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesTotalPlantsChartProps): JSX.Element {
   type Data = {
     labels: string[];
     values: number[];
@@ -35,7 +36,7 @@ export default function SpeciesTotalPlantsChart({ species }: SpeciesTotalPlantsC
       chartLabels={mortalityRates.labels}
       chartValues={mortalityRates.values}
       barWidth={0}
-      minHeight='170px'
+      minHeight={minHeight}
     />
   );
 }

--- a/src/components/Observations/common/SpeciesMortalityRateChart.tsx
+++ b/src/components/Observations/common/SpeciesMortalityRateChart.tsx
@@ -35,7 +35,7 @@ export default function SpeciesTotalPlantsChart({ species }: SpeciesTotalPlantsC
       chartLabels={mortalityRates.labels}
       chartValues={mortalityRates.values}
       barWidth={0}
-      minHeight='185px'
+      minHeight='170px'
     />
   );
 }

--- a/src/components/Observations/common/SpeciesMortalityRateChart.tsx
+++ b/src/components/Observations/common/SpeciesMortalityRateChart.tsx
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+import { ObservationSpeciesResults } from 'src/types/Observations';
+import BarChart from 'src/components/common/Chart/BarChart';
+
+export type SpeciesTotalPlantsChartProps = {
+  species?: ObservationSpeciesResults[];
+};
+
+export default function SpeciesTotalPlantsChart({ species }: SpeciesTotalPlantsChartProps): JSX.Element {
+  type Data = {
+    labels: string[];
+    values: number[];
+  };
+
+  const mortalityRates = useMemo((): Data => {
+    const data: Data = { labels: [], values: [] };
+
+    species?.forEach((specie) => {
+      const { speciesCommonName, speciesName, speciesScientificName, mortalityRate } = specie;
+
+      if (mortalityRate !== undefined) {
+        const label: string = speciesName ?? speciesCommonName ?? speciesScientificName;
+        const value: number = mortalityRate;
+        data.labels.push(label);
+        data.values.push(value);
+      }
+    });
+
+    return data;
+  }, [species]);
+
+  return (
+    <BarChart
+      chartId='observationsTotalPlantsBySpecies'
+      chartLabels={mortalityRates.labels}
+      chartValues={mortalityRates.values}
+      barWidth={0}
+    />
+  );
+}

--- a/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
+++ b/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
@@ -34,7 +34,7 @@ export default function SpeciesTotalPlantsChart({ species }: SpeciesTotalPlantsC
       chartLabels={totals.labels}
       chartValues={totals.values}
       barWidth={0}
-      minHeight='185px'
+      minHeight='170px'
     />
   );
 }

--- a/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
+++ b/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+import { ObservationSpeciesResults } from 'src/types/Observations';
+import BarChart from 'src/components/common/Chart/BarChart';
+
+export type SpeciesTotalPlantsChartProps = {
+  species?: ObservationSpeciesResults[];
+};
+
+export default function SpeciesTotalPlantsChart({ species }: SpeciesTotalPlantsChartProps): JSX.Element {
+  type Data = {
+    labels: string[];
+    values: number[];
+  };
+
+  const totals = useMemo((): Data => {
+    const data: Data = { labels: [], values: [] };
+
+    species?.forEach((specie) => {
+      const { speciesCommonName, speciesName, speciesScientificName, totalDead, totalExisting, totalLive } = specie;
+
+      const label: string = speciesName ?? speciesCommonName ?? speciesScientificName;
+      const totalPlants: number = totalDead + totalExisting + totalLive;
+
+      data.labels.push(label);
+      data.values.push(totalPlants);
+    });
+
+    return data;
+  }, [species]);
+
+  return (
+    <BarChart
+      chartId='observationsTotalPlantsBySpecies'
+      chartLabels={totals.labels}
+      chartValues={totals.values}
+      barWidth={0}
+    />
+  );
+}

--- a/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
+++ b/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
@@ -3,10 +3,11 @@ import { ObservationSpeciesResults } from 'src/types/Observations';
 import BarChart from 'src/components/common/Chart/BarChart';
 
 export type SpeciesTotalPlantsChartProps = {
+  minHeight?: string;
   species?: ObservationSpeciesResults[];
 };
 
-export default function SpeciesTotalPlantsChart({ species }: SpeciesTotalPlantsChartProps): JSX.Element {
+export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesTotalPlantsChartProps): JSX.Element {
   type Data = {
     labels: string[];
     values: number[];
@@ -34,7 +35,7 @@ export default function SpeciesTotalPlantsChart({ species }: SpeciesTotalPlantsC
       chartLabels={totals.labels}
       chartValues={totals.values}
       barWidth={0}
-      minHeight='170px'
+      minHeight={minHeight}
     />
   );
 }

--- a/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
+++ b/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
@@ -34,6 +34,7 @@ export default function SpeciesTotalPlantsChart({ species }: SpeciesTotalPlantsC
       chartLabels={totals.labels}
       chartValues={totals.values}
       barWidth={0}
+      minHeight='185px'
     />
   );
 }

--- a/src/components/Observations/details/index.tsx
+++ b/src/components/Observations/details/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
-import { Box } from '@mui/material';
+import { Box, Grid } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
 import strings from 'src/strings';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
@@ -13,6 +13,7 @@ import Card from 'src/components/common/Card';
 import Table from 'src/components/common/table';
 import Search, { SearchInputProps } from 'src/components/Observations/search';
 import DetailsPage from 'src/components/Observations/common/DetailsPage';
+import AggregatedPlantsStats from 'src/components/Observations/common/AggregatedPlantsStats';
 import ObservationDetailsRenderer from './ObservationDetailsRenderer';
 
 const columns = (): TableColumnType[] => [
@@ -55,9 +56,11 @@ export default function ObservationDetails({ search, onSearch }: ObservationDeta
 
   return (
     <DetailsPage title={title} plantingSiteId={plantingSiteId}>
-      <Box display='flex' flexGrow={1} flexDirection='column'>
-        <Box margin={1}>TODO: add info cards and charts here</Box>
-        <Box>
+      <Grid container spacing={3}>
+        <Grid item xs={12}>
+          <AggregatedPlantsStats {...(details || {})} />
+        </Grid>
+        <Grid item xs={12}>
           <Card style={isMobile ? { borderRadius: 0, marginLeft: -3, marginRight: -3 } : {}}>
             <Search search={search} onSearch={onSearch} />
             <Box marginTop={2}>
@@ -70,8 +73,8 @@ export default function ObservationDetails({ search, onSearch }: ObservationDeta
               />
             </Box>
           </Card>
-        </Box>
-      </Box>
+        </Grid>
+      </Grid>
     </DetailsPage>
   );
 }

--- a/src/components/Observations/details/index.tsx
+++ b/src/components/Observations/details/index.tsx
@@ -58,7 +58,7 @@ export default function ObservationDetails({ search, onSearch }: ObservationDeta
     <DetailsPage title={title} plantingSiteId={plantingSiteId}>
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <AggregatedPlantsStats {...(details || {})} />
+          <AggregatedPlantsStats {...(details ?? {})} />
         </Grid>
         <Grid item xs={12}>
           <Card style={isMobile ? { borderRadius: 0, marginLeft: -3, marginRight: -3 } : {}}>

--- a/src/components/Observations/zone/index.tsx
+++ b/src/components/Observations/zone/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Box } from '@mui/material';
+import { Box, Grid } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
 import strings from 'src/strings';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
@@ -11,6 +11,7 @@ import Card from 'src/components/common/Card';
 import Table from 'src/components/common/table';
 import Search from 'src/components/Observations/search';
 import DetailsPage from 'src/components/Observations/common/DetailsPage';
+import AggregatedPlantsStats from 'src/components/Observations/common/AggregatedPlantsStats';
 import ObservationPlantingZoneRenderer from './ObservationPlantingZoneRenderer';
 
 const columns = (): TableColumnType[] => [
@@ -52,9 +53,11 @@ export default function ObservationPlantingZone(): JSX.Element {
       plantingSiteId={plantingSiteId}
       observationId={observationId}
     >
-      <Box display='flex' flexGrow={1} flexDirection='column'>
-        <Box margin={1}>TODO: add info cards and charts here</Box>
-        <Box>
+      <Grid container spacing={3}>
+        <Grid item xs={12}>
+          <AggregatedPlantsStats {...(plantingZone ?? {})} />
+        </Grid>
+        <Grid item xs={12}>
           <Card style={isMobile ? { borderRadius: 0, marginLeft: -3, marginRight: -3 } : {}}>
             <Search search={search} onSearch={(value: string) => onSearch(value)} />
             <Box marginTop={2}>
@@ -71,8 +74,8 @@ export default function ObservationPlantingZone(): JSX.Element {
               />
             </Box>
           </Card>
-        </Box>
-      </Box>
+        </Grid>
+      </Grid>
     </DetailsPage>
   );
 }

--- a/src/components/Plants/PlantBySpeciesChart.tsx
+++ b/src/components/Plants/PlantBySpeciesChart.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Box, Typography, useTheme } from '@mui/material';
 import { cardTitleStyle } from './PlantingSiteDetails';
 import strings from 'src/strings';
-import DashboardChart from './DashboardChart';
+import BarChart from 'src/components/common/Chart/BarChart';
 
 export interface PlantBySpeciesChartProps {
   plantsBySpecies?: { [key: string]: number } | undefined;
@@ -27,7 +27,7 @@ export default function PlantBySpeciesChart({ plantsBySpecies }: PlantBySpeciesC
     <>
       <Typography sx={cardTitleStyle}>{strings.NUMBER_OF_PLANTS_BY_SPECIES}</Typography>
       <Box sx={{ marginTop: theme.spacing(3), display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
-        <DashboardChart chartId='plantsBySpecies' chartLabels={labels} chartValues={values} />
+        <BarChart chartId='plantsBySpecies' chartLabels={labels} chartValues={values} />
       </Box>
     </>
   );

--- a/src/components/Plants/SpeciesBySubzoneChart.tsx
+++ b/src/components/Plants/SpeciesBySubzoneChart.tsx
@@ -3,7 +3,7 @@ import { Box, Typography, useTheme } from '@mui/material';
 import { PlantingSiteZone, PlantingSiteSubzone } from 'src/types/PlantingSite';
 import { cardTitleStyle } from './PlantingSiteDetails';
 import strings from 'src/strings';
-import DashboardChart from './DashboardChart';
+import BarChart from 'src/components/common/Chart/BarChart';
 import SubzoneSelector, { SubzoneInfo, ZoneInfo } from 'src/components/SubzoneSelector';
 
 export interface Props {
@@ -122,7 +122,7 @@ export default function SpeciesBySubzoneChart(props: Props): JSX.Element {
           />
         )}
         <Box sx={{ marginTop: 2 }}>
-          <DashboardChart chartId='speciesBySubzoneChart' chartLabels={labels} chartValues={values} minHeight='126px' />
+          <BarChart chartId='speciesBySubzoneChart' chartLabels={labels} chartValues={values} minHeight='126px' />
         </Box>
       </Box>
     </>

--- a/src/components/common/Chart/BarChart.tsx
+++ b/src/components/common/Chart/BarChart.tsx
@@ -2,8 +2,8 @@ import { useState, useEffect, useRef } from 'react';
 import { makeStyles } from '@mui/styles';
 import { Theme, useTheme } from '@mui/material';
 import { generateTerrawareRandomColors } from 'src/utils/generateRandomColor';
-import { useLocalization } from '../../providers';
-import { newChart } from '../common/Chart';
+import { useLocalization } from 'src/providers';
+import { newChart } from './';
 import { Chart } from 'chart.js';
 
 export interface StyleProps {
@@ -16,14 +16,15 @@ const useStyles = makeStyles<Theme, StyleProps>(() => ({
   },
 }));
 
-export interface DashboardChartProps {
+export interface BarChartProps {
   chartId: string;
   chartLabels?: string[];
   chartValues?: number[];
   minHeight?: string;
+  barWidth?: number;
 }
 
-export default function DashboardChart(props: DashboardChartProps): JSX.Element | null {
+export default function BarChart(props: BarChartProps): JSX.Element | null {
   const { chartLabels, chartValues } = props;
   const { activeLocale } = useLocalization();
   const [locale, setLocale] = useState<string | null>(null);
@@ -37,7 +38,7 @@ export default function DashboardChart(props: DashboardChartProps): JSX.Element 
   }
 
   return (
-    <DashboardChartContent
+    <BarChartContent
       {...props}
       locale={locale}
       chartLabels={chartLabels}
@@ -47,20 +48,24 @@ export default function DashboardChart(props: DashboardChartProps): JSX.Element 
   );
 }
 
-interface DashboardChartContentProps {
+interface BarChartContentProps {
   chartId: string;
   chartLabels: string[];
   chartValues: number[];
   minHeight?: string;
   locale: string;
+  barWidth?: number;
 }
 
-function DashboardChartContent(props: DashboardChartContentProps): JSX.Element {
+function BarChartContent(props: BarChartContentProps): JSX.Element {
   const { chartId, chartLabels, chartValues, minHeight, locale } = props;
   const classes = useStyles({ minHeight });
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const chartRef = useRef<Chart | null>(null);
   const theme = useTheme();
+
+  const barWidth = props.barWidth;
+  const barThickness = barWidth === undefined ? 50 : barWidth === 0 ? 'flex' : barWidth;
 
   useEffect(() => {
     const createChart = async () => {
@@ -79,7 +84,7 @@ function DashboardChartContent(props: DashboardChartContentProps): JSX.Element {
             datasets: [
               {
                 data: chartValues,
-                barThickness: 50, // number (pixels) or 'flex'
+                barThickness,
                 backgroundColor: colors,
                 minBarLength: 3,
               },

--- a/src/components/common/OverviewItemCard.tsx
+++ b/src/components/common/OverviewItemCard.tsx
@@ -67,6 +67,7 @@ export default function OverviewItemCard({
             fontWeight: 500,
             justifyContent: isMobile ? 'space-between' : 'normal',
             lineHeight: '24px',
+            minHeight: '24px',
             width: '100%',
           }}
         >

--- a/src/redux/features/observations/utils.ts
+++ b/src/redux/features/observations/utils.ts
@@ -136,6 +136,7 @@ export const mergeObservations = (
           species,
           site.timeZone ?? defaultTimeZone
         ),
+        species: mergeSpecies(observation.species, species),
       };
     });
 };

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -513,6 +513,7 @@ MONTH_11,November
 MONTH_12,December
 MORE_OPTIONS,More Options
 MORTALITY_RATE,Mortality Rate
+MORTALITY_RATE_BY_SPECIES,Mortality Rate by Species
 MORTALITY_RATE_IN_FIELD,Mortality Rate in Field (%)
 MORTALITY_RATE_IN_FIELD_REQUIRED,Mortality Rate in Field (%) *
 MORTALITY_RATE_IN_NURSERY,Mortality Rate in Nursery (%)

--- a/src/types/Observations.ts
+++ b/src/types/Observations.ts
@@ -52,7 +52,7 @@ export type ObservationMonitoringPlotPhoto = components['schemas']['ObservationM
 export type ObservationSpeciesResultsPayload = components['schemas']['ObservationSpeciesResultsPayload'];
 export type ObservationSpeciesResults = ObservationSpeciesResultsPayload & {
   speciesCommonName?: string;
-  speciesScientificName?: string;
+  speciesScientificName: string;
 };
 
 export const getStatus = (state: ObservationState): string => {

--- a/src/types/Observations.ts
+++ b/src/types/Observations.ts
@@ -52,7 +52,7 @@ export type ObservationMonitoringPlotPhoto = components['schemas']['ObservationM
 export type ObservationSpeciesResultsPayload = components['schemas']['ObservationSpeciesResultsPayload'];
 export type ObservationSpeciesResults = ObservationSpeciesResultsPayload & {
   speciesCommonName?: string;
-  speciesScientificName: string;
+  speciesScientificName?: string;
 };
 
 export const getStatus = (state: ObservationState): string => {

--- a/src/types/Observations.ts
+++ b/src/types/Observations.ts
@@ -19,6 +19,7 @@ export type ObservationResults = ObservationResultsPayload &
   Boundary & {
     plantingSiteName: string;
     plantingZones: ObservationPlantingZoneResults[];
+    species: ObservationSpeciesResults[];
   };
 
 // zone level results -> contains a list of subzone level results


### PR DESCRIPTION
- info cards for observation details' and zone level details' plants stats
- extracted out plants dashboard chart for reusability
- added charts for root level observation details and planting zone observations
- updated generated types to account for species in observation details (requires a [BE PR](https://github.com/terraware/terraware-server/pull/1205) to be merged.. to build)

<img width="759" alt="Terraware App 2023-06-12 08-07-22" src="https://github.com/terraware/terraware-web/assets/1865174/1345c877-f897-4e30-91a3-8061abcf58e2">

<img width="762" alt="Terraware App 2023-06-12 08-07-38" src="https://github.com/terraware/terraware-web/assets/1865174/06c8c4d2-75b3-4a76-87f3-ea14b4571938">
