### PR TITLE
SW-3761 Show upcoming observation event notification messages 

### DIFF
--- a/src/components/Observations/ObservationsDataView.tsx
+++ b/src/components/Observations/ObservationsDataView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react';
-import { Box, Typography, useTheme } from '@mui/material';
+import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { FieldOptionsMap } from 'src/types/Search';
 import { useAppSelector } from 'src/redux/store';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
@@ -34,9 +34,7 @@ export default function ObservationsDataView(props: ObservationsDataViewProps): 
     )
   );
 
-  const upcomingObservations = useAppSelector((state) =>
-    selectPlantingSiteObservations(state, -1, 'Upcoming')
-  );
+  const upcomingObservations = useAppSelector((state) => selectPlantingSiteObservations(state, -1, 'Upcoming'));
 
   const zoneNames = useAppSelector((state) => selectObservationsZoneNames(state, selectedPlantingSiteId));
 
@@ -49,17 +47,17 @@ export default function ObservationsDataView(props: ObservationsDataViewProps): 
     });
   }, [setFilterOptions, zoneNames]);
 
-  const observationsEvents = useMemo(() => {
+  const observationsEvents = useMemo<ObservationEvent[]>(() => {
     if (!upcomingObservations) {
       return [];
     }
     const now = Date.now();
     // return observations that haven't passed
-    return upcomingObservations.filter(observation => now <= (new Date(observation.endDate)).getTime());
+    return upcomingObservations.filter((observation) => now <= new Date(observation.endDate).getTime());
   }, [upcomingObservations]);
 
   return (
-    <>
+    <Grid container>
       <ObservationsEventsNotification events={observationsEvents} />
       <ListMapView
         initialView='list'
@@ -73,7 +71,7 @@ export default function ObservationsDataView(props: ObservationsDataViewProps): 
           )
         }
       />
-    </>
+    </Grid>
   );
 }
 

--- a/src/components/Observations/ObservationsEventsNotification.tsx
+++ b/src/components/Observations/ObservationsEventsNotification.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { Box } from '@mui/material';
 import { Button, Message } from '@terraware/web-components';
 import strings from 'src/strings';
+import { SEED_COLLECTOR_APP_STORE_LINK, SEED_COLLECTOR_GOOGLE_PLAY_LINK } from 'src/constants';
 import { useLocalization } from 'src/providers';
 import { getLongDate } from 'src/utils/dateFormatter';
 
@@ -67,7 +68,7 @@ export default function ObservationsEventsNotification({ events }: ObservationsE
             key='1'
             priority='secondary'
             type='passive'
-            onClick={() => openTab('https://apps.apple.com/us/app/terraware/id1568369900')}
+            onClick={() => openTab(SEED_COLLECTOR_APP_STORE_LINK)}
           />,
           <Button
             label={strings.DOWNLOAD_ON_GOOGLE_PLAY}
@@ -75,7 +76,7 @@ export default function ObservationsEventsNotification({ events }: ObservationsE
             key='2'
             priority='secondary'
             type='passive'
-            onClick={() => openTab('https://play.google.com/store/apps/details?id=com.terraformation.seedcollector')}
+            onClick={() => openTab(SEED_COLLECTOR_GOOGLE_PLAY_LINK)}
           />,
         ]}
       />

