### PR TITLE
Add zone-name filters for observations results, detail view and map view

### DIFF
--- a/src/components/Observations/ObservationsDataView.tsx
+++ b/src/components/Observations/ObservationsDataView.tsx
@@ -3,7 +3,7 @@ import { Box, Typography, useTheme } from '@mui/material';
 import { FieldOptionsMap } from 'src/types/Search';
 import { useAppSelector } from 'src/redux/store';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
-import { searchObservations } from 'src/redux/features/observations/observationsSelectors';
+import { searchObservations, selectObservationsZoneNames } from 'src/redux/features/observations/observationsSelectors';
 import ListMapView from 'src/components/ListMapView';
 import Search, { SearchProps } from 'src/components/common/SearchFiltersWrapper';
 import OrgObservationsListView from './org/OrgObservationsListView';
@@ -20,14 +20,25 @@ export default function ObservationsDataView(props: ObservationsDataViewProps): 
   const defaultTimeZone = useDefaultTimeZone();
 
   const observationsResults = useAppSelector((state) =>
-    searchObservations(state, selectedPlantingSiteId, defaultTimeZone.get().id, searchProps.search)
+    searchObservations(
+      state,
+      selectedPlantingSiteId,
+      defaultTimeZone.get().id,
+      searchProps.search,
+      searchProps.filtersProps?.filters.zone?.values ?? []
+    )
   );
+
+  const zoneNames = useAppSelector((state) => selectObservationsZoneNames(state, selectedPlantingSiteId));
 
   useEffect(() => {
     setFilterOptions({
-      zone: { partial: false, values: [] },
+      zone: {
+        partial: false,
+        values: zoneNames,
+      },
     });
-  }, [setFilterOptions]);
+  }, [setFilterOptions, zoneNames]);
 
   return (
     <ListMapView
@@ -38,11 +49,7 @@ export default function ObservationsDataView(props: ObservationsDataViewProps): 
         selectedPlantingSiteId === -1 ? (
           <AllPlantingSitesMapView />
         ) : (
-          <ObservationMapView
-            observationsResults={observationsResults}
-            search={searchProps.search}
-            onSearch={searchProps.onSearch}
-          />
+          <ObservationMapView observationsResults={observationsResults} {...searchProps} />
         )
       }
     />

--- a/src/components/Observations/map/ObservationMapView.tsx
+++ b/src/components/Observations/map/ObservationMapView.tsx
@@ -133,6 +133,8 @@ export default function ObservationMapView({
     ]
   );
 
+  const hasSearchCriteria = search.trim() || filterZoneNames.length;
+
   return (
     <Box display='flex' flexDirection='column' flexGrow={1}>
       <Box marginBottom={theme.spacing(2)}>
@@ -171,11 +173,11 @@ export default function ObservationMapView({
                 return <p>{`${properties.type} ${properties.id}: ${properties.name}`}</p>;
               },
             }}
-            highlightEntities={search === '' && !filterZoneNames.length ? [] : searchZoneEntities}
+            highlightEntities={hasSearchCriteria ? searchZoneEntities : []}
             focusEntities={
-              search === '' && searchZoneEntities.length === 0
+              !hasSearchCriteria && searchZoneEntities.length === 0
                 ? [{ sourceId: 'sites', id: selectedObservation?.plantingSiteId }]
-                : search !== '' || filterZoneNames.length
+                : hasSearchCriteria
                 ? searchZoneEntities
                 : []
             }

--- a/src/redux/features/observations/observationsSelectors.ts
+++ b/src/redux/features/observations/observationsSelectors.ts
@@ -1,5 +1,6 @@
 import { createCachedSelector } from 're-reselect';
 import { createSelector } from '@reduxjs/toolkit';
+import { ObservationResults, ObservationPlantingZoneResults } from 'src/types/Observations';
 import { RootState } from 'src/redux/rootReducer';
 import { selectSpecies } from 'src/redux/features/species/speciesSelectors';
 import { selectPlantingSites } from 'src/redux/features/tracking/trackingSelectors';
@@ -40,11 +41,25 @@ export const selectMergedPlantingSiteObservations = createCachedSelector(
 
 // search observations (search planting zone name only)
 export const searchObservations = createCachedSelector(
-  (state: RootState, plantingSiteId: number, defaultTimeZone: string, search: string) => search,
-  (state: RootState, plantingSiteId: number, defaultTimeZone: string, search: string) =>
+  (state: RootState, plantingSiteId: number, defaultTimeZone: string, search: string, zoneNames: string[]) => search,
+  (state: RootState, plantingSiteId: number, defaultTimeZone: string, search: string, zoneNames: string[]) => zoneNames,
+  (state: RootState, plantingSiteId: number, defaultTimeZone: string, search: string, zoneNames: string[]) =>
     selectMergedPlantingSiteObservations(state, plantingSiteId, defaultTimeZone),
   searchZones
 )(
-  (state: RootState, plantingSiteId: number, defaultTimeZone: string, search: string) =>
-    `${plantingSiteId}_${defaultTimeZone}_${search}`
+  (state: RootState, plantingSiteId: number, defaultTimeZone: string, search: string, zoneNames: string[]) =>
+    `${plantingSiteId}_${defaultTimeZone}_${search}_${Array.from(new Set(zoneNames)).toString()}`
 );
+
+// get zone names in observations
+export const selectObservationsZoneNames = createCachedSelector(
+  (state: RootState, plantingSiteId: number) => selectMergedPlantingSiteObservations(state, plantingSiteId, ''),
+  (observations) =>
+    Array.from(
+      new Set(
+        (observations ?? []).flatMap((observation: ObservationResults) =>
+          observation.plantingZones.map((plantingZone: ObservationPlantingZoneResults) => plantingZone.plantingZoneName)
+        )
+      )
+    )
+)((state: RootState, plantingSiteId: number) => plantingSiteId.toString());

--- a/src/redux/features/observations/utils.ts
+++ b/src/redux/features/observations/utils.ts
@@ -35,22 +35,30 @@ export const searchResultPlots = (search: string, plotType?: boolean, zone?: Obs
   };
 };
 
