### PR TITLE
SW-3762 Error handling in drill down url routes

### DIFF
--- a/src/components/Observations/ObservationsHome.tsx
+++ b/src/components/Observations/ObservationsHome.tsx
@@ -41,7 +41,7 @@ export default function ObservationsHome(props: ObservationsHomeProps): JSX.Elem
     <PlantsPrimaryPage
       title={strings.OBSERVATIONS}
       onSelect={onSelect}
-      pagePath={APP_PATHS.PLANTING_SITE_OBSERVATIONS}
+      pagePath={APP_PATHS.OBSERVATIONS_SITE}
       lastVisitedPreferenceName='plants.observations.lastVisitedPlantingSite'
       plantsSitePreferences={plantsSitePreferences}
       setPlantsSitePreferences={onPreferences}

--- a/src/components/Observations/details/index.tsx
+++ b/src/components/Observations/details/index.tsx
@@ -1,7 +1,8 @@
-import { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { useEffect, useMemo } from 'react';
+import { useHistory, useParams } from 'react-router-dom';
 import { Box, Grid } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
+import { APP_PATHS } from 'src/constants';
 import strings from 'src/strings';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 import { getShortDate } from 'src/utils/dateFormatter';
@@ -33,6 +34,7 @@ export default function ObservationDetails({ search, onSearch }: ObservationDeta
   }>();
   const { activeLocale } = useLocalization();
   const defaultTimeZone = useDefaultTimeZone();
+  const history = useHistory();
 
   const details = useAppSelector((state) =>
     searchObservationDetails(
@@ -51,6 +53,12 @@ export default function ObservationDetails({ search, onSearch }: ObservationDeta
     const completionDate = details?.completedDate ? getShortDate(details.completedDate, activeLocale) : '';
     return `${completionDate} (${plantingSiteName})`;
   }, [activeLocale, details]);
+
+  useEffect(() => {
+    if (details === null) {
+      history.push(APP_PATHS.OBSERVATIONS_SITE.replace(':plantingSiteId', Number(plantingSiteId).toString()));
+    }
+  }, [details, history, plantingSiteId]);
 
   return (
     <DetailsPage title={title} plantingSiteId={plantingSiteId}>

--- a/src/components/Observations/index.tsx
+++ b/src/components/Observations/index.tsx
@@ -88,7 +88,7 @@ const ObservationsWrapper = (): JSX.Element => {
       <Route exact path={APP_PATHS.OBSERVATION_DETAILS}>
         <ObservationDetails {...searchInputProps} />
       </Route>
-      <Route exact path={APP_PATHS.PLANTING_SITE_OBSERVATIONS}>
+      <Route exact path={APP_PATHS.OBSERVATIONS_SITE}>
         <ObservationsHome {...searchInputProps} />
       </Route>
       <Route path={'*'}>

--- a/src/components/Observations/plot/index.tsx
+++ b/src/components/Observations/plot/index.tsx
@@ -1,7 +1,8 @@
-import { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { useEffect, useMemo } from 'react';
+import { useHistory, useParams } from 'react-router-dom';
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Textfield } from '@terraware/web-components';
+import { APP_PATHS } from 'src/constants';
 import strings from 'src/strings';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import { getShortTime } from 'src/utils/dateFormatter';
@@ -24,6 +25,7 @@ export default function ObservationMonitoringPlot(): JSX.Element {
     monitoringPlotId: string;
   }>();
   const defaultTimeZone = useDefaultTimeZone();
+  const history = useHistory();
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
   const { activeLocale } = useLocalization();
@@ -86,6 +88,16 @@ export default function ObservationMonitoringPlot(): JSX.Element {
       {text}
     </Typography>
   );
+
+  useEffect(() => {
+    if (monitoringPlot === null) {
+      history.push(
+        APP_PATHS.OBSERVATION_PLANTING_ZONE_DETAILS.replace(':plantingSiteId', Number(plantingSiteId).toString())
+          .replace(':observationId', Number(observationId).toString())
+          .replace(':plantingZoneId', Number(plantingZoneId).toString())
+      );
+    }
+  }, [history, monitoringPlot, observationId, plantingZoneId, plantingSiteId]);
 
   return (
     <DetailsPage

--- a/src/components/Observations/zone/index.tsx
+++ b/src/components/Observations/zone/index.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useHistory, useParams } from 'react-router-dom';
 import { Box, Grid } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
+import { APP_PATHS } from 'src/constants';
 import strings from 'src/strings';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 import { useAppSelector } from 'src/redux/store';
@@ -30,6 +31,7 @@ export default function ObservationPlantingZone(): JSX.Element {
     plantingZoneId: string;
   }>();
   const defaultTimeZone = useDefaultTimeZone();
+  const history = useHistory();
   const [search, onSearch] = useState<string>('');
 
   const plantingZone = useAppSelector((state) =>
@@ -44,6 +46,17 @@ export default function ObservationPlantingZone(): JSX.Element {
       defaultTimeZone.get().id
     )
   );
+
+  useEffect(() => {
+    if (plantingZone === null) {
+      history.push(
+        APP_PATHS.OBSERVATION_DETAILS.replace(':plantingSiteId', Number(plantingSiteId).toString()).replace(
+          ':observationId',
+          Number(observationId).toString()
+        )
+      );
+    }
+  }, [history, observationId, plantingSiteId, plantingZone]);
 
   return (
     <DetailsPage

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,7 +35,6 @@ export enum APP_PATHS {
   PEOPLE = '/people',
   PLANTS_DASHBOARD = '/plants/dashboard',
   PLANTING_SITE_DASHBOARD = '/plants/dashboard/:plantingSiteId',
-  PLANTING_SITE_OBSERVATIONS = '/observations/:plantingSiteId',
   REPORTS = '/reports',
   REPORTS_EDIT = '/reports/:reportId/edit',
   REPORTS_VIEW = '/reports/:reportId',

--- a/src/redux/features/observations/observationDetailsSelectors.ts
+++ b/src/redux/features/observations/observationDetailsSelectors.ts
@@ -25,7 +25,9 @@ export const selectObservationDetails = createSelector(
     (state, params, defaultTimeZone) => params,
   ],
   (observationsResults, params) =>
-    observationsResults?.find((observation: ObservationResults) => observation.observationId === params.observationId)
+    observationsResults?.find(
+      (observation: ObservationResults) => observation.observationId === params.observationId
+    ) ?? null
 );
 
 export const searchObservationDetails = createCachedSelector(

--- a/src/redux/features/observations/observationMonitoringPlotSelectors.ts
+++ b/src/redux/features/observations/observationMonitoringPlotSelectors.ts
@@ -22,5 +22,5 @@ export const selectObservationMonitoringPlot = createSelector(
           plantingSubzoneName: subzone.plantingSubzoneName,
         }))
       )
-      .find((monitoringPlot: PlotObservations) => monitoringPlot.monitoringPlotId === params.monitoringPlotId)
+      .find((monitoringPlot: PlotObservations) => monitoringPlot.monitoringPlotId === params.monitoringPlotId) ?? null
 );

--- a/src/redux/features/observations/observationPlantingZoneSelectors.ts
+++ b/src/redux/features/observations/observationPlantingZoneSelectors.ts
@@ -16,7 +16,7 @@ export const selectObservationPlantingZone = createSelector(
   (observationDetails, params) =>
     observationDetails?.plantingZones.find(
       (plantingZone: ObservationPlantingZoneResults) => plantingZone.plantingZoneId === params.plantingZoneId
-    )
+    ) ?? null
 );
 
 export const searchObservationPlantingZone = createCachedSelector(

--- a/src/redux/features/observations/utils.ts
+++ b/src/redux/features/observations/utils.ts
@@ -17,7 +17,7 @@ import { regexMatch } from 'src/utils/search';
 
 // utils
 
-export const searchResultPlots = (search: string, zone?: ObservationPlantingZoneResults) => {
+export const searchResultPlots = (search: string, zone: ObservationPlantingZoneResults | null) => {
   if (!search.trim() || !zone) {
     return zone;
   }
@@ -34,7 +34,7 @@ export const searchResultPlots = (search: string, zone?: ObservationPlantingZone
   };
 };
 
-export const searchResultZones = (search: string, observation?: ObservationResults) => {
+export const searchResultZones = (search: string, observation: ObservationResults | null) => {
   if (!search.trim() || !observation) {
     return observation;
   }


### PR DESCRIPTION
- the drill down pages are driven by url path parameters
- add error handling where we redirect to the parent in the drill-down hierarchy, if a parameter is not valid (otherwise the view shows empty data)
- example, if a monitoring plot is not found by id, redirect to the parent planting zone
- if planting zone is not found, redirect to parent observation details
- if observation details not found by id, redirect to parent planting site
- we already have error validation on the planting site
- updated selectors to return a valid value or null (undefined => selector hasn't completed it's fetching)