### PR TITLE
SW-3959 Fix map errors when navigating away while a popup is open

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -426,6 +426,9 @@ export default function Map(props: MapProps): JSX.Element {
     return source.entities?.some((entity) => entity?.boundary?.length);
   });
 
+  // keep track of map being destroyed, this is not bound by react event loop
+  let destroying = false;
+
   return (
     <Box sx={{ display: 'flex', flexGrow: 1, height: '100%', minHeight: 250, position: 'relative' }} ref={containerRef}>
       {bannerMessage && <MapBanner message={bannerMessage} />}
@@ -444,6 +447,9 @@ export default function Map(props: MapProps): JSX.Element {
           style={style}
           attributionControl={false}
           onLoad={onLoad}
+          onRemove={() => {
+            destroying = true;
+          }}
           ref={mapRefCb}
           onRender={(event) => event.target.resize()}
         >
@@ -456,6 +462,9 @@ export default function Map(props: MapProps): JSX.Element {
               longitude={Number(popupInfo.lng)}
               latitude={Number(popupInfo.lat)}
               onClose={() => {
+                if (destroying) {
+                  return; // otherwise errors out updating feature state while map is being destroyed
+                }
                 setPopupInfo(null);
                 updateFeatureState(selectStateId, 'select', [{ sourceId: popupInfo.sourceId }]);
               }}


### PR DESCRIPTION
- navigating away was destroying the map as expected
- the popup cleanup code was being triggered as well but errors out due to map being in a partially destroyed state
- keep track of whether map is being destroyed (this is not part of react eventloop)