### PR TITLE
SW-3900 Add subzone filter to nursery withdrawals table

### DIFF
--- a/src/components/NurseryWithdrawals/NurseryWithdrawalsTable.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawalsTable.tsx
@@ -72,6 +72,7 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
             { name: 'purpose', label: strings.PURPOSE, type: 'multiple_selection' },
             { name: 'facility_name', label: strings.FROM_NURSERY, type: 'multiple_selection' },
             { name: 'destinationName', label: strings.DESTINATION, type: 'multiple_selection' },
+            { name: 'plantingSubzoneNames', label: strings.SUBZONE, type: 'multiple_selection' },
             {
               name: 'batchWithdrawals.batch_species_scientificName',
               label: strings.SPECIES,

--- a/src/services/NurseryWithdrawalService.ts
+++ b/src/services/NurseryWithdrawalService.ts
@@ -194,22 +194,48 @@ const getFilterOptions = async (organizationId: number): Promise<FieldOptionsMap
   return (data ?? []).reduce((acc, d) => {
     return Object.keys(d).reduce((innerAcc, k) => {
       const isBatchWithdrawals = k === 'batchWithdrawals';
+      const isSubzones = k === 'plantingSubzoneNames';
       const newKey = isBatchWithdrawals ? 'batchWithdrawals.batch_species_scientificName' : k;
       if (!innerAcc[newKey]) {
         innerAcc[newKey] = { partial: false, values: [] };
       }
-      const value = isBatchWithdrawals
-        ? (d[k] as any[]).map((batchWithdrawal) => batchWithdrawal.batch_species_scientificName)
-        : d[k];
-      if (Array.isArray(value)) {
-        (innerAcc[newKey] as Record<string, any>).values.push(...value);
+      let value;
+      if (isBatchWithdrawals) {
+        value = (d[k] as any[]).map((batchWithdrawal) => batchWithdrawal.batch_species_scientificName);
+      } else if (isSubzones) {
+        value = parsePlantingSubzones(d[k] as string);
       } else {
-        (innerAcc[newKey] as Record<string, any>).values.push(value);
+        value = d[k];
       }
+      const record = innerAcc[newKey] as Record<string, any>;
+      const currentValues = record.values;
+      if (Array.isArray(value)) {
+        currentValues.push(...value);
+      } else {
+        currentValues.push(value);
+      }
+      // sort the values (uniquification in set is not necessary but helps with sort perf)
+      const newValues = Array.from(new Set([...currentValues])).sort((a, b) => a.localeCompare(b));
+      record.values = newValues;
       return innerAcc;
     }, acc);
   }, {}) as FieldOptionsMap;
 };
+
+/**
+ * Parse subzones from following patterns:
+ * 'subzone'
+ * 'subzone (subzone)'
+ * 'subzone (subzone1, subzone2)' [basically (subzone1, subzone2..., subzoneN)]
+ */
+const parsePlantingSubzones = (value: string): string[] =>
+  (value || '')
+    .replaceAll('(', '') // remove ( and ) and ,
+    .replaceAll(')', '')
+    .replaceAll(',', '')
+    .split(' ') // split on space
+    .map((s) => s.trim()) // return trimmed value and filter out empty values
+    .filter((x) => x);
 
 /**
  * Exported functions


### PR DESCRIPTION
- parse subzones filter options in service (sort values)
- enable subzones filter option
- this will be used in a follow up PR to set filters based on url params

<img width="728" alt="Terraware App 2023-07-20 10-58-41" src="https://github.com/terraware/terraware-web/assets/1865174/a5fa34e2-b0c0-4e03-ab39-c23586f73f24">

<img width="623" alt="Terraware App 2023-07-20 10-57-47" src="https://github.com/terraware/terraware-web/assets/1865174/0e4697aa-3064-4150-90d0-e17011875786">

<img width="260" alt="Terraware App 2023-07-20 10-57-22" src="https://github.com/terraware/terraware-web/assets/1865174/32265206-3fc2-4909-a1bb-814fda5ebac0">

<img width="750" alt="Terraware App 2023-07-20 10-52-53" src="https://github.com/terraware/terraware-web/assets/1865174/8f27a358-42bb-4159-a7d5-b2d11245bd37">

