### PR TITLE
SW-3953 Show planting site details page when tracking-v2 is disabled

### DIFF
--- a/src/components/PlantingSites/index.tsx
+++ b/src/components/PlantingSites/index.tsx
@@ -46,6 +46,7 @@ export function PlantingSitesWrapper({ reloadTracking }: PlantingSitesProps): JS
   const { plantingSiteId } = useParams<{ plantingSiteId: string }>();
   const dispatch = useAppDispatch();
   const trackingV2 = isEnabled('TrackingV2');
+
   const observationsResults = useAppSelector((state) =>
     selectPlantingSiteObservationsResults(state, Number(plantingSiteId))
   );

--- a/src/components/PlantingSites/index.tsx
+++ b/src/components/PlantingSites/index.tsx
@@ -46,7 +46,6 @@ export function PlantingSitesWrapper({ reloadTracking }: PlantingSitesProps): JS
   const { plantingSiteId } = useParams<{ plantingSiteId: string }>();
   const dispatch = useAppDispatch();
   const trackingV2 = isEnabled('TrackingV2');
-
   const observationsResults = useAppSelector((state) =>
     selectPlantingSiteObservationsResults(state, Number(plantingSiteId))
   );
@@ -66,7 +65,7 @@ export function PlantingSitesWrapper({ reloadTracking }: PlantingSitesProps): JS
 
   // show spinner while initializing data
   if (
-    (observationsResults === undefined && !observationsResultsError) ||
+    (trackingV2 && observationsResults === undefined && !observationsResultsError) ||
     (plantingSites === undefined && !plantingSitesError)
   ) {
     return <CircularProgress sx={{ margin: 'auto' }} />;


### PR DESCRIPTION
- skip observations results status check if tracking v2 is disabled
- we were not showing data while observations data was not requested, this should only happen with trackingv2 enabled