### PR TITLE
SW-3127 Replace Endangered with Conservation Category

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -2389,8 +2389,17 @@ export interface components {
     SpeciesLookupDetailsResponsePayload: {
       /** @description List of known common names for the species, if any. */
       commonNames?: components["schemas"]["SpeciesLookupCommonNamePayload"][];
-      /** @description True if the species is known to be endangered, false if the species is known to not be endangered. This value will not be present if the server's taxonomic database doesn't indicate whether or not the species is endangered. */
-      endangered?: boolean;
+      /** @description IUCN Red List conservation category code. */
+      conservationCategory?:
+        | "CR"
+        | "DD"
+        | "EN"
+        | "EW"
+        | "EX"
+        | "LC"
+        | "NE"
+        | "NT"
+        | "VU";
       familyName: string;
       /** @description If this is not the accepted name for the species, the type of problem the name has. Currently, this will always be "Name Is Synonym". */
       problemType?: "Name Misspelled" | "Name Not Found" | "Name Is Synonym";
@@ -2414,6 +2423,17 @@ export interface components {
     };
     SpeciesRequestPayload: {
       commonName?: string;
+      /** @description IUCN Red List conservation category code. */
+      conservationCategory?:
+        | "CR"
+        | "DD"
+        | "EN"
+        | "EW"
+        | "EX"
+        | "LC"
+        | "NE"
+        | "NT"
+        | "VU";
       ecosystemTypes?: (
         | "Boreal forests/Taiga"
         | "Deserts and xeric shrublands"
@@ -2430,7 +2450,6 @@ export interface components {
         | "Tropical and subtropical moist broad leaf forests"
         | "Tundra"
       )[];
-      endangered?: boolean;
       familyName?: string;
       growthForm?:
         | "Tree"
@@ -2456,6 +2475,17 @@ export interface components {
     };
     SpeciesResponseElement: {
       commonName?: string;
+      /** @description IUCN Red List conservation category code. */
+      conservationCategory?:
+        | "CR"
+        | "DD"
+        | "EN"
+        | "EW"
+        | "EX"
+        | "LC"
+        | "NE"
+        | "NT"
+        | "VU";
       ecosystemTypes?: (
         | "Boreal forests/Taiga"
         | "Deserts and xeric shrublands"
@@ -2472,7 +2502,6 @@ export interface components {
         | "Tropical and subtropical moist broad leaf forests"
         | "Tundra"
       )[];
-      endangered?: boolean;
       familyName?: string;
       growthForm?:
         | "Tree"

--- a/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
+++ b/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
@@ -17,10 +17,9 @@ export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesT
     const data: Data = { labels: [], values: [] };
 
     species?.forEach((specie) => {
-      const { speciesCommonName, speciesName, speciesScientificName, totalDead, totalExisting, totalLive } = specie;
+      const { speciesCommonName, speciesName, speciesScientificName, totalPlants } = specie;
 
       const label: string = speciesName ?? speciesCommonName ?? speciesScientificName;
-      const totalPlants: number = totalDead + totalExisting + totalLive;
 
       data.labels.push(label);
       data.values.push(totalPlants);

--- a/src/components/Species/AddSpeciesModal.tsx
+++ b/src/components/Species/AddSpeciesModal.tsx
@@ -1,10 +1,11 @@
 import { Grid } from '@mui/material';
 import { Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import { Dropdown, IconTooltip, MultiSelect } from '@terraware/web-components';
+import { Dropdown, MultiSelect } from '@terraware/web-components';
 import React, { useEffect, useState } from 'react';
 import strings from 'src/strings';
 import {
+  conservationCategories,
   EcosystemType,
   ecosystemTypes,
   growthForms,
@@ -21,7 +22,6 @@ import DialogBox from '../common/DialogBox/DialogBox';
 import Select from '../common/Select/Select';
 import TextField from '../common/Textfield/Textfield';
 import TooltipLearnMoreModal, {
-  LearnMoreModalContentConservationStatus,
   LearnMoreModalContentGrowthForm,
   LearnMoreModalContentSeedStorageBehavior,
   LearnMoreLink,
@@ -121,15 +121,15 @@ export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Elemen
                 return {
                   ...previousRecord,
                   familyName: speciesDetails.familyName,
-                  endangered: speciesDetails.endangered ?? previousRecord.endangered,
                   commonName: speciesDetails.commonNames[0].name,
+                  conservationCategory: speciesDetails.conservationCategory ?? previousRecord.conservationCategory,
                 };
               } else {
                 setOptionsForCommonName(speciesDetails?.commonNames?.map((cN) => cN.name));
                 return {
                   ...previousRecord,
+                  conservationCategory: speciesDetails?.conservationCategory ?? previousRecord.conservationCategory,
                   familyName: speciesDetails?.familyName ?? previousRecord.familyName,
-                  endangered: speciesDetails?.endangered ?? previousRecord.endangered,
                 };
               }
             });
@@ -265,35 +265,20 @@ export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Elemen
           />
         </Grid>
         <Grid item xs={12}>
-          <span>
-            {strings.CONSERVATION_STATUS}
-            <IconTooltip
-              title={
-                <>
-                  {strings.TOOLTIP_SPECIES_CONSERVATION_STATUS}
-                  <LearnMoreLink
-                    onClick={() =>
-                      openTooltipLearnMoreModal({
-                        title: strings.CONSERVATION_STATUS,
-                        content: <LearnMoreModalContentConservationStatus />,
-                      })
-                    }
-                  />
-                </>
-              }
-            />
-          </span>
-          <Checkbox
-            id='Endangered'
-            name='conservationStatus'
-            label={strings.ENDANGERED}
-            onChange={() => onChange('endangered', !record.endangered)}
-            value={record.endangered}
-            className={classes.blockCheckbox}
+          <Dropdown
+            id='conservationCategory'
+            label={strings.CONSERVATION_CATEGORY}
+            aria-label={strings.CONSERVATION_CATEGORY}
+            fullWidth={true}
+            onChange={(value: string) => onChange('conservationCategory', value)}
+            placeholder={strings.SELECT}
+            options={conservationCategories()}
+            selectedValue={record.conservationCategory}
+            tooltipTitle={strings.TOOLTIP_SPECIES_CONSERVATION_CATEGORY}
           />
           <Checkbox
             id='Rare'
-            name='conservationStatus'
+            name='rare'
             label={strings.RARE}
             onChange={() => onChange('rare', !record.rare)}
             value={record.rare}

--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -118,7 +118,14 @@ type SpeciesSearchResultRow = Omit<
   ecosystemTypes?: string[];
 };
 
-const BE_SORTED_FIELDS = ['scientificName', 'commonName', 'familyName', 'growthForm', 'seedStorageBehavior'];
+const BE_SORTED_FIELDS = [
+  'scientificName',
+  'commonName',
+  'conservationCategory',
+  'familyName',
+  'growthForm',
+  'seedStorageBehavior',
+];
 
 export default function SpeciesList({ reloadData, species }: SpeciesListProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
@@ -340,14 +347,7 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
   const getParams = useCallback(() => {
     const params: SearchNodePayload = {
       prefix: 'species',
-      fields: [
-        ...BE_SORTED_FIELDS,
-        'id',
-        'conservationCategory',
-        'rare',
-        'ecosystemTypes.ecosystemType',
-        'organization_id',
-      ],
+      fields: [...BE_SORTED_FIELDS, 'id', 'rare', 'ecosystemTypes.ecosystemType', 'organization_id'],
       search: {
         operation: 'and',
         children: [

--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -27,7 +27,6 @@ import useDeviceInfo from 'src/utils/useDeviceInfo';
 import useSnackbar from 'src/utils/useSnackbar';
 import { isContributor } from 'src/utils/organization';
 import TooltipLearnMoreModal, {
-  LearnMoreModalContentConservationStatus,
   LearnMoreModalContentGrowthForm,
   LearnMoreModalContentSeedStorageBehavior,
   LearnMoreLink,
@@ -37,7 +36,6 @@ import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import { DropdownItem, SortOrder } from '@terraware/web-components';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
 import { PillList, PillListItem, Tooltip } from '@terraware/web-components';
-import { isTrue } from 'src/utils/boolean';
 import FilterGroup, { FilterField } from 'src/components/common/FilterGroup';
 import { SpeciesService } from 'src/services';
 import OptionsMenu from 'src/components/common/OptionsMenu';
@@ -109,9 +107,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-type SpeciesSearchResultRow = Omit<Species, 'growthForm' | 'seedStorageBehavior' | 'ecosystemTypes'> & {
-  conservationStatus?: string;
+type SpeciesSearchResultRow = Omit<
+  Species,
+  'growthForm' | 'seedStorageBehavior' | 'ecosystemTypes' | 'conservationCategory' | 'rare'
+> & {
+  conservationCategory?: string;
   growthForm?: string;
+  rare?: string;
   seedStorageBehavior?: string;
   ecosystemTypes?: string[];
 };
@@ -160,21 +162,6 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
     setTooltipLearnMoreModalOpen(false);
   };
 
-  const getConservationStatusString = (result: { [key: string]: unknown }) => {
-    const endangered = isTrue(result.endangered);
-    const rare = isTrue(result.rare);
-
-    if (endangered && rare) {
-      return strings.RARE_ENDANGERED;
-    } else if (endangered) {
-      return strings.ENDANGERED;
-    } else if (rare) {
-      return strings.RARE;
-    } else {
-      return '';
-    }
-  };
-
   const columns: TableColumnType[] = React.useMemo(() => {
     // No-op to make lint happy so it doesn't think the dependency is unused.
     if (!activeLocale) {
@@ -219,22 +206,16 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
         ),
       },
       {
-        key: 'conservationStatus',
-        name: strings.CONSERVATION_STATUS,
+        key: 'conservationCategory',
+        name: strings.CONSERVATION_CATEGORY,
         type: 'string',
-        tooltipTitle: (
-          <>
-            {strings.TOOLTIP_SPECIES_CONSERVATION_STATUS}
-            <LearnMoreLink
-              onClick={() =>
-                openTooltipLearnMoreModal({
-                  title: strings.CONSERVATION_STATUS,
-                  content: <LearnMoreModalContentConservationStatus />,
-                })
-              }
-            />
-          </>
-        ),
+        tooltipTitle: strings.TOOLTIP_SPECIES_CONSERVATION_CATEGORY,
+      },
+      {
+        key: 'rare',
+        name: strings.RARE,
+        type: 'boolean',
+        tooltipTitle: strings.TOOLTIP_SPECIES_RARE,
       },
       {
         key: 'seedStorageBehavior',
@@ -279,7 +260,8 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
       activeLocale
         ? [
             { name: 'growthForm', label: strings.GROWTH_FORM, type: 'multiple_selection' },
-            { name: 'conservationStatus', label: strings.CONSERVATION_STATUS, type: 'multiple_selection' },
+            { name: 'conservationCategory', label: strings.CONSERVATION_CATEGORY, type: 'multiple_selection' },
+            { name: 'rare', label: strings.RARE, type: 'multiple_selection' },
             { name: 'seedStorageBehavior', label: strings.SEED_STORAGE_BEHAVIOR, type: 'multiple_selection' },
             { name: 'ecosystemTypes.ecosystemType', label: strings.ECOSYSTEM_TYPE, type: 'multiple_selection' },
           ]
@@ -294,7 +276,14 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
     const getApiSearchResults = async () => {
       const searchParams: SearchRequestPayload = {
         prefix: 'species',
-        fields: ['id', 'growthForm', 'seedStorageBehavior', 'ecosystemTypes.ecosystemType'],
+        fields: [
+          'id',
+          'growthForm',
+          'seedStorageBehavior',
+          'ecosystemTypes.ecosystemType',
+          'conservationCategory',
+          'rare',
+        ],
         search: {
           operation: 'and',
           children: [
@@ -327,7 +316,7 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
           return innerAcc;
         }, acc);
       }, {}) as FieldOptionsMap;
-      result.conservationStatus = { partial: false, values: [strings.RARE, strings.ENDANGERED] };
+      result.rare = { partial: false, values: [strings.YES, strings.NO] };
       setFilterOptions(result);
     };
     getApiSearchResults();
@@ -351,7 +340,14 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
   const getParams = useCallback(() => {
     const params: SearchNodePayload = {
       prefix: 'species',
-      fields: [...BE_SORTED_FIELDS, 'id', 'endangered', 'rare', 'ecosystemTypes.ecosystemType', 'organization_id'],
+      fields: [
+        ...BE_SORTED_FIELDS,
+        'id',
+        'conservationCategory',
+        'rare',
+        'ecosystemTypes.ecosystemType',
+        'organization_id',
+      ],
       search: {
         operation: 'and',
         children: [
@@ -401,33 +397,28 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
       });
     }
 
-    if (filters.conservationStatus) {
-      const conservationStatusFilter: FieldNodePayload[] = [];
-      const values = filters.conservationStatus.values as string[];
-      if (values.find((s) => s === strings.RARE)) {
-        const newNode: FieldNodePayload = {
-          operation: 'field',
-          field: 'rare',
-          type: 'Exact',
-          values: [strings.BOOLEAN_TRUE],
-        };
-        conservationStatusFilter.push(newNode);
+    if (filters.rare) {
+      const searchValues: (string | null)[] = [];
+      const selectedValues = filters.rare.values as string[];
+      if (selectedValues.find((s) => s === strings.YES)) {
+        searchValues.push(strings.BOOLEAN_TRUE);
       }
-      if (values.find((s) => s === strings.ENDANGERED)) {
-        const newNode: FieldNodePayload = {
-          operation: 'field',
-          field: 'endangered',
-          type: 'Exact',
-          values: [strings.BOOLEAN_TRUE],
-        };
-        conservationStatusFilter.push(newNode);
+      if (selectedValues.find((s) => s === strings.NO)) {
+        searchValues.push(strings.BOOLEAN_FALSE);
+        searchValues.push(null);
       }
-      params.search.children.push({
-        operation: 'or',
-        children: conservationStatusFilter,
-      });
+      const newNode: FieldNodePayload = {
+        operation: 'field',
+        field: 'rare',
+        type: 'Exact',
+        values: searchValues,
+      };
+      params.search.children.push(newNode);
     }
 
+    if (filters.conservationCategory) {
+      params.search.children.push(filters.conservationCategory);
+    }
     if (filters.growthForm) {
       params.search.children.push(filters.growthForm);
     }
@@ -462,9 +453,8 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
               growthForm: result.growthForm as string,
               seedStorageBehavior: result.seedStorageBehavior as string,
               ecosystemTypes: (result.ecosystemTypes as any[])?.map((et) => et.ecosystemType) as string[],
-              rare: isTrue(result.rare),
-              endangered: isTrue(result.endangered),
-              conservationStatus: getConservationStatusString(result),
+              rare: result.rare === strings.BOOLEAN_TRUE ? 'true' : 'false',
+              conservationCategory: result.conservationCategory as string,
             });
           });
 
@@ -652,15 +642,22 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
 
   const getFilterPillData = (): PillListItem<string>[] => {
     const result = [];
-    if (filters.conservationStatus) {
+    if (filters.conservationCategory) {
       result.push({
-        id: 'conservationStatus',
-        label: strings.CONSERVATION_STATUS,
-        value: filters.conservationStatus.values?.join(', ') ?? '',
-        onRemove: () => onRemoveFilter('conservationStatus'),
+        id: 'conservationCategory',
+        label: strings.CONSERVATION_CATEGORY,
+        value: filters.conservationCategory.values?.join(', ') ?? '',
+        onRemove: () => onRemoveFilter('conservationCategory'),
       });
     }
-
+    if (filters.rare) {
+      result.push({
+        id: 'rare',
+        label: strings.RARE,
+        value: filters.rare.values?.join(', ') ?? '',
+        onRemove: () => onRemoveFilter('rare'),
+      });
+    }
     if (filters.growthForm) {
       result.push({
         id: 'growthForm',

--- a/src/components/TooltipLearnMoreModal/index.tsx
+++ b/src/components/TooltipLearnMoreModal/index.tsx
@@ -95,17 +95,6 @@ export const LearnMoreModalContentGrowthForm = (): JSX.Element => (
   </>
 );
 
-export const LearnMoreModalContentConservationStatus = (): JSX.Element => (
-  <>
-    <p>
-      <strong>{strings.ENDANGERED}:</strong> {strings.LEARN_MORE_CONSERVATION_STATUS_ENDANGERED}
-    </p>
-    <p>
-      <strong>{strings.RARE}:</strong> {strings.LEARN_MORE_CONSERVATION_STATUS_RARE}
-    </p>
-  </>
-);
-
 export const LearnMoreModalContentSeedStorageBehavior = (): JSX.Element => (
   <>
     <p>

--- a/src/services/SpeciesService.ts
+++ b/src/services/SpeciesService.ts
@@ -71,7 +71,7 @@ const createSpecies = async (species: Omit<Species, 'id'>, organizationId: numbe
   const entity: CreateSpeciesRequestPayload = {
     ecosystemTypes: species.ecosystemTypes,
     commonName: species.commonName,
-    endangered: species.endangered,
+    conservationCategory: species.conservationCategory,
     familyName: species.familyName,
     growthForm: species.growthForm,
     organizationId,
@@ -113,7 +113,7 @@ const updateSpecies = async (species: Species, organizationId: number): Promise<
   const entity: UpdateSpeciesRequestPayload = {
     ecosystemTypes: species.ecosystemTypes,
     commonName: species.commonName,
-    endangered: species.endangered,
+    conservationCategory: species.conservationCategory,
     familyName: species.familyName,
     growthForm: species.growthForm,
     organizationId,

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -170,8 +170,7 @@ COMPLETED,Completed
 COMPROMISED_SEEDS,Compromised Seeds
 CONNECT_FAILED,Connect failed
 CONNECTED,Connected
-CONSERV_STATUS,Conserv. Status
-CONSERVATION_STATUS,Conservation Status
+CONSERVATION_CATEGORY,IUCN Conservation Category
 CONTACT_US,Contact Us
 CONTACT_US_DESCRIPTION,Have a question or would like to get in touch with someone from our team? We’re always happy to answer questions and help make sure you are getting the most out of Terraware! You can reach us using this form or by emailing {0}
 CONTACT_US_TO_RESOLVE_ISSUE,Please contact us to resolve this issue.
@@ -303,7 +302,6 @@ END,End
 END_DATE,End Date
 END_DRYING_REMINDER,End-Drying Reminder
 END_DRYING_REMINDER_OFF,End-drying Reminder Off
-ENDANGERED,Endangered
 ENTER_SIX_DIGIT_KEY,Enter 6-digit key
 ENVIRONMENTAL_NOTES,Environmental Notes
 ENVIRONMENTAL_NOTES_PLACEHOLDER,"Important notes about landscape, climate, and environmental conditions"
@@ -425,6 +423,15 @@ INVENTORY_IMPORT_COMPLETE,Inventory data import complete!
 INVENTORY_ONBOARDING_NURSERIES_MSG,Define nurseries assigned to seedlings inventory
 INVENTORY_ONBOARDING_SPECIES_MSG,Define a list of species used in your seedlings inventory
 ISSUE,Issue
+IUCN_EXTINCT,Extinct (EX),IUCN conservation category. Keep the two-letter code as is; only translate the description.
+IUCN_EXTINCT_IN_THE_WILD,Extinct in the Wild (EW),IUCN conservation category. Keep the two-letter code as is; only translate the description.
+IUCN_CRITICALLY_ENDANGERED,Critically Endangered (CR),IUCN conservation category. Keep the two-letter code as is; only translate the description.
+IUCN_ENDANGERED,Endangered (EN),IUCN conservation category. Keep the two-letter code as is; only translate the description.
+IUCN_VULNERABLE,Vulnerable (VU),IUCN conservation category. Keep the two-letter code as is; only translate the description.
+IUCN_NEAR_THREATENED,Near Threatened (NT),IUCN conservation category. Keep the two-letter code as is; only translate the description.
+IUCN_LEAST_CONCERN,Least Concern (LC),IUCN conservation category. Keep the two-letter code as is; only translate the description.
+IUCN_DATA_DEFICIENT,Data Deficient (DD),IUCN conservation category. Keep the two-letter code as is; only translate the description.
+IUCN_NOT_EVALUATED,Not Evaluated (NE),IUCN conservation category. Keep the two-letter code as is; only translate the description.
 KEEP_ORIGINAL,Keep Original
 KEY_BELONGS_TO_ANOTHER_SEED_BANK,Key is associated with another seed bank.
 KEY_LESSONS,Key Lessons Learned
@@ -446,8 +453,6 @@ LATITUDE_LONGITUDE,"Latitude, Longitude"
 LB,lb
 LB_POUNDS,lb (pounds)
 LEARN_MORE,Learn more
-LEARN_MORE_CONSERVATION_STATUS_ENDANGERED,Species that are rare and whose wild populations have a high risk of extinction; see also any local definitions.
-LEARN_MORE_CONSERVATION_STATUS_RARE,"Species with limited wild population sizes, often found in isolated geographical locations; may meet criteria for endangered or threatened status but have not yet been legally listed or assessed."
 LEARN_MORE_GROWTH_FORM_FERN,"A non-flowering vascular plant that reproduces by spores, in the plant division Pteridophyta."
 LEARN_MORE_GROWTH_FORM_FORB,"A herbaceous (non-woody) plant that is NOT a graminoid (grass, sedge, or rush)."
 LEARN_MORE_GROWTH_FORM_FUNGUS,"Usually a eukaryotic organism (non-plant) that is heterotrophic (cannot produce its own food), grows in filaments (hyphae), and produces spores."
@@ -744,7 +749,6 @@ PV_SYSTEM,PV system
 QUANTIFY,Quantify
 QUANTITY,Quantity
 RARE,Rare
-RARE_ENDANGERED,"Rare, Endangered"
 REACH_OUT_TO_ADMIN_TITLE,Please reach out to an administrator from your organization.
 READY,Ready
 READY_QUANTITY,Ready Quantity
@@ -1057,9 +1061,10 @@ TOOLTIP_GERMINATING_QUANTITY,Germinating indicates that seedlings have not yet e
 TOOLTIP_NOT_READY_QUANTITY,What determines a plant as “not ready” is up to your team and is often species specific. For example: size of plant or amount of time acclimated.
 TOOLTIP_READY_QUANTITY,What determines a plant as “ready” is up to your team and is often species specific. For example: size of plant or amount of time acclimated.
 TOOLTIP_SCIENTIFIC_NAME,The binomial Latin name (genus + species) currently accepted in the botanical literature.
-TOOLTIP_SPECIES_CONSERVATION_STATUS,"A species' risk of extinction, usually a legal designation or a Red List assessment."
+TOOLTIP_SPECIES_CONSERVATION_CATEGORY,"IUCN Red List conservation category."
 TOOLTIP_SPECIES_FAMILY,The scientific name of the plant family currently accepted in the botanical literature.
 TOOLTIP_SPECIES_GROWTH_FORM,A structural category consisting of individuals or species of the same general habit of growth but not necessarily related.
+TOOLTIP_SPECIES_RARE,"Species with limited wild population sizes, often found in isolated geographical locations; may meet criteria for endangered or threatened status but have not yet been legally listed or assessed."
 TOOLTIP_SPECIES_SEED_STORAGE_BEHAVIOR,The capacity of seeds to survive desiccation and temperatures to levels necessary for ex site (off site) storage.
 TOOLTIP_TIME_ZONE_MY_ACCOUNT,We use time zones to display notifications in your local time. Select the time zone that applies to you.
 TOOLTIP_TIME_ZONE_NURSERY,We use time zones for notifications and to determine the correct date for your region. Select the time zone that applies to this nursery. All work done in this nursery will use this time zone.

--- a/src/strings/csv/es.csv
+++ b/src/strings/csv/es.csv
@@ -170,8 +170,6 @@ COMPLETED,Completado
 COMPROMISED_SEEDS,Semillas comprometidas
 CONNECT_FAILED,La conexión ha fallado
 CONNECTED,Conectado
-CONSERV_STATUS,Estado de conservación
-CONSERVATION_STATUS,Estado de conservación
 CONTACT_US,Contáctenos
 CONTACT_US_DESCRIPTION,¿Tiene una pregunta o desea ponerse en contacto con un miembro de nuestro equipo? ¡Siempre estamos dispuestos a responder sus preguntas y a asegurarnos de que pueda sacarle provecho a Terraware! Puede ponerse en contacto con nosotros con este formulario o enviando un correo electrónico a {0}
 CONTACT_US_TO_RESOLVE_ISSUE,Contáctenos para resolver este problema.
@@ -303,7 +301,6 @@ END,Fin
 END_DATE,Fecha de finalización
 END_DRYING_REMINDER,Recordatorio de final de secado
 END_DRYING_REMINDER_OFF,Recordatorio de final de secado desactivado
-ENDANGERED,En peligro de extinción
 ENTER_SIX_DIGIT_KEY,Introduzca la clave de 6 dígitos
 ENVIRONMENTAL_NOTES,Notas medioambientales
 ENVIRONMENTAL_NOTES_PLACEHOLDER,"Notas importantes sobre el paisaje, el clima y las condiciones ambientales"
@@ -446,8 +443,6 @@ LATITUDE_LONGITUDE,"Latitud, longitud"
 LB,lb
 LB_POUNDS,lb (libras)
 LEARN_MORE,Más información
-LEARN_MORE_CONSERVATION_STATUS_ENDANGERED,Especies poco comunes y cuyas poblaciones silvestres corren un alto riesgo de extinción; consulte también las definiciones locales.
-LEARN_MORE_CONSERVATION_STATUS_RARE,"Especies con poblaciones silvestres de tamaño limitado, que a menudo se encuentran en lugares geográficos aislados; pueden cumplir los criterios de situación en peligro o bajo amenaza pero aún no se han incluido o evaluado legalmente."
 LEARN_MORE_GROWTH_FORM_FERN,"Planta vascular que no florece y se reproduce mediante esporas, que pertenece al grupo de plantas de las pteridofitas."
 LEARN_MORE_GROWTH_FORM_FORB,"Planta herbácea (no leñosa) que NO es una gramínea (césped, juncia o junco)."
 LEARN_MORE_GROWTH_FORM_FUNGUS,"Usualmente, un organismo eucariota (no vegetal) que es heterótrofo (que no puede producir su propio alimento), que crece en filamentos (hifas) y que produce esporas."
@@ -1057,7 +1052,6 @@ TOOLTIP_GERMINATING_QUANTITY,En germinación indica que las plántulas aún no h
 TOOLTIP_NOT_READY_QUANTITY,"Lo que determina que una planta figure como ""no lista"" depende de su equipo y suele ser específico de cada especie. Por ejemplo, en función del tamaño de la planta o el tiempo de aclimatación."
 TOOLTIP_READY_QUANTITY,"Lo que determina que una planta figure como ""lista"" depende de su equipo y suele ser específico de cada especie. Por ejemplo, en función del tamaño de la planta o el tiempo de aclimatación."
 TOOLTIP_SCIENTIFIC_NAME,El nombre latino binomial (género + especie) aceptado en la actualidad en la bibliografía botánica.
-TOOLTIP_SPECIES_CONSERVATION_STATUS,"Riesgo de extinción de una especie, normalmente una designación legal o una valoración de la Lista Roja."
 TOOLTIP_SPECIES_FAMILY,El nombre científico de la familia de la planta aceptado en la actualidad en la bibliografía botánica.
 TOOLTIP_SPECIES_GROWTH_FORM,Una categoría estructural compuesta por individuos o especies del mismo hábito general de crecimiento pero no necesariamente relacionados.
 TOOLTIP_SPECIES_SEED_STORAGE_BEHAVIOR,La capacidad de las semillas para sobrevivir a la desecación y a las temperaturas hasta los niveles necesarios para el almacenamiento ex situ (fuera del sitio).

--- a/src/types/Species.ts
+++ b/src/types/Species.ts
@@ -4,7 +4,7 @@ import strings from 'src/strings';
 export type Species = {
   id: number;
   commonName?: string;
-  endangered?: boolean;
+  conservationCategory?: 'CR' | 'DD' | 'EN' | 'EW' | 'EX' | 'LC' | 'NE' | 'NT' | 'VU';
   familyName?: string;
   growthForm?: 'Tree' | 'Shrub' | 'Forb' | 'Graminoid' | 'Fern' | 'Fungus' | 'Lichen' | 'Moss';
   scientificName: string;
@@ -38,6 +38,20 @@ export type SpeciesProblemElement = {
   suggestedValue?: string;
 };
 
+export function conservationCategories() {
+  return [
+    { label: strings.IUCN_EXTINCT, value: 'EX' },
+    { label: strings.IUCN_EXTINCT_IN_THE_WILD, value: 'EW' },
+    { label: strings.IUCN_CRITICALLY_ENDANGERED, value: 'CR' },
+    { label: strings.IUCN_ENDANGERED, value: 'EN' },
+    { label: strings.IUCN_VULNERABLE, value: 'VU' },
+    { label: strings.IUCN_NEAR_THREATENED, value: 'NT' },
+    { label: strings.IUCN_LEAST_CONCERN, value: 'LC' },
+    { label: strings.IUCN_DATA_DEFICIENT, value: 'DD' },
+    { label: strings.IUCN_NOT_EVALUATED, value: 'NE' },
+  ];
+}
+
 export function growthForms(useLocalizedValues = false) {
   return [
     { label: strings.TREE, value: useLocalizedValues ? strings.TREE : 'Tree' },
@@ -57,13 +71,6 @@ export function storageBehaviors(useLocalizedValues = false) {
     { label: strings.RECALCITRANT, value: useLocalizedValues ? strings.RECALCITRANT : 'Recalcitrant' },
     { label: strings.INTERMEDIATE, value: useLocalizedValues ? strings.INTERMEDIATE : 'Intermediate' },
     { label: strings.UNKNOWN, value: useLocalizedValues ? strings.UNKNOWN : 'Unknown' },
-  ];
-}
-
-export function conservationStatuses() {
-  return [
-    { label: strings.RARE, value: 'Rare' },
-    { label: strings.ENDANGERED, value: 'Endangered' },
   ];
 }
 


### PR DESCRIPTION
Remove the "endangered" flag from the species data and replace it with
the IUCN conservation category.

The change affects a few parts of the species UI:

* The table view now has separate columns for IUCN Conservation Category
  and Rare; previously the two values were combined in one column.

* The filter list also breaks these two fields out into separate settings.

* The add/edit species dialog now has a dropdown for conservation category.
  The checkbox for "Rare" is still present.

* The "conservation status" grouping is gone since it only existed to tie
  Endangered and Rare together.
