### PR TITLE
SW-3956 Bar width should be consistent

### DIFF
--- a/src/components/PlantsV2/components/PlantingDensityPerZoneCard.tsx
+++ b/src/components/PlantsV2/components/PlantingDensityPerZoneCard.tsx
@@ -96,7 +96,7 @@ export default function PlantingDensityPerZoneCard({ plantingSiteId }: PlantingD
             <BarChart
               showLegend={!!observation}
               elementColor={theme.palette.TwClrBgBrand}
-              barWidth={0}
+              barWidth={observation && actuals?.length ? 0 : undefined}
               chartId='plantingDensityByZone'
               chartData={chartData}
               customTooltipTitles={tooltipTitles}


### PR DESCRIPTION
I think this was happening for no observations, because if we have observations, we are showing two bars per zone in the Target Planting Density chart and bar-width necessarily has to be smaller.

In the case of no observations, we were setting the width to be responsive for this chart and fixed for the planting progress. So, the fix is to make it fixed for both charts (when no observations).

<img width="1048" alt="Screenshot 2023-07-24 at 15 27 24" src="https://github.com/terraware/terraware-web/assets/5919083/efc893de-8e41-44a9-8c95-b40b5ab2b3cc">
