### PR TITLE
SW-3127 Add link to IUCN categories page

### DIFF
--- a/src/components/Species/AddSpeciesModal.tsx
+++ b/src/components/Species/AddSpeciesModal.tsx
@@ -275,7 +275,18 @@ export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Elemen
             placeholder={strings.SELECT}
             options={conservationCategories()}
             selectedValue={record.conservationCategory}
-            tooltipTitle={strings.TOOLTIP_SPECIES_CONSERVATION_CATEGORY}
+            tooltipTitle={
+              <>
+                {`${strings.TOOLTIP_SPECIES_CONSERVATION_CATEGORY} `}
+                <a
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  href='https://www.iucnredlist.org/resources/categories-and-criteria'
+                >
+                  {strings.LEARN_MORE}
+                </a>
+              </>
+            }
           />
           <Checkbox
             id='Rare'

--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -216,7 +216,18 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
         key: 'conservationCategory',
         name: strings.CONSERVATION_CATEGORY,
         type: 'string',
-        tooltipTitle: strings.TOOLTIP_SPECIES_CONSERVATION_CATEGORY,
+        tooltipTitle: (
+          <>
+            {`${strings.TOOLTIP_SPECIES_CONSERVATION_CATEGORY} `}
+            <a
+              target='_blank'
+              rel='noopener noreferrer'
+              href='https://www.iucnredlist.org/resources/categories-and-criteria'
+            >
+              {strings.LEARN_MORE}
+            </a>
+          </>
+        ),
       },
       {
         key: 'rare',


### PR DESCRIPTION
Add a "Learn More" link to the IUCN Conservation Category tooltip
that opens the landing page for the official IUCN Red List
Categories and Criteria documentation.
