### PR TITLE
Misc fixes in observations view

### DIFF
--- a/src/components/Observations/ObservationsDataView.tsx
+++ b/src/components/Observations/ObservationsDataView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import { Box, Grid, Typography, useTheme } from '@mui/material';
+import strings from 'src/strings';
 import { FieldOptionsMap } from 'src/types/Search';
 import { useAppSelector } from 'src/redux/store';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
@@ -57,7 +58,7 @@ export default function ObservationsDataView(props: ObservationsDataViewProps): 
   }, [upcomingObservations]);
 
   return (
-    <Grid container>
+    <Grid container display='flex' flexDirection='column'>
       <ObservationsEventsNotification events={observationsEvents} />
       <ListMapView
         initialView='list'
@@ -81,7 +82,7 @@ const AllPlantingSitesMapView = (): JSX.Element => {
   return (
     <Box textAlign='center' marginTop={6}>
       <Typography fontSize='18px' fontWeight={500} color={theme.palette.TwClrTxtSecondary}>
-        Placeholder: Select a single planting site to view data
+        {strings.OBSERVATIONS_MAP_VIEW_PROMPT}
       </Typography>
     </Box>
   );

--- a/src/components/Observations/ObservationsEventsNotification.tsx
+++ b/src/components/Observations/ObservationsEventsNotification.tsx
@@ -36,7 +36,7 @@ export default function ObservationsEventsNotification({ events }: ObservationsE
   }, [activeLocale, events]);
 
   return (
-    <Box marginBottom={3} display='flex' flexGrow={1}>
+    <Box marginBottom={3} display='flex' flexDirection='column' width='100%'>
       <Message
         type='page'
         priority='info'

--- a/src/components/Observations/common/DetailsPage.tsx
+++ b/src/components/Observations/common/DetailsPage.tsx
@@ -72,13 +72,13 @@ export default function DetailsPage({
 
         data.push({
           name,
-          to: `/${observationId}`,
+          to: `/results/${observationId}`,
         });
 
         if (plantingZoneId) {
           data.push({
             name: plantingZone?.plantingZoneName ?? '',
-            to: `/${plantingZoneId}`,
+            to: `/zone/${plantingZoneId}`,
           });
         }
       }

--- a/src/components/Observations/common/SpeciesMortalityRateChart.tsx
+++ b/src/components/Observations/common/SpeciesMortalityRateChart.tsx
@@ -16,10 +16,10 @@ export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesT
   const mortalityRates = useMemo((): Data => {
     const data: Data = { labels: [], values: [] };
 
-    species?.forEach((specie) => {
-      const { speciesCommonName, speciesName, speciesScientificName, mortalityRate } = specie;
+    species?.forEach((speciesData) => {
+      const { speciesCommonName, speciesName, speciesScientificName, mortalityRate } = speciesData;
 
-      if (mortalityRate !== undefined) {
+      if (mortalityRate !== undefined && mortalityRate !== null) {
         const label: string = speciesName ?? speciesCommonName ?? speciesScientificName;
         const value: number = mortalityRate;
         data.labels.push(label);

--- a/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
+++ b/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
@@ -16,8 +16,8 @@ export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesT
   const totals = useMemo((): Data => {
     const data: Data = { labels: [], values: [] };
 
-    species?.forEach((specie) => {
-      const { speciesCommonName, speciesName, speciesScientificName, totalPlants } = specie;
+    species?.forEach((speciesData) => {
+      const { speciesCommonName, speciesName, speciesScientificName, totalPlants } = speciesData;
 
       const label: string = speciesName ?? speciesCommonName ?? speciesScientificName;
 

--- a/src/components/Observations/details/ObservationDetailsRenderer.tsx
+++ b/src/components/Observations/details/ObservationDetailsRenderer.tsx
@@ -22,7 +22,7 @@ const ObservationDetailsRenderer =
     }
 
     if (column.key === 'mortalityRate') {
-      return <CellRenderer {...props} value={`${value}%`} />;
+      return <CellRenderer {...props} value={value !== undefined && value !== null ? `${value}%` : ''} />;
     }
 
     if (column.key === 'status') {

--- a/src/components/Observations/org/OrgObservationsRenderer.tsx
+++ b/src/components/Observations/org/OrgObservationsRenderer.tsx
@@ -52,7 +52,7 @@ const OrgObservationsRenderer =
     }
 
     if (column.key === 'mortalityRate') {
-      return <CellRenderer {...props} value={`${value}%`} />;
+      return <CellRenderer {...props} value={value !== undefined && value !== null ? `${value}%` : ''} />;
     }
 
     return <CellRenderer {...props} />;

--- a/src/components/Observations/zone/ObservationPlantingZoneRenderer.tsx
+++ b/src/components/Observations/zone/ObservationPlantingZoneRenderer.tsx
@@ -24,7 +24,7 @@ const ObservationPlantingZoneRenderer =
     }
 
     if (column.key === 'mortalityRate') {
-      return <CellRenderer {...props} value={`${value}%`} />;
+      return <CellRenderer {...props} value={value !== undefined && value !== null ? `${value}%` : ''} />;
     }
 
     if (column.key === 'status') {

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -659,6 +659,7 @@ OBSERVATIONS_DOWNLOAD_APP,"To complete observations, download the Terraware app 
 OBSERVATIONS_EMPTY_STATE_MESSAGE_1,"Observations are when you record data from a sample of monitoring plots using our mobile app in the field. This allows us to calculate mortality rates, and eventually carbon sequestration."
 OBSERVATIONS_EMPTY_STATE_MESSAGE_2,"You will be notified when it is time to take your observations (typically, the next time you end a planting season). After you've completed your first observations, you'll see the records here."
 OBSERVATIONS_EMPTY_STATE_TITLE,No Observations Yet
+OBSERVATIONS_MAP_VIEW_PROMPT,"In order to access map view, please select a single planting site."
 OBSERVATIONS_REQUIRED_BY_DATE,{0} monitoring plots require observation by {1}.,"Example: 5 monitoring plots require observation by June 30, 2023"
 OBSERVATIONS_WITH_THE_TERRAWARE_APP,Observations with the Terraware App
 OBSERVER,Observer


### PR DESCRIPTION
- map and notifications were assembled horizontally, make that vertical
- remove extra spacing in notifications
- update copy for map view when all planting sites are selected

## Before
<img width="889" alt="Terraware App 2023-07-05 10-40-09" src="https://github.com/terraware/terraware-web/assets/1865174/c3fd4194-2ba0-4949-ae3e-c49bff26a0ca">
<img width="899" alt="Terraware App 2023-07-05 10-39-50" src="https://github.com/terraware/terraware-web/assets/1865174/beac4f2f-6d84-4335-9fdd-f6cfadd33a8f">
<img width="897" alt="Terraware App 2023-07-05 10-39-36" src="https://github.com/terraware/terraware-web/assets/1865174/29087fe8-d720-4c8d-9446-4fdef0c07744">

## After
<img width="886" alt="Terraware App 2023-07-05 10-20-12" src="https://github.com/terraware/terraware-web/assets/1865174/0f48caef-3594-40fd-909b-f4b4f1a10f61">
<img width="888" alt="Terraware App 2023-07-05 10-19-46" src="https://github.com/terraware/terraware-web/assets/1865174/4121e8c9-0e0f-4e28-9af2-e5231caef420">
<img width="888" alt="Terraware App 2023-07-05 10-19-25" src="https://github.com/terraware/terraware-web/assets/1865174/9b336bd1-b1d7-4b4c-ae00-84e353159ec7">
