### PR TITLE
SW-3868 Handle locales with country codes

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -2952,6 +2952,7 @@ export interface components {
       preferences: { [key: string]: unknown };
     };
     UpdateUserRequestPayload: {
+      countryCode?: string;
       /** @description If true, the user wants to receive all the notifications for their organizations via email. This does not apply to certain kinds of notifications such as "You've been added to a new organization." If null, leave the existing value as-is. */
       emailNotificationsEnabled?: boolean;
       firstName: string;
@@ -3066,6 +3067,7 @@ export interface components {
       status: components["schemas"]["SuccessOrError"];
     };
     UserProfilePayload: {
+      countryCode?: string;
       email: string;
       /** @description If true, the user wants to receive all the notifications for their organizations via email. This does not apply to certain kinds of notifications such as "You've been added to a new organization." */
       emailNotificationsEnabled: boolean;

--- a/src/components/LocaleSelector.tsx
+++ b/src/components/LocaleSelector.tsx
@@ -1,5 +1,5 @@
 import { Dropdown, DropdownItem, PopoverMenu } from '@terraware/web-components';
-import { useSupportedLocales } from '../strings/locales';
+import { findLocaleDetails, useSupportedLocales } from '../strings/locales';
 import { LocalizationContext } from '../providers/contexts';
 import { UserService } from 'src/services';
 import { useUser } from '../providers';
@@ -53,13 +53,15 @@ export default function LocaleSelector({
           }
         };
 
+        const localeDetails = findLocaleDetails(supportedLocales, localeSelected || selectedLocale);
+
         return (
           <>
             {transparent ? (
               <PopoverMenu
                 anchor={
                   <span className={classes.selected}>
-                    {localeItems.find((iLocale) => iLocale.value === selectedLocale)?.label}
+                    {localeItems.find((iLocale) => iLocale.value === localeDetails.id)?.label}
                   </span>
                 }
                 menuSections={[localeItems]}
@@ -70,7 +72,7 @@ export default function LocaleSelector({
                 <Dropdown
                   label={strings.LANGUAGE}
                   onChange={onChangeLocale}
-                  selectedValue={localeSelected}
+                  selectedValue={localeDetails.id}
                   options={localeItems}
                 />
               )

--- a/src/components/MyAccount/index.tsx
+++ b/src/components/MyAccount/index.tsx
@@ -31,7 +31,7 @@ import { getUTC } from 'src/utils/useTimeZoneUtils';
 import { weightSystems } from 'src/units';
 import WeightSystemSelector from 'src/components/WeightSystemSelector';
 import LocaleSelector from '../LocaleSelector';
-import { useSupportedLocales } from 'src/strings/locales';
+import { findLocaleDetails, useSupportedLocales } from 'src/strings/locales';
 import DeleteAccountModal from './DeleteAccountModal';
 
 type MyAccountProps = {
@@ -416,7 +416,7 @@ const MyAccountContent = ({
                   label={strings.LANGUAGE}
                   id='locale'
                   type='text'
-                  value={supportedLocales.find((sLocale) => sLocale.id === selectedLocale)?.name}
+                  value={findLocaleDetails(supportedLocales, selectedLocale).name}
                   display={true}
                 />
               )}

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -57,6 +57,7 @@ const getUser = async (): Promise<UserResponse> => {
           emailNotificationsEnabled: data.user.emailNotificationsEnabled,
           timeZone: data.user.timeZone,
           locale: data.user.locale,
+          countryCode: data.user.countryCode,
         }
       : undefined,
   }));
@@ -77,6 +78,7 @@ const updateUser = async (user: User, options: UpdateOptions = {}): Promise<Resp
     lastName: user.lastName || '',
     timeZone: user.timeZone,
     locale: user.locale,
+    countryCode: user.countryCode,
   };
   if (user.emailNotificationsEnabled !== undefined) {
     entity.emailNotificationsEnabled = user.emailNotificationsEnabled;

--- a/src/strings/locales.ts
+++ b/src/strings/locales.ts
@@ -22,3 +22,29 @@ export const useSupportedLocales = (): LocaleDetails[] => {
     [isProduction]
   );
 };
+
+/**
+ * Returns the locale from the list of supported locales that matches the user's selected langauge.
+ *
+ * The user's locale can include both a language and a country code, but entries in the menu of
+ * languages usually don't have country codes. So we need to find the entry that is the longest
+ * prefix of the user's locale.
+ *
+ * If the locale is es-MX and the list of locales only has es, we want the es item to be selected
+ * in the dropdown. But if the locale is zh-CN and the list of locales has both zh-CN and zh-TW,
+ * we want zh-CN to be selected.
+ *
+ * If none of the locales in the list matches, returns the first locale from the list.
+ */
+export function findLocaleDetails(locales: LocaleDetails[], locale: string): LocaleDetails {
+  return locales.reduce((bestMatch, candidate) => {
+    if (
+      locale.startsWith(candidate.id) &&
+      (!bestMatch.id.startsWith(locale) || candidate.id.length > bestMatch.id.length)
+    ) {
+      return candidate;
+    } else {
+      return bestMatch;
+    }
+  });
+}

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -8,6 +8,7 @@ export type User = {
   emailNotificationsEnabled?: boolean;
   timeZone?: string;
   locale?: string;
+  countryCode?: string;
 };
 
 export type OrganizationUser = {


### PR DESCRIPTION
To support variation of number formatting rules in different Spanish-speaking
countries, we're going to keep track of users' countries. If the user has selected
a country, their locale will include a country code as well as a language.

For the most part, locales with country codes work transparently because they're
well supported by browsers. However, our application code currently expects the
locale to only include a language. If the server sends back a locale like `es-MX`,
the client doesn't know which item in the locale selector it should use.

We could just strip off the country code, but in the future, we'll likely need to
support languages where the country code is more significant, e.g., Chinese.
Instead, update the client to pick the longest match from its list of supported
locales.

There will be a separate field in the user API payloads for country code; add it
to the type definitions and make the client code pass it back to the server when
updating user data. A later change will add UI to let users see and edit their
countries, but for now, this lets us test locale selection by manually setting
the country in the server's database.
