### PR TITLE
Tooltips for planting density and total plants cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@mui/styled-engine-sc": "^5.12.0",
     "@mui/styles": "^5.11.9",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^2.3.45",
+    "@terraware/web-components": "^2.3.47",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^14.4.3",

--- a/src/components/Observations/common/AggregatedPlantsStats.tsx
+++ b/src/components/Observations/common/AggregatedPlantsStats.tsx
@@ -26,7 +26,7 @@ export default function AggregatedPlantsStats({
   const { isMobile } = useDeviceInfo();
   const infoCardGridSize = isMobile ? 12 : 3;
   const chartGridSize = isMobile ? 12 : 6;
-  console.log(totalPlants, plantingDensity);
+
   const getData = () => [
     {
       label: strings.PLANTS,

--- a/src/components/Observations/common/AggregatedPlantsStats.tsx
+++ b/src/components/Observations/common/AggregatedPlantsStats.tsx
@@ -14,7 +14,6 @@ export type AggregatedPlantsStatsProps = {
   plantingDensity?: number;
   mortalityRate?: number;
   species?: ObservationSpeciesResults[];
-  isSite?: boolean;
 };
 
 export default function AggregatedPlantsStats({
@@ -23,16 +22,23 @@ export default function AggregatedPlantsStats({
   plantingDensity,
   mortalityRate,
   species,
-  isSite,
 }: AggregatedPlantsStatsProps): JSX.Element {
   const { isMobile } = useDeviceInfo();
   const infoCardGridSize = isMobile ? 12 : 3;
   const chartGridSize = isMobile ? 12 : 6;
 
   const getData = () => [
-    { label: strings.PLANTS, value: totalPlants, toolTip: isSite ? strings.PLANTS_MISSING_TOOLTIP : '' },
+    {
+      label: strings.PLANTS,
+      value: totalPlants,
+      toolTip: totalPlants === undefined ? strings.PLANTS_MISSING_TOOLTIP : '',
+    },
     { label: strings.SPECIES, value: totalSpecies },
-    { label: strings.PLANTING_DENSITY, value: plantingDensity, toolTip: strings.PLANTING_DENSITY_MISSING_TOOLTIP },
+    {
+      label: strings.PLANTING_DENSITY,
+      value: plantingDensity,
+      toolTip: plantingDensity === undefined ? strings.PLANTING_DENSITY_MISSING_TOOLTIP : '',
+    },
     { label: strings.MORTALITY_RATE, value: mortalityRate },
   ];
 

--- a/src/components/Observations/common/AggregatedPlantsStats.tsx
+++ b/src/components/Observations/common/AggregatedPlantsStats.tsx
@@ -14,6 +14,7 @@ export type AggregatedPlantsStatsProps = {
   plantingDensity?: number;
   mortalityRate?: number;
   species?: ObservationSpeciesResults[];
+  isSite?: boolean;
 };
 
 export default function AggregatedPlantsStats({
@@ -22,15 +23,16 @@ export default function AggregatedPlantsStats({
   plantingDensity,
   mortalityRate,
   species,
+  isSite,
 }: AggregatedPlantsStatsProps): JSX.Element {
   const { isMobile } = useDeviceInfo();
   const infoCardGridSize = isMobile ? 12 : 3;
   const chartGridSize = isMobile ? 12 : 6;
 
   const getData = () => [
-    { label: strings.PLANTS, value: totalPlants },
+    { label: strings.PLANTS, value: totalPlants, toolTip: isSite ? strings.PLANTS_MISSING_TOOLTIP : '' },
     { label: strings.SPECIES, value: totalSpecies },
-    { label: strings.PLANTING_DENSITY, value: plantingDensity },
+    { label: strings.PLANTING_DENSITY, value: plantingDensity, toolTip: strings.PLANTING_DENSITY_MISSING_TOOLTIP },
     { label: strings.MORTALITY_RATE, value: mortalityRate },
   ];
 
@@ -39,7 +41,12 @@ export default function AggregatedPlantsStats({
       <Grid container spacing={3} marginBottom={3}>
         {getData().map((data) => (
           <Grid item xs={infoCardGridSize} key={data.label}>
-            <OverviewItemCard isEditable={false} title={data.label} contents={data.value?.toString() ?? '--'} />
+            <OverviewItemCard
+              isEditable={false}
+              title={data.label}
+              contents={data.value?.toString() ?? null}
+              titleInfoTooltip={data.toolTip}
+            />
           </Grid>
         ))}
       </Grid>

--- a/src/components/Observations/common/AggregatedPlantsStats.tsx
+++ b/src/components/Observations/common/AggregatedPlantsStats.tsx
@@ -26,18 +26,18 @@ export default function AggregatedPlantsStats({
   const { isMobile } = useDeviceInfo();
   const infoCardGridSize = isMobile ? 12 : 3;
   const chartGridSize = isMobile ? 12 : 6;
-
+  console.log(totalPlants, plantingDensity);
   const getData = () => [
     {
       label: strings.PLANTS,
       value: totalPlants,
-      toolTip: totalPlants === undefined ? strings.PLANTS_MISSING_TOOLTIP : '',
+      toolTip: totalPlants === null ? strings.PLANTS_MISSING_TOOLTIP : '',
     },
     { label: strings.SPECIES, value: totalSpecies },
     {
       label: strings.PLANTING_DENSITY,
       value: plantingDensity,
-      toolTip: plantingDensity === undefined ? strings.PLANTING_DENSITY_MISSING_TOOLTIP : '',
+      toolTip: plantingDensity === null ? strings.PLANTING_DENSITY_MISSING_TOOLTIP : '',
     },
     { label: strings.MORTALITY_RATE, value: mortalityRate },
   ];

--- a/src/components/Observations/details/index.tsx
+++ b/src/components/Observations/details/index.tsx
@@ -56,7 +56,7 @@ export default function ObservationDetails({ search, onSearch }: ObservationDeta
     <DetailsPage title={title} plantingSiteId={plantingSiteId}>
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <AggregatedPlantsStats {...(details ?? {})} isSite />
+          <AggregatedPlantsStats {...(details ?? {})} />
         </Grid>
         <Grid item xs={12}>
           <Card flushMobile>

--- a/src/components/Observations/details/index.tsx
+++ b/src/components/Observations/details/index.tsx
@@ -56,7 +56,7 @@ export default function ObservationDetails({ search, onSearch }: ObservationDeta
     <DetailsPage title={title} plantingSiteId={plantingSiteId}>
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <AggregatedPlantsStats {...(details ?? {})} />
+          <AggregatedPlantsStats {...(details ?? {})} isSite />
         </Grid>
         <Grid item xs={12}>
           <Card flushMobile>

--- a/src/components/Observations/plot/index.tsx
+++ b/src/components/Observations/plot/index.tsx
@@ -104,7 +104,7 @@ export default function ObservationMonitoringPlot(): JSX.Element {
                   <Textfield
                     id={`plot-observation-${index}`}
                     label={datum.label}
-                    value={datum.value ?? '--'}
+                    value={datum.value}
                     type={datum.text ? 'textarea' : 'text'}
                     preserveNewlines={true}
                     display={true}

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -685,6 +685,7 @@ PLANT_ID,Plant ID
 PLANT_ID_TOOLTIP,It’s the ID of a plant for tracking or conservation purpose. Ideally seeds from a tracked plant do not mix with others in a same accession.
 PLANT_LABEL,Plant
 PLANTING_DENSITY,Planting Density
+PLANTING_DENSITY_MISSING_TOOLTIP,"Once your planting site has been marked as complete for planting and you’ve completed your observations, you’ll be able to view the planting density."
 PLANTING_SITE,Planting Site
 PLANTING_SITE_TYPE,Planting Site Type
 PLANTING_SITE_WITH_MAP_HELP,"If you are a Terraformation partner or accelerator participant, please [contact us] to create a site with a map."
@@ -692,6 +693,7 @@ PLANTING_SITES,Planting Sites
 PLANTING_ZONE,Planting Zone
 PLANTING_ZONES,Planting Zones
 PLANTS,Plants
+PLANTS_MISSING_TOOLTIP,"Once your planting site has been marked as complete for planting and you’ve completed your observations, you’ll be able to view the total plants."
 PLANTS_CARD_DESCRIPTION,They’ve taken root! View all your plants in one place.
 PLEASE_TRY_AGAIN,Please try again.
 PLOTS_PERMANENT,Permanent Plots

--- a/yarn.lock
+++ b/yarn.lock
@@ -3813,10 +3813,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^2.3.45":
-  version "2.3.45"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.3.45.tgz#0497a8a848e7b3904a82b0eb6c7dc12df0c9022f"
-  integrity sha512-KnTvBKAs9whgDvqXzmEiFQ1Qd1t2t9VQBvafzWNEjQPiqd4yBMPkY90/oHgLPe2/J87+CDcRFz13oMZ489XRJQ==
+"@terraware/web-components@^2.3.47":
+  version "2.3.47"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.3.47.tgz#657365ed3adf7c889e493a637d9f47e55bfed36d"
+  integrity sha512-vVD7x3qdMz/oEWWaA3onUFSA1GOcSoDjauMjWnRViGEIlOt/SdIPFO0Vi6SCbDVJ335zTuEGRsXnamHHNciEng==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.16.1"


### PR DESCRIPTION
- Rachel asked to show tooltip instead of '--'
- also the monitoring plot details will have all the data, removed '--' from there and not showing any tooltips there either
- don't know if we want to show tooltips only when data is missing, for now we show it all the time

<img width="1503" alt="Screen Shot 2023-06-13 at 3 42 11 PM" src="https://github.com/terraware/terraware-web/assets/1865174/10ab17b4-caa4-4b25-b4cd-1a39d4495c4d">

<img width="1502" alt="Screen Shot 2023-06-13 at 3 41 32 PM" src="https://github.com/terraware/terraware-web/assets/1865174/2785f5d2-89f6-41f9-9f3d-24a4d75a4388">
