### PR TITLE
Fix 'invalid date time' display in observations tables

### DIFF
--- a/src/components/Observations/ObservationsDataView.tsx
+++ b/src/components/Observations/ObservationsDataView.tsx
@@ -18,7 +18,7 @@ export default function ObservationsDataView({
 }: ObservationsDataViewProps): JSX.Element {
   const defaultTimeZone = useDefaultTimeZone();
   const observationsResults = useAppSelector((state) =>
-    searchObservations(state, selectedPlantingSiteId, defaultTimeZone.get(), search)
+    searchObservations(state, selectedPlantingSiteId, defaultTimeZone.get().id, search)
   );
 
   return (

--- a/src/components/Observations/common/DetailsPage.tsx
+++ b/src/components/Observations/common/DetailsPage.tsx
@@ -41,7 +41,7 @@ export default function DetailsPage({
         observationId: Number(observationId),
         plantingZoneId: Number(plantingZoneId),
       },
-      defaultTimeZone.get()
+      defaultTimeZone.get().id
     )
   );
 
@@ -52,7 +52,7 @@ export default function DetailsPage({
         plantingSiteId: Number(plantingSiteId),
         observationId: Number(observationId),
       },
-      defaultTimeZone.get()
+      defaultTimeZone.get().id
     )
   );
 

--- a/src/components/Observations/details/index.tsx
+++ b/src/components/Observations/details/index.tsx
@@ -44,7 +44,7 @@ export default function ObservationDetails({ search, onSearch }: ObservationDeta
         observationId: Number(observationId),
         search,
       },
-      defaultTimeZone.get()
+      defaultTimeZone.get().id
     )
   );
 

--- a/src/components/Observations/plot/index.tsx
+++ b/src/components/Observations/plot/index.tsx
@@ -23,7 +23,7 @@ export default function ObservationMonitoringPlot(): JSX.Element {
         plantingZoneId: Number(plantingZoneId),
         monitoringPlotId: Number(monitoringPlotId),
       },
-      defaultTimeZone.get()
+      defaultTimeZone.get().id
     )
   );
 

--- a/src/components/Observations/zone/index.tsx
+++ b/src/components/Observations/zone/index.tsx
@@ -43,7 +43,7 @@ export default function ObservationPlantingZone(): JSX.Element {
         plantingZoneId: Number(plantingZoneId),
         search,
       },
-      defaultTimeZone.get()
+      defaultTimeZone.get().id
     )
   );
 


### PR DESCRIPTION
- when a site didn't have a timezone set, code fallsback to the default time zone
- the default time zone was being passed as an object.. leading to incorred date/time generation by Intl
- pass the time zone id from the object instead