### PR TITLE
SW-3647 Accession species only editable if no deliveries

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -470,6 +470,8 @@ export interface components {
       estimatedWeight?: components["schemas"]["SeedQuantityPayload"];
       /** Format: int64 */
       facilityId: number;
+      /** @description If true, plants from this accession's seeds were delivered to a planting site. */
+      hasDeliveries?: boolean;
       /**
        * Format: int64
        * @description Server-generated unique identifier for the accession. This is unique across all seed banks, but is not suitable for display to end users.

--- a/src/components/accession2/edit/Accession2EditModal.tsx
+++ b/src/components/accession2/edit/Accession2EditModal.tsx
@@ -108,8 +108,10 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
         <Species2Dropdown
           speciesId={record.speciesId}
           record={record}
+          disabled={record.hasDeliveries}
           setRecord={setRecord}
           validate={validateFields}
+          tooltipTitle={record.hasDeliveries ? strings.TOOLTIP_ACCESSIONS_HAS_DELIVERIES : undefined}
         />
         <CollectedReceivedDate2
           onChange={onChange}

--- a/src/components/accession2/properties/Species2Dropdown.tsx
+++ b/src/components/accession2/properties/Species2Dropdown.tsx
@@ -15,13 +15,14 @@ interface SpeciesDropdownProps<T extends AccessionPostRequestBody> {
   setRecord: React.Dispatch<React.SetStateAction<T>>;
   disabled?: boolean;
   validate?: boolean;
+  tooltipTitle?: string;
 }
 
 export default function Species2Dropdown<T extends AccessionPostRequestBody>(
   props: SpeciesDropdownProps<T>
 ): JSX.Element {
   const { selectedOrganization } = useOrganization();
-  const { speciesId, record, setRecord, disabled, validate } = props;
+  const { speciesId, record, setRecord, disabled, validate, tooltipTitle } = props;
   const [speciesList, setSpeciesList] = useState<Species[]>([]);
   const [selectedValue, setSelectedValue] = useState<Species>();
   const [temporalSearchValue, setTemporalSearchValue] = useState('');
@@ -112,6 +113,7 @@ export default function Species2Dropdown<T extends AccessionPostRequestBody>(
           fullWidth={true}
           editable={true}
           errorText={validate && !record.speciesId ? strings.REQUIRED_FIELD : ''}
+          tooltipTitle={tooltipTitle}
         />
       </Grid>
     </>

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -1074,6 +1074,7 @@ TO_SUBZONE,To: Subzone
 TOOLTIP_ACCESSIONS_ADD_COLLECTING_SITE,The place where seeds were collected. It is recommended to name these referencing stable landmarks or features that do not change.
 TOOLTIP_ACCESSIONS_ADD_PLANT_ID,The unique identifier given to a plant for tracking or conservation purposes. Ideally seeds from a plant with a plant ID are kept separate from other plants (not pooled together) in collections and accessions.
 TOOLTIP_ACCESSIONS_COLLECTION_SOURCE,The type of plant population where seeds are collected.
+TOOLTIP_ACCESSIONS_HAS_DELIVERIES,This accession's species cannot be changed because plants from its seeds have been planted at a planting site.
 TOOLTIP_ACCESSIONS_ID,"A unique identifier for a seed collection accepted into a seed bank. Any collection from a new species, location, and/or date would typically become a new accession in the seed bank."
 TOOLTIP_ACCESSIONS_LOCATION,Place where seeds are being processed.
 TOOLTIP_ACCESSIONS_SUBLOCATION,Specific area within the place where seeds are being processed.


### PR DESCRIPTION
In preparation for an upcoming change that causes changes to an accession's
species to be propagated to seedling batches that come from that accession,
add logic to prevent editing an accession's species if the accession's seeds
have already been sent to a nursery, and seedlings have already been withdrawn
from the nursery and delivered to a planting site.

This prevents accession species changes from causing inconsistencies between
nursery withdrawals and the species populations at planting sites. In the
future we may remove this restriction and make the species changes propagate to
planting site data too, but doing so would introduce a number of edge cases
that would require more detailed requirements definition.

If the species dropdown is disabled, there is a tooltip explaining why.
