### PR TITLE
SW-3942 Prevent Zoom to Site on Marking Subzones Complete

### DIFF
--- a/src/components/NurseryWithdrawals/PlantingProgressMap.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressMap.tsx
@@ -48,6 +48,7 @@ export default function PlantingProgressMap({ plantingSiteId }: PlantingProgress
         setFocusEntities([{ sourceId: 'sites', id: plantingSite?.id }]);
       } else {
         setMapData(undefined);
+        setFocusEntities([]);
       }
     }
     setDispatching(false);

--- a/src/components/NurseryWithdrawals/PlantingProgressMap.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressMap.tsx
@@ -38,16 +38,20 @@ export default function PlantingProgressMap({ plantingSiteId }: PlantingProgress
   const [dispatching, setDispatching] = useState(false);
   const [requestId, setRequestId] = useState<string>('');
   const updateStatus = useAppSelector((state) => selectUpdatePlantingCompleted(state, requestId));
+  const [focusEntities, setFocusEntities] = useState<{ sourceId: string; id: number }[]>([]);
   const snackbar = useSnackbar();
 
   useEffect(() => {
-    if (plantingSite?.boundary) {
-      setMapData(MapService.getMapDataFromPlantingSite(plantingSite));
-    } else {
-      setMapData(undefined);
+    if (!mapData?.site?.entities || plantingSite?.id !== mapData.site.entities[0]?.id) {
+      if (plantingSite?.boundary) {
+        setMapData(MapService.getMapDataFromPlantingSite(plantingSite));
+        setFocusEntities([{ sourceId: 'sites', id: plantingSite?.id }]);
+      } else {
+        setMapData(undefined);
+      }
     }
     setDispatching(false);
-  }, [plantingSite]);
+  }, [plantingSite, mapData?.site?.entities]);
 
   const subzonesComplete: Record<number, boolean> = useMemo(() => {
     const result: Record<number, boolean> = {};
@@ -86,6 +90,7 @@ export default function PlantingProgressMap({ plantingSiteId }: PlantingProgress
         })
       );
       setRequestId(request.requestId);
+      setFocusEntities([]);
       setDispatching(true);
     },
     [dispatch]
@@ -94,7 +99,7 @@ export default function PlantingProgressMap({ plantingSiteId }: PlantingProgress
   return mapData ? (
     <PlantingSiteMap
       mapData={mapData}
-      focusEntities={[{ sourceId: 'sites', id: plantingSiteId }]}
+      focusEntities={focusEntities}
       contextRenderer={{
         render: (properties: MapSourceProperties) => (
           <PlantingProgressMapDialog


### PR DESCRIPTION
- prevent updating map data more than once
- set focus to site when updating map data
- set focus to none when dispatching update subzone request

![Kapture 2023-07-20 at 15 40 35](https://github.com/terraware/terraware-web/assets/114949086/88879baf-b56d-4391-af4d-680b77dbbf55)
(site and site2 have the same map)