### PR TITLE
SW-3683 Stop using /api/v1/seedbank/values/all

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -245,9 +245,6 @@ export interface paths {
   "/api/v1/seedbank/values": {
     post: operations["listFieldValues"];
   };
-  "/api/v1/seedbank/values/all": {
-    post: operations["listAllFieldValues"];
-  };
   "/api/v1/species": {
     get: operations["listSpecies"];
     post: operations["createSpecies"];
@@ -1666,17 +1663,6 @@ export interface components {
     } & {
       coordinates: unknown;
       type: unknown;
-    };
-    ListAllFieldValuesRequestPayload: {
-      fields: string[];
-      /** Format: int64 */
-      organizationId: number;
-    };
-    ListAllFieldValuesResponsePayload: {
-      results: {
-        [key: string]: components["schemas"]["AllFieldValuesPayload"];
-      };
-      status: components["schemas"]["SuccessOrError"];
     };
     ListAssignedPlotsResponsePayload: {
       plots: components["schemas"]["AssignedPlotPayload"][];
@@ -4831,21 +4817,6 @@ export interface operations {
     requestBody: {
       content: {
         "application/json": components["schemas"]["ListFieldValuesRequestPayload"];
-      };
-    };
-  };
-  listAllFieldValues: {
-    responses: {
-      /** OK */
-      200: {
-        content: {
-          "application/json": components["schemas"]["ListAllFieldValuesResponsePayload"];
-        };
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ListAllFieldValuesRequestPayload"];
       };
     };
   };

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -4,11 +4,7 @@ import { makeStyles } from '@mui/styles';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import useQuery from '../../../utils/useQuery';
-import SeedBankService, {
-  DEFAULT_SEED_SEARCH_FILTERS,
-  AllFieldValuesMap,
-  FieldValuesMap,
-} from 'src/services/SeedBankService';
+import SeedBankService, { DEFAULT_SEED_SEARCH_FILTERS, FieldValuesMap } from 'src/services/SeedBankService';
 import { SearchNodePayload, SearchResponseElement, SearchCriteria, SearchSortOrder } from 'src/types/Search';
 import Button from 'src/components/common/button/Button';
 import { BaseTable as Table } from 'src/components/common/table';
@@ -194,7 +190,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
    * keys: all single and multi select search fields.
    * values: all the existing values that the field has in the database, for all accessions.
    */
-  const [fieldOptions, setFieldOptions] = useState<AllFieldValuesMap | null>();
+  const [fieldOptions, setFieldOptions] = useState<FieldValuesMap | null>();
   /*
    * availableFieldOptions is a list of records
    * keys: all single and multi select search fields.
@@ -444,7 +440,11 @@ export default function Database(props: DatabaseProps): JSX.Element {
 
       const populateFieldOptions = async () => {
         const singleAndMultiChoiceFields = filterSelectFields(searchColumns);
-        const allValues = await SeedBankService.getAllFieldValues(singleAndMultiChoiceFields, selectedOrganization.id);
+        const allValues = await SeedBankService.searchFieldValues(
+          singleAndMultiChoiceFields,
+          {},
+          selectedOrganization.id
+        );
 
         if (activeRequests) {
           setFieldOptions(allValues);

--- a/src/services/SeedBankService.ts
+++ b/src/services/SeedBankService.ts
@@ -14,17 +14,11 @@ import { getPromisesResponse } from './utils';
 const SUMMARY_ENDPOINT = '/api/v1/seedbank/summary';
 const STORAGE_LOCATIONS_ENDPOINT = '/api/v1/seedbank/storageLocations';
 const ACCESSIONS_ENDPOINT = '/api/v2/seedbank/accessions';
-const ALL_FIELD_VALUES_ENDPOINT = '/api/v1/seedbank/values/all';
 const FIELD_VALUES_ENDPOINT = '/api/v1/seedbank/values';
 const ACCESSIONS_TEMPLATE_ENDPOINT = '/api/v2/seedbank/accessions/uploads/template';
 const ACCESSIONS_UPLOADS_ENDPOINT = '/api/v2/seedbank/accessions/uploads';
 const ACCESSIONS_UPLOAD_STATUS_ENDPOINT = '/api/v2/seedbank/accessions/uploads/{uploadId}';
 const ACCESSIONS_UPLOAD_RESOLVE_ENDPOINT = '/api/v2/seedbank/accessions/uploads/{uploadId}/resolve';
-
-type ListAllFieldValuesRequestPayload =
-  paths[typeof ALL_FIELD_VALUES_ENDPOINT]['post']['requestBody']['content']['application/json'];
-type ListAllFieldValuesResponsePayload =
-  paths[typeof ALL_FIELD_VALUES_ENDPOINT]['post']['responses'][200]['content']['application/json'];
 
 type ValuesPostRequestBody = paths[typeof FIELD_VALUES_ENDPOINT]['post']['requestBody']['content']['application/json'];
 type ValuesPostResponse = paths[typeof FIELD_VALUES_ENDPOINT]['post']['responses'][200]['content']['application/json'];
@@ -32,7 +26,6 @@ type ValuesPostResponse = paths[typeof FIELD_VALUES_ENDPOINT]['post']['responses
 type StorageLocationsResponsePayload =
   paths[typeof STORAGE_LOCATIONS_ENDPOINT]['get']['responses'][200]['content']['application/json'];
 
-export type AllFieldValuesMap = ListAllFieldValuesResponsePayload['results'];
 export type FieldValuesMap = ValuesPostResponse['results'];
 export const DEFAULT_SEED_SEARCH_FILTERS = {};
 export const DEFAULT_SEED_SEARCH_SORT_ORDER = { field: 'receivedDate', direction: 'Descending' } as SearchSortOrder;
@@ -129,39 +122,6 @@ const searchAccessions = async ({
 };
 
 /**
- * listAllFieldValues() is a helper function for INTERNAL USE ONLY.
- * DOES NOT DO ANY ERROR HANDLING.
- */
-const listAllFieldValues = async (
-  entity: ListAllFieldValuesRequestPayload
-): Promise<ListAllFieldValuesResponsePayload> => {
-  return (await HttpService.root(ALL_FIELD_VALUES_ENDPOINT).post({ entity })).data as ListAllFieldValuesResponsePayload;
-};
-
-/**
- * getAllFieldValues() returns all the possible values associated with the requested accession fields.
- * This function does not filter based on which values are currently being used by existing accessions.
- * Returns null if the API request failed.
- *
- * For example, if one of the requested field names was 'stage', this function's return value would
- * include all accession stage options: [dried, drying, in storage, nursery, pending, processed,
- * processing, withdrawn] even if only some stages such as [pending, processed] were being used by
- * existing accessions in the given facility. This example simplifies the input and return type details;
- * see the type definitions for more precise information.
- */
-const getAllFieldValues = async (fields: string[], organizationId: number): Promise<AllFieldValuesMap | null> => {
-  try {
-    const params: ListAllFieldValuesRequestPayload = {
-      fields,
-      organizationId,
-    };
-    return (await listAllFieldValues(params)).results;
-  } catch {
-    return null;
-  }
-};
-
-/**
  * searchFieldValues() returns values for the specified fields, given that those values are associated
  * with an accession that match the given search criteria. If no search criteria is specified, the default
  * "search" will be "all accession associated with the given organizationId".
@@ -190,13 +150,9 @@ const searchFieldValues = async (
  */
 const getCollectors = async (organizationId: number): Promise<string[] | undefined> => {
   try {
-    const params: ListAllFieldValuesRequestPayload = {
-      organizationId,
-      fields: ['collectors_name'],
-    };
-
-    const collectors = (await listAllFieldValues(params)).results.collectors_name.values;
-    return collectors.filter((colector) => colector !== null);
+    const collectors =
+      (await searchFieldValues(['collectors_name'], {}, organizationId))?.collectors_name?.values || [];
+    return collectors.filter((collector) => collector !== null) as string[];
   } catch {
     return undefined;
   }
@@ -338,7 +294,6 @@ const SeedBankService = {
   createAccession,
   searchAccessions,
   searchFieldValues,
-  getAllFieldValues,
   getCollectors,
   getPendingAccessions,
   downloadAccessionsTemplate,


### PR DESCRIPTION
The seedbank API has two endpoints to list all the values of a field. One of
them lists all the values that are currently present on any accessions, and
the other lists all possible values, even if they're not used.

In early versions of the app, there was a list of seed collectors that was
maintained separately from the accession data; you could add names to the list
and they would show up as available collectors when creating a new accession.
The app thus called the "list all possible values" endpoint since it needed to
include collectors that hadn't yet been associated with any accessions.

But we moved away from that model, and the collector name is now freeform text
with a typeahead that suggests the existing collector names. There is no list
of names separate from the accession data, so the "list all possible values"
endpoint returns exactly the same results as the "list all values found on all
accessions" one.

Getting the list of collector names was the only remaining use of the "list all
possible values" endpoint. We want to remove that endpoint from the server;
switch the client over to the other one in preparation.
