### PR TITLE
Perform Population Summation Calculation Differently

### DIFF
--- a/src/components/PlantsV2/components/TotalReportedPlantsCard.tsx
+++ b/src/components/PlantsV2/components/TotalReportedPlantsCard.tsx
@@ -15,20 +15,11 @@ export default function TotalReportedPlantsCard({ plantingSiteId }: TotalReporte
   const [totalPlants, setTotalPlants] = useState(0);
   useEffect(() => {
     if (populationSelector) {
-      const sum =
-        populationSelector?.reduce((acc1, zone) => {
-          const sum1 = Number(
-            zone.plantingSubzones?.reduce((acc2, sz) => {
-              const sum2 = Number(
-                sz.populations?.reduce((acc3, pop) => {
-                  return acc3 + pop.totalPlants;
-                }, 0)
-              );
-              return acc2 + (isNaN(sum2) ? 0 : sum2);
-            }, 0)
-          );
-          return acc1 + (isNaN(sum1) ? 0 : sum1);
-        }, 0) ?? 0;
+      const populations = populationSelector
+        .flatMap((zone) => zone.plantingSubzones)
+        .flatMap((sz) => sz.populations)
+        .filter((pop) => pop !== undefined);
+      const sum = populations.reduce((acc, pop) => +pop.totalPlants + acc, 0);
       setTotalPlants(sum);
     }
   }, [populationSelector]);


### PR DESCRIPTION
- previously the calculation was extremely cumbersome
- it sometimes produced the wrong result
- simplify it

## Very Incorrect Total Plants:
<img width="859" alt="image" src="https://github.com/terraware/terraware-web/assets/114949086/d3494cd0-9093-42ef-bcbc-f4690d3a7f6a">

## Very Correct Total, Matches V1 Dashboard
<img width="878" alt="image" src="https://github.com/terraware/terraware-web/assets/114949086/e039d8ac-da8b-40ab-ad98-f339f5b13de6">
