### PR TITLE
SW-3748 redux to list observations (not results)

### DIFF
--- a/src/components/Observations/ObservationsDataView.tsx
+++ b/src/components/Observations/ObservationsDataView.tsx
@@ -3,7 +3,11 @@ import { Box, Typography, useTheme } from '@mui/material';
 import { FieldOptionsMap } from 'src/types/Search';
 import { useAppSelector } from 'src/redux/store';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
-import { searchObservations, selectObservationsZoneNames } from 'src/redux/features/observations/observationsSelectors';
+import {
+  searchObservations,
+  selectObservationsZoneNames,
+  selectPlantingSiteObservations,
+} from 'src/redux/features/observations/observationsSelectors';
 import ListMapView from 'src/components/ListMapView';
 import Search, { SearchProps } from 'src/components/common/SearchFiltersWrapper';
 import OrgObservationsListView from './org/OrgObservationsListView';
@@ -29,6 +33,13 @@ export default function ObservationsDataView(props: ObservationsDataViewProps): 
     )
   );
 
+  const upcomingObservations = useAppSelector((state) =>
+    selectPlantingSiteObservations(state, selectedPlantingSiteId, 'Upcoming')
+  );
+  const inProgressObservations = useAppSelector((state) =>
+    selectPlantingSiteObservations(state, selectedPlantingSiteId, 'InProgress')
+  );
+
   const zoneNames = useAppSelector((state) => selectObservationsZoneNames(state, selectedPlantingSiteId));
 
   useEffect(() => {
@@ -39,6 +50,20 @@ export default function ObservationsDataView(props: ObservationsDataViewProps): 
       },
     });
   }, [setFilterOptions, zoneNames]);
+
+  useEffect(() => {
+    if (upcomingObservations?.length) {
+      /**
+       * enable message notification showing upcoming notifications and app download prompt
+       */
+    } else {
+      if (!inProgressObservations?.length) {
+        /**
+         * enable message notification with app download prompt
+         */
+      }
+    }
+  }, [upcomingObservations, inProgressObservations]);
 
   return (
     <ListMapView

--- a/src/components/Observations/details/index.tsx
+++ b/src/components/Observations/details/index.tsx
@@ -13,6 +13,7 @@ import {
   searchObservationDetails,
   selectDetailsZoneNames,
 } from 'src/redux/features/observations/observationDetailsSelectors';
+import { selectObservation } from 'src/redux/features/observations/observationsSelectors';
 import Card from 'src/components/common/Card';
 import Table from 'src/components/common/table';
 import Search, { SearchProps } from 'src/components/common/SearchFiltersWrapper';
@@ -58,6 +59,10 @@ export default function ObservationDetails(props: ObservationDetailsProps): JSX.
     )
   );
 
+  const observation = useAppSelector((state) =>
+    selectObservation(state, Number(plantingSiteId), Number(observationId))
+  );
+
   const zoneNames = useAppSelector((state) =>
     selectDetailsZoneNames(state, Number(plantingSiteId), Number(observationId))
   );
@@ -94,6 +99,14 @@ export default function ObservationDetails(props: ObservationDetailsProps): JSX.
       }));
     }
   }, [zoneNames, searchProps.filtersProps]);
