### PR TITLE
Chart Grouping

### DIFF
--- a/src/components/Observations/common/SpeciesMortalityRateChart.tsx
+++ b/src/components/Observations/common/SpeciesMortalityRateChart.tsx
@@ -32,7 +32,7 @@ export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesT
 
   return (
     <BarChart
-      chartId='observationsTotalPlantsBySpecies'
+      chartId='observationsMortalityRateBySpecies'
       chartData={{
         labels: mortalityRates.labels,
         datasets: [

--- a/src/components/Observations/common/SpeciesMortalityRateChart.tsx
+++ b/src/components/Observations/common/SpeciesMortalityRateChart.tsx
@@ -33,8 +33,14 @@ export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesT
   return (
     <BarChart
       chartId='observationsTotalPlantsBySpecies'
-      chartLabels={mortalityRates.labels}
-      chartValues={mortalityRates.values}
+      chartData={{
+        labels: mortalityRates.labels,
+        datasets: [
+          {
+            values: mortalityRates.values,
+          },
+        ],
+      }}
       barWidth={0}
       minHeight={minHeight}
     />

--- a/src/components/Observations/common/SpeciesMortalityRateChart.tsx
+++ b/src/components/Observations/common/SpeciesMortalityRateChart.tsx
@@ -30,16 +30,17 @@ export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesT
     return data;
   }, [species]);
 
-  const chartData = useMemo(() => {
-    return {
+  const chartData = useMemo(
+    () => ({
       labels: mortalityRates.labels,
       datasets: [
         {
           values: mortalityRates.values,
         },
       ],
-    };
-  }, [mortalityRates]);
+    }),
+    [mortalityRates]
+  );
 
   return (
     <BarChart chartId='observationsMortalityRateBySpecies' chartData={chartData} barWidth={0} minHeight={minHeight} />

--- a/src/components/Observations/common/SpeciesMortalityRateChart.tsx
+++ b/src/components/Observations/common/SpeciesMortalityRateChart.tsx
@@ -30,19 +30,18 @@ export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesT
     return data;
   }, [species]);
 
+  const chartData = useMemo(() => {
+    return {
+      labels: mortalityRates.labels,
+      datasets: [
+        {
+          values: mortalityRates.values,
+        },
+      ],
+    };
+  }, [mortalityRates]);
+
   return (
-    <BarChart
-      chartId='observationsMortalityRateBySpecies'
-      chartData={{
-        labels: mortalityRates.labels,
-        datasets: [
-          {
-            values: mortalityRates.values,
-          },
-        ],
-      }}
-      barWidth={0}
-      minHeight={minHeight}
-    />
+    <BarChart chartId='observationsMortalityRateBySpecies' chartData={chartData} barWidth={0} minHeight={minHeight} />
   );
 }

--- a/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
+++ b/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
@@ -28,19 +28,18 @@ export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesT
     return data;
   }, [species]);
 
+  const chartData = useMemo(() => {
+    return {
+      labels: totals.labels,
+      datasets: [
+        {
+          values: totals.values,
+        },
+      ],
+    };
+  }, [totals]);
+
   return (
-    <BarChart
-      chartId='observationsTotalPlantsBySpecies'
-      chartData={{
-        labels: totals.labels,
-        datasets: [
-          {
-            values: totals.values,
-          },
-        ],
-      }}
-      barWidth={0}
-      minHeight={minHeight}
-    />
+    <BarChart chartId='observationsTotalPlantsBySpecies' chartData={chartData} barWidth={0} minHeight={minHeight} />
   );
 }

--- a/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
+++ b/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
@@ -31,8 +31,14 @@ export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesT
   return (
     <BarChart
       chartId='observationsTotalPlantsBySpecies'
-      chartLabels={totals.labels}
-      chartValues={totals.values}
+      chartData={{
+        labels: totals.labels,
+        datasets: [
+          {
+            values: totals.values,
+          },
+        ],
+      }}
       barWidth={0}
       minHeight={minHeight}
     />

--- a/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
+++ b/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
@@ -28,16 +28,17 @@ export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesT
     return data;
   }, [species]);
 
