### PR TITLE
SW-3903 Add Planting Site Selector for Map View

### DIFF
--- a/src/components/NurseryWithdrawals/PlantingProgressMap.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressMap.tsx
@@ -1,3 +1,7 @@
-export default function PlantingProgressList(): JSX.Element {
-  return <p>'I am a map'</p>;
+type PlantingProgressMapProps = {
+  plantingSiteId: number;
+};
+
+export default function PlantingProgressMap({ plantingSiteId }: PlantingProgressMapProps): JSX.Element {
+  return <p>{`I am a map of planting site ${plantingSiteId}`}</p>;
 }

--- a/src/components/NurseryWithdrawals/PlantingProgressTabContent.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressTabContent.tsx
@@ -10,6 +10,10 @@ import { FilterField } from 'src/components/common/FilterGroup';
 import Search, { SearchProps } from 'src/components/common/SearchFiltersWrapper';
 import PlantingProgressList from './PlantingProgressList';
 import PlantingProgressMap from './PlantingProgressMap';
+import { View } from 'src/components/common/ListMapSelector';
+import PlantingSiteSelector from 'src/components/common/PlantingSiteSelector';
+
+const initialView: View = 'list';
 
 export default function PlantingProgress(): JSX.Element {
   const theme = useTheme();
@@ -18,6 +22,8 @@ export default function PlantingProgress(): JSX.Element {
   const [search, setSearch] = useState<string>('');
   const [filters, setFilters] = useState<Record<string, any>>({});
   const [filterOptions, setFilterOptions] = useState<FieldOptionsMap>({});
+  const [activeView, setActiveView] = useState<View>(initialView);
+  const [selectedPlantingSiteId, setSelectedPlantingSiteId] = useState<number>(-1);
 
   const filterColumns = useMemo<FilterField[]>(
     () =>
@@ -58,11 +64,31 @@ export default function PlantingProgress(): JSX.Element {
       </Typography>
       <ListMapView
         style={{ padding: isMobile ? theme.spacing(3) : theme.spacing(3, 0, 0) }}
-        initialView='list'
-        search={<Search {...searchProps} />}
+        initialView={initialView}
+        onView={setActiveView}
+        search={<SearchComponent view={activeView} onChangePlantingSite={setSelectedPlantingSiteId} {...searchProps} />}
         list={<PlantingProgressList />}
-        map={<PlantingProgressMap />}
+        map={<PlantingProgressMap plantingSiteId={selectedPlantingSiteId} />}
       />
     </Card>
+  );
+}
+
+type SearchComponentProps = SearchProps & {
+  view: View;
+  onChangePlantingSite: (newSiteId: number) => void;
+};
+
+function SearchComponent(props: SearchComponentProps): JSX.Element {
+  const { search, onSearch, filtersProps, view, onChangePlantingSite } = props;
+  return (
+    <>
+      <div style={{ display: view === 'list' ? 'flex' : 'none' }}>
+        <Search search={search} onSearch={onSearch} filtersProps={filtersProps} />
+      </div>
+      <div style={{ display: view === 'map' ? 'flex' : 'none' }}>
+        <PlantingSiteSelector onChange={onChangePlantingSite} />
+      </div>
+    </>
   );
 }

--- a/src/components/common/PlantingSiteSelector.tsx
+++ b/src/components/common/PlantingSiteSelector.tsx
@@ -24,7 +24,7 @@ export default function PlantingSiteSelector({ onChange }: PlantingSiteSelectorP
       setSelectedPlantingSiteId(isNaN(id) ? -1 : id);
       onChange(isNaN(id) ? -1 : id);
     },
-    [onChange, setSelectedPlantingSiteId]
+    [onChange]
   );
 
   useEffect(() => {

--- a/src/components/common/PlantingSiteSelector.tsx
+++ b/src/components/common/PlantingSiteSelector.tsx
@@ -1,0 +1,44 @@
+import { Dropdown } from '@terraware/web-components';
+import { useAppSelector } from 'src/redux/store';
+import { selectPlantingSites } from 'src/redux/features/tracking/trackingSelectors';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import strings from 'src/strings';
+
+type PlantingSiteSelectorProps = {
+  onChange: (plantingSiteId: number) => void;
+};
+
+export default function PlantingSiteSelector({ onChange }: PlantingSiteSelectorProps): JSX.Element {
+  // assume `requestPlantingSites` thunk has been dispatched by consumer
+  const plantingSites = useAppSelector(selectPlantingSites);
+  const [selectedPlantingSiteId, setSelectedPlantingSiteId] = useState<number | undefined>();
+
+  const options = useMemo(
+    () => plantingSites?.map((site) => ({ label: site.name, value: site.id })) ?? [],
+    [plantingSites]
+  );
+
+  const updateSelection = useCallback(
+    (newValue: any) => {
+      const id = Number(newValue);
+      setSelectedPlantingSiteId(isNaN(id) ? -1 : id);
+      onChange(isNaN(id) ? -1 : id);
+    },
+    [onChange, setSelectedPlantingSiteId]
+  );
+
+  useEffect(() => {
+    if (plantingSites && (selectedPlantingSiteId === undefined || selectedPlantingSiteId === -1)) {
+      updateSelection(plantingSites[0]?.id);
+    }
+  }, [plantingSites, selectedPlantingSiteId, updateSelection]);
+
+  return (
+    <Dropdown
+      placeholder={strings.SELECT}
+      onChange={updateSelection}
+      options={options}
+      selectedValue={selectedPlantingSiteId}
+    />
+  );
+}


### PR DESCRIPTION
- create a common PlantingSiteSelector component
- create a component that variably displays search or the selector based on view
- keep track of the selected planting site id and pass to map

<img width="1252" alt="image" src="https://github.com/terraware/terraware-web/assets/114949086/1325244f-1f3e-4529-a803-168d487b3016">
