### PR TITLE
SW-3869 Refactor routing for planting sites views to support drill downs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,8 +44,6 @@ import Inventory from './components/Inventory';
 import NurseryDetails from './components/Nursery';
 import InventoryCreate from './components/Inventory/InventoryCreate';
 import InventoryView from './components/Inventory/InventoryView';
-import { CreatePlantingSite, PlantingSitesList } from './components/PlantingSites';
-import PlantingSiteView from './components/PlantingSites/PlantingSiteView';
 import {
   BatchBulkWithdrawWrapperComponent,
   SpeciesBulkWithdrawWrapperComponent,
@@ -65,6 +63,7 @@ import isEnabled from 'src/features';
 import Observations from 'src/components/Observations';
 import { getRgbaFromHex } from 'src/utils/color';
 import PlantsDashboardV2 from 'src/components/PlantsV2';
+import PlantingSites from 'src/components/PlantingSites';
 
 interface StyleProps {
   isDesktop?: boolean;
@@ -458,17 +457,8 @@ function AppContent() {
             <Route path={APP_PATHS.BATCH_WITHDRAW}>
               <BatchBulkWithdrawWrapperComponent withdrawalCreatedCallback={() => setWithdrawalCreated(true)} />
             </Route>
-            <Route exact path={APP_PATHS.PLANTING_SITES_NEW}>
-              <CreatePlantingSite reloadPlantingSites={reloadTracking} />
-            </Route>
-            <Route exact path={APP_PATHS.PLANTING_SITES_EDIT}>
-              <CreatePlantingSite reloadPlantingSites={reloadTracking} />
-            </Route>
-            <Route exact path={APP_PATHS.PLANTING_SITES}>
-              <PlantingSitesList />
-            </Route>
-            <Route path={APP_PATHS.PLANTING_SITES_VIEW}>
-              <PlantingSiteView />
+            <Route path={APP_PATHS.PLANTING_SITES}>
+              <PlantingSites reloadTracking={reloadTracking} />
             </Route>
             <Route exact path={APP_PATHS.NURSERY_WITHDRAWALS}>
               <NurseryWithdrawals />

--- a/src/components/PlantingSites/PlantingSiteSubzoneView.tsx
+++ b/src/components/PlantingSites/PlantingSiteSubzoneView.tsx
@@ -1,0 +1,9 @@
+import TfMain from 'src/components/common/TfMain';
+
+export default function PlantingSiteSubzoneView() {
+  return (
+    <TfMain>
+      <h3>Placeholder: planting site subzone view</h3>
+    </TfMain>
+  );
+}

--- a/src/components/PlantingSites/PlantingSiteZoneView.tsx
+++ b/src/components/PlantingSites/PlantingSiteZoneView.tsx
@@ -1,0 +1,9 @@
+import TfMain from 'src/components/common/TfMain';
+
+export default function PlantingSiteZoneView() {
+  return (
+    <TfMain>
+      <h3>Placeholder: planting site zone view</h3>
+    </TfMain>
+  );
+}

--- a/src/components/PlantingSites/index.tsx
+++ b/src/components/PlantingSites/index.tsx
@@ -1,4 +1,67 @@
-import CreatePlantingSite from './PlantingSiteCreate';
+import { useState } from 'react';
+import { CircularProgress } from '@mui/material';
+import { Route, Switch } from 'react-router-dom';
+import { APP_PATHS } from 'src/constants';
+import isEnabled from 'src/features';
+import PlantingSiteCreate from './PlantingSiteCreate';
 import PlantingSitesList from './PlantingSitesList';
+import PlantingSiteView from './PlantingSiteView';
+import PlantingSiteSubzoneView from './PlantingSiteSubzoneView';
+import PlantingSiteZoneView from './PlantingSiteZoneView';
 
-export { CreatePlantingSite, PlantingSitesList };
+/**
+ * This page will route to the correct component based on url params
+ */
+export type PlantingSitesProps = {
+  reloadTracking: () => void;
+};
+
+export default function PlantingSites(props: PlantingSitesProps): JSX.Element {
+  const [initializingData] = useState<boolean>(false);
+
+  /**
+   * TODO: intialize data
+   */
+
+  // show spinner while initializing data
+  if (initializingData) {
+    return <CircularProgress sx={{ margin: 'auto' }} />;
+  }
+
+  return <PlantingSitesWrapper {...props} />;
+}
+
+const PlantingSitesWrapper = ({ reloadTracking }: PlantingSitesProps): JSX.Element => {
+  const trackingV2 = isEnabled('TrackingV2');
+
+  /**
+   * TODO: handle the various options
+   */
+
+  return (
+    <Switch>
+      {trackingV2 && (
+        <Route path={APP_PATHS.PLANTING_SITES_SUBZONE_VIEW}>
+          <PlantingSiteSubzoneView />
+        </Route>
+      )}
+      {trackingV2 && (
+        <Route path={APP_PATHS.PLANTING_SITES_ZONE_VIEW}>
+          <PlantingSiteZoneView />
+        </Route>
+      )}
+      <Route path={APP_PATHS.PLANTING_SITES_NEW}>
+        <PlantingSiteCreate reloadPlantingSites={reloadTracking} />
+      </Route>
+      <Route path={APP_PATHS.PLANTING_SITES_EDIT}>
+        <PlantingSiteCreate reloadPlantingSites={reloadTracking} />
+      </Route>
+      <Route path={APP_PATHS.PLANTING_SITES_VIEW}>
+        <PlantingSiteView />
+      </Route>
+      <Route path={'*'}>
+        <PlantingSitesList />
+      </Route>
+    </Switch>
+  );
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -56,6 +56,8 @@ export enum APP_PATHS {
   PLANTING_SITES_NEW = '/planting-sites/new',
   PLANTING_SITES_VIEW = '/planting-sites/:plantingSiteId',
   PLANTING_SITES_EDIT = '/planting-sites/:plantingSiteId/edit',
+  PLANTING_SITES_ZONE_VIEW = '/planting-sites/:plantingSiteId/zone/:zoneId',
+  PLANTING_SITES_SUBZONE_VIEW = '/planting-sites/:plantingSiteId/zone/:zoneId/subzone/:subzoneId',
   NURSERY_WITHDRAWALS = '/nursery/withdrawals',
   NURSERY_WITHDRAWALS_DETAILS = '/nursery/withdrawals/:withdrawalId',
   NURSERY_REASSIGNMENT = '/nursery/reassignment/:deliveryId',


### PR DESCRIPTION
- similar to observations routing, refactor planting sites routing
- App.tsx now calls the root planting sites component for any route starting with `/planting-sites`
- the root planting sites component handles the various routing for planting sites view, edit, create, drill downs
- this also simplifies App.tsx context
- added placeholder content for zone/subzone views