### PR TITLE
SW-3880 Add map tooltip popups on planting site details page

### DIFF
--- a/src/components/Map/MapRenderUtils.tsx
+++ b/src/components/Map/MapRenderUtils.tsx
@@ -3,7 +3,7 @@ import { Box, Typography, useTheme } from '@mui/material';
 import { MapPopupRenderer, MapSourceProperties } from 'src/types/Map';
 import strings from 'src/strings';
 
-const useStyles = makeStyles(() => ({
+export const useStyles = makeStyles(() => ({
   popup: {
     '& > .mapboxgl-popup-content': {
       borderRadius: '8px',
@@ -25,19 +25,6 @@ export function useSpeciesPlantsRenderer(subzonesWithPlants: any): MapPopupRende
     color: theme.palette.TwClrBaseBlack as string,
   };
 
-  const quantityStyle = {
-    ...textStyle,
-    textAlign: 'right',
-    marginRight: theme.spacing(1),
-  };
-
-  const speciesStyle = {
-    ...textStyle,
-    textAlign: 'left',
-    marginLeft: theme.spacing(1),
-    overflowWrap: 'anywhere',
-  };
-
   return {
     className: classes.popup,
     render: (data: MapSourceProperties): JSX.Element => {
@@ -53,21 +40,73 @@ export function useSpeciesPlantsRenderer(subzonesWithPlants: any): MapPopupRende
       }
 
       return (
-        <table>
-          <tbody>
-            {populations.map((population: any, index: number) => (
-              <tr key={index}>
-                <td>
-                  <Typography sx={quantityStyle}>{population.totalPlants}</Typography>
-                </td>
-                <td>
-                  <Typography sx={speciesStyle}>{population.species_scientificName}</Typography>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <MapTooltip
+          properties={populations.map((population: any) => ({
+            key: population.totalPlants,
+            value: population.species_scientificName,
+          }))}
+        />
       );
     },
   };
+}
+
+/**
+ * Generic tooltip renderer
+ */
+export type TooltipProperty = {
+  key: string;
+  value: string | number;
+};
+
+export type MapTooltipProps = {
+  title?: string;
+  properties: TooltipProperty[];
+};
+
+export function MapTooltip({ title, properties }: MapTooltipProps): JSX.Element {
+  const theme = useTheme();
+
+  const textStyle = {
+    fontWeight: 400,
+    fontSize: '16px',
+    color: theme.palette.TwClrBaseBlack as string,
+  };
+
+  const keyStyle = {
+    ...textStyle,
+    textAlign: 'right',
+    marginRight: theme.spacing(1),
+  };
+
+  const valueStyle = {
+    ...textStyle,
+    textAlign: 'left',
+    marginLeft: theme.spacing(1),
+    overflowWrap: 'anywhere',
+  };
+
+  return (
+    <>
+      {title && (
+        <Typography fontSize='16px' fontWeight={600} marginBottom={theme.spacing(2)} textAlign='center'>
+          {title}
+        </Typography>
+      )}
+      <table>
+        <tbody>
+          {properties.map((prop: TooltipProperty, index: number) => (
+            <tr key={index}>
+              <td>
+                <Typography sx={keyStyle}>{prop.key}</Typography>
+              </td>
+              <td>
+                <Typography sx={valueStyle}>{prop.value}</Typography>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
+  );
 }

--- a/src/components/Map/MapRenderUtils.tsx
+++ b/src/components/Map/MapRenderUtils.tsx
@@ -3,7 +3,7 @@ import { Box, Typography, useTheme } from '@mui/material';
 import { MapPopupRenderer, MapSourceProperties } from 'src/types/Map';
 import strings from 'src/strings';
 
-export const useStyles = makeStyles(() => ({
+const useStyles = makeStyles(() => ({
   popup: {
     '& > .mapboxgl-popup-content': {
       borderRadius: '8px',

--- a/src/components/PlantingSites/BoundariesAndZones.tsx
+++ b/src/components/PlantingSites/BoundariesAndZones.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { makeStyles } from '@mui/styles';
 import { Box, Typography, useTheme } from '@mui/material';
+import getDateDisplayValue from '@terraware/web-components/utils/date';
 import strings from 'src/strings';
 import { PlantingSite, PlantingZone } from 'src/types/Tracking';
-import { MapEntityId } from 'src/types/Map';
+import { MapEntityId, MapSourceProperties } from 'src/types/Map';
 import { ZoneAggregation } from 'src/types/Observations';
 import { useAppSelector } from 'src/redux/store';
+import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 import { regexMatch } from 'src/utils/search';
 import { PlantingSiteMap } from '../Map';
 import { searchPlantingSiteZones } from 'src/redux/features/observations/plantingSiteDetailsSelectors';
@@ -17,6 +20,17 @@ import Search, { SearchProps } from 'src/components/common/SearchFiltersWrapper'
 import { View } from 'src/components/common/ListMapSelector';
 import ListMapView from 'src/components/ListMapView';
 import PlantingSiteDetailsTable from './PlantingSiteDetailsTable';
+import { TooltipProperty, MapTooltip } from 'src/components/Map/MapRenderUtils';
+
+export const useMapTooltipStyles = makeStyles(() => ({
+  popup: {
+    '& > .mapboxgl-popup-content': {
+      borderRadius: '8px',
+      padding: '10px',
+      minWidth: '260px',
+    },
+  },
+}));
 
 type BoundariesAndZonesProps = {
   plantingSite: PlantingSite;
@@ -113,9 +127,12 @@ type PlantingSiteMapViewProps = {
 };
 
 function PlantingSiteMapView({ plantingSite, data, search }: PlantingSiteMapViewProps): JSX.Element | null {
+  const classes = useMapTooltipStyles();
   const [searchZoneEntities, setSearchZoneEntities] = useState<MapEntityId[]>([]);
   const layerOptions: MapLayer[] = ['Planting Site', 'Zones', 'Sub-Zones', 'Monitoring Plots'];
   const [includedLayers, setIncludedLayers] = useState<MapLayer[]>(['Planting Site', 'Zones', 'Monitoring Plots']);
+  const defaultTimeZone = useDefaultTimeZone();
+  const timeZone = plantingSite.timeZone ?? defaultTimeZone.get().id;
 
   const layerOptionLabels: Record<MapLayer, string> = {
     'Planting Site': strings.PLANTING_SITE,
@@ -148,6 +165,10 @@ function PlantingSiteMapView({ plantingSite, data, search }: PlantingSiteMapView
         layers={includedLayers}
         highlightEntities={searchZoneEntities}
         focusEntities={searchZoneEntities.length ? searchZoneEntities : [{ sourceId: 'sites', id: plantingSite.id }]}
+        contextRenderer={{
+          render: contextRenderer(plantingSite, data, timeZone),
+          className: classes.popup,
+        }}
         topRightMapControl={
           <MapLayerSelect
             initialSelection={includedLayers}
@@ -164,3 +185,55 @@ function PlantingSiteMapView({ plantingSite, data, search }: PlantingSiteMapView
     </Box>
   );
 }
+
+const contextRenderer =
+  (site: PlantingSite, data: ZoneAggregation[], timeZone: string) =>
+  (entity: MapSourceProperties): JSX.Element => {
+    let properties: TooltipProperty[] = [];
+    let title: string | undefined;
+    if (entity.type === 'site') {
+      title = site.name;
+      properties = [
+        { key: strings.ZONES, value: data.length },
+        { key: strings.SUBZONES, value: data.flatMap((z) => z.plantingSubzones).length },
+        {
+          key: strings.MONITORING_PLOTS,
+          value: data.flatMap((z) => z.plantingSubzones).flatMap((sz) => sz.monitoringPlots).length,
+        },
+      ];
+    } else if (entity.type === 'zone') {
+      const zone = data.find((z) => z.id === entity.id);
+      title = zone?.name;
+      properties = [
+        { key: strings.SUBZONES, value: zone?.plantingSubzones.length ?? 0 },
+        {
+          key: strings.MONITORING_PLOTS,
+          value: zone?.plantingSubzones.flatMap((sz) => sz.monitoringPlots).length ?? 0,
+        },
+        {
+          key: strings.LAST_OBSERVED,
+          value: zone?.completedTime ? getDateDisplayValue(zone.completedTime, timeZone) : '',
+        },
+      ];
+    } else if (entity.type === 'subzone') {
+      const subzone = data.flatMap((z) => z.plantingSubzones).find((sz) => sz.id === entity.id);
+      title = subzone?.fullName;
+      properties = [{ key: strings.MONITORING_PLOTS, value: subzone?.monitoringPlots.length ?? 0 }];
+    } else {
+      // monitoring plot
+      const plot = data
+        .flatMap((z) => z.plantingSubzones)
+        .flatMap((sz) => sz.monitoringPlots)
+        .find((mp) => mp.monitoringPlotId === entity.id);
+      title = plot?.monitoringPlotName;
+      properties = [
+        { key: strings.PLOT_TYPE, value: plot ? (plot.isPermanent ? strings.PERMANENT : strings.TEMPORARY) : '' },
+        {
+          key: strings.LAST_OBSERVED,
+          value: plot?.completedTime ? getDateDisplayValue(plot.completedTime, timeZone) : '',
+        },
+      ];
+    }
+
+    return <MapTooltip title={title} properties={properties} />;
+  };


### PR DESCRIPTION
- reused styles/layout from existing render utils that shows simple stats
- refactored some for reusability

<img width="249" alt="Terraware App 2023-07-13 11-18-21" src="https://github.com/terraware/terraware-web/assets/1865174/8b5766ef-7c04-4586-b144-1969328c466f">

<img width="241" alt="Terraware App 2023-07-13 11-18-03" src="https://github.com/terraware/terraware-web/assets/1865174/cf4dc64c-cbae-4c1e-9700-8f6fc4fdf3f5">

<img width="254" alt="Terraware App 2023-07-13 11-17-19" src="https://github.com/terraware/terraware-web/assets/1865174/aaa6b126-cd06-40b8-b6a0-12fb99d1403f">

<img width="613" alt="Terraware App 2023-07-13 11-16-23" src="https://github.com/terraware/terraware-web/assets/1865174/9bfa59ce-bb16-4cdb-bd6f-bbe45de7b685">
