### PR TITLE
SW-3850 / SW-3851 Add Planting Site details' zone/subzone views with bread crumbs

### DIFF
--- a/src/components/BreadCrumbs/index.tsx
+++ b/src/components/BreadCrumbs/index.tsx
@@ -1,6 +1,10 @@
-import { Box, Typography, useTheme } from '@mui/material';
+import React, { useRef } from 'react';
+import { Box, Grid, Typography, useTheme } from '@mui/material';
 import BackToLink from 'src/components/common/BackToLink';
 import Link from 'src/components/common/Link';
+import TfMain from 'src/components/common/TfMain';
+import PageSnackbar from 'src/components/PageSnackbar';
+import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 
 export type Crumb = {
   name: string; // name of crumb
@@ -45,5 +49,47 @@ export default function BreadCrumbs({ hierarchical, crumbs }: BreadCrumbsProps):
         </Box>
       ))}
     </Box>
+  );
+}
+
+type PageProps = {
+  crumbs: Crumb[];
+  title: string;
+  children: React.ReactNode;
+};
+
+/**
+ * A generic page structure with bread crumbs, title, header wrapper and instantiated children.
+ */
+export function Page({ crumbs, title, children }: PageProps): JSX.Element {
+  const contentRef = useRef(null);
+  const theme = useTheme();
+
+  return (
+    <TfMain>
+      <PageHeaderWrapper nextElement={contentRef.current}>
+        <BreadCrumbs crumbs={crumbs} hierarchical={true} />
+        <Grid container>
+          <Typography
+            sx={{
+              marginTop: theme.spacing(3),
+              marginBottom: theme.spacing(4),
+              paddingLeft: theme.spacing(3),
+              fontSize: '20px',
+              fontWeight: 600,
+              color: theme.palette.TwClrBaseGray800,
+            }}
+          >
+            {title}
+          </Typography>
+          <Grid item xs={12}>
+            <PageSnackbar />
+          </Grid>
+        </Grid>
+      </PageHeaderWrapper>
+      <Grid container ref={contentRef}>
+        {children}
+      </Grid>
+    </TfMain>
   );
 }

--- a/src/components/BreadCrumbs/index.tsx
+++ b/src/components/BreadCrumbs/index.tsx
@@ -52,7 +52,7 @@ export default function BreadCrumbs({ hierarchical, crumbs }: BreadCrumbsProps):
   );
 }
 
