### PR TITLE
SW-3828 Use import format for species CSV export

### DIFF
--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -127,6 +127,18 @@ const BE_SORTED_FIELDS = [
   'seedStorageBehavior',
 ];
 
+// These need to be in the same order as in the import template.
+const CSV_FIELDS = [
+  'scientificName',
+  'commonName',
+  'familyName',
+  'conservationCategory',
+  'rare',
+  'growthForm',
+  'seedStorageBehavior',
+  'ecosystemTypes.ecosystemType',
+];
+
 export default function SpeciesList({ reloadData, species }: SpeciesListProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const classes = useStyles();
@@ -195,24 +207,6 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
         tooltipTitle: strings.TOOLTIP_SPECIES_FAMILY,
       },
       {
-        key: 'growthForm',
-        name: strings.GROWTH_FORM,
-        type: 'string',
-        tooltipTitle: (
-          <>
-            {strings.TOOLTIP_SPECIES_GROWTH_FORM}
-            <LearnMoreLink
-              onClick={() =>
-                openTooltipLearnMoreModal({
-                  title: strings.GROWTH_FORM,
-                  content: <LearnMoreModalContentGrowthForm />,
-                })
-              }
-            />
-          </>
-        ),
-      },
-      {
         key: 'conservationCategory',
         name: strings.CONSERVATION_CATEGORY,
         type: 'string',
@@ -234,6 +228,24 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
         name: strings.RARE,
         type: 'boolean',
         tooltipTitle: strings.TOOLTIP_SPECIES_RARE,
+      },
+      {
+        key: 'growthForm',
+        name: strings.GROWTH_FORM,
+        type: 'string',
+        tooltipTitle: (
+          <>
+            {strings.TOOLTIP_SPECIES_GROWTH_FORM}
+            <LearnMoreLink
+              onClick={() =>
+                openTooltipLearnMoreModal({
+                  title: strings.GROWTH_FORM,
+                  content: <LearnMoreModalContentGrowthForm />,
+                })
+              }
+            />
+          </>
+        ),
       },
       {
         key: 'seedStorageBehavior',
@@ -558,6 +570,7 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
     if (!params.search.children.length) {
       params.search = null;
     }
+    params.fields = CSV_FIELDS;
     const apiResponse = await SearchService.searchCsv(params);
 
     if (apiResponse !== null) {


### PR DESCRIPTION
Users want to share species lists between organizations by exporting and importing
them, but currently, the export format isn't the same as the import format so they
have to manually edit the files first.

Change the species list UI so the columns appear in the same order as in the
import template, and change the export code so it omits a couple of ID columns
that are required by the UI code but aren't needed for import.
