### PR TITLE
SW-3957 Fix odd zoom-to-fit behavior on map when switching between list and map views

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -67,7 +67,8 @@ export default function Map(props: MapProps): JSX.Element {
   const hoverStateId: FeatureStateId = useMemo(() => ({}), []);
   const selectStateId: FeatureStateId = useMemo(() => ({}), []);
   const highlightStateId: FeatureStateId = useMemo(() => ({}), []);
-  const [firstVisible, setFirstVisible] = useState(false);
+  const [firstVisible, setFirstVisible] = useState<boolean>(false);
+  const [resized, setResized] = useState<boolean>(false);
   const visible = useIsVisible(containerRef);
   const snackbar = useSnackbar();
   const theme = useTheme();
@@ -458,7 +459,12 @@ export default function Map(props: MapProps): JSX.Element {
             destroying = true;
           }}
           ref={mapRefCb}
-          onRender={(event) => event.target.resize()}
+          onRender={(event) => {
+            if (!resized) {
+              setResized(true);
+              event.target.resize();
+            }
+          }}
         >
           {mapSources}
           <NavigationControl showCompass={false} style={navControlStyle} position='bottom-right' />

--- a/src/components/NurseryWithdrawals/NurseryPlantingsAndWithdrawals.tsx
+++ b/src/components/NurseryWithdrawals/NurseryPlantingsAndWithdrawals.tsx
@@ -4,6 +4,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Box, Grid, Typography, useTheme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { Tabs } from '@terraware/web-components';
 import strings from 'src/strings';
 import useQuery from 'src/utils/useQuery';
@@ -18,11 +19,30 @@ import PlantingProgress from './PlantingProgressTabContent';
 import NurseryWithdrawals from './NurseryWithdrawalsTabContent';
 import { requestPlantingSitesSearchResults } from 'src/redux/features/tracking/trackingThunks';
 
+const useStyles = makeStyles(() => ({
+  tabs: {
+    '& .MuiTabPanel-root[hidden]': {
+      flexGrow: 0,
+    },
+    '& .MuiTabPanel-root': {
+      display: 'flex',
+      flexDirection: 'column',
+      flexGrow: 1,
+    },
+    '& >.MuiBox-root': {
+      display: 'flex',
+      flexDirection: 'column',
+      flexGrow: 1,
+    },
+  },
+}));
+
 type NurseryWithdrawalsProps = {
   reloadTracking: () => void;
 };
 
 export default function NurseryPlantingsAndWithdrawals({ reloadTracking }: NurseryWithdrawalsProps): JSX.Element {
+  const classes = useStyles();
   const { activeLocale } = useLocalization();
   const { selectedOrganization } = useOrganization();
   const theme = useTheme();
@@ -56,8 +76,8 @@ export default function NurseryPlantingsAndWithdrawals({ reloadTracking }: Nurse
 
   return (
     <TfMain>
-      <Box sx={{ paddingLeft: theme.spacing(3) }}>
-        <Grid container spacing={3} sx={{ marginTop: 0 }}>
+      <Box sx={{ paddingLeft: theme.spacing(3) }} display='flex' flexDirection='column' flexGrow={1}>
+        <Grid container spacing={3} sx={{ marginTop: 0 }} display='flex' flexDirection='column' flexGrow={1}>
           <PageHeaderWrapper nextElement={contentRef.current}>
             <Grid container spacing={3} sx={{ paddingLeft: theme.spacing(3), paddingBottom: theme.spacing(4) }}>
               <Grid item xs={8}>
@@ -70,7 +90,7 @@ export default function NurseryPlantingsAndWithdrawals({ reloadTracking }: Nurse
           <Grid item xs={12}>
             <PageSnackbar />
           </Grid>
-          <Box ref={contentRef} display='flex' flexDirection='column' flexGrow={1}>
+          <Box ref={contentRef} display='flex' flexDirection='column' flexGrow={1} className={classes.tabs}>
             <Tabs
               activeTab={activeTab}
               onTabChange={onTabChange}

--- a/src/components/NurseryWithdrawals/PlantingProgressTabContent.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressTabContent.tsx
@@ -78,7 +78,7 @@ export default function PlantingProgress({ reloadTracking }: PlantingProgressPro
   }, [activeLocale]);
 
   return (
-    <Card flushMobile>
+    <Card flushMobile style={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
       <Typography fontSize='20px' fontWeight={600} color={theme.palette.TwClrTxt} marginBottom={theme.spacing(1)}>
         {strings.PLANTING_PROGRESS}
       </Typography>


### PR DESCRIPTION
- See Jira for video of behavior
- onRender hook was resizing on every render, which happens a lot and leads to some undesirable behavior
- added state in onRender to only resize the first time
- also added more height for the map in desktop mode, fill up remaining height in browser

<img width="815" alt="Terraware App 2023-07-31 14-34-14" src="https://github.com/terraware/terraware-web/assets/1865174/8a346c0b-8e1a-48e5-9193-4c6e0d437d4e">
