### PR TITLE
SW-3951 Show withdrawals filtered to the query/params

### DIFF
--- a/src/components/NurseryWithdrawals/PlantingProgressList.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressList.tsx
@@ -217,7 +217,7 @@ const DetailsRenderer =
       const filterParam = row.subzoneName
         ? `subzoneName=${encodeURIComponent(row.subzoneName)}`
         : `siteName=${encodeURIComponent(row.siteName)}`;
-      const url = `${APP_PATHS.NURSERY_WITHDRAWALS}?tab=${strings.WITHDRAWAL_HISTORY}&${filterParam}`;
+      const url = `${APP_PATHS.NURSERY_WITHDRAWALS}?tab=withdrawal_history&${filterParam}`;
       return <Link to={url}>{row.totalSeedlingsSent as React.ReactNode}</Link>;
     };
 

--- a/src/components/NurseryWithdrawals/PlantingProgressMapDialog.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressMapDialog.tsx
@@ -46,7 +46,7 @@ export default function PlantingProgressMapDialog({
 
   const getWithdrawalHistoryLink = () => {
     const filterParam = `subzoneName=${encodeURIComponent(name)}`;
-    const url = `${APP_PATHS.NURSERY_WITHDRAWALS}?tab=${strings.WITHDRAWAL_HISTORY}&${filterParam}`;
+    const url = `${APP_PATHS.NURSERY_WITHDRAWALS}?tab=withdrawal_history&${filterParam}`;
     return (
       <Link className={classes.withdrawalHistoryLink} to={url}>
         {strings.SEE_WITHDRAWAL_HISTORY}


### PR DESCRIPTION
- this is when user clicks on the seedlings sent from table, or the 'see withdrawal history' link in map dialog
- best to test in vercel

![screencast 2023-07-21 10-29-41](https://github.com/terraware/terraware-web/assets/1865174/a8f2d972-6a01-4483-ada6-86d1a35647aa)
