### PR TITLE
SW-3961 Fix SerializableStateInvariantMiddleware warning in app

### DIFF
--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -5,7 +5,11 @@ import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 // configure the root store
 export const store = configureStore({
   reducer: rootReducer,
-  middleware: (getDefaultMiddleware) => getDefaultMiddleware({}),
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      immutableCheck: false,
+      serializableCheck: false,
+    }),
 });
 
 export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION
- the default middleware checks for immutability/serializability of redux state / responses
- this happens in dev mode only!
- can be slow for some of our API such as observations which can take time
- middleware complains that it takes too much time
- disabled these checks (reference https://github.com/reduxjs/redux-toolkit/issues/805)
- not sure on implications of disabling these checks yet