### PR TITLE
SW-3799 fix species edit modal clearing data

### DIFF
--- a/src/components/Species/AddSpeciesModal.tsx
+++ b/src/components/Species/AddSpeciesModal.tsx
@@ -63,13 +63,13 @@ export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Elemen
   const classes = useStyles();
   const { open, onClose, initialSpecies } = props;
   const [record, setRecord, onChange] = useForm<Species>(initSpecies());
-  const [scientificNameSearchTerm, setScientificNameSearchTerm] = useState<string>('');
+  const [userSearched, setUserSearched] = useState<boolean>(false);
   const [nameFormatError, setNameFormatError] = useState<string | string[]>('');
   const [optionsForName, setOptionsForName] = useState<string[]>();
   const [optionsForCommonName, setOptionsForCommonName] = useState<string[]>();
   const [newScientificName, setNewScientificName] = useState(false);
   // Debounce search term so that it only gives us latest value if searchTerm has not been updated within last 500ms.
-  const debouncedSearchTerm = useDebounce(scientificNameSearchTerm, 250);
+  const debouncedSearchTerm = useDebounce(record.scientificName, 250);
   const [showWarning, setShowWarning] = useState(false);
 
   const [tooltipLearnMoreModalOpen, setTooltipLearnMoreModalOpen] = useState(false);
@@ -140,9 +140,11 @@ export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Elemen
       }
     };
 
-    getOptionsForTyped();
-    getDetails();
-  }, [debouncedSearchTerm, setRecord]);
+    if (userSearched) {
+      getOptionsForTyped();
+      getDetails();
+    }
+  }, [debouncedSearchTerm, setRecord, userSearched]);
 
   const handleCancel = () => {
     onClose(false);
@@ -177,7 +179,9 @@ export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Elemen
   const onChangeScientificName = (value: string) => {
     setNameFormatError('');
     setNewScientificName(false);
-    setScientificNameSearchTerm(value);
+    if (!userSearched) {
+      setUserSearched(true);
+    }
     onChange('scientificName', value);
   };
 

--- a/src/components/Species/AddSpeciesModal.tsx
+++ b/src/components/Species/AddSpeciesModal.tsx
@@ -63,12 +63,13 @@ export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Elemen
   const classes = useStyles();
   const { open, onClose, initialSpecies } = props;
   const [record, setRecord, onChange] = useForm<Species>(initSpecies());
+  const [scientificNameSearchTerm, setScientificNameSearchTerm] = useState<string>('');
   const [nameFormatError, setNameFormatError] = useState<string | string[]>('');
   const [optionsForName, setOptionsForName] = useState<string[]>();
   const [optionsForCommonName, setOptionsForCommonName] = useState<string[]>();
   const [newScientificName, setNewScientificName] = useState(false);
   // Debounce search term so that it only gives us latest value if searchTerm has not been updated within last 500ms.
-  const debouncedSearchTerm = useDebounce(record.scientificName, 250);
+  const debouncedSearchTerm = useDebounce(scientificNameSearchTerm, 250);
   const [showWarning, setShowWarning] = useState(false);
 
   const [tooltipLearnMoreModalOpen, setTooltipLearnMoreModalOpen] = useState(false);
@@ -120,15 +121,15 @@ export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Elemen
                 return {
                   ...previousRecord,
                   familyName: speciesDetails.familyName,
-                  endangered: speciesDetails.endangered,
+                  endangered: speciesDetails.endangered ?? previousRecord.endangered,
                   commonName: speciesDetails.commonNames[0].name,
                 };
               } else {
                 setOptionsForCommonName(speciesDetails?.commonNames?.map((cN) => cN.name));
                 return {
                   ...previousRecord,
-                  familyName: speciesDetails?.familyName,
-                  endangered: speciesDetails?.endangered,
+                  familyName: speciesDetails?.familyName ?? previousRecord.familyName,
+                  endangered: speciesDetails?.endangered ?? previousRecord.endangered,
                 };
               }
             });
@@ -176,6 +177,7 @@ export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Elemen
   const onChangeScientificName = (value: string) => {
     setNameFormatError('');
     setNewScientificName(false);
+    setScientificNameSearchTerm(value);
     onChange('scientificName', value);
   };
 

--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -718,7 +718,13 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
         onClose={() => setDeleteSpeciesModalOpen(false)}
         onSubmit={deleteSelectedSpecies}
       />
-      <AddSpeciesModal open={editSpeciesModalOpen} onClose={onCloseEditSpeciesModal} initialSpecies={selectedSpecies} />
+      {editSpeciesModalOpen && (
+        <AddSpeciesModal
+          open={editSpeciesModalOpen}
+          onClose={onCloseEditSpeciesModal}
+          initialSpecies={selectedSpecies}
+        />
+      )}
       <ImportSpeciesModal
         open={importSpeciesModalOpen}
         onClose={onCloseImportSpeciesModal}

--- a/src/services/SpeciesService.ts
+++ b/src/services/SpeciesService.ts
@@ -1,5 +1,5 @@
 import { paths } from 'src/api/types/generated-schema';
-import HttpService, { Response } from './HttpService';
+import HttpService, { Response, ServerData } from './HttpService';
 import { Species, SpeciesDetails } from 'src/types/Species';
 import { GetUploadStatusResponsePayload, UploadFileResponse } from 'src/types/File';
 
@@ -54,7 +54,8 @@ type UpdateSpeciesRequestPayload =
 type SpeciesResponsePayload = paths[typeof SPECIES_ENDPOINT]['get']['responses'][200]['content']['application/json'];
 type SpeciesIdResponsePayload =
   paths[typeof SPECIES_ID_ENDPOINT]['get']['responses'][200]['content']['application/json'];
-type SpeciesDetailsResponsePayload = { speciesDetails: SpeciesDetails; status?: 'ok' | 'error' };
+type SpeciesDetailsResponsePayload =
+  paths[typeof SPECIES_DETAILS_ENDPOINT]['get']['responses'][200]['content']['application/json'] & ServerData;
 type SpeciesNamesResponsePayload =
   paths[typeof SPECIES_NAMES_ENDPOINT]['get']['responses'][200]['content']['application/json'];
 
@@ -253,7 +254,7 @@ const getSpeciesDetails = async (scientificName: string): Promise<SpeciesDetails
     {
       params,
     },
-    (data) => ({ speciesDetails: data?.speciesDetails })
+    (data) => ({ speciesDetails: data })
   );
 
   return response;


### PR DESCRIPTION
- add/edit modal was auto searching for the scientific name and updating the form when it was open
- this search was only intended when user actually types something
- updated code to have search trigger after has typed something
- also the species details code was incorrect and returning undefined, fixed that to return valid data
- also added conditional rendering on the modal so we don't have cross contamination issues across last opened species states