### PR TITLE
SW-3857 Initial redux to fetch observations results for a single planting site

### DIFF
--- a/src/redux/features/observations/observationsSlice.ts
+++ b/src/redux/features/observations/observationsSlice.ts
@@ -48,3 +48,26 @@ export const observationsSlice = createSlice({
 
 export const { setObservationsAction } = observationsSlice.actions;
 export const observationsReducer = observationsSlice.reducer;
+
+type PlantingSitePayload = {
+  plantingSiteId: number;
+  data: ResultsData;
+};
+
+type PlantingSiteData = Record<number, ResultsData>;
+
+const plantingSiteInitialResultsState: PlantingSiteData = {};
+
+export const plantingSiteObservationsResultsSlice = createSlice({
+  name: 'plantingSiteObservationsResultsSlice',
+  initialState: plantingSiteInitialResultsState,
+  reducers: {
+    setPlantingSiteObservationsResultsAction: (state, action: PayloadAction<PlantingSitePayload>) => {
+      const data: ResultsData = action.payload.data;
+      state[action.payload.plantingSiteId] = data;
+    },
+  },
+});
+
+export const { setPlantingSiteObservationsResultsAction } = plantingSiteObservationsResultsSlice.actions;
+export const plantingSiteObservationsResultsReducer = plantingSiteObservationsResultsSlice.reducer;

--- a/src/redux/features/observations/observationsThunks.ts
+++ b/src/redux/features/observations/observationsThunks.ts
@@ -1,7 +1,11 @@
 import { Dispatch } from 'redux';
 import { ObservationsService } from 'src/services';
 import { RootState } from 'src/redux/rootReducer';
-import { setObservationsAction, setObservationsResultsAction } from './observationsSlice';
+import {
+  setObservationsAction,
+  setObservationsResultsAction,
+  setPlantingSiteObservationsResultsAction,
+} from './observationsSlice';
 
 /**
  * Fetch observation results
@@ -21,6 +25,28 @@ export const requestObservationsResults = (organizationId: number) => {
       // should not happen, the response above captures any http request errors
       // tslint:disable-next-line: no-console
       console.error('Error dispatching observations results', e);
+    }
+  };
+};
+
+/**
+ * Fetch planting site observation results
+ */
+export const requestPlantingSiteObservationsResults = (organizationId: number, plantingSiteId: number) => {
+  return async (dispatch: Dispatch, _getState: () => RootState) => {
+    try {
+      const response = await ObservationsService.listObservationsResults(organizationId, plantingSiteId);
+      const { error, observations } = response;
+      dispatch(
+        setPlantingSiteObservationsResultsAction({
+          plantingSiteId,
+          data: { error, observations },
+        })
+      );
+    } catch (e) {
+      // should not happen, the response above captures any http request errors
+      // tslint:disable-next-line: no-console
+      console.error('Error dispatching planting site observations results', e);
     }
   };
 };

--- a/src/redux/features/observations/plantingSiteObservationsSelectors.ts
+++ b/src/redux/features/observations/plantingSiteObservationsSelectors.ts
@@ -1,0 +1,14 @@
+import { RootState } from 'src/redux/rootReducer';
+
+/**
+ * Observations results selectors below
+ */
+export const selectPlantingSiteObservationsResults = (state: RootState, plantingSiteId: number) =>
+  state.plantingSiteObservationsResults?.[plantingSiteId]?.observations;
+export const selectPlantingSiteObservationsResultsError = (state: RootState, plantingSiteId: number) =>
+  state.plantingSiteObservationsResults?.[plantingSiteId]?.error;
+
+/**
+ * TODO: Add selectors that provide aggregated information across observations results for a planting site
+ * Example: total number of monitoring plots (de-duped across results)
+ */

--- a/src/redux/rootReducer.ts
+++ b/src/redux/rootReducer.ts
@@ -1,6 +1,10 @@
 import { Action, combineReducers } from '@reduxjs/toolkit';
 import { appVersionReducer } from './features/appVersion/appVersionSlice';
-import { observationsReducer, observationsResultsReducer } from './features/observations/observationsSlice';
+import {
+  observationsReducer,
+  observationsResultsReducer,
+  plantingSiteObservationsResultsReducer,
+} from './features/observations/observationsSlice';
 import { speciesReducer } from './features/species/speciesSlice';
 import { trackingReducer, sitePopulationReducer } from './features/tracking/trackingSlice';
 
@@ -12,6 +16,7 @@ export const reducers = {
   species: speciesReducer,
   tracking: trackingReducer,
   sitePopulation: sitePopulationReducer,
+  plantingSiteObservationsResults: plantingSiteObservationsResultsReducer,
 };
 const combinedReducers = combineReducers(reducers);
 

--- a/src/services/ObservationsService.ts
+++ b/src/services/ObservationsService.ts
@@ -31,12 +31,12 @@ const httpObservations = HttpService.root(OBSERVATIONS_ENDPOINT);
 
 /**
  * List all observations results
- * 'full=false' is looking ahead, we will have abridged data soon
  */
 const listObservationsResults = async (
   organizationId: number,
-  full?: boolean
+  plantingSiteId?: number
 ): Promise<ObservationsResultsData & Response> => {
+  const params: Record<string, string> = plantingSiteId ? { plantingSiteId: plantingSiteId.toString() } : {};
   const response: ObservationsResultsData & Response = await httpObservationsResults.get<
     ObservationsResultsResponsePayload,
     ObservationsResultsData
@@ -44,7 +44,7 @@ const listObservationsResults = async (
     {
       params: {
         organizationId: organizationId.toString(),
-        full: (full || false).toString(),
+        ...params,
       },
     },
     (data) => ({ observations: data?.observations ?? [] })


### PR DESCRIPTION
- Redux to dispatch/select planting-site observations results, advanced selectors to aggregate information will be in subsequent PRs
- This will be used on the location->PlantingSites->PlantingSite page
- We already have redux for the org-wide results, which is a superset of what this PR does
- We could theoretically leverage the org-wide redux for this view but it seems wasteful to fetch all the data when not needed
- Optionally we could trigger the fetching of org-wide data during App initialization and select what we want in this view (and for the observations views), downside is we may have stale data over time unless we periodically refresh the data, another downside is the load on server because app load guarantees we fetch observations results for all sessions
- Downside to this current PR is maintaining two code paths to fetch observations results (org-wide versus planting-site specific)
- Prefer a downside that affects us versus one that affects the end-user, thoughts?