-export const searchResultZones = (search: string, observation?: ObservationResults) => {
-  if (!search.trim() || !observation) {
+export const searchResultZones = (search: string, zoneNames: string[], observation?: ObservationResults) => {
+  if ((!search.trim() && !zoneNames.length) || !observation) {
     return observation;
   }
   return {
     ...observation,
-    plantingZones: observation.plantingZones.filter((zone: ObservationPlantingZoneResults) => matchZone(zone, search)),
+    plantingZones: observation.plantingZones.filter(
+      (zone: ObservationPlantingZoneResults) =>
+        (!zoneNames.length || zoneNames.includes(zone.plantingZoneName)) && matchZone(zone, search)
+    ),
   };
 };
 
-export const searchZones = (search: string, observations?: ObservationResults[]) => {
-  if (!search.trim()) {
+export const searchZones = (search: string, zoneNames: string[], observations?: ObservationResults[]) => {
+  if (!search.trim() && !zoneNames.length) {
     return observations;
   }
-  return observations?.filter((observation: ObservationResults) =>
-    observation.plantingZones.some((zone: ObservationPlantingZoneResults) => matchZone(zone, search))
+  return observations?.filter(
+    (observation: ObservationResults) =>
+      (!zoneNames.length ||
+        observation.plantingZones.some((zone: ObservationPlantingZoneResults) =>
+          zoneNames.includes(zone.plantingZoneName)
+        )) &&
+      observation.plantingZones.some((zone: ObservationPlantingZoneResults) => matchZone(zone, search))
   );
 };
 

--- a/src/redux/features/tracking/trackingSelectors.ts
+++ b/src/redux/features/tracking/trackingSelectors.ts
@@ -1,8 +1,21 @@
+import { createCachedSelector } from 're-reselect';
 import { RootState } from 'src/redux/rootReducer';
-import { PlantingSite } from 'src/types/Tracking';
+import { PlantingSite, PlantingZone } from 'src/types/Tracking';
 
 export const selectPlantingSites = (state: RootState) => state.tracking?.plantingSites;
 export const selectPlantingSitesError = (state: RootState) => state.tracking?.error;
 
 export const selectPlantingSite = (state: RootState, plantingSiteId: number) =>
   selectPlantingSites(state)?.find((site: PlantingSite) => site.id === plantingSiteId);
+
+export const selectPlantingZoneNames = createCachedSelector(
+  (state: RootState, plantingSiteId: number) =>
+    plantingSiteId !== -1 ? [selectPlantingSite(state, plantingSiteId)] : selectPlantingSites(state),
+  (plantingSites) => {
+    const plantingZones: PlantingZone[] = (plantingSites ?? [])
+      .filter((plantingSite?: PlantingSite) => !!plantingSite?.plantingZones)
+      .flatMap((plantingSite?: PlantingSite) => plantingSite!.plantingZones!);
+
+    return Array.from(new Set(plantingZones.map((plantingZone) => plantingZone.name)));
+  }
+)((state: RootState, plantingSiteId: number) => plantingSiteId.toString());

--- a/src/redux/features/tracking/trackingSelectors.ts
+++ b/src/redux/features/tracking/trackingSelectors.ts
@@ -1,21 +1,8 @@
-import { createCachedSelector } from 're-reselect';
 import { RootState } from 'src/redux/rootReducer';
-import { PlantingSite, PlantingZone } from 'src/types/Tracking';
+import { PlantingSite } from 'src/types/Tracking';
 
 export const selectPlantingSites = (state: RootState) => state.tracking?.plantingSites;
 export const selectPlantingSitesError = (state: RootState) => state.tracking?.error;
 
 export const selectPlantingSite = (state: RootState, plantingSiteId: number) =>
   selectPlantingSites(state)?.find((site: PlantingSite) => site.id === plantingSiteId);
-
-export const selectPlantingZoneNames = createCachedSelector(
-  (state: RootState, plantingSiteId: number) =>
-    plantingSiteId !== -1 ? [selectPlantingSite(state, plantingSiteId)] : selectPlantingSites(state),
-  (plantingSites) => {
-    const plantingZones: PlantingZone[] = (plantingSites ?? [])
-      .filter((plantingSite?: PlantingSite) => !!plantingSite?.plantingZones)
-      .flatMap((plantingSite?: PlantingSite) => plantingSite!.plantingZones!);
-
-    return Array.from(new Set(plantingZones.map((plantingZone) => plantingZone.name)));
-  }
-)((state: RootState, plantingSiteId: number) => plantingSiteId.toString());


### PR DESCRIPTION
- preserve zone names in drill down if possible
- drill down may lose zone names that don't exist in the context
- updated search in map view
- best to test in vercel

<img width="566" alt="Terraware App 2023-06-15 17-34-48" src="https://github.com/terraware/terraware-web/assets/1865174/f459ffda-c0c0-4b33-bb5e-7ad2262c3d22">

<img width="699" alt="Terraware App 2023-06-15 17-34-24" src="https://github.com/terraware/terraware-web/assets/1865174/c200c27d-e526-40e9-b35c-2317837df0ce">

<img width="768" alt="Terraware App 2023-06-15 17-34-02" src="https://github.com/terraware/terraware-web/assets/1865174/a7248d44-bdb8-437a-a1c5-a39571d71b37">
