### PR TITLE
SW-3798 translate species growth-form and seed-storage-behavior

### DIFF
--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -8,13 +8,7 @@ import { OrderPreserveableTable as Table } from 'src/components/common/table';
 import { TableColumnType } from 'src/components/common/table/types';
 import speciesAtom from 'src/state/species';
 import strings from 'src/strings';
-import {
-  EcosystemType,
-  getEcosystemTypesString,
-  getGrowthFormString,
-  getSeedStorageBehaviorString,
-  Species,
-} from 'src/types/Species';
+import { EcosystemType, getEcosystemTypesString, Species } from 'src/types/Species';
 import TfMain from 'src/components/common/TfMain';
 import PageSnackbar from 'src/components/PageSnackbar';
 import AddSpeciesModal from './AddSpeciesModal';
@@ -465,8 +459,8 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
               scientificName: result.scientificName as string,
               commonName: result.commonName as string,
               familyName: result.familyName as string,
-              growthForm: getGrowthFormString(result as Species),
-              seedStorageBehavior: getSeedStorageBehaviorString(result as Species),
+              growthForm: result.growthForm as string,
+              seedStorageBehavior: result.seedStorageBehavior as string,
               ecosystemTypes: getEcosystemTypesString({
                 ...result,
                 ecosystemTypes: (result.ecosystemTypes as Record<string, EcosystemType>[])?.map((r) => r.ecosystemType),

--- a/src/types/Species.ts
+++ b/src/types/Species.ts
@@ -123,23 +123,6 @@ export function getGrowthFormString(species: Species) {
   }
 }
 
-export function getSeedStorageBehaviorString(species: Species) {
-  if (species.seedStorageBehavior) {
-    switch (species.seedStorageBehavior) {
-      case 'Intermediate':
-        return strings.INTERMEDIATE;
-      case 'Orthodox':
-        return strings.ORTHODOX;
-      case 'Recalcitrant':
-        return strings.RECALCITRANT;
-      case 'Unknown':
-        return strings.UNKNOWN;
-    }
-  } else {
-    return undefined;
-  }
-}
-
 export const getEcosystemTypesString = (species: Species) => {
   const result =
     species.ecosystemTypes?.map((et) => ecosystemTypes().find((obj) => obj.label === et)?.value ?? '') ?? [];


### PR DESCRIPTION
- the BE returns translated values in search responses
- FE was attempting to translate those values again and it failed
- removed util to get seed storage behavior
- re util to get growth form it is used in reports and in a valid use-case