### PR TITLE
Show tooltips for total plants and planting density even when there is data

### DIFF
--- a/src/components/Observations/common/AggregatedPlantsStats.tsx
+++ b/src/components/Observations/common/AggregatedPlantsStats.tsx
@@ -14,6 +14,7 @@ export type AggregatedPlantsStatsProps = {
   plantingDensity?: number;
   mortalityRate?: number;
   species?: ObservationSpeciesResults[];
+  isSite?: boolean;
 };
 
 export default function AggregatedPlantsStats({
@@ -22,6 +23,7 @@ export default function AggregatedPlantsStats({
   plantingDensity,
   mortalityRate,
   species,
+  isSite,
 }: AggregatedPlantsStatsProps): JSX.Element {
   const { isMobile } = useDeviceInfo();
   const infoCardGridSize = isMobile ? 12 : 3;
@@ -31,13 +33,13 @@ export default function AggregatedPlantsStats({
     {
       label: strings.PLANTS,
       value: totalPlants,
-      toolTip: totalPlants === null ? strings.PLANTS_MISSING_TOOLTIP : '',
+      toolTip: isSite ? strings.PLANTS_MISSING_TOOLTIP : '',
     },
     { label: strings.SPECIES, value: totalSpecies },
     {
       label: strings.PLANTING_DENSITY,
       value: plantingDensity,
-      toolTip: plantingDensity === null ? strings.PLANTING_DENSITY_MISSING_TOOLTIP : '',
+      toolTip: strings.PLANTING_DENSITY_MISSING_TOOLTIP,
     },
     { label: strings.MORTALITY_RATE, value: mortalityRate },
   ];

--- a/src/components/Observations/details/index.tsx
+++ b/src/components/Observations/details/index.tsx
@@ -99,7 +99,7 @@ export default function ObservationDetails(props: ObservationDetailsProps): JSX.
     <DetailsPage title={title} plantingSiteId={plantingSiteId}>
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <AggregatedPlantsStats {...(details ?? {})} />
+          <AggregatedPlantsStats {...(details ?? {})} isSite />
         </Grid>
         <Grid item xs={12}>
           <Card flushMobile>


### PR DESCRIPTION
- previously we were showing these tooltips only when data was missing
- Rachel provided feedback that we should show the tooltips for context all the time
- note that total plants tooltip is only relevant for the site level observations