### PR TITLE
SW-3818 Add new growth forms

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -2459,7 +2459,12 @@ export interface components {
         | "Fern"
         | "Fungus"
         | "Lichen"
-        | "Moss";
+        | "Moss"
+        | "Vine"
+        | "Liana"
+        | "Shrub/Tree"
+        | "Subshrub"
+        | "Multiple Forms";
       /**
        * Format: int64
        * @description Which organization's species list to update.
@@ -2511,7 +2516,12 @@ export interface components {
         | "Fern"
         | "Fungus"
         | "Lichen"
-        | "Moss";
+        | "Moss"
+        | "Vine"
+        | "Liana"
+        | "Shrub/Tree"
+        | "Subshrub"
+        | "Multiple Forms";
       /** Format: int64 */
       id: number;
       problems?: components["schemas"]["SpeciesProblemElement"][];

--- a/src/components/Species/AddSpeciesModal.tsx
+++ b/src/components/Species/AddSpeciesModal.tsx
@@ -27,7 +27,7 @@ import TooltipLearnMoreModal, {
   LearnMoreLink,
   TooltipLearnMoreModalData,
 } from 'src/components/TooltipLearnMoreModal';
-import { useOrganization } from 'src/providers/hooks';
+import { useLocalization, useOrganization } from 'src/providers/hooks';
 import { SpeciesService } from 'src/services';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -58,6 +58,7 @@ function initSpecies(species?: Species): Species {
 }
 
 export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Element {
+  const { activeLocale } = useLocalization();
   const { selectedOrganization } = useOrganization();
   const organizationId = selectedOrganization.id;
   const classes = useStyles();
@@ -290,7 +291,7 @@ export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Elemen
             id='growthForm'
             selectedValue={record.growthForm}
             onChange={(value) => onChange('growthForm', value)}
-            options={growthForms()}
+            options={growthForms(activeLocale)}
             label={strings.GROWTH_FORM}
             aria-label={strings.GROWTH_FORM}
             placeholder={strings.SELECT}

--- a/src/components/TooltipLearnMoreModal/index.tsx
+++ b/src/components/TooltipLearnMoreModal/index.tsx
@@ -87,12 +87,10 @@ export const LearnMoreModalContentGrowthForm = (): JSX.Element => {
     [strings.MULTIPLE_FORMS, strings.LEARN_MORE_GROWTH_FORM_MULTIPLE_FORMS],
   ]
     .sort((a, b) => collator.compare(a[0], b[0]))
-    .map((x) => (
-      <>
-        <p>
-          <strong>{x[0]}:</strong> {x[1]}
-        </p>
-      </>
+    .map(([name, description], index) => (
+      <p key={`growthForm-${index}`}>
+        <strong>{name}:</strong> {description}
+      </p>
     ));
 
   return <>{elements}</>;

--- a/src/components/TooltipLearnMoreModal/index.tsx
+++ b/src/components/TooltipLearnMoreModal/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import strings from 'src/strings';
 import Button from '../common/button/Button';
 import DialogBox from '../common/DialogBox/DialogBox';
+import { useLocalization } from 'src/providers';
 
 const useStyles = makeStyles((theme: Theme) => ({
   spacing: {
@@ -66,34 +67,36 @@ export const LearnMoreLink = (props: { onClick: () => void }): JSX.Element => {
   );
 };
 
-export const LearnMoreModalContentGrowthForm = (): JSX.Element => (
-  <>
-    <p>
-      <strong>{strings.FERN}:</strong> {strings.LEARN_MORE_GROWTH_FORM_FERN}
-    </p>
-    <p>
-      <strong>{strings.GRAMINOID}:</strong> {strings.LEARN_MORE_GROWTH_FORM_GRAMINOID}
-    </p>
-    <p>
-      <strong>{strings.FORB}:</strong> {strings.LEARN_MORE_GROWTH_FORM_FORB}
-    </p>
-    <p>
-      <strong>{strings.SHRUB}:</strong> {strings.LEARN_MORE_GROWTH_FORM_SHRUB}
-    </p>
-    <p>
-      <strong>{strings.TREE}:</strong> {strings.LEARN_MORE_GROWTH_FORM_TREE}
-    </p>
-    <p>
-      <strong>{strings.FUNGUS}:</strong> {strings.LEARN_MORE_GROWTH_FORM_FUNGUS}
-    </p>
-    <p>
-      <strong>{strings.LICHEN}:</strong> {strings.LEARN_MORE_GROWTH_FORM_LICHEN}
-    </p>
-    <p>
-      <strong>{strings.MOSS}:</strong> {strings.LEARN_MORE_GROWTH_FORM_MOSS}
-    </p>
-  </>
-);
+export const LearnMoreModalContentGrowthForm = (): JSX.Element => {
+  const { activeLocale } = useLocalization();
+  const collator = new Intl.Collator(activeLocale || undefined);
+
+  const elements: JSX.Element[] = [
+    [strings.FERN, strings.LEARN_MORE_GROWTH_FORM_FERN],
+    [strings.GRAMINOID, strings.LEARN_MORE_GROWTH_FORM_GRAMINOID],
+    [strings.FORB, strings.LEARN_MORE_GROWTH_FORM_FORB],
+    [strings.SHRUB, strings.LEARN_MORE_GROWTH_FORM_SHRUB],
+    [strings.TREE, strings.LEARN_MORE_GROWTH_FORM_TREE],
+    [strings.FUNGUS, strings.LEARN_MORE_GROWTH_FORM_FUNGUS],
+    [strings.LICHEN, strings.LEARN_MORE_GROWTH_FORM_LICHEN],
+    [strings.MOSS, strings.LEARN_MORE_GROWTH_FORM_MOSS],
+    [strings.VINE, strings.LEARN_MORE_GROWTH_FORM_VINE],
+    [strings.LIANA, strings.LEARN_MORE_GROWTH_FORM_LIANA],
+    [strings.SHRUB_TREE, strings.LEARN_MORE_GROWTH_FORM_SHRUB_TREE],
+    [strings.SUBSHRUB, strings.LEARN_MORE_GROWTH_FORM_SUBSHRUB],
+    [strings.MULTIPLE_FORMS, strings.LEARN_MORE_GROWTH_FORM_MULTIPLE_FORMS],
+  ]
+    .sort((a, b) => collator.compare(a[0], b[0]))
+    .map((x) => (
+      <>
+        <p>
+          <strong>{x[0]}:</strong> {x[1]}
+        </p>
+      </>
+    ));
+
+  return <>{elements}</>;
+};
 
 export const LearnMoreModalContentSeedStorageBehavior = (): JSX.Element => (
   <>

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -458,15 +458,21 @@ LEARN_MORE_GROWTH_FORM_FERN,"A non-flowering vascular plant that reproduces by s
 LEARN_MORE_GROWTH_FORM_FORB,"A herbaceous (non-woody) plant that is NOT a graminoid (grass, sedge, or rush)."
 LEARN_MORE_GROWTH_FORM_FUNGUS,"Usually a eukaryotic organism (non-plant) that is heterotrophic (cannot produce its own food), grows in filaments (hyphae), and produces spores."
 LEARN_MORE_GROWTH_FORM_GRAMINOID,"A herbaceous (non-woody) plant with a grass-like morphology, that is elongated culms with long, blade-like leaves, in the grass, sedge, or rush family."
+LEARN_MORE_GROWTH_FORM_LIANA,"A climbing plant, often found in tropical rainforests, that hangs from trees."
 LEARN_MORE_GROWTH_FORM_LICHEN,"A symbiotic cluster of fungus and alga, fungus being the dominant partner, lending to its thallus shape and fruiting body."
 LEARN_MORE_GROWTH_FORM_MOSS,"A non-vascular flowerless plant typically formed as dense green clumps or mats, often in damp or shady locations."
+LEARN_MORE_GROWTH_FORM_MULTIPLE_FORMS,A plant that can grow in more than one form.
 LEARN_MORE_GROWTH_FORM_SHRUB,A woody plant which is smaller than a tree and has several main stems arising at or near the ground.
+LEARN_MORE_GROWTH_FORM_SHRUB_TREE,A plant that can be in the form of either a shrub or a tree.
+LEARN_MORE_GROWTH_FORM_SUBSHRUB,"A dwarf shrub, usually only woody at its base."
 LEARN_MORE_GROWTH_FORM_TREE,"A woody perennial plant, typically having a single stem or trunk growing to a considerable height and bearing lateral branches at some distance from the ground."
+LEARN_MORE_GROWTH_FORM_VINE,A climbing or trailing plant with a woody stem.
 LEARN_MORE_SEED_STORAGE_BEHAVIOR_INTERMEDIATE,"Seeds are between orthodox and recalcitrant seeds in their behavior; may include tolerating partial desiccation, tolerating cool but not freezing temperatures, or being short-lived regardless of storage conditions."
 LEARN_MORE_SEED_STORAGE_BEHAVIOR_ORTHODOX,Seeds tolerate levels of desiccation required for frozen storage (5-8% moisture content) and temperatures of -20°C or lower.
 LEARN_MORE_SEED_STORAGE_BEHAVIOR_RECALCITRANT,Seeds do not tolerate levels of desiccation required for ex situ (off-site) conservation.
 LEAVE_AND_SAVE,Leave and Save
 LEAVE_ORGANIZATION,Leave Organization
+LIANA,Liana,A type of plant.
 LICHEN,Lichen
 LIGHT,Light
 LIST,List
@@ -531,6 +537,7 @@ MORTALITY_RATE_PERCENT_REQUIRED,Mortality Rate (%) *
 MOSS,Moss
 MOST_RECENT_PERCENTAGE_VIABILITY,Most Recent % Viability
 MOVE,Move
+MULTIPLE_FORMS,Multiple Forms,"Describes a plant that can grow in more than one form, e.g., both a shrub and a forb."
 MY_ACCOUNT,My Account
 MY_ACCOUNT_DESC,Manage your account information.
 MY_ACCOUNT_NOTIFICATIONS_DESC,Notifications alert you when there are important updates about your organizations. You will receive them through email.
@@ -948,6 +955,7 @@ SET_UP_YOUR_SENSOR_KIT,Set Up Your Sensor Kit
 SET_UP_YOUR_SENSOR_KIT_MSG,"If your seed bank was built by Terraformation, it is equipped with a sensor kit that you can remotely monitor things like the seed bank's temperature and humidity. To set this up, you'll need to connect your seed bank to the Terraware web app. This may take up to 30 minutes."
 SETTINGS,Settings
 SHRUB,Shrub
+SHRUB_TREE,Shrub/Tree
 SILVOPASTURE,Silvopasture
 SITE,Site
 SITE_DETAIL,Site Detail
@@ -1010,6 +1018,7 @@ SUBMITTED_BY,Submitted By
 SUBSET_COUNT,Subset Count
 SUBSET_WEIGHT,Weight of Seed Subset
 SUBSET_WEIGHT_ERROR,Subset weight should be less than seed weight
+SUBSHRUB,Subshrub
 SUBSTRATE,Substrate
 SUBTITLE_GET_STARTED,"To get started, please create your organization now. You'll also be able to set up and manage information on people and species."
 SUBZONE,Subzone
@@ -1174,6 +1183,7 @@ VIABILITY_TREATMENT,Viability Treatment
 VIEW,View
 VIEW_ACCESSION,View accession
 VIEW_SITES_ZONES_SUBZONES,"View Sites, Zones, and Subzones on a map."
+VINE,Vine,A type of plant.
 WAITING_TO_DOWNLOAD,Waiting to download...
 WATTS_VALUE,{0}W
 WEIGHT_GRAMS,Weight (g)

--- a/src/types/Species.ts
+++ b/src/types/Species.ts
@@ -6,7 +6,7 @@ export type Species = {
   commonName?: string;
   conservationCategory?: 'CR' | 'DD' | 'EN' | 'EW' | 'EX' | 'LC' | 'NE' | 'NT' | 'VU';
   familyName?: string;
-  growthForm?: 'Tree' | 'Shrub' | 'Forb' | 'Graminoid' | 'Fern' | 'Fungus' | 'Lichen' | 'Moss';
+  growthForm?: GrowthForm;
   scientificName: string;
   rare?: boolean;
   seedStorageBehavior?: 'Orthodox' | 'Recalcitrant' | 'Intermediate' | 'Unknown';
@@ -30,6 +30,21 @@ export type EcosystemType =
   | 'Tropical and subtropical moist broad leaf forests'
   | 'Tundra';
 
+export type GrowthForm =
+  | 'Tree'
+  | 'Shrub'
+  | 'Forb'
+  | 'Graminoid'
+  | 'Fern'
+  | 'Fungus'
+  | 'Lichen'
+  | 'Moss'
+  | 'Vine'
+  | 'Liana'
+  | 'Shrub/Tree'
+  | 'Subshrub'
+  | 'Multiple Forms';
+
 export type SpeciesProblemElement = {
   id: number;
   field: 'Scientific Name';
@@ -52,17 +67,24 @@ export function conservationCategories() {
   ];
 }
 
-export function growthForms(useLocalizedValues = false) {
+export function growthForms(activeLocale: string | null) {
+  const collator = new Intl.Collator(activeLocale || undefined);
+
   return [
-    { label: strings.TREE, value: useLocalizedValues ? strings.TREE : 'Tree' },
-    { label: strings.SHRUB, value: useLocalizedValues ? strings.SHRUB : 'Shrub' },
-    { label: strings.FORB, value: useLocalizedValues ? strings.FORB : 'Forb' },
-    { label: strings.GRAMINOID, value: useLocalizedValues ? strings.GRAMINOID : 'Graminoid' },
-    { label: strings.FERN, value: useLocalizedValues ? strings.FERN : 'Fern' },
-    { label: strings.FUNGUS, value: useLocalizedValues ? strings.FUNGUS : 'Fungus' },
-    { label: strings.LICHEN, value: useLocalizedValues ? strings.LICHEN : 'Lichen' },
-    { label: strings.MOSS, value: useLocalizedValues ? strings.MOSS : 'Moss' },
-  ];
+    { label: strings.FERN, value: 'Fern' },
+    { label: strings.FORB, value: 'Forb' },
+    { label: strings.FUNGUS, value: 'Fungus' },
+    { label: strings.GRAMINOID, value: 'Graminoid' },
+    { label: strings.LIANA, value: 'Liana' },
+    { label: strings.LICHEN, value: 'Lichen' },
+    { label: strings.MOSS, value: 'Moss' },
+    { label: strings.MULTIPLE_FORMS, value: 'Multiple Forms' },
+    { label: strings.SHRUB, value: 'Shrub' },
+    { label: strings.SHRUB_TREE, value: 'Shrub/Tree' },
+    { label: strings.SUBSHRUB, value: 'Subshrub' },
+    { label: strings.TREE, value: 'Tree' },
+    { label: strings.VINE, value: 'Vine' },
+  ].sort((a, b) => collator.compare(a.label, b.label));
 }
 
 export function storageBehaviors(useLocalizedValues = false) {
@@ -116,14 +138,24 @@ export function getGrowthFormString(species: Species) {
         return strings.FUNGUS;
       case 'Graminoid':
         return strings.GRAMINOID;
+      case 'Liana':
+        return strings.LIANA;
       case 'Lichen':
         return strings.LICHEN;
       case 'Moss':
         return strings.MOSS;
+      case 'Multiple Forms':
+        return strings.MULTIPLE_FORMS;
       case 'Shrub':
         return strings.SHRUB;
+      case 'Shrub/Tree':
+        return strings.SHRUB_TREE;
+      case 'Subshrub':
+        return strings.SUBSHRUB;
       case 'Tree':
         return strings.TREE;
+      case 'Vine':
+        return strings.VINE;
     }
   } else {
     return undefined;


### PR DESCRIPTION
The forestry team requested some new growth forms; add them.

Start sorting the list of growth forms in drop-down menus and the
Learn More popup to make it easier for users to find the growth form
they're looking for, since the list is now too long to take in at a
glance all at once.
