### PR TITLE
SW-3795 react hook to export supported locales for the FE environment (prod vs non-prod)

### DIFF
--- a/src/components/FeatureNotification/UserNotification.tsx
+++ b/src/components/FeatureNotification/UserNotification.tsx
@@ -3,7 +3,7 @@ import { APP_PATHS } from 'src/constants';
 import strings from 'src/strings';
 import { Notification } from 'src/types/Notifications';
 import { weightSystemsNames } from 'src/units';
-import { supportedLocales } from 'src/strings/locales';
+import { useSupportedLocales } from 'src/strings/locales';
 import TextWithLink from 'src/components/common/TextWithLink';
 import { useOrganization, useTimeZones, useUser } from 'src/providers';
 import { getTodaysDateFormatted } from '@terraware/web-components/utils';
@@ -15,6 +15,7 @@ import { InitializedUnits } from 'src/units';
 import { featureNotificationExpired } from 'src/utils/featureNotifications';
 
 export default function UserNotification(): Notification | null {
+  const supportedLocales = useSupportedLocales();
   const [unitNotification, setUnitNotification] = useState(false);
   const [unitNotificationRead, setUnitNotificationRead] = useState(false);
   const [timeZoneUserNotification, setTimeZoneUserNotification] = useState(false);
@@ -146,5 +147,6 @@ export default function UserNotification(): Notification | null {
     userTimeZone,
     timeZoneUserNotificationRead,
     unitNotificationRead,
+    supportedLocales,
   ]);
 }

--- a/src/components/LocaleSelector.tsx
+++ b/src/components/LocaleSelector.tsx
@@ -1,5 +1,5 @@
 import { Dropdown, DropdownItem, PopoverMenu } from '@terraware/web-components';
-import { supportedLocales } from '../strings/locales';
+import { useSupportedLocales } from '../strings/locales';
 import { LocalizationContext } from '../providers/contexts';
 import { UserService } from 'src/services';
 import { useUser } from '../providers';
@@ -27,6 +27,7 @@ export default function LocaleSelector({
   localeSelected,
 }: LocaleSelectorProps): JSX.Element {
   const { user, reloadUser } = useUser();
+  const supportedLocales = useSupportedLocales();
   const localeItems: DropdownItem[] = supportedLocales.map((supportedLocale) => ({
     value: supportedLocale.id,
     label: supportedLocale.name,

--- a/src/components/MyAccount/index.tsx
+++ b/src/components/MyAccount/index.tsx
@@ -31,7 +31,7 @@ import { getUTC } from 'src/utils/useTimeZoneUtils';
 import { weightSystems } from 'src/units';
 import WeightSystemSelector from 'src/components/WeightSystemSelector';
 import LocaleSelector from '../LocaleSelector';
-import { supportedLocales } from 'src/strings/locales';
+import { useSupportedLocales } from 'src/strings/locales';
 import DeleteAccountModal from './DeleteAccountModal';
 
 type MyAccountProps = {
@@ -87,6 +87,7 @@ const MyAccountContent = ({
   reloadData,
 }: MyAccountContentProps): JSX.Element => {
   const { isMobile } = useDeviceInfo();
+  const supportedLocales = useSupportedLocales();
   const theme = useTheme();
   const [selectedRows, setSelectedRows] = useState<PersonOrganization[]>([]);
   const [personOrganizations, setPersonOrganizations] = useState<PersonOrganization[]>([]);

--- a/src/providers/LocalizationProvider.tsx
+++ b/src/providers/LocalizationProvider.tsx
@@ -3,7 +3,7 @@ import { LocalizationContext } from './contexts';
 import { TimeZoneDescription } from 'src/types/TimeZones';
 import strings, { ILocalizedStringsMap } from 'src/strings';
 import { ProvidedLocalizationData, useUser } from '.';
-import { supportedLocales } from '../strings/locales';
+import { useSupportedLocales } from '../strings/locales';
 import { HttpService, LocationService } from 'src/services';
 
 export type LocalizationProviderProps = {
@@ -23,6 +23,7 @@ export default function LocalizationProvider({
 }: LocalizationProviderProps): JSX.Element | null {
   const [timeZones, setTimeZones] = useState<TimeZoneDescription[]>([]);
   const { user } = useUser();
+  const supportedLocales = useSupportedLocales();
 
   useEffect(() => {
     if (user?.locale) {
@@ -76,7 +77,7 @@ export default function LocalizationProvider({
     };
 
     fetchStrings();
-  }, [selectedLocale, setActiveLocale]);
+  }, [selectedLocale, setActiveLocale, supportedLocales]);
 
   const context: ProvidedLocalizationData = {
     activeLocale,

--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -27,6 +27,10 @@ export interface LocaleDetails {
    * Webpack knows to split the strings modules out into separate downloadable artifacts.
    */
   loadModule: () => Promise<StringsModule>;
+  /**
+   * Whether this locale is in development and not ready for production.
+   */
+  inDevelopment?: boolean;
 }
 
 // By default, we have no strings to show, but react-localization requires there to be at least

--- a/src/strings/locales.ts
+++ b/src/strings/locales.ts
@@ -17,7 +17,8 @@ export const useSupportedLocales = (): LocaleDetails[] => {
   const { isProduction } = useEnvironment();
 
   // this can be extended for languages in development
-  return useMemo(() => {
-    return !isProduction ? supportedLocales.filter((locale) => !locale.inDevelopment) : supportedLocales;
-  }, [isProduction]);
+  return useMemo(
+    () => (isProduction ? supportedLocales.filter((locale) => !locale.inDevelopment) : supportedLocales),
+    [isProduction]
+  );
 };

--- a/src/strings/locales.ts
+++ b/src/strings/locales.ts
@@ -1,12 +1,23 @@
+import { useMemo } from 'react';
 import { LocaleDetails } from '.';
+import useEnvironment from 'src/utils/useEnvironment';
 
 /** Supported locales in the order they should appear in the locale selector. */
-export const supportedLocales: LocaleDetails[] = [
+const supportedLocales: LocaleDetails[] = [
   { id: 'en', name: 'English', loadModule: () => import('./strings-en') },
   { id: 'es', name: 'Español', loadModule: () => import('./strings-es') },
-  { id: 'gx', name: 'Gibberish', loadModule: () => import('./strings-gx') },
+  { id: 'gx', name: 'Gibberish', loadModule: () => import('./strings-gx'), inDevelopment: true },
 ];
 
 const supportedLocaleIds = supportedLocales.map((locale: LocaleDetails) => locale.id);
 
 export type SupportedLocaleId = typeof supportedLocaleIds[number];
+
+export const useSupportedLocales = (): LocaleDetails[] => {
+  const { isProduction } = useEnvironment();
+
+  // this can be extended for languages in development
+  return useMemo(() => {
+    return !isProduction ? supportedLocales.filter((locale) => !locale.inDevelopment) : supportedLocales;
+  }, [isProduction]);
+};


### PR DESCRIPTION
- added an optional inDevelopment flag for locales
- added a hook to fetch supported locales which filters out inDevelopment locales in production
- tested by flipping the inProduction condition locally