### PR TITLE
SW-3914 Fix Highlight for Map

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -219,8 +219,11 @@ export default function Map(props: MapProps): JSX.Element {
     const { sources } = options;
 
     clearFeatureVar(hoverStateId);
-    clearFeatureVar(selectStateId);
     clearFeatureVar(highlightStateId);
+    if (!popupInfo) {
+      // don't clear select state if popup is open
+      clearFeatureVar(selectStateId);
+    }
 
     const mouseMoveCallbacks = sources
       .filter((source) => source.isInteractive)
@@ -267,7 +270,7 @@ export default function Map(props: MapProps): JSX.Element {
         map.off('mouseleave', layerId, cb[layerId]);
       });
     };
-  }, [options, highlightStateId, selectStateId, hoverStateId, updateFeatureState]);
+  }, [options, highlightStateId, selectStateId, hoverStateId, popupInfo, updateFeatureState]);
 
   const onLoad = () => {
     if (deferredHighlightEntity) {


### PR DESCRIPTION
Previously, the map could get into a state where the highlight from
selection of a map entity was stuck. This was due to the select state
being cleared when the map data changed and a map popup was still open.
In the code for updating callbacks on map data change, only clear the
select map feature if the popup is not open. This allows the popup
close handler to properly reset this feature state.