### PR TITLE
Add a Comment to Note the Sense of the Word "Outstanding" to Translators

### DIFF
--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -652,7 +652,7 @@ OUNCES,Ounces
 OUT_PLANTING,Out-planting
 OUTPLANT,Outplant
 OUTPLANTS_REQUIRE_READY_SEEDLINGS,"Outplants require batches with seedlings that are ""ready."""
-OUTSTANDING,Outstanding,In the sense of Pending Unresolved or Remaining to be Done
+OUTSTANDING,Outstanding,In the sense of Pending or Unresolved
 OVER_WORD_LIMIT,Over word limit
 OVERDUE,Overdue
 OWNER,Owner

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -652,7 +652,7 @@ OUNCES,Ounces
 OUT_PLANTING,Out-planting
 OUTPLANT,Outplant
 OUTPLANTS_REQUIRE_READY_SEEDLINGS,"Outplants require batches with seedlings that are ""ready."""
-OUTSTANDING,Outstanding,In the sense of Pending, Unresolved, or Remaining to be Done
+OUTSTANDING,Outstanding,In the sense of Pending Unresolved or Remaining to be Done
 OVER_WORD_LIMIT,Over word limit
 OVERDUE,Overdue
 OWNER,Owner

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -652,7 +652,7 @@ OUNCES,Ounces
 OUT_PLANTING,Out-planting
 OUTPLANT,Outplant
 OUTPLANTS_REQUIRE_READY_SEEDLINGS,"Outplants require batches with seedlings that are ""ready."""
-OUTSTANDING,Outstanding,In the sense of "Pending" or "Unresolved"
+OUTSTANDING,Outstanding,In the sense of Pending or Unresolved
 OVER_WORD_LIMIT,Over word limit
 OVERDUE,Overdue
 OWNER,Owner

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -652,7 +652,7 @@ OUNCES,Ounces
 OUT_PLANTING,Out-planting
 OUTPLANT,Outplant
 OUTPLANTS_REQUIRE_READY_SEEDLINGS,"Outplants require batches with seedlings that are ""ready."""
-OUTSTANDING,Outstanding
+OUTSTANDING,Outstanding,In the sense of "Pending" or "Unresolved"
 OVER_WORD_LIMIT,Over word limit
 OVERDUE,Overdue
 OWNER,Owner

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -652,7 +652,7 @@ OUNCES,Ounces
 OUT_PLANTING,Out-planting
 OUTPLANT,Outplant
 OUTPLANTS_REQUIRE_READY_SEEDLINGS,"Outplants require batches with seedlings that are ""ready."""
-OUTSTANDING,Outstanding,In the sense of Pending or Unresolved
+OUTSTANDING,Outstanding,In the sense of Pending, Unresolved, or Remaining to be Done
 OVER_WORD_LIMIT,Over word limit
 OVERDUE,Overdue
 OWNER,Owner


### PR DESCRIPTION
The word "outstanding" was previously translated as "destacado," which seems to be the wrong sense of the word.