--- a/src/components/Observations/ObservationsEventsNotification.tsx
+++ b/src/components/Observations/ObservationsEventsNotification.tsx
@@ -1,0 +1,61 @@
+import { Box } from '@mui/material';
+import { Button, Message } from '@terraware/web-components';
+import strings from 'src/strings';
+import { getLongDate } from 'src/utils/dateFormatter';
+
+type ObservationEvent = {
+  startDate: string;
+  plantingSiteName: string;
+};
+
+type ObservationsEventsNotificationProps = {
+  events: ObservationEvent[];
+};
+
+export default function ObservationsEventsNotification({ events }: ObservationsEventsNotificationProps): JSX.Element {
+
+  const openTab = (url: string) => window.open(url, '_blank');
+
+  return (
+    <Box marginBottom={3} display='flex' flexGrow={1}>
+      <Message
+        type='page'
+        priority='info'
+        title={strings.OBSERVATIONS_WITH_THE_TERRAWARE_APP}
+        body={
+          <>
+            <Box marginBottom={3}>
+              {
+                strings.formatString(
+                  strings.OBSERVATIONS_REQUIRED_BY_DATE,
+                  statusSummary.pendingPlots.toString(),
+                  statusSummary.endDate
+                ) as string
+              }
+            </Box>
+            <Box>{strings.OBSERVATIONS_DOWNLOAD_APP}</Box>
+          </>
+        }
+        pageButtons={[
+          <Button
+            label={strings.DOWNLOAD_ON_APP_STORE}
+            size='small'
+            key='1'
+            priority='secondary'
+            type='passive'
+            onClick={() => openTab('link')}
+          />,
+          <Button
+            label={strings.DOWNLOAD_ON_GOOGLE_PLAY}
+            size='small'
+            key='2'
+            priority='secondary'
+            type='passive'
+            onClick={() => openTab('link')}
+          />,
+        ]}
+      />
+    </Box>
+
+  );
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,9 @@
 export const API_PULL_INTERVAL = 60000;
 
+export const SEED_COLLECTOR_APP_STORE_LINK = 'https://apps.apple.com/us/app/terraware/id1568369900';
+export const SEED_COLLECTOR_GOOGLE_PLAY_LINK =
+  'https://play.google.com/store/apps/details?id=com.terraformation.seedcollector';
+
 export enum APP_PATHS {
   ACCESSIONS = '/accessions',
   ACCESSIONS2_NEW = '/accessions/new',

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -622,6 +622,8 @@ NURSERY_MEDIA,Nursery Media
 NURSERY_MORTALITY_RATE,Nursery Mortality Rate
 NURSERY_REQUIRED,Nursery *
 NURSERY_TRANSFER,Nursery Transfer
+OBSERVATION_EVENTS_SCHEDULED,Observation event is scheduled for {0} for {1} and {2}.,"Example: Observation event is scheduled for June 1, 2023 for Site-A and Site-B."
+OBSERVATION_EVENT_SCHEDULED,Observation event is scheduled for {0} for {1}.,"Example: Observation event is scheduled for June 1, 2023 for Site-A."
 OBSERVATION_IN_PROGRESS,Observation in Progress
 OBSERVATION_STATUS,Observation Status
 OBSERVATION_STATUS_OUTSTANDING,Outstanding,In the sense of Pending or Unresolved

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -246,6 +246,8 @@ DOWNLOAD_CSV_TEMPLATE,Download a CSV template here.
 DOWNLOAD_FAILED,Download failed
 DOWNLOAD_FAILED_DESCRIPTION,The download has failed. Please email {0} so we can assist you.
 DOWNLOAD_IN_PROGRESS,Download in progress...
+DOWNLOAD_ON_APP_STORE,Download on the App Store
+DOWNLOAD_ON_GOOGLE_PLAY,Get it on Google Play
 DOWNLOAD_REPORT_DESCRIPTION,You are about to download this datatable as a report. This csv file can be found in your Downloads. Please name your report below.
 DOWNLOAD_THE_CSV_TEMPLATE,Download the CSV template.
 DRIED,Dried
@@ -625,10 +627,12 @@ OBSERVATION_STATUS,Observation Status
 OBSERVATION_STATUS_OUTSTANDING,Outstanding,In the sense of Pending or Unresolved
 OBSERVATIONS,Observations
 OBSERVATIONS_COMPLETION_PERCENTAGE,Observations for {0} of {1} monitoring plots ({2}%) have been completed.,Example: Observations for 5 of 10 monitoring plots (50%) have been completed.
+OBSERVATIONS_DOWNLOAD_APP,"To complete observations, download the Terraware app on the App Store or Google Play."
 OBSERVATIONS_EMPTY_STATE_MESSAGE_1,"Observations are when you record data from a sample of monitoring plots using our mobile app in the field. This allows us to calculate mortality rates, and eventually carbon sequestration."
 OBSERVATIONS_EMPTY_STATE_MESSAGE_2,"You will be notified when it is time to take your observations (typically, the next time you end a planting season). After you've completed your first observations, you'll see the records here."
 OBSERVATIONS_EMPTY_STATE_TITLE,No Observations Yet
 OBSERVATIONS_REQUIRED_BY_DATE,{0} monitoring plots require observation by {1}.,"Example: 5 monitoring plots require observation by June 30, 2023"
+OBSERVATIONS_WITH_THE_TERRAWARE_APP,Observations with the Terraware App
 OBSERVER,Observer
 ONBOARDING_ADMIN_TITLE,"Just a moment, let’s complete setup first"
 OPPORTUNITIES,Opportunities


### PR DESCRIPTION
- show event notification messages, the string construction is a bit iffy but may pass
- show app download instructions alone.. if there are no upcoming observations

<img width="782" alt="Terraware App 2023-06-20 14-30-58" src="https://github.com/terraware/terraware-web/assets/1865174/07f1066e-b31d-4354-805e-6fdc6b92edaf">

<img width="200" alt="Terraware App 2023-06-20 14-30-19" src="https://github.com/terraware/terraware-web/assets/1865174/24328c63-df59-4b98-aa3e-9181c7a28447">

<img width="781" alt="Terraware App 2023-06-20 14-31-30" src="https://github.com/terraware/terraware-web/assets/1865174/deb3598e-9179-49d1-bbf3-fd1d62bcc035">

<img width="782" alt="Terraware App 2023-06-20 14-33-38" src="https://github.com/terraware/terraware-web/assets/1865174/0e0d843c-695d-4c7a-85dc-cb58930ee1ff">

