### PR TITLE
SW-3978 Get Correct Planting Site Progress %

### DIFF
--- a/src/components/PlantsV2/components/PlantingSiteProgressCard.tsx
+++ b/src/components/PlantsV2/components/PlantingSiteProgressCard.tsx
@@ -1,9 +1,9 @@
 import OverviewItemCard from 'src/components/common/OverviewItemCard';
 import { Box, Typography, useTheme } from '@mui/material';
 import strings from 'src/strings';
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useAppSelector } from 'src/redux/store';
-import { selectPlantingSite } from 'src/redux/features/tracking/trackingSelectors';
+import { selectSiteReportedPlants } from 'src/redux/features/tracking/trackingSelectors';
 import FormattedNumber from 'src/components/common/FormattedNumber';
 
 type PlantingSiteProgressCardProps = {
@@ -12,16 +12,7 @@ type PlantingSiteProgressCardProps = {
 
 export default function PlantingSiteProgressCard({ plantingSiteId }: PlantingSiteProgressCardProps): JSX.Element {
   const theme = useTheme();
-  const plantingSite = useAppSelector((state) => selectPlantingSite(state, plantingSiteId));
-
-  const totalArea = plantingSite?.areaHa ?? 0;
-  const totalPlantedArea = useMemo(() => {
-    return (
-      plantingSite?.plantingZones
-        ?.flatMap((zone) => zone.plantingSubzones)
-        ?.reduce((prev, curr) => (curr.plantingCompleted ? +curr.areaHa + prev : prev), 0) ?? 0
-    );
-  }, [plantingSite]);
+  const reportedPlants = useAppSelector((state) => selectSiteReportedPlants(state, plantingSiteId));
 
   return (
     <OverviewItemCard
@@ -32,7 +23,7 @@ export default function PlantingSiteProgressCard({ plantingSiteId }: PlantingSit
             {strings.PLANTING_PROGRESS_CARD_TITLE}
           </Typography>
           <Typography fontSize='84px' fontWeight={600} lineHeight={1} marginBottom={theme.spacing(3)}>
-            {totalArea > 0 ? <FormattedNumber value={Math.round((100 * totalPlantedArea) / totalArea) || 0} /> : '0'}%
+            <FormattedNumber value={reportedPlants?.progressPercent ?? 0} />%
           </Typography>
           <Typography fontSize='12px' fontWeight={400} marginBottom={theme.spacing(1.5)}>
             {strings.PLANTING_PROGRESS_DESCRIPTION_1}

--- a/src/redux/features/tracking/trackingSelectors.ts
+++ b/src/redux/features/tracking/trackingSelectors.ts
@@ -19,14 +19,11 @@ export const selectSiteReportedPlantsError = (state: RootState, plantingSiteId: 
 
 export const selectZoneProgress = createCachedSelector(
   (state: RootState, plantingSiteId: number) => selectPlantingSite(state, plantingSiteId),
-  (plantingSite) => {
+  (state: RootState, plantingSiteId: number) => selectSiteReportedPlants(state, plantingSiteId),
+  (plantingSite, reportedPlants) => {
     const zoneProgress: Record<number, { name: string; progress: number; targetDensity: number }> = {};
     plantingSite?.plantingZones?.forEach((zone) => {
-      let completedPlantingArea = 0;
-      zone.plantingSubzones.forEach((sz) => {
-        completedPlantingArea += sz.plantingCompleted ? +sz.areaHa : 0;
-      });
-      const percentProgress = Math.round((100 * completedPlantingArea) / +zone.areaHa);
+      const percentProgress = reportedPlants?.plantingZones?.find((z) => z.id === zone.id)?.progressPercent ?? 0;
       zoneProgress[zone.id] = { name: zone.name, progress: percentProgress, targetDensity: zone.targetPlantingDensity };
     });
     return zoneProgress;


### PR DESCRIPTION
We were previously calculating the progress based on how much subzone area was
marked as completed planting. This was incorrect. Instead use the planting
progress percentages reported by the BE for each zone and the site.

<img width="853" alt="image" src="https://github.com/terraware/terraware-web/assets/114949086/3a606df9-f095-4caf-97fe-5ccebce9bb90">
<img width="1229" alt="image" src="https://github.com/terraware/terraware-web/assets/114949086/04a690fd-3092-4b2d-99b4-604771930bff">
