### PR TITLE
Refactor planting-sites fetch to use redux + initial map/list view in planting sites details page

### DIFF
--- a/src/components/ListMapView/index.tsx
+++ b/src/components/ListMapView/index.tsx
@@ -14,9 +14,10 @@ export type ListMapViewProps = {
   map: React.ReactNode;
   initialView: View;
   onView?: (view: View) => void;
+  style?: Record<string, string | number>;
 };
 
-export default function ListMapView({ search, list, map, onView, initialView }: ListMapViewProps): JSX.Element {
+export default function ListMapView({ search, list, map, onView, style, initialView }: ListMapViewProps): JSX.Element {
   const [view, setView] = useState<View>(initialView);
   const theme = useTheme();
 
@@ -33,6 +34,7 @@ export default function ListMapView({ search, list, map, onView, initialView }: 
         display: 'flex',
         flexDirection: 'column',
         flexGrow: 1,
+        ...style,
       }}
       flushMobile
     >

--- a/src/components/Observations/index.tsx
+++ b/src/components/Observations/index.tsx
@@ -9,7 +9,6 @@ import { useLocalization, useOrganization } from 'src/providers';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { requestObservations, requestObservationsResults } from 'src/redux/features/observations/observationsThunks';
 import { requestSpecies } from 'src/redux/features/species/speciesThunks';
-import { requestPlantingSites } from 'src/redux/features/tracking/trackingThunks';
 import {
   selectObservationsResultsError,
   selectObservationsResults,
@@ -45,7 +44,6 @@ export default function Observations(): JSX.Element {
 
   useEffect(() => {
     dispatch(requestSpecies(selectedOrganization.id));
-    dispatch(requestPlantingSites(selectedOrganization.id));
   }, [dispatch, selectedOrganization.id]);
 
   useEffect(() => {

--- a/src/components/PlantingSites/BoundariesAndZones.tsx
+++ b/src/components/PlantingSites/BoundariesAndZones.tsx
@@ -1,19 +1,56 @@
-import { Typography, Box, CircularProgress } from '@mui/material';
+import React, { useMemo, useState } from 'react';
+import { Typography, Box } from '@mui/material';
 import { theme } from '@terraware/web-components';
 import strings from 'src/strings';
 import { PlantingSite } from 'src/types/Tracking';
 import { PlantingSiteMap } from '../Map';
-import React, { useState } from 'react';
 import MapLayerSelect, { MapLayer } from 'src/components/common/MapLayerSelect';
 import { MapService } from 'src/services';
+import isEnabled from 'src/features';
+import Search, { SearchProps } from 'src/components/common/SearchFiltersWrapper';
+import ListMapView from 'src/components/ListMapView';
 
 type BoundariesAndZonesProps = {
   plantingSite: PlantingSite;
 };
 
-export default function BoundariesAndZones(props: BoundariesAndZonesProps): JSX.Element {
-  const { plantingSite } = props;
+export default function BoundariesAndZones({ plantingSite }: BoundariesAndZonesProps): JSX.Element {
+  const [search, setSearch] = useState<string>('');
+  const trackingV2 = isEnabled('TrackingV2');
 
+  const searchProps = useMemo<SearchProps>(
+    () => ({
+      search,
+      onSearch: (value: string) => setSearch(value),
+    }),
+    [search]
+  );
+
+  return (
+    <Box display='flex' flexGrow={plantingSite?.boundary ? 1 : 0} flexDirection='column' paddingTop={theme.spacing(3)}>
+      <Box display='flex' flexGrow={0}>
+        <Typography fontSize='16px' fontWeight={600} margin={theme.spacing(3, 0)}>
+          {strings.BOUNDARIES_AND_ZONES}
+        </Typography>
+      </Box>
+      {plantingSite.boundary && trackingV2 && (
+        <ListMapView
+          style={{ padding: 0 }}
+          initialView='map'
+          search={<Search {...searchProps} />}
+          list={<PlantingSiteListView />}
+          map={<PlantingSiteMapView plantingSite={plantingSite} />}
+        />
+      )}
+      {plantingSite.boundary && !trackingV2 && <PlantingSiteMapView plantingSite={plantingSite} />}
+    </Box>
+  );
+}
+
+/**
+ * Map view for planting site
+ */
+function PlantingSiteMapView({ plantingSite }: BoundariesAndZonesProps): JSX.Element {
   const layerOptions: MapLayer[] = ['Planting Site', 'Zones', 'Sub-Zones'];
   const [includedLayers, setIncludedLayers] = useState<MapLayer[]>(layerOptions);
 
@@ -25,41 +62,33 @@ export default function BoundariesAndZones(props: BoundariesAndZonesProps): JSX.
   };
 
   return (
-    <Box display='flex' flexGrow={plantingSite?.boundary ? 1 : 0} flexDirection='column' paddingTop={theme.spacing(3)}>
-      <Box display='flex' flexGrow={0}>
-        <Typography fontSize='16px' fontWeight={600} margin={theme.spacing(3, 0)}>
-          {strings.BOUNDARIES_AND_ZONES}
-        </Typography>
-      </Box>
-      <Box display='flex' sx={{ flexGrow: 1 }}>
-        {plantingSite ? (
-          <>
-            {plantingSite.boundary ? (
-              <PlantingSiteMap
-                mapData={MapService.getMapDataFromPlantingSite(plantingSite)}
-                style={{ borderRadius: '24px' }}
-                layers={includedLayers}
-                topRightMapControl={
-                  <MapLayerSelect
-                    initialSelection={layerOptions}
-                    onUpdateSelection={(selection) => setIncludedLayers(selection)}
-                    menuSections={[
-                      layerOptions.map((opt) => ({
-                        label: layerOptionLabels[opt],
-                        value: opt,
-                      })),
-                    ]}
-                  />
-                }
-              />
-            ) : null}
-          </>
-        ) : (
-          <Box sx={{ position: 'fixed', top: '50%', left: '50%' }}>
-            <CircularProgress />
-          </Box>
-        )}
-      </Box>
+    <Box display='flex' sx={{ flexGrow: 1 }}>
+      {plantingSite.boundary ? (
+        <PlantingSiteMap
+          mapData={MapService.getMapDataFromPlantingSite(plantingSite)}
+          style={{ borderRadius: '24px' }}
+          layers={includedLayers}
+          topRightMapControl={
+            <MapLayerSelect
+              initialSelection={layerOptions}
+              onUpdateSelection={(selection) => setIncludedLayers(selection)}
+              menuSections={[
+                layerOptions.map((opt) => ({
+                  label: layerOptionLabels[opt],
+                  value: opt,
+                })),
+              ]}
+            />
+          }
+        />
+      ) : null}
     </Box>
   );
+}
+
+/**
+ * Planting site list view
+ */
+function PlantingSiteListView(): JSX.Element {
+  return <span>placeholder</span>;
 }

--- a/src/components/PlantingSites/BoundariesAndZones.tsx
+++ b/src/components/PlantingSites/BoundariesAndZones.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { Typography, Box } from '@mui/material';
 import { theme } from '@terraware/web-components';
 import strings from 'src/strings';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
 import { PlantingSite } from 'src/types/Tracking';
 import { PlantingSiteMap } from '../Map';
 import MapLayerSelect, { MapLayer } from 'src/components/common/MapLayerSelect';
@@ -17,6 +18,7 @@ type BoundariesAndZonesProps = {
 export default function BoundariesAndZones({ plantingSite }: BoundariesAndZonesProps): JSX.Element {
   const [search, setSearch] = useState<string>('');
   const trackingV2 = isEnabled('TrackingV2');
+  const { isMobile } = useDeviceInfo();
 
   const searchProps = useMemo<SearchProps>(
     () => ({
@@ -35,7 +37,7 @@ export default function BoundariesAndZones({ plantingSite }: BoundariesAndZonesP
       </Box>
       {plantingSite.boundary && trackingV2 && (
         <ListMapView
-          style={{ padding: 0 }}
+          style={{ padding: isMobile ? 3 : 0 }}
           initialView='map'
           search={<Search {...searchProps} />}
           list={<PlantingSiteListView />}

--- a/src/components/PlantingSites/PlantingSiteCreate.tsx
+++ b/src/components/PlantingSites/PlantingSiteCreate.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import TfMain from 'src/components/common/TfMain';
 import { Typography, Box, Container, Grid, useTheme } from '@mui/material';
 import strings from 'src/strings';
@@ -9,7 +10,8 @@ import { APP_PATHS } from 'src/constants';
 import { useHistory, useParams } from 'react-router-dom';
 import useSnackbar from 'src/utils/useSnackbar';
 import TextField from '@terraware/web-components/components/Textfield/Textfield';
-import { useEffect, useState } from 'react';
+import { useAppSelector } from 'src/redux/store';
+import { selectPlantingSite } from 'src/redux/features/tracking/trackingSelectors';
 import PageSnackbar from '../PageSnackbar';
 import { PlantingSite } from 'src/types/Tracking';
 import BoundariesAndZones from 'src/components/PlantingSites/BoundariesAndZones';
@@ -36,9 +38,9 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
   const history = useHistory();
   const snackbar = useSnackbar();
   const [nameError, setNameError] = useState('');
-  const [selectedPlantingSite, setSelectedPlantingSite] = useState<PlantingSite>();
   const [loaded, setLoaded] = useState(false);
   const trackingV2 = isEnabled('TrackingV2');
+  const selectedPlantingSite = useAppSelector((state) => selectPlantingSite(state, Number(plantingSiteId)));
 
   const defaultPlantingSite = (): PlantingSite => ({
     id: -1,
@@ -46,22 +48,11 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
     organizationId: selectedOrganization.id,
   });
 
-  useEffect(() => {
-    const fetchPlantingSite = async () => {
-      if (plantingSiteId) {
-        const serverResponse = await TrackingService.getPlantingSite(Number.parseInt(plantingSiteId, 10));
-        if (serverResponse.requestSucceeded) {
-          setSelectedPlantingSite(serverResponse.site);
-          setLoaded(true);
-        }
-      } else {
-        setLoaded(true);
-      }
-    };
-
-    fetchPlantingSite();
-  }, [plantingSiteId, selectedOrganization]);
   const [record, setRecord, onChange] = useForm<PlantingSite>(defaultPlantingSite());
+
+  useEffect(() => {
+    setLoaded(true);
+  }, [selectedPlantingSite]);
 
   useEffect(() => {
     setRecord({

--- a/src/components/PlantingSites/PlantingSiteView.tsx
+++ b/src/components/PlantingSites/PlantingSiteView.tsx
@@ -3,14 +3,13 @@ import { Typography, Grid, Theme, useTheme } from '@mui/material';
 import { Button } from '@terraware/web-components';
 import strings from 'src/strings';
 import { useDeviceInfo } from '@terraware/web-components/utils';
-import { TrackingService } from 'src/services';
 import { APP_PATHS } from 'src/constants';
 import { useHistory, useParams } from 'react-router-dom';
 import TextField from '@terraware/web-components/components/Textfield/Textfield';
-import { useEffect, useState } from 'react';
+import { useAppSelector } from 'src/redux/store';
+import { selectPlantingSite } from 'src/redux/features/tracking/trackingSelectors';
 import PageSnackbar from '../PageSnackbar';
 import { makeStyles } from '@mui/styles';
-import { PlantingSite } from 'src/types/Tracking';
 import BoundariesAndZones from 'src/components/PlantingSites/BoundariesAndZones';
 import BackToLink from 'src/components/common/BackToLink';
 import { useLocationTimeZone } from 'src/utils/useTimeZoneUtils';
@@ -34,21 +33,10 @@ export default function PlantingSiteView(): JSX.Element {
   const classes = useStyles();
   const theme = useTheme();
   const { plantingSiteId } = useParams<{ plantingSiteId: string }>();
-  const [plantingSite, setPlantingSite] = useState<PlantingSite>();
+  const plantingSite = useAppSelector((state) => selectPlantingSite(state, Number(plantingSiteId)));
   const history = useHistory();
   const tz = useLocationTimeZone().get(plantingSite);
   const trackingV2 = isEnabled('TrackingV2');
-
-  useEffect(() => {
-    const loadPlantingSite = async () => {
-      const response = await TrackingService.getPlantingSite(Number.parseInt(plantingSiteId, 10));
-      if (response.requestSucceeded) {
-        setPlantingSite(response.site);
-      }
-    };
-
-    loadPlantingSite();
-  }, [plantingSiteId]);
 
   const gridSize = () => {
     if (isMobile) {


### PR DESCRIPTION
- was working on the tv2 updates for planting sites and had a need to fetch planting sites list
- realized we are already overfetching (in the App, in the Observations page, etc.)
- update the App to dispatch a redux request
- all components now rely on the dispatched request in the App to select planting sites
- also, when we update (edit/create) planting sites, the app reloads planting sites
- simplifies code
- added initial map/list view for planting site details page

<img width="775" alt="Terraware App 🔊 2023-07-10 13-27-02" src="https://github.com/terraware/terraware-web/assets/1865174/de48932d-a038-4b8f-a0da-cb961670a0a4">

<img width="776" alt="Terraware App 🔊 2023-07-10 13-26-44" src="https://github.com/terraware/terraware-web/assets/1865174/2aa16502-77a5-4b46-9214-d5cb06d23fe6">
