### PR TITLE
SW-3996 Fix positioning of empty state message in Observations view

### DIFF
--- a/src/components/Observations/ObservationsHome.tsx
+++ b/src/components/Observations/ObservationsHome.tsx
@@ -56,7 +56,7 @@ export default function ObservationsHome(props: ObservationsHomeProps): JSX.Elem
       ) : selectedPlantingSite && observationsResults?.length ? (
         <ObservationsDataView selectedPlantingSiteId={selectedPlantingSite.id} {...props} />
       ) : (
-        <Card style={{ margin: 'auto' }}>
+        <Card style={{ margin: '56px auto 0', borderRadius: '24px', height: 'fit-content' }}>
           <EmptyStateContent
             title={strings.OBSERVATIONS_EMPTY_STATE_TITLE}
             subtitle={[strings.OBSERVATIONS_EMPTY_STATE_MESSAGE_1, strings.OBSERVATIONS_EMPTY_STATE_MESSAGE_2]}


### PR DESCRIPTION
- fix distance from page title
- fix border radius
- fix height of content
- the layout here is a bit different from our older pages, hence different way to style

<img width="209" alt="Terraware App 2023-08-01 11-34-12" src="https://github.com/terraware/terraware-web/assets/1865174/c545afb2-db2b-4350-a948-577155b33950">

<img width="752" alt="Terraware App 2023-08-01 11-33-53" src="https://github.com/terraware/terraware-web/assets/1865174/d0a5faef-67b7-4858-a2a5-2edeb152c14f">
