### PR TITLE
SW-3921 Feedback changes, add missing tooltips + fix tooltip style

### DIFF
--- a/src/components/Map/MapRenderUtils.tsx
+++ b/src/components/Map/MapRenderUtils.tsx
@@ -72,17 +72,17 @@ export function MapTooltip({ title, properties }: MapTooltipProps): JSX.Element 
     fontSize: '16px',
     color: theme.palette.TwClrBaseBlack as string,
     whiteSpace: 'pre',
+    textAlign: 'left',
   };
 
   const keyStyle = {
     ...textStyle,
-    textAlign: 'right',
     marginRight: theme.spacing(1),
+    overflowWrap: 'anywhere',
   };
 
   const valueStyle = {
     ...textStyle,
-    textAlign: 'left',
     marginLeft: theme.spacing(1),
     overflowWrap: 'anywhere',
   };

--- a/src/components/Map/MapRenderUtils.tsx
+++ b/src/components/Map/MapRenderUtils.tsx
@@ -71,6 +71,7 @@ export function MapTooltip({ title, properties }: MapTooltipProps): JSX.Element 
     fontWeight: 400,
     fontSize: '16px',
     color: theme.palette.TwClrBaseBlack as string,
+    whiteSpace: 'pre',
   };
 
   const keyStyle = {

--- a/src/components/Map/MapRenderUtils.tsx
+++ b/src/components/Map/MapRenderUtils.tsx
@@ -90,7 +90,7 @@ export function MapTooltip({ title, properties }: MapTooltipProps): JSX.Element 
   return (
     <>
       {title && (
-        <Typography fontSize='16px' fontWeight={600} marginBottom={theme.spacing(2)} textAlign='center'>
+        <Typography fontSize='16px' fontWeight={600} marginBottom={theme.spacing(2)} textAlign='left'>
           {title}
         </Typography>
       )}

--- a/src/components/PlantingSites/BoundariesAndZones.tsx
+++ b/src/components/PlantingSites/BoundariesAndZones.tsx
@@ -241,9 +241,5 @@ const contextRenderer =
       ];
     }
 
-    return (
-      <Box display='flex' flexDirection='column'>
-        <MapTooltip title={title} properties={properties} />
-      </Box>
-    );
+    return <MapTooltip title={title} properties={properties} />;
   };

--- a/src/components/PlantingSites/BoundariesAndZones.tsx
+++ b/src/components/PlantingSites/BoundariesAndZones.tsx
@@ -27,7 +27,8 @@ export const useMapTooltipStyles = makeStyles(() => ({
     '& > .mapboxgl-popup-content': {
       borderRadius: '8px',
       padding: '10px',
-      minWidth: '260px',
+      width: 'fit-content',
+      maxWidth: '350px',
     },
   },
 }));
@@ -205,6 +206,8 @@ const contextRenderer =
       const zone = data.find((z) => z.id === entity.id);
       title = zone?.name;
       properties = [
+        { key: strings.TARGET_PLANTING_DENSITY, value: zone?.targetPlantingDensity ?? 0 },
+        { key: strings.PLANTING_COMPLETE, value: zone?.plantingCompleted ? strings.YES : strings.NO },
         { key: strings.SUBZONES, value: zone?.plantingSubzones.length ?? 0 },
         {
           key: strings.MONITORING_PLOTS,
@@ -218,7 +221,10 @@ const contextRenderer =
     } else if (entity.type === 'subzone') {
       const subzone = data.flatMap((z) => z.plantingSubzones).find((sz) => sz.id === entity.id);
       title = subzone?.fullName;
-      properties = [{ key: strings.MONITORING_PLOTS, value: subzone?.monitoringPlots.length ?? 0 }];
+      properties = [
+        { key: strings.PLANTING_COMPLETE, value: subzone?.plantingCompleted ? strings.YES : strings.NO },
+        { key: strings.MONITORING_PLOTS, value: subzone?.monitoringPlots.length ?? 0 },
+      ];
     } else {
       // monitoring plot
       const plot = data
@@ -235,5 +241,9 @@ const contextRenderer =
       ];
     }
 
-    return <MapTooltip title={title} properties={properties} />;
+    return (
+      <Box display='flex' flexDirection='column'>
+        <MapTooltip title={title} properties={properties} />
+      </Box>
+    );
   };

--- a/src/services/TrackingService.ts
+++ b/src/services/TrackingService.ts
@@ -176,6 +176,7 @@ const getTotalPlantsInZones = async (organizationId: number, siteId: number): Pr
       'plantingSubzones.populations.species_scientificName',
       'plantingSubzones.populations.species_organization_id',
       'plantingSubzones.populations.totalPlants(raw)',
+      'plantingSubzones.populations.totalPlants',
       'id',
       'name',
     ],


### PR DESCRIPTION
- demo'd to Chudo, found some missing tooltip properties and style issues
- added missing tooltips
- give more width to tooltip based on content
- added back a field in service which is needed in the previous plants dashboard map tooltip (totalPlants as localized by server)

<img width="193" alt="Terraware App 2023-07-14 07-00-27" src="https://github.com/terraware/terraware-web/assets/1865174/df4ba6b1-577b-45e9-8b3d-5c6c59a5f57e">

<img width="212" alt="Terraware App 2023-07-14 07-00-12" src="https://github.com/terraware/terraware-web/assets/1865174/e97a0260-af1b-45ad-918a-946a4dee8c89">

<img width="188" alt="Terraware App 2023-07-14 06-59-52" src="https://github.com/terraware/terraware-web/assets/1865174/a8a942e3-bb66-454e-b66c-0b0395a49b46">

<img width="205" alt="Terraware App 2023-07-14 06-59-29" src="https://github.com/terraware/terraware-web/assets/1865174/87c95248-6c8f-4697-86b2-b565a5a12396">
