### PR TITLE
Display monitoring plot observation photos

### DIFF
--- a/src/components/Observations/plot/MonitoringPlotPhotos.tsx
+++ b/src/components/Observations/plot/MonitoringPlotPhotos.tsx
@@ -1,0 +1,89 @@
+import { useMemo, useState } from 'react';
+import { Box, useTheme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { ViewPhotosDialog } from '@terraware/web-components';
+import strings from 'src/strings';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
+import { ObservationMonitoringPlotPhoto } from 'src/types/Observations';
+
+type StyleProps = {
+  isMobile: boolean;
+};
+
+const useStyles = makeStyles(() => ({
+  thumbnail: {
+    objectFit: 'cover',
+    display: 'flex',
+    width: (props: StyleProps) => (props.isMobile ? '105px' : '220px'),
+    height: '120px',
+  },
+}));
+
+const PHOTO_URL = '/api/v1/tracking/observations/{observationId}/plots/{monitoringPlotId}/photos/{fileId}';
+
+export type MonitoringPlotPhotosProps = {
+  observationId: number;
+  monitoringPlotId: number;
+  photos?: ObservationMonitoringPlotPhoto[];
+};
+
+export default function MonitoringPlotPhotos({
+  observationId,
+  monitoringPlotId,
+  photos,
+}: MonitoringPlotPhotosProps): JSX.Element {
+  const { isMobile } = useDeviceInfo();
+  const [selectedSlide, setSelectedSlide] = useState<number>(0);
+  const [photosModalOpened, setPhotosModalOpened] = useState<boolean>(false);
+  const theme = useTheme();
+  const classes = useStyles({ isMobile });
+
+  const photoUrls = useMemo(() => {
+    const rootUrl = PHOTO_URL.replace('{observationId}', observationId.toString()).replace(
+      '{monitoringPlotId}',
+      monitoringPlotId.toString()
+    );
+
+    return (photos ?? []).map((photo: ObservationMonitoringPlotPhoto) =>
+      rootUrl.replace('{fileId}', photo.fileId.toString())
+    );
+  }, [observationId, monitoringPlotId, photos]);
+
+  return (
+    <>
+      {photosModalOpened && (
+        <ViewPhotosDialog
+          photos={photoUrls.map((url) => ({ url }))}
+          open={photosModalOpened}
+          onClose={() => setPhotosModalOpened(false)}
+          initialSelectedSlide={selectedSlide}
+          nextButtonLabel={strings.NEXT}
+          prevButtonLabel={strings.PREVIOUS}
+          title={strings.PHOTOS}
+        />
+      )}
+      <Box display='flex' flexWrap='wrap'>
+        {photoUrls.map((photoUrl, index) => (
+          <Box
+            key={index}
+            marginRight={theme.spacing(isMobile ? 2 : 3)}
+            marginTop={theme.spacing(2)}
+            width={isMobile ? '105px' : '220px'}
+            height='120px'
+            sx={{ cursor: 'pointer' }}
+          >
+            <img
+              className={classes.thumbnail}
+              src={`${photoUrl}?maxHeight=120`}
+              alt={`${index}`}
+              onClick={() => {
+                setSelectedSlide(index);
+                setPhotosModalOpened(true);
+              }}
+            />
+          </Box>
+        ))}
+      </Box>
+    </>
+  );
+}

--- a/src/components/Observations/plot/MonitoringPlotPhotos.tsx
+++ b/src/components/Observations/plot/MonitoringPlotPhotos.tsx
@@ -1,23 +1,6 @@
-import { useMemo, useState } from 'react';
-import { Box, useTheme } from '@mui/material';
-import { makeStyles } from '@mui/styles';
-import { ViewPhotosDialog } from '@terraware/web-components';
-import strings from 'src/strings';
-import useDeviceInfo from 'src/utils/useDeviceInfo';
+import { useMemo } from 'react';
 import { ObservationMonitoringPlotPhoto } from 'src/types/Observations';
-
-type StyleProps = {
-  isMobile: boolean;
-};
-
-const useStyles = makeStyles(() => ({
-  thumbnail: {
-    objectFit: 'cover',
-    display: 'flex',
-    width: (props: StyleProps) => (props.isMobile ? '105px' : '220px'),
-    height: '120px',
-  },
-}));
+import PhotosList from 'src/components/common/PhotosList';
 
 const PHOTO_URL = '/api/v1/tracking/observations/{observationId}/plots/{monitoringPlotId}/photos/{fileId}';
 
@@ -32,12 +15,6 @@ export default function MonitoringPlotPhotos({
   monitoringPlotId,
   photos,
 }: MonitoringPlotPhotosProps): JSX.Element {
-  const { isMobile } = useDeviceInfo();
-  const [selectedSlide, setSelectedSlide] = useState<number>(0);
-  const [photosModalOpened, setPhotosModalOpened] = useState<boolean>(false);
-  const theme = useTheme();
-  const classes = useStyles({ isMobile });
-
   const photoUrls = useMemo(() => {
     const rootUrl = PHOTO_URL.replace('{observationId}', observationId.toString()).replace(
       '{monitoringPlotId}',
@@ -49,39 +26,5 @@ export default function MonitoringPlotPhotos({
     );
   }, [observationId, monitoringPlotId, photos]);
 
-  return (
-    <>
-      <ViewPhotosDialog
-        photos={photoUrls.map((url) => ({ url }))}
-        open={photosModalOpened}
-        onClose={() => setPhotosModalOpened(false)}
-        initialSelectedSlide={selectedSlide}
-        nextButtonLabel={strings.NEXT}
-        prevButtonLabel={strings.PREVIOUS}
-        title={strings.PHOTOS}
-      />
-      <Box display='flex' flexWrap='wrap'>
-        {photoUrls.map((photoUrl, index) => (
-          <Box
-            key={index}
-            marginRight={theme.spacing(isMobile ? 2 : 3)}
-            marginTop={theme.spacing(2)}
-            width={isMobile ? '105px' : '220px'}
-            height='120px'
-            sx={{ cursor: 'pointer' }}
-          >
-            <img
-              className={classes.thumbnail}
-              src={`${photoUrl}?maxHeight=120`}
-              alt={`${index}`}
-              onClick={() => {
-                setSelectedSlide(index);
-                setPhotosModalOpened(true);
-              }}
-            />
-          </Box>
-        ))}
-      </Box>
-    </>
-  );
+  return <PhotosList photoUrls={photoUrls} />;
 }

--- a/src/components/Observations/plot/MonitoringPlotPhotos.tsx
+++ b/src/components/Observations/plot/MonitoringPlotPhotos.tsx
@@ -51,17 +51,15 @@ export default function MonitoringPlotPhotos({
 
   return (
     <>
-      {photosModalOpened && (
-        <ViewPhotosDialog
-          photos={photoUrls.map((url) => ({ url }))}
-          open={photosModalOpened}
-          onClose={() => setPhotosModalOpened(false)}
-          initialSelectedSlide={selectedSlide}
-          nextButtonLabel={strings.NEXT}
-          prevButtonLabel={strings.PREVIOUS}
-          title={strings.PHOTOS}
-        />
-      )}
+      <ViewPhotosDialog
+        photos={photoUrls.map((url) => ({ url }))}
+        open={photosModalOpened}
+        onClose={() => setPhotosModalOpened(false)}
+        initialSelectedSlide={selectedSlide}
+        nextButtonLabel={strings.NEXT}
+        prevButtonLabel={strings.PREVIOUS}
+        title={strings.PHOTOS}
+      />
       <Box display='flex' flexWrap='wrap'>
         {photoUrls.map((photoUrl, index) => (
           <Box

--- a/src/components/Observations/plot/index.tsx
+++ b/src/components/Observations/plot/index.tsx
@@ -14,6 +14,7 @@ import Card from 'src/components/common/Card';
 import DetailsPage from 'src/components/Observations/common/DetailsPage';
 import SpeciesTotalPlantsChart from 'src/components/Observations/common/SpeciesTotalPlantsChart';
 import SpeciesMortalityRateChart from 'src/components/Observations/common/SpeciesMortalityRateChart';
+import MonitoringPlotPhotos from './MonitoringPlotPhotos';
 
 export default function ObservationMonitoringPlot(): JSX.Element {
   const { plantingSiteId, observationId, plantingZoneId, monitoringPlotId } = useParams<{
@@ -120,7 +121,11 @@ export default function ObservationMonitoringPlot(): JSX.Element {
               <SpeciesMortalityRateChart minHeight='360px' species={monitoringPlot?.species} />
             </Box>
             {title(strings.PHOTOS)}
-            TODO: Add photos
+            <MonitoringPlotPhotos
+              observationId={Number(observationId)}
+              monitoringPlotId={Number(monitoringPlotId)}
+              photos={monitoringPlot?.photos}
+            />
           </Card>
         </Grid>
       </Grid>

--- a/src/components/common/PhotosList.tsx
+++ b/src/components/common/PhotosList.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { Box, useTheme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { ViewPhotosDialog } from '@terraware/web-components';
+import strings from 'src/strings';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
+
+type StyleProps = {
+  isMobile: boolean;
+};
+
+const useStyles = makeStyles(() => ({
+  thumbnail: {
+    objectFit: 'cover',
+    display: 'flex',
+    width: (props: StyleProps) => (props.isMobile ? '105px' : '220px'),
+    height: '120px',
+  },
+}));
+
+export type PhotosListProps = {
+  photoUrls: string[];
+  initialSlide?: number;
+};
+
+export default function PhotosList({ photoUrls, initialSlide }: PhotosListProps): JSX.Element {
+  const { isMobile } = useDeviceInfo();
+  const [selectedSlide, setSelectedSlide] = useState<number>(initialSlide ?? 0);
+  const [photosModalOpened, setPhotosModalOpened] = useState<boolean>(false);
+  const theme = useTheme();
+  const classes = useStyles({ isMobile });
+
+  return (
+    <>
+      <ViewPhotosDialog
+        photos={photoUrls.map((url) => ({ url }))}
+        open={photosModalOpened}
+        onClose={() => setPhotosModalOpened(false)}
+        initialSelectedSlide={selectedSlide}
+        nextButtonLabel={strings.NEXT}
+        prevButtonLabel={strings.PREVIOUS}
+        title={strings.PHOTOS}
+      />
+      <Box display='flex' flexWrap='wrap'>
+        {photoUrls.map((photoUrl, index) => (
+          <Box
+            key={index}
+            marginRight={theme.spacing(isMobile ? 2 : 3)}
+            marginTop={theme.spacing(2)}
+            width={isMobile ? '105px' : '220px'}
+            height='120px'
+            sx={{ cursor: 'pointer' }}
+          >
+            <img
+              className={classes.thumbnail}
+              src={`${photoUrl}?maxHeight=120`}
+              alt={`${index}`}
+              onClick={() => {
+                setSelectedSlide(index);
+                setPhotosModalOpened(true);
+              }}
+            />
+          </Box>
+        ))}
+      </Box>
+    </>
+  );
+}


### PR DESCRIPTION
- mostly a copy of what we do in nursery withdrawals details plus some customization for monitoring plots
- added photos in staging, switch to dev org and go here /observations/56/3/106/270028

<img width="190" alt="Terraware App 2023-06-13 11-38-26" src="https://github.com/terraware/terraware-web/assets/1865174/d8d8f5e0-1e2e-4d68-b868-15a41586f3ac">

<img width="751" alt="Terraware App 2023-06-13 11-33-30" src="https://github.com/terraware/terraware-web/assets/1865174/0963555b-35e0-4afa-8a97-5674e299cefa">

<img width="557" alt="Terraware App 2023-06-13 11-49-04" src="https://github.com/terraware/terraware-web/assets/1865174/4dab1972-f0d9-4c4d-a073-5d0170a663fb">
