### PR TITLE
SW-3394 Deploy using Tailscale instead of bastion

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -3,7 +3,13 @@
 mkdir -p ~/.ssh
 echo "$SSH_KEY" > ~/.ssh/key
 chmod 600 ~/.ssh/key
-echo "$SSH_CONFIG" > ~/.ssh/config
+
+cat >> ~/.ssh/config << END
+Host terraware*
+  User $SSH_USER
+  IdentityFile ~/.ssh/key
+  StrictHostKeyChecking no
+END
 
 aws ec2 describe-instances --filters "Name=tag:Application,Values=terraware" \
   | jq -r ' .Reservations[].Instances[].Tags[] | select(.Key == "Hostname") | .Value' \

--- a/.github/scripts/set-environment.sh
+++ b/.github/scripts/set-environment.sh
@@ -28,8 +28,8 @@ docker_tags="${docker_image}:$commit_sha,${docker_image}:${TIER}"
 # Define secret names based on the tier
 echo "TIER=$TIER
 IS_CD=$IS_CD
-SSH_CONFIG_SECRET_NAME=${TIER}_SSH_CONFIG
 SSH_KEY_SECRET_NAME=${TIER}_SSH_KEY
+SSH_USER_SECRET_NAME=${TIER}_SSH_USER
 AWS_REGION_SECRET_NAME=${TIER}_AWS_REGION
 AWS_ROLE_SECRET_NAME=${TIER}_AWS_ROLE
 COMMIT_SHA=$commit_sha

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -130,11 +130,16 @@ jobs:
           aws-region: ${{ secrets[env.AWS_REGION_SECRET_NAME] }}
           role-to-assume: ${{ secrets[env.AWS_ROLE_SECRET_NAME] }}
 
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v1
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+
       - name: Deploy
         if: env.IS_CD == 'true'
         env:
-          SSH_CONFIG: ${{ secrets[env.SSH_CONFIG_SECRET_NAME] }}
           SSH_KEY: ${{ secrets[env.SSH_KEY_SECRET_NAME] }}
+          SSH_USER: ${{ secrets[env.SSH_USER_SECRET_NAME] }}
         run: ./.github/scripts/deploy.sh
 
       - name: Jira Login


### PR DESCRIPTION
When deploying to the AWS hosts, connect to the VPC network using Tailscale and
ssh directly to the hosts rather than bouncing through a bastion host.
