### PR TITLE
SW-3895-table Add plantings progress table

### DIFF
--- a/src/components/NurseryWithdrawals/PlantingProgressList.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressList.tsx
@@ -1,7 +1,116 @@
+import { makeStyles } from '@mui/styles';
+import { Box, CircularProgress } from '@mui/material';
+import { TableColumnType } from '@terraware/web-components';
+import strings from 'src/strings';
+import { APP_PATHS } from 'src/constants';
 import { useAppSelector } from 'src/redux/store';
 import { searchPlantingProgress } from 'src/redux/features/plantings/plantingsSelectors';
+import CellRenderer, { TableRowType } from 'src/components/common/table/TableCellRenderer';
+import { RendererProps } from 'src/components/common/table/types';
+import Table from 'src/components/common/table';
+import Link from 'src/components/common/Link';
 
-export default function PlantingProgressList(): JSX.Element {
-  const data = useAppSelector((state: any) => searchPlantingProgress(state, ''));
-  return <p>I am a list {data.length}</p>;
+const useStyles = makeStyles(() => ({
+  text: {
+    fontSize: '14px',
+    '& > p': {
+      fontSize: '14px',
+    },
+  },
+}));
+
+const columnsWithoutZones = (): TableColumnType[] => [
+  {
+    key: 'siteName',
+    name: strings.PLANTING_SITE,
+    type: 'string',
+  },
+  {
+    key: 'totalSeedlingsSent',
+    name: strings.TOTAL_SEEDLINGS_SENT,
+    type: 'number',
+  },
+];
+
+const columnsWithZones = (): TableColumnType[] => [
+  {
+    key: 'subzoneName',
+    name: strings.SUBZONE,
+    type: 'string',
+  },
+  {
+    key: 'plantingCompleted',
+    name: strings.PLANTING_COMPLETE,
+    tooltipTitle: strings.PLANTING_COMPLETE_TOOLTIP,
+    type: 'boolean',
+  },
+  {
+    key: 'siteName',
+    name: strings.PLANTING_SITE,
+    type: 'string',
+  },
+  {
+    key: 'zoneName',
+    name: strings.ZONE,
+    type: 'string',
+  },
+  {
+    key: 'targetPlantingDensity',
+    name: strings.TARGET_PLANTING_DENSITY,
+    tooltipTitle: strings.TARGET_PLANTING_DENSITY_TOOLTIP,
+    type: 'number',
+  },
+  {
+    key: 'totalSeedlingsSent',
+    name: strings.TOTAL_SEEDLINGS_SENT,
+    type: 'number',
+  },
+];
+
+export type PlantingProgressListProps = {
+  search: string;
+  plantingCompleted?: boolean;
+};
+
+export default function PlantingProgressList({ search, plantingCompleted }: PlantingProgressListProps): JSX.Element {
+  const classes = useStyles();
+  const data = useAppSelector((state: any) => searchPlantingProgress(state, search, plantingCompleted));
+
+  const hasZones = data?.some((d) => d.subzoneName);
+
+  if (!data) {
+    return <CircularProgress sx={{ margin: 'auto' }} />;
+  }
+
+  return (
+    <Box>
+      <Table
+        id='plantings-progress-table'
+        columns={hasZones ? columnsWithZones : columnsWithoutZones}
+        rows={data}
+        orderBy={hasZones ? 'subzoneName' : 'siteName'}
+        Renderer={DetailsRenderer(classes)}
+      />
+    </Box>
+  );
 }
+
+const DetailsRenderer =
+  (classes: any) =>
+  (props: RendererProps<TableRowType>): JSX.Element => {
+    const { column, row } = props;
+
+    const createLinkToWithdrawals = () => {
+      const filterParam = row.subzoneName
+        ? `subzoneName=${encodeURIComponent(row.subzoneName)}`
+        : `siteName=${encodeURIComponent(row.siteName)}`;
+      const url = `${APP_PATHS.NURSERY_WITHDRAWALS}?tab=${strings.WITHDRAWAL_HISTORY}&${filterParam}`;
+      return <Link to={url}>{row.totalSeedlingsSent as React.ReactNode}</Link>;
+    };
+
+    if (column.key === 'totalSeedlingsSent') {
+      return <CellRenderer {...props} value={createLinkToWithdrawals()} className={classes.text} />;
+    }
+
+    return <CellRenderer {...props} className={classes.text} />;
+  };

--- a/src/components/NurseryWithdrawals/PlantingProgressTabContent.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressTabContent.tsx
@@ -45,6 +45,12 @@ export default function PlantingProgress(): JSX.Element {
     [filters, filterColumns, filterOptions, search]
   );
 
+  const plantingCompleted = useMemo<boolean | undefined>(() => {
+    if (activeLocale && filters.plantingCompleted?.values?.length > 0) {
+      return filters.plantingCompleted.values[0] === strings.YES;
+    }
+  }, [filters, activeLocale]);
+
   useEffect(() => {
     setFilterOptions({
       plantingCompleted: {
@@ -69,7 +75,7 @@ export default function PlantingProgress(): JSX.Element {
         initialView={initialView}
         onView={setActiveView}
         search={<SearchComponent view={activeView} onChangePlantingSite={setSelectedPlantingSiteId} {...searchProps} />}
-        list={<PlantingProgressList />}
+        list={<PlantingProgressList search={search} plantingCompleted={plantingCompleted} />}
         map={<PlantingProgressMap plantingSiteId={selectedPlantingSiteId} />}
       />
     </Card>

--- a/src/redux/features/plantings/plantingsSelectors.ts
+++ b/src/redux/features/plantings/plantingsSelectors.ts
@@ -59,7 +59,7 @@ export const selectPlantingProgress = createSelector(
                 subzoneName: sz.fullName,
                 plantingCompleted: sz.plantingCompleted,
                 plantingSite: ps.name,
-                zone: zone.name,
+                zoneName: zone.name,
                 targetPlantingDensity: zone.targetPlantingDensity,
                 totalSeedlingsSent: plantingsBySubzone[sz.id],
               }))
@@ -79,8 +79,8 @@ export const searchPlantingProgress = createSelector(
     (state: RootState, query: string, plantingCompleted?: boolean) => plantingCompleted,
   ],
   (plantingProgress, query, plantingCompleted) => {
-    return (plantingProgress ?? [])
-      .filter((planting) => planting.totalPlants > 0)
+    return plantingProgress
+      ?.filter((planting) => planting.totalPlants > 0)
       .reduce((acc, curr) => {
         const { siteId, siteName, totalPlants, reported } = curr;
         if (reported && reported.length > 0) {
@@ -93,7 +93,7 @@ export const searchPlantingProgress = createSelector(
             }
           });
         } else if (!query && plantingCompleted === undefined) {
-          acc.push({ siteId, siteName, totalPlants });
+          acc.push({ siteId, siteName, totalSeedlingsSent: totalPlants });
         }
         return acc;
       }, [] as any[]);

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -1190,6 +1190,7 @@ TOTAL_PLANTS_PLANTED_HELPER_TEXT,Species not classified as “trees” in the sp
 TOTAL_QUANTITY,Total Quantity
 TOTAL_READY_QUANTITY,Total Ready Quantity
 TOTAL_SEED_COUNT,Total Seed Count
+TOTAL_SEEDLINGS_SENT,Total Seedlings Sent
 TOTAL_SEEDS_COUNT_ESTIMATION,Total Seeds Count Estimation
 TOTAL_SEEDS_GERMINATED,Total Seeds Germinated
 TOTAL_SEEDS_GERMINATED_ERROR,Germinated amount should not be more than tested amount.

--- a/src/types/PlantingSite.ts
+++ b/src/types/PlantingSite.ts
@@ -24,7 +24,7 @@ export type PlantingProgressSubzone = {
   subzoneName: string;
   plantingCompleted: boolean;
   plantingSite: string;
-  zone: string;
+  zoneName: string;
   targetPlantingDensity: number;
   totalSeedlingsSent?: number;
 };


### PR DESCRIPTION
- added table
- table selection etc is a follow up
- renderer with link to withdrawals (this requires more work on withdrawals component as a follow up)
- cleaned up some selectors
- linked with search

<img width="748" alt="Terraware App 2023-07-18 16-11-27" src="https://github.com/terraware/terraware-web/assets/1865174/875b6e37-4c4f-47d0-a8e8-6fe8083264df">

<img width="728" alt="Terraware App 2023-07-18 16-10-59" src="https://github.com/terraware/terraware-web/assets/1865174/44cccc5d-5acc-4bef-ac12-ab20871916f9">

<img width="736" alt="Terraware App 2023-07-18 16-10-27" src="https://github.com/terraware/terraware-web/assets/1865174/5a32cd88-3e10-4daa-b330-572df1fad60a">

<img width="744" alt="Terraware App 2023-07-18 16-08-28" src="https://github.com/terraware/terraware-web/assets/1865174/28fb2e55-e517-4677-95c3-8b60fdbce943">
