### PR TITLE
SW-3966 Add planting site selector on withdrawal log

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,7 @@ import {
   SpeciesBulkWithdrawWrapperComponent,
 } from './components/Inventory/withdraw';
 import PlantsDashboard from './components/Plants';
-import { NurseryWithdrawals, NurseryWithdrawalsDetails, NurseryReassignment } from './components/NurseryWithdrawals';
+import { NurseryWithdrawals, NurseryReassignment } from './components/NurseryWithdrawals';
 import { SpeciesService } from 'src/services';
 import { PlantingSite } from 'src/types/Tracking';
 import { useLocalization, useOrganization, useUser } from 'src/providers';
@@ -462,14 +462,12 @@ function AppContent() {
             <Route path={APP_PATHS.PLANTING_SITES}>
               <PlantingSites reloadTracking={reloadTracking} />
             </Route>
-            <Route exact path={APP_PATHS.NURSERY_WITHDRAWALS}>
-              <NurseryWithdrawals reloadTracking={reloadTracking} />
-            </Route>
-            <Route exact path={APP_PATHS.NURSERY_WITHDRAWALS_V2}>
-              <NurseryWithdrawals reloadTracking={reloadTracking} />
-            </Route>
-            <Route exact path={APP_PATHS.NURSERY_WITHDRAWALS_DETAILS}>
-              <NurseryWithdrawalsDetails species={species} plantingSubzoneNames={plantingSubzoneNames} />
+            <Route path={APP_PATHS.NURSERY_WITHDRAWALS}>
+              <NurseryWithdrawals
+                reloadTracking={reloadTracking}
+                species={species}
+                plantingSubzoneNames={plantingSubzoneNames}
+              />
             </Route>
             <Route exact path={APP_PATHS.NURSERY_REASSIGNMENT}>
               <NurseryReassignment />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -465,6 +465,9 @@ function AppContent() {
             <Route exact path={APP_PATHS.NURSERY_WITHDRAWALS}>
               <NurseryWithdrawals reloadTracking={reloadTracking} />
             </Route>
+            <Route exact path={APP_PATHS.NURSERY_WITHDRAWALS_V2}>
+              <NurseryWithdrawals reloadTracking={reloadTracking} />
+            </Route>
             <Route exact path={APP_PATHS.NURSERY_WITHDRAWALS_DETAILS}>
               <NurseryWithdrawalsDetails species={species} plantingSubzoneNames={plantingSubzoneNames} />
             </Route>

--- a/src/components/NurseryWithdrawals/NurseryPlantingsAndWithdrawals.tsx
+++ b/src/components/NurseryWithdrawals/NurseryPlantingsAndWithdrawals.tsx
@@ -1,9 +1,9 @@
 /**
  * Nursery plantings and withdrawals
  */
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { Box, Grid, useTheme } from '@mui/material';
+import { Box, Grid } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { Tabs } from '@terraware/web-components';
 import strings from 'src/strings';
@@ -12,7 +12,6 @@ import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
 import { useLocalization, useOrganization } from 'src/providers';
 import { useAppDispatch } from 'src/redux/store';
 import { requestPlantings } from 'src/redux/features/plantings/plantingsThunks';
-import PageSnackbar from 'src/components/PageSnackbar';
 import PlantingProgress from './PlantingProgressTabContent';
 import NurseryWithdrawals from './NurseryWithdrawalsTabContent';
 import { requestPlantingSitesSearchResults } from 'src/redux/features/tracking/trackingThunks';
@@ -48,11 +47,9 @@ export default function NurseryPlantingsAndWithdrawals({
   const classes = useStyles();
   const { activeLocale } = useLocalization();
   const { selectedOrganization } = useOrganization();
-  const theme = useTheme();
   const query = useQuery();
   const history = useHistory();
   const location = useStateLocation();
-  const contentRef = useRef(null);
   const dispatch = useAppDispatch();
   const tab = query.get('tab') || 'planting_progress';
 
@@ -78,31 +75,34 @@ export default function NurseryPlantingsAndWithdrawals({
   }, [tab, activeLocale]);
 
   return (
-    <Box sx={{ paddingLeft: theme.spacing(3) }} display='flex' flexDirection='column' flexGrow={1}>
-      <Grid container spacing={3} sx={{ marginTop: 0 }} display='flex' flexDirection='column' flexGrow={1}>
-        <Grid item xs={12}>
-          <PageSnackbar />
-        </Grid>
-        <Box ref={contentRef} display='flex' flexDirection='column' flexGrow={1} className={classes.tabs}>
-          <Tabs
-            activeTab={activeTab}
-            onTabChange={onTabChange}
-            tabs={[
-              {
-                id: 'planting_progress',
-                label: strings.PLANTING_PROGRESS,
-                children: (
-                  <PlantingProgress reloadTracking={reloadTracking} selectedPlantingSiteId={selectedPlantingSite.id} />
-                ),
-              },
-              {
-                id: 'withdrawal_history',
-                label: strings.WITHDRAWAL_HISTORY,
-                children: <NurseryWithdrawals selectedPlantingSite={selectedPlantingSite} />,
-              },
-            ]}
-          />
-        </Box>
+    <Box sx={{ paddingLeft: 3 }} display='flex' flexDirection='column' flexGrow={1}>
+      <Grid
+        container
+        spacing={3}
+        sx={{ marginTop: 0 }}
+        display='flex'
+        flexDirection='column'
+        flexGrow={1}
+        className={classes.tabs}
+      >
+        <Tabs
+          activeTab={activeTab}
+          onTabChange={onTabChange}
+          tabs={[
+            {
+              id: 'planting_progress',
+              label: strings.PLANTING_PROGRESS,
+              children: (
+                <PlantingProgress reloadTracking={reloadTracking} selectedPlantingSiteId={selectedPlantingSite.id} />
+              ),
+            },
+            {
+              id: 'withdrawal_history',
+              label: strings.WITHDRAWAL_HISTORY,
+              children: <NurseryWithdrawals selectedPlantingSite={selectedPlantingSite} />,
+            },
+          ]}
+        />
       </Grid>
     </Box>
   );

--- a/src/components/NurseryWithdrawals/NurseryPlantingsAndWithdrawals.tsx
+++ b/src/components/NurseryWithdrawals/NurseryPlantingsAndWithdrawals.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { Box, Grid, Typography, useTheme } from '@mui/material';
+import { Box, Grid, useTheme } from '@mui/material';
 import { Tabs } from '@terraware/web-components';
 import strings from 'src/strings';
 import useQuery from 'src/utils/useQuery';
@@ -12,17 +12,20 @@ import { useLocalization, useOrganization } from 'src/providers';
 import { useAppDispatch } from 'src/redux/store';
 import { requestPlantings } from 'src/redux/features/plantings/plantingsThunks';
 import PageSnackbar from 'src/components/PageSnackbar';
-import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
-import TfMain from 'src/components/common/TfMain';
 import PlantingProgress from './PlantingProgressTabContent';
 import NurseryWithdrawals from './NurseryWithdrawalsTabContent';
 import { requestPlantingSitesSearchResults } from 'src/redux/features/tracking/trackingThunks';
+import { PlantingSite } from 'src/types/Tracking';
 
 type NurseryWithdrawalsProps = {
   reloadTracking: () => void;
+  selectedPlantingSite: PlantingSite;
 };
 
-export default function NurseryPlantingsAndWithdrawals({ reloadTracking }: NurseryWithdrawalsProps): JSX.Element {
+export default function NurseryPlantingsAndWithdrawals({
+  reloadTracking,
+  selectedPlantingSite,
+}: NurseryWithdrawalsProps): JSX.Element {
   const { activeLocale } = useLocalization();
   const { selectedOrganization } = useOrganization();
   const theme = useTheme();
@@ -55,37 +58,32 @@ export default function NurseryPlantingsAndWithdrawals({ reloadTracking }: Nurse
   }, [tab, activeLocale]);
 
   return (
-    <TfMain>
-      <Box sx={{ paddingLeft: theme.spacing(3) }}>
-        <Grid container spacing={3} sx={{ marginTop: 0 }}>
-          <PageHeaderWrapper nextElement={contentRef.current}>
-            <Grid container spacing={3} sx={{ paddingLeft: theme.spacing(3), paddingBottom: theme.spacing(4) }}>
-              <Grid item xs={8}>
-                <Typography sx={{ marginTop: 0, marginBottom: 0, fontSize: '24px', fontWeight: 600 }}>
-                  {strings.WITHDRAWALS}
-                </Typography>
-              </Grid>
-            </Grid>
-          </PageHeaderWrapper>
-          <Grid item xs={12}>
-            <PageSnackbar />
-          </Grid>
-          <Box ref={contentRef} display='flex' flexDirection='column' flexGrow={1}>
-            <Tabs
-              activeTab={activeTab}
-              onTabChange={onTabChange}
-              tabs={[
-                {
-                  id: 'planting_progress',
-                  label: strings.PLANTING_PROGRESS,
-                  children: <PlantingProgress reloadTracking={reloadTracking} />,
-                },
-                { id: 'withdrawal_history', label: strings.WITHDRAWAL_HISTORY, children: <NurseryWithdrawals /> },
-              ]}
-            />
-          </Box>
+    <Box sx={{ paddingLeft: theme.spacing(3) }}>
+      <Grid container spacing={3} sx={{ marginTop: 0 }}>
+        <Grid item xs={12}>
+          <PageSnackbar />
         </Grid>
-      </Box>
-    </TfMain>
+        <Box ref={contentRef} display='flex' flexDirection='column' flexGrow={1}>
+          <Tabs
+            activeTab={activeTab}
+            onTabChange={onTabChange}
+            tabs={[
+              {
+                id: 'planting_progress',
+                label: strings.PLANTING_PROGRESS,
+                children: (
+                  <PlantingProgress reloadTracking={reloadTracking} selectedPlantingSiteId={selectedPlantingSite.id} />
+                ),
+              },
+              {
+                id: 'withdrawal_history',
+                label: strings.WITHDRAWAL_HISTORY,
+                children: <NurseryWithdrawals selectedPlantingSite={selectedPlantingSite} />,
+              },
+            ]}
+          />
+        </Box>
+      </Grid>
+    </Box>
   );
 }

--- a/src/components/NurseryWithdrawals/NurseryReassignment.tsx
+++ b/src/components/NurseryWithdrawals/NurseryReassignment.tsx
@@ -9,6 +9,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import strings from 'src/strings';
 import { APP_PATHS } from 'src/constants';
+import isEnabled from 'src/features';
 import TfMain from 'src/components/common/TfMain';
 import TitleDescription from 'src/components/common/TitleDescription';
 import Card from 'src/components/common/Card';
@@ -59,6 +60,7 @@ export default function NurseryReassignment(): JSX.Element {
   const [reassignments, setReassignments] = useState<{ [subzoneId: string]: Reassignment }>({});
   const [noReassignments, setNoReassignments] = useState<boolean>(false);
   const contentRef = useRef(null);
+  const trackingV2 = isEnabled('TrackingV2');
 
   const numericFormatter = useMemo(() => numberFormatter(user?.locale), [numberFormatter, user?.locale]);
 
@@ -224,7 +226,7 @@ export default function NurseryReassignment(): JSX.Element {
             id='back'
             to={APP_PATHS.NURSERY_WITHDRAWALS}
             className={classes.backToWithdrawals}
-            name={strings.WITHDRAWAL_LOG}
+            name={trackingV2 ? strings.WITHDRAWALS : strings.WITHDRAWAL_LOG}
           />
         </Box>
         <Box marginTop={theme.spacing(3)}>

--- a/src/components/NurseryWithdrawals/NurserySiteWithdrawals.tsx
+++ b/src/components/NurseryWithdrawals/NurserySiteWithdrawals.tsx
@@ -1,0 +1,46 @@
+import { useCallback, useState } from 'react';
+import strings from 'src/strings';
+import { APP_PATHS } from 'src/constants';
+import { PlantingSite } from 'src/types/Tracking';
+import { useAppSelector } from 'src/redux/store';
+import { selectPlantingSites } from 'src/redux/features/tracking/trackingSelectors';
+import useQuery from 'src/utils/useQuery';
+import NurseryPlantingsAndWithdrawals from './NurseryPlantingsAndWithdrawals';
+import PlantsPrimaryPage from '../PlantsPrimaryPage';
+
+/**
+ * Primary route management for nursery withdrawals.
+ */
+type NurserySiteWithdrawalsProps = {
+  reloadTracking: () => void;
+};
+
+export default function NurserySiteWithdrawals({ reloadTracking }: NurserySiteWithdrawalsProps): JSX.Element {
+  const [selectedPlantingSite, setSelectedPlantingSite] = useState<PlantingSite>();
+  const [plantsSitePreferences, setPlantsSitePreferences] = useState<Record<string, unknown>>();
+  const plantingSites = useAppSelector(selectPlantingSites);
+  const onSelect = useCallback((site: PlantingSite) => setSelectedPlantingSite(site), [setSelectedPlantingSite]);
+  const query = useQuery();
+  const onPreferences = useCallback(
+    (preferences: Record<string, unknown>) => setPlantsSitePreferences(preferences),
+    [setPlantsSitePreferences]
+  );
+
+  return (
+    <PlantsPrimaryPage
+      title={strings.WITHDRAWALS}
+      onSelect={onSelect}
+      pagePath={APP_PATHS.NURSERY_SITE_WITHDRAWALS}
+      lastVisitedPreferenceName='seedlings.withdrawals.lastVisitedPlantingSite'
+      plantsSitePreferences={plantsSitePreferences}
+      setPlantsSitePreferences={onPreferences}
+      allowAllAsSiteSelection={true}
+      isEmptyState={!plantingSites?.length}
+      query={query.toString()}
+    >
+      {selectedPlantingSite && (
+        <NurseryPlantingsAndWithdrawals reloadTracking={reloadTracking} selectedPlantingSite={selectedPlantingSite} />
+      )}
+    </PlantsPrimaryPage>
+  );
+}

--- a/src/components/NurseryWithdrawals/NurseryWithdrawalsDetails.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawalsDetails.tsx
@@ -4,6 +4,7 @@ import { Box, Tab, Theme, Typography, useTheme } from '@mui/material';
 import { APP_PATHS } from 'src/constants';
 import { Button } from '@terraware/web-components';
 import strings from 'src/strings';
+import isEnabled from 'src/features';
 import PageSnackbar from 'src/components/PageSnackbar';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import { useEffect, useRef, useState } from 'react';
@@ -76,6 +77,9 @@ export default function NurseryWithdrawalsDetails({
   const [withdrawalSummary, setWithdrawalSummary] = useState<WithdrawalSummary | undefined>(undefined);
   const [delivery, setDelivery] = useState<Delivery | undefined>(undefined);
   const [batches, setBatches] = useState<Batch[] | undefined>(undefined);
+
+  const trackingV2 = isEnabled('TrackingV2');
+
   useEffect(() => {
     const updateWithdrawal = async () => {
       const withdrawalResponse = await NurseryWithdrawalService.getNurseryWithdrawal(Number(withdrawalId));
@@ -166,7 +170,7 @@ export default function NurseryWithdrawalsDetails({
               id='back'
               to={APP_PATHS.NURSERY_WITHDRAWALS}
               className={classes.backToWithdrawals}
-              name={strings.WITHDRAWAL_LOG}
+              name={trackingV2 ? strings.WITHDRAWALS : strings.WITHDRAWAL_LOG}
             />
           </Box>
           <Box

--- a/src/components/NurseryWithdrawals/NurseryWithdrawalsTabContent.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawalsTabContent.tsx
@@ -2,8 +2,15 @@ import { Typography, useTheme } from '@mui/material';
 import strings from 'src/strings';
 import Card from 'src/components/common/Card';
 import NurseryWithdrawalsTable from './NurseryWithdrawalsTable';
+import { PlantingSite } from 'src/types/Tracking';
 
-export default function NurseryWithdrawalsTabContent(): JSX.Element {
+type NurseryWithdrawalsTabContentProps = {
+  selectedPlantingSite: PlantingSite;
+};
+
+export default function NurseryWithdrawalsTabContent({
+  selectedPlantingSite,
+}: NurseryWithdrawalsTabContentProps): JSX.Element {
   const theme = useTheme();
 
   return (
@@ -18,7 +25,7 @@ export default function NurseryWithdrawalsTabContent(): JSX.Element {
       >
         {strings.WITHDRAWAL_HISTORY}
       </Typography>
-      <NurseryWithdrawalsTable />
+      <NurseryWithdrawalsTable selectedPlantingSite={selectedPlantingSite} />
     </Card>
   );
 }

--- a/src/components/NurseryWithdrawals/NurseryWithdrawalsTable.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawalsTable.tsx
@@ -18,6 +18,7 @@ import { Button, PillList } from '@terraware/web-components';
 import Table from 'src/components/common/table';
 import { TableColumnType } from '@terraware/web-components/components/table/types';
 import FilterGroup, { FilterField } from 'src/components/common/FilterGroup';
+import { PlantingSite } from 'src/types/Tracking';
 
 const useStyles = makeStyles((theme: Theme) => ({
   searchField: {
@@ -44,7 +45,11 @@ const columns = (): TableColumnType[] => [
   { key: 'hasReassignments', name: '', type: 'string' },
 ];
 
-export default function NurseryWithdrawalsTable(): JSX.Element {
+type NurseryWithdrawalsTableProps = {
+  selectedPlantingSite?: PlantingSite;
+};
+
+export default function NurseryWithdrawalsTable({ selectedPlantingSite }: NurseryWithdrawalsTableProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const { activeLocale } = useLocalization();
   const query = useQuery();
@@ -136,14 +141,6 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
       };
       searchValueChildren.push(fromNurseryNode);
 
-      const destinationNurseryNode: FieldNodePayload = {
-        operation: 'field',
-        field: 'destinationName',
-        type: 'Fuzzy',
-        values: [debouncedSearchTerm],
-      };
-      searchValueChildren.push(destinationNurseryNode);
-
       const speciesNameNode: FieldNodePayload = {
         operation: 'field',
         field: 'batchWithdrawals.batch_species_scientificName',
@@ -151,6 +148,26 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
         values: [debouncedSearchTerm],
       };
       searchValueChildren.push(speciesNameNode);
+
+      if (!selectedPlantingSite) {
+        const destinationNurseryNode: FieldNodePayload = {
+          operation: 'field',
+          field: 'destinationName',
+          type: 'Fuzzy',
+          values: [debouncedSearchTerm],
+        };
+        searchValueChildren.push(destinationNurseryNode);
+      }
+    }
+
+    if (selectedPlantingSite && selectedPlantingSite.id !== -1) {
+      const destinationNurseryNode: FieldNodePayload = {
+        operation: 'field',
+        field: 'destinationName',
+        type: 'Fuzzy',
+        values: [selectedPlantingSite.name],
+      };
+      searchValueChildren.push(destinationNurseryNode);
     }
 
     const filterValueChildren: FieldNodePayload[] = [...Object.values(filters)];
@@ -182,7 +199,7 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
       finalSearchValueChildren.push(filterValueNodes);
     }
     return finalSearchValueChildren;
-  }, [filters, debouncedSearchTerm]);
+  }, [filters, debouncedSearchTerm, selectedPlantingSite]);
 
   const onApplyFilters = useCallback(async () => {
     const searchChildren: FieldNodePayload[] = getSearchChildren();

--- a/src/components/NurseryWithdrawals/PlantingProgressList.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressList.tsx
@@ -81,16 +81,20 @@ export type PlantingProgressListProps = {
   search: string;
   plantingCompleted?: boolean;
   reloadTracking: () => void;
+  plantingSiteId: number;
 };
 
 export default function PlantingProgressList({
   search,
   plantingCompleted,
   reloadTracking,
+  plantingSiteId,
 }: PlantingProgressListProps): JSX.Element {
   const [hasZones, setHasZones] = useState<boolean | undefined>();
   const classes = useStyles();
-  const data = useAppSelector((state: any) => searchPlantingProgress(state, search.trim(), plantingCompleted));
+  const data = useAppSelector((state: any) =>
+    searchPlantingProgress(state, search.trim(), plantingCompleted, plantingSiteId)
+  );
   const [selectedRows, setSelectedRows] = useState<any[]>([]);
   const dispatch = useAppDispatch();
   const defaultTimeZone = useDefaultTimeZone();

--- a/src/components/NurseryWithdrawals/PlantingProgressMap.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressMap.tsx
@@ -158,8 +158,8 @@ export default function PlantingProgressMap({ plantingSiteId, reloadTracking }: 
       />
     </>
   ) : (
-    <Typography fontSize='14px' fontWeight={400} color={theme.palette.TwClrTxt} textAlign='center'>
-      {strings.NO_MAP_DATA}
+    <Typography fontSize='18px' fontWeight={500} color={theme.palette.TwClrTxtSecondary} textAlign='center'>
+      {plantingSiteId === -1 ? strings.PLANTING_SITE_MAP_VIEW_PROMPT : strings.NO_MAP_DATA}
     </Typography>
   );
 }

--- a/src/components/NurseryWithdrawals/PlantingProgressTabContent.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressTabContent.tsx
@@ -11,7 +11,6 @@ import Search, { SearchProps } from 'src/components/common/SearchFiltersWrapper'
 import PlantingProgressList from './PlantingProgressList';
 import PlantingProgressMap from './PlantingProgressMap';
 import { View } from 'src/components/common/ListMapSelector';
-import PlantingSiteSelector from 'src/components/common/PlantingSiteSelector';
 import { useAppDispatch } from 'src/redux/store';
 import { requestObservationsResults } from 'src/redux/features/observations/observationsThunks';
 
@@ -19,9 +18,13 @@ const initialView: View = 'list';
 
 type PlantingProgressProps = {
   reloadTracking: () => void;
+  selectedPlantingSiteId: number;
 };
 
-export default function PlantingProgress({ reloadTracking }: PlantingProgressProps): JSX.Element {
+export default function PlantingProgress({
+  reloadTracking,
+  selectedPlantingSiteId,
+}: PlantingProgressProps): JSX.Element {
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
   const { activeLocale } = useLocalization();
@@ -29,7 +32,6 @@ export default function PlantingProgress({ reloadTracking }: PlantingProgressPro
   const [filters, setFilters] = useState<Record<string, any>>({});
   const [filterOptions, setFilterOptions] = useState<FieldOptionsMap>({});
   const [activeView, setActiveView] = useState<View>(initialView);
-  const [selectedPlantingSiteId, setSelectedPlantingSiteId] = useState<number>(-1);
   const dispatch = useAppDispatch();
   const { selectedOrganization } = useOrganization();
 
@@ -91,12 +93,13 @@ export default function PlantingProgress({ reloadTracking }: PlantingProgressPro
         style={{ padding: isMobile ? theme.spacing(3) : theme.spacing(3, 0, 0) }}
         initialView={initialView}
         onView={setActiveView}
-        search={<SearchComponent view={activeView} onChangePlantingSite={setSelectedPlantingSiteId} {...searchProps} />}
+        search={<SearchComponent view={activeView} {...searchProps} />}
         list={
           <PlantingProgressList
             search={search}
             plantingCompleted={plantingCompleted}
             reloadTracking={reloadTrackingAndObservations}
+            plantingSiteId={selectedPlantingSiteId}
           />
         }
         map={<PlantingProgressMap plantingSiteId={selectedPlantingSiteId} />}
@@ -107,18 +110,14 @@ export default function PlantingProgress({ reloadTracking }: PlantingProgressPro
 
 type SearchComponentProps = SearchProps & {
   view: View;
-  onChangePlantingSite: (newSiteId: number) => void;
 };
 
 function SearchComponent(props: SearchComponentProps): JSX.Element {
-  const { search, onSearch, filtersProps, view, onChangePlantingSite } = props;
+  const { search, onSearch, filtersProps, view } = props;
   return (
     <>
       <div style={{ display: view === 'list' ? 'flex' : 'none' }}>
         <Search search={search} onSearch={onSearch} filtersProps={filtersProps} />
-      </div>
-      <div style={{ display: view === 'map' ? 'flex' : 'none' }}>
-        <PlantingSiteSelector onChange={onChangePlantingSite} />
       </div>
     </>
   );

--- a/src/components/NurseryWithdrawals/PlantingProgressTabContent.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressTabContent.tsx
@@ -117,10 +117,8 @@ type SearchComponentProps = SearchProps & {
 function SearchComponent(props: SearchComponentProps): JSX.Element {
   const { search, onSearch, filtersProps, view } = props;
   return (
-    <>
-      <div style={{ display: view === 'list' ? 'flex' : 'none' }}>
-        <Search search={search} onSearch={onSearch} filtersProps={filtersProps} />
-      </div>
-    </>
+    <div style={{ display: 'flex' }}>
+      {view === 'list' && <Search search={search} onSearch={onSearch} filtersProps={filtersProps} />}
+    </div>
   );
 }

--- a/src/components/NurseryWithdrawals/index.tsx
+++ b/src/components/NurseryWithdrawals/index.tsx
@@ -1,57 +1,46 @@
+import { Route, Switch } from 'react-router-dom';
+import { APP_PATHS } from 'src/constants';
+import { Species } from 'src/types/Species';
 import isEnabled from 'src/features';
 import NurseryReassignment from './NurseryReassignment';
 import NurseryWithdrawalsBase from './NurseryWithdrawals';
-import NurseryPlantingsAndWithdrawals from './NurseryPlantingsAndWithdrawals';
 import NurseryWithdrawalsDetails from './NurseryWithdrawalsDetails';
-import PlantsPrimaryPage from '../PlantsPrimaryPage';
-import strings from 'src/strings';
-import { APP_PATHS } from 'src/constants';
-import { useCallback, useState } from 'react';
-import { PlantingSite } from 'src/types/Tracking';
-import { useAppSelector } from 'src/redux/store';
-import { selectPlantingSites } from 'src/redux/features/tracking/trackingSelectors';
-import useQuery from 'src/utils/useQuery';
+import NurserySiteWithdrawals from './NurserySiteWithdrawals';
 
 /**
  * Primary route management for nursery withdrawals.
  */
 type NurseryWithdrawalsProps = {
   reloadTracking: () => void;
+  species: Species[];
+  plantingSubzoneNames: Record<number, string>;
 };
-export default function NurseryWithdrawals({ reloadTracking }: NurseryWithdrawalsProps): JSX.Element {
+
+function NurseryWithdrawals({ reloadTracking, species, plantingSubzoneNames }: NurseryWithdrawalsProps): JSX.Element {
   const trackingV2 = isEnabled('TrackingV2');
-  const [selectedPlantingSite, setSelectedPlantingSite] = useState<PlantingSite>();
-  const [plantsSitePreferences, setPlantsSitePreferences] = useState<Record<string, unknown>>();
-  const plantingSites = useAppSelector(selectPlantingSites);
-  const onSelect = useCallback((site: PlantingSite) => setSelectedPlantingSite(site), [setSelectedPlantingSite]);
-  const query = useQuery();
-  const onPreferences = useCallback(
-    (preferences: Record<string, unknown>) => setPlantsSitePreferences(preferences),
-    [setPlantsSitePreferences]
+
+  return (
+    <Switch>
+      <Route exact path={APP_PATHS.NURSERY_WITHDRAWALS_DETAILS}>
+        <NurseryWithdrawalsDetails species={species} plantingSubzoneNames={plantingSubzoneNames} />
+      </Route>
+      {trackingV2 && (
+        <Route path={APP_PATHS.NURSERY_SITE_WITHDRAWALS}>
+          <NurserySiteWithdrawals reloadTracking={reloadTracking} />
+        </Route>
+      )}
+      {trackingV2 && (
+        <Route path={'*'}>
+          <NurserySiteWithdrawals reloadTracking={reloadTracking} />
+        </Route>
+      )}
+      {!trackingV2 && (
+        <Route path={'*'}>
+          <NurseryWithdrawalsBase />
+        </Route>
+      )}
+    </Switch>
   );
-
-  if (trackingV2) {
-    return (
-      <PlantsPrimaryPage
-        title={strings.WITHDRAWALS}
-        onSelect={onSelect}
-        pagePath={APP_PATHS.NURSERY_WITHDRAWALS_V2}
-        lastVisitedPreferenceName='seedlings.withdrawals.lastVisitedPlantingSite'
-        plantsSitePreferences={plantsSitePreferences}
-        setPlantsSitePreferences={onPreferences}
-        allowAllAsSiteSelection={true}
-        isEmptyState={!plantingSites?.length}
-        query={query.toString()}
-      >
-        {selectedPlantingSite && (
-          <NurseryPlantingsAndWithdrawals reloadTracking={reloadTracking} selectedPlantingSite={selectedPlantingSite} />
-        )}
-        ;
-      </PlantsPrimaryPage>
-    );
-  }
-
-  return <NurseryWithdrawalsBase />;
 }
 
-export { NurseryReassignment, NurseryWithdrawals, NurseryWithdrawalsDetails };
+export { NurseryReassignment, NurseryWithdrawals };

--- a/src/components/NurseryWithdrawals/index.tsx
+++ b/src/components/NurseryWithdrawals/index.tsx
@@ -3,6 +3,14 @@ import NurseryReassignment from './NurseryReassignment';
 import NurseryWithdrawalsBase from './NurseryWithdrawals';
 import NurseryPlantingsAndWithdrawals from './NurseryPlantingsAndWithdrawals';
 import NurseryWithdrawalsDetails from './NurseryWithdrawalsDetails';
+import PlantsPrimaryPage from '../PlantsPrimaryPage';
+import strings from 'src/strings';
+import { APP_PATHS } from 'src/constants';
+import { useCallback, useState } from 'react';
+import { PlantingSite } from 'src/types/Tracking';
+import { useAppSelector } from 'src/redux/store';
+import { selectPlantingSites } from 'src/redux/features/tracking/trackingSelectors';
+import useQuery from 'src/utils/useQuery';
 
 /**
  * Primary route management for nursery withdrawals.
@@ -12,9 +20,35 @@ type NurseryWithdrawalsProps = {
 };
 export default function NurseryWithdrawals({ reloadTracking }: NurseryWithdrawalsProps): JSX.Element {
   const trackingV2 = isEnabled('TrackingV2');
+  const [selectedPlantingSite, setSelectedPlantingSite] = useState<PlantingSite>();
+  const [plantsSitePreferences, setPlantsSitePreferences] = useState<Record<string, unknown>>();
+  const plantingSites = useAppSelector(selectPlantingSites);
+  const onSelect = useCallback((site: PlantingSite) => setSelectedPlantingSite(site), [setSelectedPlantingSite]);
+  const query = useQuery();
+  const onPreferences = useCallback(
+    (preferences: Record<string, unknown>) => setPlantsSitePreferences(preferences),
+    [setPlantsSitePreferences]
+  );
 
   if (trackingV2) {
-    return <NurseryPlantingsAndWithdrawals reloadTracking={reloadTracking} />;
+    return (
+      <PlantsPrimaryPage
+        title={strings.WITHDRAWALS}
+        onSelect={onSelect}
+        pagePath={APP_PATHS.NURSERY_WITHDRAWALS_V2}
+        lastVisitedPreferenceName='seedlings.withdrawals.lastVisitedPlantingSite'
+        plantsSitePreferences={plantsSitePreferences}
+        setPlantsSitePreferences={onPreferences}
+        allowAllAsSiteSelection={true}
+        isEmptyState={!plantingSites?.length}
+        query={query.toString()}
+      >
+        {selectedPlantingSite && (
+          <NurseryPlantingsAndWithdrawals reloadTracking={reloadTracking} selectedPlantingSite={selectedPlantingSite} />
+        )}
+        ;
+      </PlantsPrimaryPage>
+    );
   }
 
   return <NurseryWithdrawalsBase />;

--- a/src/components/Observations/ObservationsDataView.tsx
+++ b/src/components/Observations/ObservationsDataView.tsx
@@ -82,7 +82,7 @@ const AllPlantingSitesMapView = (): JSX.Element => {
   return (
     <Box textAlign='center' marginTop={6}>
       <Typography fontSize='18px' fontWeight={500} color={theme.palette.TwClrTxtSecondary}>
-        {strings.OBSERVATIONS_MAP_VIEW_PROMPT}
+        {strings.PLANTING_SITE_MAP_VIEW_PROMPT}
       </Typography>
     </Box>
   );

--- a/src/components/PlantsPrimaryPage/index.tsx
+++ b/src/components/PlantsPrimaryPage/index.tsx
@@ -20,6 +20,7 @@ export type PlantsPrimaryPageProps = {
   isEmptyState?: boolean; // optional boolean to indicate this is an empty state view
   // this is to allow redux based components to pass in already selected data
   plantingSitesData?: PlantingSite[];
+  query?: string;
 };
 
 const allSitesOption = (organizationId: number): PlantingSite => ({
@@ -40,6 +41,7 @@ export default function PlantsPrimaryPage({
   allowAllAsSiteSelection,
   isEmptyState,
   plantingSitesData,
+  query,
 }: PlantsPrimaryPageProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const [selectedPlantingSite, setSelectedPlantingSite] = useState<PlantingSite>();
@@ -85,10 +87,10 @@ export default function PlantsPrimaryPage({
   const setActivePlantingSite = useCallback(
     (site: PlantingSite | undefined) => {
       if (site) {
-        history.push(pagePath.replace(':plantingSiteId', site.id.toString()));
+        history.push({ pathname: pagePath.replace(':plantingSiteId', site.id.toString()), search: query });
       }
     },
-    [history, pagePath]
+    [history, pagePath, query]
   );
 
   useEffect(() => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -59,7 +59,7 @@ export enum APP_PATHS {
   PLANTING_SITES_ZONE_VIEW = '/planting-sites/:plantingSiteId/zone/:zoneId',
   PLANTING_SITES_SUBZONE_VIEW = '/planting-sites/:plantingSiteId/zone/:zoneId/subzone/:subzoneId',
   NURSERY_WITHDRAWALS = '/nursery/withdrawals',
-  NURSERY_WITHDRAWALS_V2 = '/nursery/withdrawals2/:plantingSiteId',
-  NURSERY_WITHDRAWALS_DETAILS = '/nursery/withdrawals/:withdrawalId',
+  NURSERY_WITHDRAWALS_DETAILS = '/nursery/withdrawals/details/:withdrawalId',
+  NURSERY_SITE_WITHDRAWALS = '/nursery/withdrawals/:plantingSiteId',
   NURSERY_REASSIGNMENT = '/nursery/reassignment/:deliveryId',
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -59,6 +59,7 @@ export enum APP_PATHS {
   PLANTING_SITES_ZONE_VIEW = '/planting-sites/:plantingSiteId/zone/:zoneId',
   PLANTING_SITES_SUBZONE_VIEW = '/planting-sites/:plantingSiteId/zone/:zoneId/subzone/:subzoneId',
   NURSERY_WITHDRAWALS = '/nursery/withdrawals',
+  NURSERY_WITHDRAWALS_V2 = '/nursery/withdrawals2/:plantingSiteId',
   NURSERY_WITHDRAWALS_DETAILS = '/nursery/withdrawals/:withdrawalId',
   NURSERY_REASSIGNMENT = '/nursery/reassignment/:deliveryId',
 }

--- a/src/redux/features/plantings/plantingsSelectors.ts
+++ b/src/redux/features/plantings/plantingsSelectors.ts
@@ -90,14 +90,16 @@ export const searchPlantingProgress = createSelector(
   (plantingProgress, query, plantingCompleted, plantingSiteId) => {
     return plantingProgress?.reduce((acc, curr) => {
       const { siteId, siteName, totalPlants, reported } = curr;
+      const matchesPlantingSite = plantingSiteId === undefined || plantingSiteId === -1 || siteId === plantingSiteId;
+      if (!matchesPlantingSite) {
+        return acc;
+      }
       if (reported && reported.length > 0) {
         reported?.forEach((progress) => {
           const matchesQuery = !query || regexMatch(progress.subzoneName, query);
           const matchesPlantingCompleted =
             plantingCompleted === undefined || progress.plantingCompleted === plantingCompleted;
-          const matchesPlantingSite =
-            plantingSiteId === undefined || plantingSiteId === -1 || siteId === plantingSiteId;
-          if (matchesQuery && matchesPlantingCompleted && matchesPlantingSite) {
+          if (matchesQuery && matchesPlantingCompleted) {
             acc.push({ siteId, siteName, totalPlants, ...progress });
           }
         });

--- a/src/redux/features/plantings/plantingsSelectors.ts
+++ b/src/redux/features/plantings/plantingsSelectors.ts
@@ -81,11 +81,13 @@ export const selectPlantingProgress = createSelector(
 // selector to search plantings
 export const searchPlantingProgress = createSelector(
   [
-    (state: RootState, query: string, plantingCompleted?: boolean) => selectPlantingProgress(state),
-    (state: RootState, query: string, plantingCompleted?: boolean) => query,
-    (state: RootState, query: string, plantingCompleted?: boolean) => plantingCompleted,
+    (state: RootState, query: string, plantingCompleted?: boolean, plantingSiteId?: number) =>
+      selectPlantingProgress(state),
+    (state: RootState, query: string, plantingCompleted?: boolean, plantingSiteId?: number) => query,
+    (state: RootState, query: string, plantingCompleted?: boolean, plantingSiteId?: number) => plantingCompleted,
+    (state: RootState, query: string, plantingCompleted?: boolean, plantingSiteId?: number) => plantingSiteId,
   ],
-  (plantingProgress, query, plantingCompleted) => {
+  (plantingProgress, query, plantingCompleted, plantingSiteId) => {
     return plantingProgress?.reduce((acc, curr) => {
       const { siteId, siteName, totalPlants, reported } = curr;
       if (reported && reported.length > 0) {
@@ -93,7 +95,9 @@ export const searchPlantingProgress = createSelector(
           const matchesQuery = !query || regexMatch(progress.subzoneName, query);
           const matchesPlantingCompleted =
             plantingCompleted === undefined || progress.plantingCompleted === plantingCompleted;
-          if (matchesQuery && matchesPlantingCompleted) {
+          const matchesPlantingSite =
+            plantingSiteId === undefined || plantingSiteId === -1 || siteId === plantingSiteId;
+          if (matchesQuery && matchesPlantingCompleted && matchesPlantingSite) {
             acc.push({ siteId, siteName, totalPlants, ...progress });
           }
         });

--- a/src/services/NurseryWithdrawalService.ts
+++ b/src/services/NurseryWithdrawalService.ts
@@ -174,7 +174,7 @@ const getWithdrawalPhotosList = async (withdrawalId: number): Promise<Response &
 /**
  * Get Filter Options
  */
-const getFilterOptions = async (organizationId: number): Promise<FieldOptionsMap> => {
+const getFilterOptions = async (organizationId: number, plantingSiteName?: string): Promise<FieldOptionsMap> => {
   const searchParams: SearchRequestPayload = {
     prefix: 'nurseryWithdrawals',
     fields: [
@@ -185,7 +185,19 @@ const getFilterOptions = async (organizationId: number): Promise<FieldOptionsMap
       'plantingSubzoneNames',
       'batchWithdrawals.batch_species_scientificName',
     ],
-    search: SearchService.convertToSearchNodePayload({}, organizationId),
+    search: SearchService.convertToSearchNodePayload(
+      plantingSiteName
+        ? [
+            {
+              operation: 'field',
+              field: 'destinationName',
+              type: 'Exact',
+              values: [plantingSiteName],
+            },
+          ]
+        : [],
+      organizationId
+    ),
     sortOrder: [{ field: 'id', direction: 'Ascending' }],
     count: 1000,
   };

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -682,7 +682,6 @@ OBSERVATIONS_DOWNLOAD_APP,"To complete observations, download the Terraware app 
 OBSERVATIONS_EMPTY_STATE_MESSAGE_1,"Observations are when you record data from a sample of monitoring plots using our mobile app in the field. This allows us to calculate mortality rates, and eventually carbon sequestration."
 OBSERVATIONS_EMPTY_STATE_MESSAGE_2,"You will be notified when it is time to take your observations (typically, the next time you end a planting season). After you've completed your first observations, you'll see the records here."
 OBSERVATIONS_EMPTY_STATE_TITLE,No Observations Yet
-OBSERVATIONS_MAP_VIEW_PROMPT,"In order to access map view, please select a single planting site."
 OBSERVATIONS_REQUIRED_BY_DATE,{0} monitoring plots require observation by {1}.,"Example: 5 monitoring plots require observation by June 30, 2023"
 OBSERVATIONS_WITH_THE_TERRAWARE_APP,Observations with the Terraware App
 OBSERVED_PLANTS_CARD_DESCRIPTION_1,This is the total number of species found in your latest observations.
@@ -775,6 +774,7 @@ PLANTING_PROGRESS_TABLE_DESCRIPTION,Use the checkboxes next to each subzone to m
 PLANTING_SEASON_END,Planting Season End
 PLANTING_SEASON_START,Planting Season Start
 PLANTING_SITE,Planting Site
+PLANTING_SITE_MAP_VIEW_PROMPT,"In order to access map view, please select a single planting site."
 PLANTING_SITE_TYPE,Planting Site Type
 PLANTING_SITE_WITH_MAP_HELP,"If you are a Terraformation partner or accelerator participant, please [contact us] to create a site with a map."
 PLANTING_SITES,Planting Sites


### PR DESCRIPTION
Missing: Remove “Destination” filter from Withdrawal History tab’s table filters to avoid conflict with top-of-page Planting Site selector.