-  const chartData = useMemo(() => {
-    return {
+  const chartData = useMemo(
+    () => ({
       labels: totals.labels,
       datasets: [
         {
           values: totals.values,
         },
       ],
-    };
-  }, [totals]);
+    }),
+    [totals]
+  );
 
   return (
     <BarChart chartId='observationsTotalPlantsBySpecies' chartData={chartData} barWidth={0} minHeight={minHeight} />

--- a/src/components/Plants/PlantBySpeciesChart.tsx
+++ b/src/components/Plants/PlantBySpeciesChart.tsx
@@ -27,7 +27,17 @@ export default function PlantBySpeciesChart({ plantsBySpecies }: PlantBySpeciesC
     <>
       <Typography sx={cardTitleStyle}>{strings.NUMBER_OF_PLANTS_BY_SPECIES}</Typography>
       <Box sx={{ marginTop: theme.spacing(3), display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
-        <BarChart chartId='plantsBySpecies' chartLabels={labels} chartValues={values} />
+        <BarChart
+          chartId='plantsBySpecies'
+          chartData={{
+            labels: labels ?? [],
+            datasets: [
+              {
+                values: values ?? [],
+              },
+            ],
+          }}
+        />
       </Box>
     </>
   );

--- a/src/components/Plants/SpeciesBySubzoneChart.tsx
+++ b/src/components/Plants/SpeciesBySubzoneChart.tsx
@@ -122,7 +122,18 @@ export default function SpeciesBySubzoneChart(props: Props): JSX.Element {
           />
         )}
         <Box sx={{ marginTop: 2 }}>
-          <BarChart chartId='speciesBySubzoneChart' chartLabels={labels} chartValues={values} minHeight='126px' />
+          <BarChart
+            chartId='speciesBySubzoneChart'
+            chartData={{
+              labels: labels ?? [],
+              datasets: [
+                {
+                  values: values ?? [],
+                },
+              ],
+            }}
+            minHeight='126px'
+          />
         </Box>
       </Box>
     </>

--- a/src/components/PlantsV2/components/LiveDeadPlantsPerSpeciesCard.tsx
+++ b/src/components/PlantsV2/components/LiveDeadPlantsPerSpeciesCard.tsx
@@ -71,7 +71,18 @@ export default function LiveDeadPlantsPerSpeciesCard({ observation }: LiveDeadPl
           />
           {showChart && (
             <Box marginTop={theme.spacing(3)}>
-              <PieChart chartId='liveDeadplantsBySpecies' chartLabels={labels} chartValues={values} maxWidth='100%' />
+              <PieChart
+                chartId='liveDeadplantsBySpecies'
+                chartData={{
+                  labels: labels ?? [],
+                  datasets: [
+                    {
+                      values: values ?? [],
+                    },
+                  ],
+                }}
+                maxWidth='100%'
+              />
             </Box>
           )}
         </Box>

--- a/src/components/PlantsV2/components/NumberOfSpeciesPlantedCard.tsx
+++ b/src/components/PlantsV2/components/NumberOfSpeciesPlantedCard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import OverviewItemCard from 'src/components/common/OverviewItemCard';
 import strings from 'src/strings';
 import { Box, Typography, useTheme } from '@mui/material';
@@ -60,6 +60,21 @@ export default function NumberOfSpeciesPlantedCard({ plantingSiteId }: NumberOfS
     }
   }, [populationSelector, speciesSelector]);
 
+  const chartData = useMemo(() => {
+    if (!labels?.length || !values?.length) {
+      return undefined;
+    }
+
+    return {
+      labels: labels ?? [],
+      datasets: [
+        {
+          values: values ?? [],
+        },
+      ],
+    };
+  }, [labels, values]);
+
   const getBarAnnotations = useCallback(() => {
     if (!values || !labels) {
       return undefined;
@@ -101,15 +116,8 @@ export default function NumberOfSpeciesPlantedCard({ plantingSiteId }: NumberOfS
           </Box>
           <Box>
             <BarChart
-              chartId='plantsBySpecies'
-              chartData={{
-                labels: labels ?? [],
-                datasets: [
-                  {
-                    values: values ?? [],
-                  },
-                ],
-              }}
+              chartId='speciesByCategory'
+              chartData={chartData}
               maxWidth='100%'
               minHeight='100px'
               barAnnotations={getBarAnnotations()}

--- a/src/components/PlantsV2/components/NumberOfSpeciesPlantedCard.tsx
+++ b/src/components/PlantsV2/components/NumberOfSpeciesPlantedCard.tsx
@@ -102,8 +102,14 @@ export default function NumberOfSpeciesPlantedCard({ plantingSiteId }: NumberOfS
           <Box>
             <BarChart
               chartId='plantsBySpecies'
-              chartLabels={labels}
-              chartValues={values}
+              chartData={{
+                labels: labels ?? [],
+                datasets: [
+                  {
+                    values: values ?? [],
+                  },
+                ],
+              }}
               maxWidth='100%'
               minHeight='100px'
               barAnnotations={getBarAnnotations()}

--- a/src/components/PlantsV2/components/PlantingProgressPerZoneCard.tsx
+++ b/src/components/PlantsV2/components/PlantingProgressPerZoneCard.tsx
@@ -53,8 +53,14 @@ export default function PlantingProgressPerZoneCard({ plantingSiteId }: Planting
             <BarChart
               elementColor={theme.palette.TwClrBgBrand}
               chartId='plantingProgressByZone'
-              chartLabels={labels}
-              chartValues={values}
+              chartData={{
+                labels: labels ?? [],
+                datasets: [
+                  {
+                    values: values ?? [],
+                  },
+                ],
+              }}
               customTooltipTitles={tooltipTitles}
               maxWidth='100%'
               yLimits={{ min: 0, max: 100 }}

--- a/src/components/PlantsV2/components/PlantingProgressPerZoneCard.tsx
+++ b/src/components/PlantsV2/components/PlantingProgressPerZoneCard.tsx
@@ -2,7 +2,7 @@ import OverviewItemCard from 'src/components/common/OverviewItemCard';
 import { Box, Typography, useTheme } from '@mui/material';
 import strings from 'src/strings';
 import BarChart from 'src/components/common/Chart/BarChart';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useAppSelector } from 'src/redux/store';
 import { selectPlantingSite } from 'src/redux/features/tracking/trackingSelectors';
 import { truncate } from 'src/utils/text';
@@ -41,6 +41,21 @@ export default function PlantingProgressPerZoneCard({ plantingSiteId }: Planting
     }
   }, [plantingSite]);
 
+  const chartData = useMemo(() => {
+    if (!labels?.length || !values?.length) {
+      return undefined;
+    }
+
+    return {
+      labels: labels ?? [],
+      datasets: [
+        {
+          values: values ?? [],
+        },
+      ],
+    };
+  }, [labels, values]);
+
   return (
     <OverviewItemCard
       isEditable={false}
@@ -53,14 +68,7 @@ export default function PlantingProgressPerZoneCard({ plantingSiteId }: Planting
             <BarChart
               elementColor={theme.palette.TwClrBgBrand}
               chartId='plantingProgressByZone'
-              chartData={{
-                labels: labels ?? [],
-                datasets: [
-                  {
-                    values: values ?? [],
-                  },
-                ],
-              }}
+              chartData={chartData}
               customTooltipTitles={tooltipTitles}
               maxWidth='100%'
               yLimits={{ min: 0, max: 100 }}

--- a/src/components/PlantsV2/components/PlantsReportedPerSpeciesCard.tsx
+++ b/src/components/PlantsV2/components/PlantsReportedPerSpeciesCard.tsx
@@ -5,16 +5,9 @@ import { Box, Typography, useTheme } from '@mui/material';
 import { useAppSelector } from 'src/redux/store';
 import { selectSitePopulation } from 'src/redux/features/tracking/sitePopulationSelector';
 import BarChart from 'src/components/common/Chart/BarChart';
+import { truncate } from 'src/utils/text';
 
 const MAX_SPECIES_NAME_LENGTH = 20;
-
-const truncateToLength = (s: string, length: number): string => {
-  if (s.length <= length) {
-    return s;
-  }
-
-  return s.slice(0, length - 3) + '...';
-};
 
 type PlantsReportedPerSpeciesCardProps = {
   plantingSiteId?: number;
@@ -46,7 +39,7 @@ export default function PlantsReportedPerSpeciesCard({
           })
         )
       );
-      setLabels(Object.keys(speciesQuantities).map((name) => truncateToLength(name, MAX_SPECIES_NAME_LENGTH)));
+      setLabels(Object.keys(speciesQuantities).map((name) => truncate(name, MAX_SPECIES_NAME_LENGTH)));
       setValues(Object.values(speciesQuantities));
       setTooltipTitles(Object.keys(speciesQuantities));
     } else {

--- a/src/components/PlantsV2/components/PlantsReportedPerSpeciesCard.tsx
+++ b/src/components/PlantsV2/components/PlantsReportedPerSpeciesCard.tsx
@@ -68,8 +68,14 @@ export default function PlantsReportedPerSpeciesCard({
             <BarChart
               elementColor={theme.palette.TwClrBasePurple300}
               chartId='plantsBySpecies'
-              chartLabels={labels}
-              chartValues={values}
+              chartData={{
+                labels: labels ?? [],
+                datasets: [
+                  {
+                    values: values ?? [],
+                  },
+                ],
+              }}
               customTooltipTitles={tooltipTitles}
               maxWidth='100%'
             />

--- a/src/components/PlantsV2/components/PlantsReportedPerSpeciesCard.tsx
+++ b/src/components/PlantsV2/components/PlantsReportedPerSpeciesCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import OverviewItemCard from 'src/components/common/OverviewItemCard';
 import strings from 'src/strings';
 import { Box, Typography, useTheme } from '@mui/material';
@@ -56,6 +56,21 @@ export default function PlantsReportedPerSpeciesCard({
     }
   }, [populationSelector]);
 
+  const chartData = useMemo(() => {
+    if (!labels?.length || !values?.length) {
+      return undefined;
+    }
+
+    return {
+      labels: labels ?? [],
+      datasets: [
+        {
+          values: values ?? [],
+        },
+      ],
+    };
+  }, [labels, values]);
+
   return (
     <OverviewItemCard
       isEditable={false}
@@ -68,14 +83,7 @@ export default function PlantsReportedPerSpeciesCard({
             <BarChart
               elementColor={theme.palette.TwClrBasePurple300}
               chartId='plantsBySpecies'
-              chartData={{
-                labels: labels ?? [],
-                datasets: [
-                  {
-                    values: values ?? [],
-                  },
-                ],
-              }}
+              chartData={chartData}
               customTooltipTitles={tooltipTitles}
               maxWidth='100%'
             />

--- a/src/components/common/Chart/BarChart.tsx
+++ b/src/components/common/Chart/BarChart.tsx
@@ -3,8 +3,6 @@ import Chart, { ChartData } from './Chart';
 
 export interface BarChartProps {
   chartId: string;
-  chartLabels?: string[];
-  chartValues?: number[];
   chartData?: ChartData;
   customTooltipTitles?: string[];
   minHeight?: string;

--- a/src/components/common/Chart/BarChart.tsx
+++ b/src/components/common/Chart/BarChart.tsx
@@ -1,10 +1,11 @@
 import { AnnotationPluginOptions } from 'chartjs-plugin-annotation/types/options';
-import Chart from './Chart';
+import Chart, { ChartData } from './Chart';
 
 export interface BarChartProps {
   chartId: string;
   chartLabels?: string[];
   chartValues?: number[];
+  chartData?: ChartData;
   customTooltipTitles?: string[];
   minHeight?: string;
   maxWidth?: string;

--- a/src/components/common/Chart/Chart.tsx
+++ b/src/components/common/Chart/Chart.tsx
@@ -121,7 +121,6 @@ function ChartContent(props: ChartContentProps): JSX.Element {
               barThickness,
               backgroundColor: ds.color ?? colors,
               minBarLength: 3,
-              stack: index.toString(),
             })),
           },
           options: {

--- a/src/components/common/Chart/Chart.tsx
+++ b/src/components/common/Chart/Chart.tsx
@@ -123,7 +123,8 @@ function ChartContent(props: ChartContentProps): JSX.Element {
 
       const ctx = canvasRef?.current?.getContext('2d');
       if (ctx) {
-        const colors = elementColor ?? generateTerrawareRandomColors(theme, chartData?.labels?.length || chartLabels?.length || 0);
+        const colors =
+          elementColor ?? generateTerrawareRandomColors(theme, chartData?.labels?.length || chartLabels?.length || 0);
         chartRef.current = await newChart(locale, ctx, {
           type,
           data: chartData
@@ -136,7 +137,7 @@ function ChartContent(props: ChartContentProps): JSX.Element {
                   backgroundColor: ds.color ?? colors,
                   minBarLength: 3,
                   stack: index.toString(),
-                }))
+                })),
               }
             : {
                 labels: chartLabels,

--- a/src/components/common/Chart/Chart.tsx
+++ b/src/components/common/Chart/Chart.tsx
@@ -10,6 +10,17 @@ import { AnnotationPluginOptions } from 'chartjs-plugin-annotation/types/options
 
 ChartJS.register(annotationPlugin);
 
+type ChartDataset = {
+  color?: string;
+  values: number[];
+  label?: string;
+};
+
+export type ChartData = {
+  labels: string[];
+  datasets: ChartDataset[];
+};
+
 export interface StyleProps {
   minHeight?: string;
   maxWidth?: string;
@@ -27,6 +38,7 @@ export interface ChartProps {
   chartId: string;
   chartLabels?: string[];
   chartValues?: number[];
+  chartData?: ChartData;
   customTooltipTitles?: string[];
   minHeight?: string;
   maxWidth?: string;
@@ -66,6 +78,7 @@ interface ChartContentProps {
   chartId: string;
   chartLabels: string[];
   chartValues: number[];
+  chartData?: ChartData;
   customTooltipTitles?: string[];
   minHeight?: string;
   maxWidth?: string;
@@ -83,6 +96,7 @@ function ChartContent(props: ChartContentProps): JSX.Element {
     chartId,
     chartLabels,
     chartValues,
+    chartData,
     customTooltipTitles,
     minHeight,
     maxWidth,
@@ -109,20 +123,32 @@ function ChartContent(props: ChartContentProps): JSX.Element {
 
       const ctx = canvasRef?.current?.getContext('2d');
       if (ctx) {
-        const colors = elementColor ?? generateTerrawareRandomColors(theme, chartLabels?.length || 0);
+        const colors = elementColor ?? generateTerrawareRandomColors(theme, chartData?.labels?.length || chartLabels?.length || 0);
         chartRef.current = await newChart(locale, ctx, {
           type,
-          data: {
-            labels: chartLabels,
-            datasets: [
-              {
-                data: chartValues,
-                barThickness,
-                backgroundColor: colors,
-                minBarLength: 3,
+          data: chartData
+            ? {
+                labels: chartData.labels,
+                datasets: chartData.datasets.map((ds, index) => ({
+                  label: ds.label,
+                  data: ds.values,
+                  barThickness,
+                  backgroundColor: ds.color ?? colors,
+                  minBarLength: 3,
+                  stack: index.toString(),
+                }))
+              }
+            : {
+                labels: chartLabels,
+                datasets: [
+                  {
+                    data: chartValues,
+                    barThickness,
+                    backgroundColor: colors,
+                    minBarLength: 3,
+                  },
+                ],
               },
-            ],
-          },
           options: {
             maintainAspectRatio: false,
             layout: {

--- a/src/components/common/Chart/Chart.tsx
+++ b/src/components/common/Chart/Chart.tsx
@@ -13,6 +13,7 @@ ChartJS.register(annotationPlugin);
 type ChartDataset = {
   color?: string;
   values: number[];
+  // Dataset label which will appear in legends and tooltips
   label?: string;
 };
 
@@ -36,8 +37,6 @@ const useStyles = makeStyles<Theme, StyleProps>(() => ({
 export interface ChartProps {
   type: keyof ChartTypeRegistry;
   chartId: string;
-  chartLabels?: string[];
-  chartValues?: number[];
   chartData?: ChartData;
   customTooltipTitles?: string[];
   minHeight?: string;
@@ -50,7 +49,7 @@ export interface ChartProps {
 }
 
 export default function Chart(props: ChartProps): JSX.Element | null {
-  const { chartLabels, chartValues } = props;
+  const { chartData } = props;
   const { activeLocale } = useLocalization();
   const [locale, setLocale] = useState<string | null>(null);
 
@@ -58,27 +57,17 @@ export default function Chart(props: ChartProps): JSX.Element | null {
     setLocale(activeLocale);
   }, [activeLocale]);
 
-  if (!locale || !chartLabels || !chartValues) {
+  if (!locale || !chartData?.labels) {
     return null;
   }
 
-  return (
-    <ChartContent
-      {...props}
-      locale={locale}
-      chartLabels={chartLabels}
-      chartValues={chartValues}
-      key={`${locale}_${chartLabels.length}_${chartValues.length}`}
-    />
-  );
+  return <ChartContent {...props} chartData={chartData} locale={locale} />;
 }
 
 interface ChartContentProps {
   type: keyof ChartTypeRegistry;
   chartId: string;
-  chartLabels: string[];
-  chartValues: number[];
-  chartData?: ChartData;
+  chartData: ChartData;
   customTooltipTitles?: string[];
   minHeight?: string;
   maxWidth?: string;
@@ -94,8 +83,6 @@ function ChartContent(props: ChartContentProps): JSX.Element {
   const {
     type,
     chartId,
-    chartLabels,
-    chartValues,
     chartData,
     customTooltipTitles,
     minHeight,
@@ -123,33 +110,20 @@ function ChartContent(props: ChartContentProps): JSX.Element {
 
       const ctx = canvasRef?.current?.getContext('2d');
       if (ctx) {
-        const colors =
-          elementColor ?? generateTerrawareRandomColors(theme, chartData?.labels?.length || chartLabels?.length || 0);
+        const colors = elementColor ?? generateTerrawareRandomColors(theme, chartData?.labels?.length || 0);
         chartRef.current = await newChart(locale, ctx, {
           type,
-          data: chartData
-            ? {
-                labels: chartData.labels,
-                datasets: chartData.datasets.map((ds, index) => ({
-                  label: ds.label,
-                  data: ds.values,
-                  barThickness,
-                  backgroundColor: ds.color ?? colors,
-                  minBarLength: 3,
-                  stack: index.toString(),
-                })),
-              }
-            : {
-                labels: chartLabels,
-                datasets: [
-                  {
-                    data: chartValues,
-                    barThickness,
-                    backgroundColor: colors,
-                    minBarLength: 3,
-                  },
-                ],
-              },
+          data: {
+            labels: chartData.labels,
+            datasets: chartData.datasets.map((ds, index) => ({
+              label: ds.label,
+              data: ds.values,
+              barThickness,
+              backgroundColor: ds.color ?? colors,
+              minBarLength: 3,
+              stack: index.toString(),
+            })),
+          },
           options: {
             maintainAspectRatio: false,
             layout: {
@@ -194,7 +168,7 @@ function ChartContent(props: ChartContentProps): JSX.Element {
     };
     createChart();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chartLabels, chartValues, locale]);
+  }, [chartData, locale]);
 
   return <canvas id={chartId} ref={canvasRef} className={classes.chart} />;
 }

--- a/src/components/common/Chart/PieChart.tsx
+++ b/src/components/common/Chart/PieChart.tsx
@@ -1,10 +1,9 @@
 import { AnnotationPluginOptions } from 'chartjs-plugin-annotation/types/options';
-import Chart from './Chart';
+import Chart, { ChartData } from './Chart';
 
 export interface PieChartProps {
   chartId: string;
-  chartLabels?: string[];
-  chartValues?: number[];
+  chartData?: ChartData;
   customTooltipTitles?: string[];
   minHeight?: string;
   maxWidth?: string;


### PR DESCRIPTION
- Allow multiple datasets per series
- For bar charts, this allows multiple bars per x-label

## Example:
- Each datum is grouped with a second bar that is half the height and the same color
<img width="617" alt="image" src="https://github.com/terraware/terraware-web/assets/114949086/a6f62aa3-fd60-4f3f-85be-773369609fdc">