-type PageProps = {
+export type PageProps = {
   crumbs: Crumb[];
   title: string;
   children: React.ReactNode;

--- a/src/components/Map/MapRenderUtils.tsx
+++ b/src/components/Map/MapRenderUtils.tsx
@@ -25,19 +25,6 @@ export function useSpeciesPlantsRenderer(subzonesWithPlants: any): MapPopupRende
     color: theme.palette.TwClrBaseBlack as string,
   };
 
-  const quantityStyle = {
-    ...textStyle,
-    textAlign: 'right',
-    marginRight: theme.spacing(1),
-  };
-
-  const speciesStyle = {
-    ...textStyle,
-    textAlign: 'left',
-    marginLeft: theme.spacing(1),
-    overflowWrap: 'anywhere',
-  };
-
   return {
     className: classes.popup,
     render: (data: MapSourceProperties): JSX.Element => {
@@ -53,21 +40,73 @@ export function useSpeciesPlantsRenderer(subzonesWithPlants: any): MapPopupRende
       }
 
       return (
-        <table>
-          <tbody>
-            {populations.map((population: any, index: number) => (
-              <tr key={index}>
-                <td>
-                  <Typography sx={quantityStyle}>{population.totalPlants}</Typography>
-                </td>
-                <td>
-                  <Typography sx={speciesStyle}>{population.species_scientificName}</Typography>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <MapTooltip
+          properties={populations.map((population: any) => ({
+            key: population.totalPlants,
+            value: population.species_scientificName,
+          }))}
+        />
       );
     },
   };
+}
+
+/**
+ * Generic tooltip renderer
+ */
+export type TooltipProperty = {
+  key: string;
+  value: string | number;
+};
+
+export type MapTooltipProps = {
+  title?: string;
+  properties: TooltipProperty[];
+};
+
+export function MapTooltip({ title, properties }: MapTooltipProps): JSX.Element {
+  const theme = useTheme();
+
+  const textStyle = {
+    fontWeight: 400,
+    fontSize: '16px',
+    color: theme.palette.TwClrBaseBlack as string,
+  };
+
+  const keyStyle = {
+    ...textStyle,
+    textAlign: 'right',
+    marginRight: theme.spacing(1),
+  };
+
+  const valueStyle = {
+    ...textStyle,
+    textAlign: 'left',
+    marginLeft: theme.spacing(1),
+    overflowWrap: 'anywhere',
+  };
+
+  return (
+    <>
+      {title && (
+        <Typography fontSize='16px' fontWeight={600} marginBottom={theme.spacing(2)} textAlign='center'>
+          {title}
+        </Typography>
+      )}
+      <table>
+        <tbody>
+          {properties.map((prop: TooltipProperty, index: number) => (
+            <tr key={index}>
+              <td>
+                <Typography sx={keyStyle}>{prop.key}</Typography>
+              </td>
+              <td>
+                <Typography sx={valueStyle}>{prop.value}</Typography>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
+  );
 }

--- a/src/components/Map/PlantingSiteMap.tsx
+++ b/src/components/Map/PlantingSiteMap.tsx
@@ -56,7 +56,6 @@ export type PlantingSiteMapProps = {
   bottomLeftMapControl?: React.ReactNode;
   topRightMapControl?: React.ReactNode;
   showMortalityRateFill?: boolean;
-  minHeight?: number;
 };
 
 export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Element | null {
@@ -70,7 +69,6 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
     bottomLeftMapControl,
     topRightMapControl,
     showMortalityRateFill,
-    minHeight,
   } = props;
   const theme = useTheme();
   const classes = useStyles();
@@ -263,7 +261,7 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
   }
 
   return (
-    <Box sx={{ display: 'flex', flexGrow: 1, position: 'relative', minHeight: `${minHeight ?? 436}px` }}>
+    <Box sx={{ display: 'flex', flexGrow: 1, position: 'relative', minHeight: '436px' }}>
       <GenericMap
         options={mapOptions}
         contextRenderer={contextRenderer}

--- a/src/components/Observations/common/DetailsPage.tsx
+++ b/src/components/Observations/common/DetailsPage.tsx
@@ -1,5 +1,4 @@
-import React, { useMemo, useRef } from 'react';
-import { useTheme, Grid, Typography } from '@mui/material';
+import { useMemo } from 'react';
 import { APP_PATHS } from 'src/constants';
 import strings from 'src/strings';
 import { getShortDate } from 'src/utils/dateFormatter';
@@ -8,10 +7,7 @@ import { useLocalization } from 'src/providers';
 import { useAppSelector } from 'src/redux/store';
 import { selectObservationPlantingZone } from 'src/redux/features/observations/observationPlantingZoneSelectors';
 import { selectObservationDetails } from 'src/redux/features/observations/observationDetailsSelectors';
-import TfMain from 'src/components/common/TfMain';
-import PageSnackbar from 'src/components/PageSnackbar';
-import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
-import BreadCrumbs, { Crumb } from 'src/components/BreadCrumbs';
+import { Crumb, Page } from 'src/components/BreadCrumbs';
 
 type DetailsPageProps = {
   plantingSiteId?: number | string;
@@ -28,8 +24,6 @@ export default function DetailsPage({
   title,
   children,
 }: DetailsPageProps): JSX.Element {
-  const contentRef = useRef(null);
-  const theme = useTheme();
   const { activeLocale } = useLocalization();
   const defaultTimeZone = useDefaultTimeZone();
 
@@ -88,30 +82,8 @@ export default function DetailsPage({
   }, [activeLocale, plantingSiteId, observationId, plantingZoneId, plantingZone, details]);
 
   return (
-    <TfMain>
-      <PageHeaderWrapper nextElement={contentRef.current}>
-        <BreadCrumbs crumbs={crumbs} hierarchical={true} />
-        <Grid container>
-          <Typography
-            sx={{
-              marginTop: theme.spacing(3),
-              marginBottom: theme.spacing(4),
-              paddingLeft: theme.spacing(3),
-              fontSize: '20px',
-              fontWeight: 600,
-              color: theme.palette.TwClrBaseGray800,
-            }}
-          >
-            {title}
-          </Typography>
-          <Grid item xs={12}>
-            <PageSnackbar />
-          </Grid>
-        </Grid>
-      </PageHeaderWrapper>
-      <Grid container ref={contentRef}>
-        {children}
-      </Grid>
-    </TfMain>
+    <Page crumbs={crumbs} title={title}>
+      {children}
+    </Page>
   );
 }

--- a/src/components/PlantingSites/BoundariesAndZones.tsx
+++ b/src/components/PlantingSites/BoundariesAndZones.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { makeStyles } from '@mui/styles';
 import { Box, Typography, useTheme } from '@mui/material';
+import getDateDisplayValue from '@terraware/web-components/utils/date';
 import strings from 'src/strings';
 import { PlantingSite, PlantingZone } from 'src/types/Tracking';
-import { MapEntityId } from 'src/types/Map';
+import { MapEntityId, MapSourceProperties } from 'src/types/Map';
 import { ZoneAggregation } from 'src/types/Observations';
 import { useAppSelector } from 'src/redux/store';
+import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 import { regexMatch } from 'src/utils/search';
 import { PlantingSiteMap } from '../Map';
 import { searchPlantingSiteZones } from 'src/redux/features/observations/plantingSiteDetailsSelectors';
@@ -17,6 +20,17 @@ import Search, { SearchProps } from 'src/components/common/SearchFiltersWrapper'
 import { View } from 'src/components/common/ListMapSelector';
 import ListMapView from 'src/components/ListMapView';
 import PlantingSiteDetailsTable from './PlantingSiteDetailsTable';
+import { TooltipProperty, MapTooltip } from 'src/components/Map/MapRenderUtils';
+
+export const useMapTooltipStyles = makeStyles(() => ({
+  popup: {
+    '& > .mapboxgl-popup-content': {
+      borderRadius: '8px',
+      padding: '10px',
+      minWidth: '260px',
+    },
+  },
+}));
 
 type BoundariesAndZonesProps = {
   plantingSite: PlantingSite;
@@ -113,9 +127,12 @@ type PlantingSiteMapViewProps = {
 };
 
 function PlantingSiteMapView({ plantingSite, data, search }: PlantingSiteMapViewProps): JSX.Element | null {
+  const classes = useMapTooltipStyles();
   const [searchZoneEntities, setSearchZoneEntities] = useState<MapEntityId[]>([]);
   const layerOptions: MapLayer[] = ['Planting Site', 'Zones', 'Sub-Zones', 'Monitoring Plots'];
   const [includedLayers, setIncludedLayers] = useState<MapLayer[]>(['Planting Site', 'Zones', 'Monitoring Plots']);
+  const defaultTimeZone = useDefaultTimeZone();
+  const timeZone = plantingSite.timeZone ?? defaultTimeZone.get().id;
 
   const layerOptionLabels: Record<MapLayer, string> = {
     'Planting Site': strings.PLANTING_SITE,
@@ -148,6 +165,10 @@ function PlantingSiteMapView({ plantingSite, data, search }: PlantingSiteMapView
         layers={includedLayers}
         highlightEntities={searchZoneEntities}
         focusEntities={searchZoneEntities.length ? searchZoneEntities : [{ sourceId: 'sites', id: plantingSite.id }]}
+        contextRenderer={{
+          render: contextRenderer(plantingSite, data, timeZone),
+          className: classes.popup,
+        }}
         topRightMapControl={
           <MapLayerSelect
             initialSelection={includedLayers}
@@ -164,3 +185,55 @@ function PlantingSiteMapView({ plantingSite, data, search }: PlantingSiteMapView
     </Box>
   );
 }
+
+const contextRenderer =
+  (site: PlantingSite, data: ZoneAggregation[], timeZone: string) =>
+  (entity: MapSourceProperties): JSX.Element => {
+    let properties: TooltipProperty[] = [];
+    let title: string | undefined;
+    if (entity.type === 'site') {
+      title = site.name;
+      properties = [
+        { key: strings.ZONES, value: data.length },
+        { key: strings.SUBZONES, value: data.flatMap((z) => z.plantingSubzones).length },
+        {
+          key: strings.MONITORING_PLOTS,
+          value: data.flatMap((z) => z.plantingSubzones).flatMap((sz) => sz.monitoringPlots).length,
+        },
+      ];
+    } else if (entity.type === 'zone') {
+      const zone = data.find((z) => z.id === entity.id);
+      title = zone?.name;
+      properties = [
+        { key: strings.SUBZONES, value: zone?.plantingSubzones.length ?? 0 },
+        {
+          key: strings.MONITORING_PLOTS,
+          value: zone?.plantingSubzones.flatMap((sz) => sz.monitoringPlots).length ?? 0,
+        },
+        {
+          key: strings.LAST_OBSERVED,
+          value: zone?.completedTime ? getDateDisplayValue(zone.completedTime, timeZone) : '',
+        },
+      ];
+    } else if (entity.type === 'subzone') {
+      const subzone = data.flatMap((z) => z.plantingSubzones).find((sz) => sz.id === entity.id);
+      title = subzone?.fullName;
+      properties = [{ key: strings.MONITORING_PLOTS, value: subzone?.monitoringPlots.length ?? 0 }];
+    } else {
+      // monitoring plot
+      const plot = data
+        .flatMap((z) => z.plantingSubzones)
+        .flatMap((sz) => sz.monitoringPlots)
+        .find((mp) => mp.monitoringPlotId === entity.id);
+      title = plot?.monitoringPlotName;
+      properties = [
+        { key: strings.PLOT_TYPE, value: plot ? (plot.isPermanent ? strings.PERMANENT : strings.TEMPORARY) : '' },
+        {
+          key: strings.LAST_OBSERVED,
+          value: plot?.completedTime ? getDateDisplayValue(plot.completedTime, timeZone) : '',
+        },
+      ];
+    }
+
+    return <MapTooltip title={title} properties={properties} />;
+  };

--- a/src/components/PlantingSites/BoundariesAndZones.tsx
+++ b/src/components/PlantingSites/BoundariesAndZones.tsx
@@ -143,7 +143,6 @@ function PlantingSiteMapView({ plantingSite, data, search }: PlantingSiteMapView
     <Box display='flex' flexDirection='column' flexGrow={1}>
       <PlantingSiteMapLegend options={['site', 'zone', 'subzone', 'permanentPlot', 'temporaryPlot']} />
       <PlantingSiteMap
-        minHeight={0}
         mapData={MapService.getMapDataFromAggregation({ ...plantingSite, plantingZones: data })}
         style={{ borderRadius: '24px' }}
         layers={includedLayers}

--- a/src/components/PlantingSites/BoundariesAndZones.tsx
+++ b/src/components/PlantingSites/BoundariesAndZones.tsx
@@ -29,7 +29,9 @@ export default function BoundariesAndZones({ plantingSite }: BoundariesAndZonesP
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
 
-  const data = useAppSelector((state) => searchPlantingSiteZones(state, plantingSite.id, view === 'map' ? '' : search));
+  const data = useAppSelector((state) =>
+    searchPlantingSiteZones(state, plantingSite.id, view === 'map' ? '' : search.trim())
+  );
 
   const searchProps = useMemo<SearchProps>(
     () => ({

--- a/src/components/PlantingSites/PlantingSiteDetailsTable.tsx
+++ b/src/components/PlantingSites/PlantingSiteDetailsTable.tsx
@@ -10,7 +10,6 @@ import CellRenderer, { TableRowType } from 'src/components/common/table/TableCel
 import { RendererProps } from 'src/components/common/table/types';
 import Link from 'src/components/common/Link';
 import Table from 'src/components/common/table';
-import { useLocalization } from 'src/providers';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 
 /**
@@ -67,7 +66,6 @@ const columns = (): TableColumnType[] => [
 ];
 
 export default function PlantingSiteDetailsTable({ data, plantingSite }: PlantingSiteDetailsTableProps): JSX.Element {
-  const { activeLocale } = useLocalization();
   const classes = useStyles();
   const defaultTimeZone = useDefaultTimeZone();
 
@@ -80,14 +78,14 @@ export default function PlantingSiteDetailsTable({ data, plantingSite }: Plantin
         columns={columns}
         rows={data}
         orderBy='name'
-        Renderer={DetailsRenderer(classes, activeLocale, timeZone, plantingSite.id)}
+        Renderer={DetailsRenderer(classes, timeZone, plantingSite.id)}
       />
     </Box>
   );
 }
 
 const DetailsRenderer =
-  (classes: any, locale: string | undefined | null, timeZone: string, plantingSiteId: number) =>
+  (classes: any, timeZone: string, plantingSiteId: number) =>
   (props: RendererProps<TableRowType>): JSX.Element => {
     const { column, row, value } = props;
 

--- a/src/components/PlantingSites/PlantingSiteSubzoneView.tsx
+++ b/src/components/PlantingSites/PlantingSiteSubzoneView.tsx
@@ -104,7 +104,7 @@ export default function PlantingSiteZoneView(): JSX.Element {
   );
 
   return (
-    <Page crumbs={crumbs} title={plantingZone?.plantingSubzones[0]?.name ?? ''}>
+    <Page crumbs={crumbs} title={plantingZone?.plantingSubzones[0]?.fullName ?? ''}>
       <Card flushMobile style={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
         <Search {...searchProps} />
         <Box>

--- a/src/components/PlantingSites/PlantingSiteSubzoneView.tsx
+++ b/src/components/PlantingSites/PlantingSiteSubzoneView.tsx
@@ -1,9 +1,150 @@
-import TfMain from 'src/components/common/TfMain';
+import { useMemo, useState } from 'react';
+import { makeStyles } from '@mui/styles';
+import { Box } from '@mui/material';
+import { useHistory, useParams } from 'react-router-dom';
+import { TableColumnType } from '@terraware/web-components';
+import getDateDisplayValue from '@terraware/web-components/utils/date';
+import strings from 'src/strings';
+import { APP_PATHS } from 'src/constants';
+import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
+import { useAppSelector } from 'src/redux/store';
+import { selectPlantingSite } from 'src/redux/features/tracking/trackingSelectors';
+import { searchPlantingSiteMonitoringPlots } from 'src/redux/features/observations/plantingSiteDetailsSelectors';
+import CellRenderer, { TableRowType } from 'src/components/common/table/TableCellRenderer';
+import { RendererProps } from 'src/components/common/table/types';
+import Card from 'src/components/common/Card';
+import Table from 'src/components/common/table';
+import Search, { SearchProps } from 'src/components/common/SearchFiltersWrapper';
+import { Page, Crumb } from 'src/components/BreadCrumbs';
 
-export default function PlantingSiteSubzoneView() {
+const useStyles = makeStyles(() => ({
+  text: {
+    fontSize: '14px',
+    '& > p': {
+      fontSize: '14px',
+    },
+  },
+}));
+
+const columns = (): TableColumnType[] => [
+  {
+    key: 'monitoringPlotName',
+    name: strings.MONITORING_PLOT,
+    type: 'string',
+  },
+  {
+    key: 'isPermanent',
+    name: strings.PLOT_TYPE,
+    type: 'string',
+  },
+  {
+    key: 'completedTime',
+    name: strings.LAST_OBSERVED,
+    type: 'string',
+  },
+];
+
+export default function PlantingSiteZoneView(): JSX.Element {
+  const [search, setSearch] = useState<string>('');
+  const classes = useStyles();
+  const history = useHistory();
+  const defaultTimeZone = useDefaultTimeZone();
+
+  const { plantingSiteId, zoneId, subzoneId } = useParams<{
+    plantingSiteId: string;
+    zoneId: string;
+    subzoneId: string;
+  }>();
+
+  const plantingSite = useAppSelector((state) => selectPlantingSite(state, Number(plantingSiteId)));
+  const plantingZone = useAppSelector((state) =>
+    searchPlantingSiteMonitoringPlots(state, Number(plantingSiteId), Number(zoneId), Number(subzoneId), '')
+  );
+
+  const timeZone = plantingSite?.timeZone ?? defaultTimeZone.get().id;
+
+  const searchProps = useMemo<SearchProps>(
+    () => ({
+      search,
+      onSearch: (value: string) => setSearch(value),
+    }),
+    [search]
+  );
+
+  if (!plantingSite) {
+    history.push(APP_PATHS.PLANTING_SITES);
+  }
+
+  if (!plantingZone) {
+    history.push(APP_PATHS.PLANTING_SITES_VIEW.replace(':plantingSiteId', plantingSiteId));
+  }
+
+  if (!plantingZone?.plantingSubzones.length) {
+    history.push(
+      APP_PATHS.PLANTING_SITES_ZONE_VIEW.replace(':plantingSiteId', plantingSiteId).replace(':zoneId', zoneId)
+    );
+  }
+
+  const crumbs: Crumb[] = useMemo(
+    () => [
+      {
+        name: strings.PLANTING_SITES,
+        to: APP_PATHS.PLANTING_SITES,
+      },
+      {
+        name: plantingSite?.name ?? '',
+        to: `/${plantingSiteId}`,
+      },
+      {
+        name: plantingZone?.name ?? '',
+        to: `/zone/${zoneId}`,
+      },
+    ],
+    [plantingSiteId, zoneId, plantingSite?.name, plantingZone?.name]
+  );
+
   return (
-    <TfMain>
-      <h3>Placeholder: planting site subzone view</h3>
-    </TfMain>
+    <Page crumbs={crumbs} title={plantingZone?.plantingSubzones[0]?.name ?? ''}>
+      <Card flushMobile style={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
+        <Search {...searchProps} />
+        <Box>
+          <Table
+            id='planting-site-subzone-details-table'
+            columns={columns}
+            rows={plantingZone?.plantingSubzones[0]?.monitoringPlots ?? []}
+            orderBy='monitoringPlotName'
+            Renderer={DetailsRenderer(classes, timeZone)}
+          />
+        </Box>
+      </Card>
+    </Page>
   );
 }
+
+const DetailsRenderer =
+  (classes: any, timeZone: string) =>
+  (props: RendererProps<TableRowType>): JSX.Element => {
+    const { column, row, value } = props;
+
+    if (column.key === 'completedTime') {
+      return (
+        <CellRenderer
+          {...props}
+          value={value ? getDateDisplayValue(value as string, timeZone) : ''}
+          className={classes.text}
+        />
+      );
+    }
+
+    if (column.key === 'isPermanent') {
+      return (
+        <CellRenderer
+          {...props}
+          value={row.isPermanent ? strings.PERMANENT : strings.TEMPORARY}
+          className={classes.text}
+        />
+      );
+    }
+
+    return <CellRenderer {...props} />;
+  };

--- a/src/components/PlantingSites/PlantingSiteZoneView.tsx
+++ b/src/components/PlantingSites/PlantingSiteZoneView.tsx
@@ -111,7 +111,7 @@ const DetailsRenderer =
     const createLinkToSubzone = () => {
       if (row.monitoringPlots.length === 0) {
         // don't link if there are no monitoring plots to show in the details view
-        return row.name;
+        return row.fullName;
       }
       const url = APP_PATHS.PLANTING_SITES_SUBZONE_VIEW.replace(':plantingSiteId', plantingSiteId.toString())
         .replace(':zoneId', zoneId.toString())

--- a/src/components/PlantingSites/PlantingSiteZoneView.tsx
+++ b/src/components/PlantingSites/PlantingSiteZoneView.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles(() => ({
 
 const columns = (): TableColumnType[] => [
   {
-    key: 'name',
+    key: 'fullName',
     name: strings.SUBZONE,
     type: 'string',
   },
@@ -94,7 +94,7 @@ export default function PlantingSiteZoneView(): JSX.Element {
             id='planting-site-zone-details-table'
             columns={columns}
             rows={plantingZone?.plantingSubzones ?? []}
-            orderBy='name'
+            orderBy='fullName'
             Renderer={DetailsRenderer(classes, Number(plantingSiteId), Number(zoneId))}
           />
         </Box>
@@ -116,10 +116,10 @@ const DetailsRenderer =
       const url = APP_PATHS.PLANTING_SITES_SUBZONE_VIEW.replace(':plantingSiteId', plantingSiteId.toString())
         .replace(':zoneId', zoneId.toString())
         .replace(':subzoneId', row.id.toString());
-      return <Link to={url}>{row.name as React.ReactNode}</Link>;
+      return <Link to={url}>{row.fullName as React.ReactNode}</Link>;
     };
 
-    if (column.key === 'name') {
+    if (column.key === 'fullName') {
       return <CellRenderer {...props} value={createLinkToSubzone()} className={classes.text} />;
     }
 

--- a/src/components/PlantingSites/index.tsx
+++ b/src/components/PlantingSites/index.tsx
@@ -1,11 +1,17 @@
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { Route, Switch } from 'react-router-dom';
+import { CircularProgress } from '@mui/material';
 import { APP_PATHS } from 'src/constants';
 import isEnabled from 'src/features';
 import { useOrganization } from 'src/providers';
-import { useAppDispatch } from 'src/redux/store';
+import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { requestPlantingSiteObservationsResults } from 'src/redux/features/observations/observationsThunks';
+import {
+  selectPlantingSiteObservationsResults,
+  selectPlantingSiteObservationsResultsError,
+} from 'src/redux/features/observations/plantingSiteDetailsSelectors';
+import { selectPlantingSites, selectPlantingSitesError } from 'src/redux/features/tracking/trackingSelectors';
 import PlantingSiteCreate from './PlantingSiteCreate';
 import PlantingSitesList from './PlantingSitesList';
 import PlantingSiteView from './PlantingSiteView';
@@ -41,12 +47,30 @@ export function PlantingSitesWrapper({ reloadTracking }: PlantingSitesProps): JS
   const dispatch = useAppDispatch();
   const trackingV2 = isEnabled('TrackingV2');
 
+  const observationsResults = useAppSelector((state) =>
+    selectPlantingSiteObservationsResults(state, Number(plantingSiteId))
+  );
+  const observationsResultsError = useAppSelector((state) =>
+    selectPlantingSiteObservationsResultsError(state, Number(plantingSiteId))
+  );
+
+  const plantingSites = useAppSelector(selectPlantingSites);
+  const plantingSitesError = useAppSelector(selectPlantingSitesError);
+
   useEffect(() => {
     const siteId = Number(plantingSiteId);
     if (!isNaN(siteId) && trackingV2) {
       dispatch(requestPlantingSiteObservationsResults(selectedOrganization.id, siteId));
     }
   }, [dispatch, selectedOrganization.id, plantingSiteId, trackingV2]);
+
+  // show spinner while initializing data
+  if (
+    (observationsResults === undefined && !observationsResultsError) ||
+    (plantingSites === undefined && !plantingSitesError)
+  ) {
+    return <CircularProgress sx={{ margin: 'auto' }} />;
+  }
 
   return (
     <Switch>

--- a/src/stories/BreadCrumbs.stories.tsx
+++ b/src/stories/BreadCrumbs.stories.tsx
@@ -1,8 +1,12 @@
 import { Story } from '@storybook/react';
-import BreadCrumbs, { BreadCrumbsProps } from 'src/components/BreadCrumbs';
+import BreadCrumbs, { BreadCrumbsProps, Page, PageProps } from 'src/components/BreadCrumbs';
 
 const BreadCrumbsTemplate: Story<BreadCrumbsProps> = (args: BreadCrumbsProps) => {
   return <BreadCrumbs {...args} />;
+};
+
+const PageTemplate: Story<PageProps> = (args: PageProps) => {
+  return <Page {...args} />;
 };
 
 export default {
@@ -53,4 +57,21 @@ NonHierarchicalCrumbs.args = {
       to: '/xyz/house',
     },
   ],
+};
+
+export const PageWithCrumbs = PageTemplate.bind({});
+
+PageWithCrumbs.args = {
+  crumbs: [
+    {
+      name: 'root',
+      to: '/root',
+    },
+    {
+      name: 'child',
+      to: '/child',
+    },
+  ],
+  title: 'hello world',
+  children: 'Test page',
 };

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -772,6 +772,7 @@ PLANTS_CARD_DESCRIPTION,They’ve taken root! View all your plants in one place.
 PLANTS_MISSING_TOOLTIP,"Once your planting site has been marked as complete for planting and you’ve completed your observations, you’ll be able to view the total plants."
 PLANTS_PER_HECTARE,plants/ha
 PLEASE_TRY_AGAIN,Please try again.
+PLOT_TYPE,Plot Type
 PLOTS_PERMANENT,Permanent Plots
 PLOTS_TEMPORARY,Temporary Plots
 POUNDS,Pounds


### PR DESCRIPTION
- extract out a common page framework with crumbs (from Observations DetailsPage.tsx)
- add search selectors for zone/subzone/monitoring-plots in planting site details
- added tables/renderers
- the zone/subzone content was very similar so added into one PR also to see refactor/componentizing opportunities
- fixed a monitoring plots population error in planting site observation results aggregation selector

<img width="748" alt="Terraware App 2023-07-12 17-26-12" src="https://github.com/terraware/terraware-web/assets/1865174/c95597a5-9622-4022-90ee-420adeb6d471">

<img width="755" alt="Terraware App 2023-07-12 16-24-17" src="https://github.com/terraware/terraware-web/assets/1865174/274b6944-6b5c-4c22-8df2-2d98244e2f30">
