### PR TITLE
SW-3766 Add status (rolled-up for site) columns in observations tables (site, zone)

### DIFF
--- a/src/components/Observations/details/ObservationDetailsRenderer.tsx
+++ b/src/components/Observations/details/ObservationDetailsRenderer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { APP_PATHS } from 'src/constants';
+import { MonitoringPlotStatus, getPlotStatus } from 'src/types/Observations';
 import CellRenderer, { TableRowType } from 'src/components/common/table/TableCellRenderer';
 import { RendererProps } from 'src/components/common/table/types';
 import Link from 'src/components/common/Link';
@@ -22,6 +23,10 @@ const ObservationDetailsRenderer =
 
     if (column.key === 'mortalityRate') {
       return <CellRenderer {...props} value={`${value}%`} />;
+    }
+
+    if (column.key === 'status') {
+      return <CellRenderer {...props} value={getPlotStatus(value as MonitoringPlotStatus)} />;
     }
 
     return <CellRenderer {...props} />;

--- a/src/components/Observations/details/index.tsx
+++ b/src/components/Observations/details/index.tsx
@@ -20,6 +20,7 @@ import ObservationDetailsRenderer from './ObservationDetailsRenderer';
 const columns = (): TableColumnType[] => [
   { key: 'plantingZoneName', name: strings.ZONE, type: 'string' },
   { key: 'completedDate', name: strings.DATE, type: 'string' },
+  { key: 'status', name: strings.STATUS, type: 'string' },
   { key: 'totalPlants', name: strings.PLANTS, type: 'number' },
   { key: 'totalSpecies', name: strings.SPECIES, type: 'number' },
   { key: 'plantingDensity', name: strings.PLANTING_DENSITY, type: 'number' },

--- a/src/components/Observations/zone/ObservationPlantingZoneRenderer.tsx
+++ b/src/components/Observations/zone/ObservationPlantingZoneRenderer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { APP_PATHS } from 'src/constants';
 import strings from 'src/strings';
+import { MonitoringPlotStatus, getPlotStatus } from 'src/types/Observations';
 import CellRenderer, { TableRowType } from 'src/components/common/table/TableCellRenderer';
 import { RendererProps } from 'src/components/common/table/types';
 import Link from 'src/components/common/Link';
@@ -24,6 +25,10 @@ const ObservationPlantingZoneRenderer =
 
     if (column.key === 'mortalityRate') {
       return <CellRenderer {...props} value={`${value}%`} />;
+    }
+
+    if (column.key === 'status') {
+      return <CellRenderer {...props} value={getPlotStatus(value as MonitoringPlotStatus)} />;
     }
 
     if (column.key === 'isPermanent') {

--- a/src/components/Observations/zone/index.tsx
+++ b/src/components/Observations/zone/index.tsx
@@ -20,6 +20,7 @@ import ObservationPlantingZoneRenderer from './ObservationPlantingZoneRenderer';
 const columns = (): TableColumnType[] => [
   { key: 'monitoringPlotName', name: strings.MONITORING_PLOT, type: 'string' },
   { key: 'completedDate', name: strings.DATE, type: 'string' },
+  { key: 'status', name: strings.STATUS, type: 'string' },
   { key: 'isPermanent', name: strings.MONITORING_PLOT_TYPE, type: 'string' },
   { key: 'totalPlants', name: strings.PLANTS, type: 'number' },
   { key: 'totalSpecies', name: strings.SPECIES, type: 'number' },

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -652,6 +652,7 @@ OUNCES,Ounces
 OUT_PLANTING,Out-planting
 OUTPLANT,Outplant
 OUTPLANTS_REQUIRE_READY_SEEDLINGS,"Outplants require batches with seedlings that are ""ready."""
+OUTSTANDING,Outstanding
 OVER_WORD_LIMIT,Over word limit
 OVERDUE,Overdue
 OWNER,Owner

--- a/src/types/Observations.ts
+++ b/src/types/Observations.ts
@@ -31,6 +31,7 @@ export type ObservationPlantingZoneResults = ObservationPlantingZoneResultsPaylo
     plantingZoneName: string;
     plantingSubzones: ObservationPlantingSubzoneResults[];
     species: ObservationSpeciesResults[];
+    status?: MonitoringPlotStatus;
   };
 
 // subzone level results -> contains lists of both species level results and monitoring plot level results
@@ -44,6 +45,7 @@ export type ObservationPlantingSubzoneResults = ObservationPlantingSubzoneResult
 
 // monitoring plot level results
 export type ObservationMonitoringPlotResultsPayload = components['schemas']['ObservationMonitoringPlotResultsPayload'];
+export type MonitoringPlotStatus = ObservationMonitoringPlotResultsPayload['status'];
 export type ObservationMonitoringPlotResults = ObservationMonitoringPlotResultsPayload & {
   completedDate?: string;
   species: ObservationSpeciesResults[];
@@ -69,5 +71,18 @@ export const getStatus = (state: ObservationState): string => {
       return strings.OVERDUE;
     default:
       return strings.UPCOMING;
+  }
+};
+
+export const getPlotStatus = (status?: MonitoringPlotStatus): string => {
+  switch (status) {
+    case 'Completed':
+      return strings.COMPLETED;
+    case 'InProgress':
+      return strings.IN_PROGRESS;
+    case 'Outstanding':
+      return strings.OUTSTANDING;
+    default:
+      return '';
   }
 };


### PR DESCRIPTION
- status in planting zones table (rolled up)
- status in monitoring plots table
- mocked statuses to test rolling up (see images)

<img width="753" alt="Terraware App 2023-06-16 10-40-27" src="https://github.com/terraware/terraware-web/assets/1865174/7c8a55ec-2aa6-439c-8a43-9026273fb448">

<img width="761" alt="Terraware App 2023-06-16 10-40-11" src="https://github.com/terraware/terraware-web/assets/1865174/aa6b07b0-805d-4b39-a17a-a21313d9f854">

<img width="782" alt="Terraware App 2023-06-16 10-32-18" src="https://github.com/terraware/terraware-web/assets/1865174/71279c7a-e82c-40f9-a6bf-4cbcaaf15d19">

<img width="772" alt="Terraware App 2023-06-16 10-32-00" src="https://github.com/terraware/terraware-web/assets/1865174/c6894758-57d4-4a4d-b9da-a7a97cbb2077">
