### PR TITLE
Upgrade to latest Tailscale GitHub Action

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,13 +34,6 @@ jobs:
       - name: Set Environment
         run: ./.github/scripts/set-environment.sh
 
-      - name: Connect to Tailscale
-        uses: tailscale/github-action@v2
-        with:
-          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
-          tags: tag:github
-
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
@@ -135,6 +128,13 @@ jobs:
         with:
           aws-region: ${{ secrets[env.AWS_REGION_SECRET_NAME] }}
           role-to-assume: ${{ secrets[env.AWS_ROLE_SECRET_NAME] }}
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          tags: tag:github
 
       - name: Deploy
         if: env.IS_CD == 'true'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,6 +34,11 @@ jobs:
       - name: Set Environment
         run: ./.github/scripts/set-environment.sh
 
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
@@ -128,11 +133,6 @@ jobs:
         with:
           aws-region: ${{ secrets[env.AWS_REGION_SECRET_NAME] }}
           role-to-assume: ${{ secrets[env.AWS_ROLE_SECRET_NAME] }}
-
-      - name: Connect to Tailscale
-        uses: tailscale/github-action@v1
-        with:
-          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 
       - name: Deploy
         if: env.IS_CD == 'true'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,7 +37,9 @@ jobs:
       - name: Connect to Tailscale
         uses: tailscale/github-action@v2
         with:
-          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-client-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          tags: tag:github
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -38,7 +38,7 @@ jobs:
         uses: tailscale/github-action@v2
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-          oauth-client-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
           tags: tag:github
 
       - name: Get yarn cache directory path


### PR DESCRIPTION
Tailscale now supports OAuth for client authentication; use it instead
of API-key-based authentication.