+
+  useEffect(() => {
+    if (observation) {
+      /**
+       * show info on due date and monitoring plot progress
+       */
+    }
+  }, [observation]);
 
   return (
     <DetailsPage title={title} plantingSiteId={plantingSiteId}>

--- a/src/components/Observations/index.tsx
+++ b/src/components/Observations/index.tsx
@@ -7,7 +7,7 @@ import { APP_PATHS } from 'src/constants';
 import useSnackbar from 'src/utils/useSnackbar';
 import { useLocalization, useOrganization } from 'src/providers';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
-import { requestObservationsResults } from 'src/redux/features/observations/observationsThunks';
+import { requestObservations, requestObservationsResults } from 'src/redux/features/observations/observationsThunks';
 import { requestSpecies } from 'src/redux/features/species/speciesThunks';
 import { requestPlantingSites } from 'src/redux/features/tracking/trackingThunks';
 import {
@@ -52,6 +52,7 @@ export default function Observations(): JSX.Element {
     if (species !== undefined && plantingSites !== undefined && !dispatched) {
       setDispatched(true);
       dispatch(requestObservationsResults(selectedOrganization.id));
+      dispatch(requestObservations(selectedOrganization.id));
     }
   }, [dispatch, selectedOrganization.id, species, plantingSites, dispatched]);
 

--- a/src/redux/features/observations/observationsSlice.ts
+++ b/src/redux/features/observations/observationsSlice.ts
@@ -1,21 +1,21 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { ObservationResultsPayload } from 'src/types/Observations';
+import { Observation, ObservationResultsPayload } from 'src/types/Observations';
 
 // Define a type for the slice state
-type Data = {
+type ResultsData = {
   error?: string;
   observations?: ObservationResultsPayload[];
 };
 
 // Define the initial state
-const initialState: Data = {};
+const initialResultsState: ResultsData = {};
 
 export const observationsResultsSlice = createSlice({
   name: 'observationsResultsSlice',
-  initialState,
+  initialState: initialResultsState,
   reducers: {
-    setObservationsResultsAction: (state, action: PayloadAction<Data>) => {
-      const data: Data = action.payload;
+    setObservationsResultsAction: (state, action: PayloadAction<ResultsData>) => {
+      const data: ResultsData = action.payload;
       state.error = data.error;
       state.observations = data.observations;
     },
@@ -23,5 +23,28 @@ export const observationsResultsSlice = createSlice({
 });
 
 export const { setObservationsResultsAction } = observationsResultsSlice.actions;
-
 export const observationsResultsReducer = observationsResultsSlice.reducer;
+
+// Define a type for the slice state
+type Data = {
+  error?: string;
+  observations?: Observation[];
+};
+
+// Define the initial state
+const initialState: Data = {};
+
+export const observationsSlice = createSlice({
+  name: 'observationsSlice',
+  initialState,
+  reducers: {
+    setObservationsAction: (state, action: PayloadAction<Data>) => {
+      const data: Data = action.payload;
+      state.error = data.error;
+      state.observations = data.observations;
+    },
+  },
+});
+
+export const { setObservationsAction } = observationsSlice.actions;
+export const observationsReducer = observationsSlice.reducer;

--- a/src/redux/features/observations/observationsThunks.ts
+++ b/src/redux/features/observations/observationsThunks.ts
@@ -1,7 +1,7 @@
 import { Dispatch } from 'redux';
 import { ObservationsService } from 'src/services';
 import { RootState } from 'src/redux/rootReducer';
-import { setObservationsResultsAction } from './observationsSlice';
+import { setObservationsAction, setObservationsResultsAction } from './observationsSlice';
 
 /**
  * Fetch observation results
@@ -21,6 +21,28 @@ export const requestObservationsResults = (organizationId: number) => {
       // should not happen, the response above captures any http request errors
       // tslint:disable-next-line: no-console
       console.error('Error dispatching observations results', e);
+    }
+  };
+};
+
+/**
+ * Fetch observations
+ */
+export const requestObservations = (organizationId: number) => {
+  return async (dispatch: Dispatch, _getState: () => RootState) => {
+    try {
+      const response = await ObservationsService.listObservations(organizationId);
+      const { error, observations } = response;
+      dispatch(
+        setObservationsAction({
+          error,
+          observations,
+        })
+      );
+    } catch (e) {
+      // should not happen, the response above captures any http request errors
+      // tslint:disable-next-line: no-console
+      console.error('Error dispatching observations', e);
     }
   };
 };

--- a/src/redux/rootReducer.ts
+++ b/src/redux/rootReducer.ts
@@ -1,6 +1,6 @@
 import { Action, combineReducers } from '@reduxjs/toolkit';
 import { appVersionReducer } from './features/appVersion/appVersionSlice';
-import { observationsResultsReducer } from './features/observations/observationsSlice';
+import { observationsReducer, observationsResultsReducer } from './features/observations/observationsSlice';
 import { speciesReducer } from './features/species/speciesSlice';
 import { trackingReducer } from './features/tracking/trackingSlice';
 
@@ -8,6 +8,7 @@ import { trackingReducer } from './features/tracking/trackingSlice';
 export const reducers = {
   appVersion: appVersionReducer,
   observationsResults: observationsResultsReducer,
+  observations: observationsReducer,
   species: speciesReducer,
   tracking: trackingReducer,
 };

--- a/src/services/ObservationsService.ts
+++ b/src/services/ObservationsService.ts
@@ -1,15 +1,19 @@
 import { paths } from 'src/api/types/generated-schema';
 import HttpService, { Response } from './HttpService';
-import { ObservationResultsPayload } from 'src/types/Observations';
+import { Observation, ObservationResultsPayload } from 'src/types/Observations';
 
 /**
  * Tracking observations related services
  */
 
 const OBSERVATIONS_RESULTS_ENDPOINT = '/api/v1/tracking/observations/results';
+const OBSERVATIONS_ENDPOINT = '/api/v1/tracking/observations';
 
 type ObservationsResultsResponsePayload =
   paths[typeof OBSERVATIONS_RESULTS_ENDPOINT]['get']['responses'][200]['content']['application/json'];
+
+type ObservationsResponsePayload =
+  paths[typeof OBSERVATIONS_ENDPOINT]['get']['responses'][200]['content']['application/json'];
 
 /**
  * exported response type
@@ -18,7 +22,12 @@ export type ObservationsResultsData = {
   observations: ObservationResultsPayload[];
 };
 
+export type ObservationsData = {
+  observations: Observation[];
+};
+
 const httpObservationsResults = HttpService.root(OBSERVATIONS_RESULTS_ENDPOINT);
+const httpObservations = HttpService.root(OBSERVATIONS_ENDPOINT);
 
 /**
  * List all observations results
@@ -44,11 +53,28 @@ const listObservationsResults = async (
   return response;
 };
 
+const listObservations = async (organizationId: number): Promise<ObservationsData & Response> => {
+  const response: ObservationsData & Response = await httpObservations.get<
+    ObservationsResponsePayload,
+    ObservationsData
+  >(
+    {
+      params: {
+        organizationId: organizationId.toString(),
+      },
+    },
+    (data) => ({ observations: data?.observations ?? [] })
+  );
+
+  return response;
+};
+
 /**
  * Exported functions
  */
 const ObservationsService = {
   listObservationsResults,
+  listObservations,
 };
 
 export default ObservationsService;


### PR DESCRIPTION
- list observations which returns a response payload around the observation (not the results)
- returns end dates, includes observations for all statuses
- added hooks in components where we would do follow up UI work