### PR TITLE
SW-3966-amended Misc fixes on top of Constanza's PR #1616

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,7 @@ import {
   SpeciesBulkWithdrawWrapperComponent,
 } from './components/Inventory/withdraw';
 import PlantsDashboard from './components/Plants';
-import { NurseryWithdrawals, NurseryWithdrawalsDetails, NurseryReassignment } from './components/NurseryWithdrawals';
+import { NurseryWithdrawals, NurseryReassignment } from './components/NurseryWithdrawals';
 import { SpeciesService } from 'src/services';
 import { PlantingSite } from 'src/types/Tracking';
 import { useLocalization, useOrganization, useUser } from 'src/providers';
@@ -462,14 +462,12 @@ function AppContent() {
             <Route path={APP_PATHS.PLANTING_SITES}>
               <PlantingSites reloadTracking={reloadTracking} />
             </Route>
-            <Route exact path={APP_PATHS.NURSERY_WITHDRAWALS}>
-              <NurseryWithdrawals reloadTracking={reloadTracking} />
-            </Route>
-            <Route exact path={APP_PATHS.NURSERY_WITHDRAWALS_V2}>
-              <NurseryWithdrawals reloadTracking={reloadTracking} />
-            </Route>
-            <Route exact path={APP_PATHS.NURSERY_WITHDRAWALS_DETAILS}>
-              <NurseryWithdrawalsDetails species={species} plantingSubzoneNames={plantingSubzoneNames} />
+            <Route path={APP_PATHS.NURSERY_WITHDRAWALS}>
+              <NurseryWithdrawals
+                reloadTracking={reloadTracking}
+                species={species}
+                plantingSubzoneNames={plantingSubzoneNames}
+              />
             </Route>
             <Route exact path={APP_PATHS.NURSERY_REASSIGNMENT}>
               <NurseryReassignment />

--- a/src/components/NurseryWithdrawals/NurseryPlantingsAndWithdrawals.tsx
+++ b/src/components/NurseryWithdrawals/NurseryPlantingsAndWithdrawals.tsx
@@ -76,7 +76,15 @@ export default function NurseryPlantingsAndWithdrawals({
 
   return (
     <Box sx={{ paddingLeft: 3 }} display='flex' flexDirection='column' flexGrow={1}>
-      <Grid container spacing={3} sx={{ marginTop: 0 }} display='flex' flexDirection='column' flexGrow={1} className={classes.tabs}>
+      <Grid
+        container
+        spacing={3}
+        sx={{ marginTop: 0 }}
+        display='flex'
+        flexDirection='column'
+        flexGrow={1}
+        className={classes.tabs}
+      >
         <Tabs
           activeTab={activeTab}
           onTabChange={onTabChange}

--- a/src/components/NurseryWithdrawals/NurseryPlantingsAndWithdrawals.tsx
+++ b/src/components/NurseryWithdrawals/NurseryPlantingsAndWithdrawals.tsx
@@ -1,9 +1,9 @@
 /**
  * Nursery plantings and withdrawals
  */
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { Box, Grid, useTheme } from '@mui/material';
+import { Box, Grid } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { Tabs } from '@terraware/web-components';
 import strings from 'src/strings';
@@ -12,7 +12,6 @@ import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
 import { useLocalization, useOrganization } from 'src/providers';
 import { useAppDispatch } from 'src/redux/store';
 import { requestPlantings } from 'src/redux/features/plantings/plantingsThunks';
-import PageSnackbar from 'src/components/PageSnackbar';
 import PlantingProgress from './PlantingProgressTabContent';
 import NurseryWithdrawals from './NurseryWithdrawalsTabContent';
 import { requestPlantingSitesSearchResults } from 'src/redux/features/tracking/trackingThunks';
@@ -48,11 +47,9 @@ export default function NurseryPlantingsAndWithdrawals({
   const classes = useStyles();
   const { activeLocale } = useLocalization();
   const { selectedOrganization } = useOrganization();
-  const theme = useTheme();
   const query = useQuery();
   const history = useHistory();
   const location = useStateLocation();
-  const contentRef = useRef(null);
   const dispatch = useAppDispatch();
   const tab = query.get('tab') || 'planting_progress';
 
@@ -78,31 +75,26 @@ export default function NurseryPlantingsAndWithdrawals({
   }, [tab, activeLocale]);
 
   return (
-    <Box sx={{ paddingLeft: theme.spacing(3) }} display='flex' flexDirection='column' flexGrow={1}>
-      <Grid container spacing={3} sx={{ marginTop: 0 }} display='flex' flexDirection='column' flexGrow={1}>
-        <Grid item xs={12}>
-          <PageSnackbar />
-        </Grid>
-        <Box ref={contentRef} display='flex' flexDirection='column' flexGrow={1} className={classes.tabs}>
-          <Tabs
-            activeTab={activeTab}
-            onTabChange={onTabChange}
-            tabs={[
-              {
-                id: 'planting_progress',
-                label: strings.PLANTING_PROGRESS,
-                children: (
-                  <PlantingProgress reloadTracking={reloadTracking} selectedPlantingSiteId={selectedPlantingSite.id} />
-                ),
-              },
-              {
-                id: 'withdrawal_history',
-                label: strings.WITHDRAWAL_HISTORY,
-                children: <NurseryWithdrawals selectedPlantingSite={selectedPlantingSite} />,
-              },
-            ]}
-          />
-        </Box>
+    <Box sx={{ paddingLeft: 3 }} display='flex' flexDirection='column' flexGrow={1}>
+      <Grid container spacing={3} sx={{ marginTop: 0 }} display='flex' flexDirection='column' flexGrow={1} className={classes.tabs}>
+        <Tabs
+          activeTab={activeTab}
+          onTabChange={onTabChange}
+          tabs={[
+            {
+              id: 'planting_progress',
+              label: strings.PLANTING_PROGRESS,
+              children: (
+                <PlantingProgress reloadTracking={reloadTracking} selectedPlantingSiteId={selectedPlantingSite.id} />
+              ),
+            },
+            {
+              id: 'withdrawal_history',
+              label: strings.WITHDRAWAL_HISTORY,
+              children: <NurseryWithdrawals selectedPlantingSite={selectedPlantingSite} />,
+            },
+          ]}
+        />
       </Grid>
     </Box>
   );

--- a/src/components/NurseryWithdrawals/NurseryReassignment.tsx
+++ b/src/components/NurseryWithdrawals/NurseryReassignment.tsx
@@ -9,6 +9,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import strings from 'src/strings';
 import { APP_PATHS } from 'src/constants';
+import isEnabled from 'src/features';
 import TfMain from 'src/components/common/TfMain';
 import TitleDescription from 'src/components/common/TitleDescription';
 import Card from 'src/components/common/Card';
@@ -59,6 +60,7 @@ export default function NurseryReassignment(): JSX.Element {
   const [reassignments, setReassignments] = useState<{ [subzoneId: string]: Reassignment }>({});
   const [noReassignments, setNoReassignments] = useState<boolean>(false);
   const contentRef = useRef(null);
+  const trackingV2 = isEnabled('TrackingV2');
 
   const numericFormatter = useMemo(() => numberFormatter(user?.locale), [numberFormatter, user?.locale]);
 
@@ -224,7 +226,7 @@ export default function NurseryReassignment(): JSX.Element {
             id='back'
             to={APP_PATHS.NURSERY_WITHDRAWALS}
             className={classes.backToWithdrawals}
-            name={strings.WITHDRAWAL_LOG}
+            name={trackingV2 ? strings.WITHDRAWALS : strings.WITHDRAWAL_LOG}
           />
         </Box>
         <Box marginTop={theme.spacing(3)}>

--- a/src/components/NurseryWithdrawals/NurserySiteWithdrawals.tsx
+++ b/src/components/NurseryWithdrawals/NurserySiteWithdrawals.tsx
@@ -1,0 +1,46 @@
+import { useCallback, useState } from 'react';
+import strings from 'src/strings';
+import { APP_PATHS } from 'src/constants';
+import { PlantingSite } from 'src/types/Tracking';
+import { useAppSelector } from 'src/redux/store';
+import { selectPlantingSites } from 'src/redux/features/tracking/trackingSelectors';
+import useQuery from 'src/utils/useQuery';
+import NurseryPlantingsAndWithdrawals from './NurseryPlantingsAndWithdrawals';
+import PlantsPrimaryPage from '../PlantsPrimaryPage';
+
+/**
+ * Primary route management for nursery withdrawals.
+ */
+type NurserySiteWithdrawalsProps = {
+  reloadTracking: () => void;
+};
+
+export default function NurserySiteWithdrawals({ reloadTracking }: NurserySiteWithdrawalsProps): JSX.Element {
+  const [selectedPlantingSite, setSelectedPlantingSite] = useState<PlantingSite>();
+  const [plantsSitePreferences, setPlantsSitePreferences] = useState<Record<string, unknown>>();
+  const plantingSites = useAppSelector(selectPlantingSites);
+  const onSelect = useCallback((site: PlantingSite) => setSelectedPlantingSite(site), [setSelectedPlantingSite]);
+  const query = useQuery();
+  const onPreferences = useCallback(
+    (preferences: Record<string, unknown>) => setPlantsSitePreferences(preferences),
+    [setPlantsSitePreferences]
+  );
+
+  return (
+    <PlantsPrimaryPage
+      title={strings.WITHDRAWALS}
+      onSelect={onSelect}
+      pagePath={APP_PATHS.NURSERY_SITE_WITHDRAWALS}
+      lastVisitedPreferenceName='seedlings.withdrawals.lastVisitedPlantingSite'
+      plantsSitePreferences={plantsSitePreferences}
+      setPlantsSitePreferences={onPreferences}
+      allowAllAsSiteSelection={true}
+      isEmptyState={!plantingSites?.length}
+      query={query.toString()}
+    >
+      {selectedPlantingSite && (
+        <NurseryPlantingsAndWithdrawals reloadTracking={reloadTracking} selectedPlantingSite={selectedPlantingSite} />
+      )}
+    </PlantsPrimaryPage>
+  );
+}

--- a/src/components/NurseryWithdrawals/NurseryWithdrawalsDetails.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawalsDetails.tsx
@@ -4,6 +4,7 @@ import { Box, Tab, Theme, Typography, useTheme } from '@mui/material';
 import { APP_PATHS } from 'src/constants';
 import { Button } from '@terraware/web-components';
 import strings from 'src/strings';
+import isEnabled from 'src/features';
 import PageSnackbar from 'src/components/PageSnackbar';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import { useEffect, useRef, useState } from 'react';
@@ -76,6 +77,9 @@ export default function NurseryWithdrawalsDetails({
   const [withdrawalSummary, setWithdrawalSummary] = useState<WithdrawalSummary | undefined>(undefined);
   const [delivery, setDelivery] = useState<Delivery | undefined>(undefined);
   const [batches, setBatches] = useState<Batch[] | undefined>(undefined);
+
+  const trackingV2 = isEnabled('TrackingV2');
+
   useEffect(() => {
     const updateWithdrawal = async () => {
       const withdrawalResponse = await NurseryWithdrawalService.getNurseryWithdrawal(Number(withdrawalId));
@@ -166,7 +170,7 @@ export default function NurseryWithdrawalsDetails({
               id='back'
               to={APP_PATHS.NURSERY_WITHDRAWALS}
               className={classes.backToWithdrawals}
-              name={strings.WITHDRAWAL_LOG}
+              name={trackingV2 ? strings.WITHDRAWALS : strings.WITHDRAWAL_LOG}
             />
           </Box>
           <Box

--- a/src/components/NurseryWithdrawals/PlantingProgressMap.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressMap.tsx
@@ -158,8 +158,8 @@ export default function PlantingProgressMap({ plantingSiteId, reloadTracking }: 
       />
     </>
   ) : (
-    <Typography fontSize='14px' fontWeight={400} color={theme.palette.TwClrTxt} textAlign='center'>
-      {strings.NO_MAP_DATA}
+    <Typography fontSize='18px' fontWeight={500} color={theme.palette.TwClrTxtSecondary} textAlign='center'>
+      {plantingSiteId === -1 ? strings.PLANTING_SITE_MAP_VIEW_PROMPT : strings.NO_MAP_DATA}
     </Typography>
   );
 }

--- a/src/components/NurseryWithdrawals/PlantingProgressTabContent.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressTabContent.tsx
@@ -103,10 +103,7 @@ export default function PlantingProgress({
           />
         }
         map={
-          <PlantingProgressMap
-            plantingSiteId={selectedPlantingSiteId}
-            reloadTracking={reloadTrackingAndObservations} 
-          />
+          <PlantingProgressMap plantingSiteId={selectedPlantingSiteId} reloadTracking={reloadTrackingAndObservations} />
         }
       />
     </Card>
@@ -120,14 +117,8 @@ type SearchComponentProps = SearchProps & {
 function SearchComponent(props: SearchComponentProps): JSX.Element {
   const { search, onSearch, filtersProps, view } = props;
   return (
-    <div style={{ display: 'flex'}}>
-      {view === 'list' && (
-        <Search
-          search={search}
-          onSearch={onSearch}
-          filtersProps={filtersProps}
-        />
-      )}
+    <div style={{ display: 'flex' }}>
+      {view === 'list' && <Search search={search} onSearch={onSearch} filtersProps={filtersProps} />}
     </div>
   );
 }

--- a/src/components/NurseryWithdrawals/PlantingProgressTabContent.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressTabContent.tsx
@@ -103,7 +103,10 @@ export default function PlantingProgress({
           />
         }
         map={
-          <PlantingProgressMap plantingSiteId={selectedPlantingSiteId} reloadTracking={reloadTrackingAndObservations} />
+          <PlantingProgressMap
+            plantingSiteId={selectedPlantingSiteId}
+            reloadTracking={reloadTrackingAndObservations} 
+          />
         }
       />
     </Card>
@@ -117,10 +120,14 @@ type SearchComponentProps = SearchProps & {
 function SearchComponent(props: SearchComponentProps): JSX.Element {
   const { search, onSearch, filtersProps, view } = props;
   return (
-    <>
-      <div style={{ display: view === 'list' ? 'flex' : 'none' }}>
-        <Search search={search} onSearch={onSearch} filtersProps={filtersProps} />
-      </div>
-    </>
+    <div style={{ display: 'flex'}}>
+      {view === 'list' && (
+        <Search
+          search={search}
+          onSearch={onSearch}
+          filtersProps={filtersProps}
+        />
+      )}
+    </div>
   );
 }

--- a/src/components/NurseryWithdrawals/index.tsx
+++ b/src/components/NurseryWithdrawals/index.tsx
@@ -46,7 +46,6 @@ export default function NurseryWithdrawals({ reloadTracking }: NurseryWithdrawal
         {selectedPlantingSite && (
           <NurseryPlantingsAndWithdrawals reloadTracking={reloadTracking} selectedPlantingSite={selectedPlantingSite} />
         )}
-        ;
       </PlantsPrimaryPage>
     );
   }

--- a/src/components/NurseryWithdrawals/index.tsx
+++ b/src/components/NurseryWithdrawals/index.tsx
@@ -1,56 +1,46 @@
+import { Route, Switch } from 'react-router-dom';
+import { APP_PATHS } from 'src/constants';
+import { Species } from 'src/types/Species';
 import isEnabled from 'src/features';
 import NurseryReassignment from './NurseryReassignment';
 import NurseryWithdrawalsBase from './NurseryWithdrawals';
-import NurseryPlantingsAndWithdrawals from './NurseryPlantingsAndWithdrawals';
 import NurseryWithdrawalsDetails from './NurseryWithdrawalsDetails';
-import PlantsPrimaryPage from '../PlantsPrimaryPage';
-import strings from 'src/strings';
-import { APP_PATHS } from 'src/constants';
-import { useCallback, useState } from 'react';
-import { PlantingSite } from 'src/types/Tracking';
-import { useAppSelector } from 'src/redux/store';
-import { selectPlantingSites } from 'src/redux/features/tracking/trackingSelectors';
-import useQuery from 'src/utils/useQuery';
+import NurserySiteWithdrawals from './NurserySiteWithdrawals';
 
 /**
  * Primary route management for nursery withdrawals.
  */
 type NurseryWithdrawalsProps = {
   reloadTracking: () => void;
+  species: Species[];
+  plantingSubzoneNames: Record<number, string>;
 };
-export default function NurseryWithdrawals({ reloadTracking }: NurseryWithdrawalsProps): JSX.Element {
+
+function NurseryWithdrawals({ reloadTracking, species, plantingSubzoneNames }: NurseryWithdrawalsProps): JSX.Element {
   const trackingV2 = isEnabled('TrackingV2');
-  const [selectedPlantingSite, setSelectedPlantingSite] = useState<PlantingSite>();
-  const [plantsSitePreferences, setPlantsSitePreferences] = useState<Record<string, unknown>>();
-  const plantingSites = useAppSelector(selectPlantingSites);
-  const onSelect = useCallback((site: PlantingSite) => setSelectedPlantingSite(site), [setSelectedPlantingSite]);
-  const query = useQuery();
-  const onPreferences = useCallback(
-    (preferences: Record<string, unknown>) => setPlantsSitePreferences(preferences),
-    [setPlantsSitePreferences]
+
+  return (
+    <Switch>
+      <Route exact path={APP_PATHS.NURSERY_WITHDRAWALS_DETAILS}>
+        <NurseryWithdrawalsDetails species={species} plantingSubzoneNames={plantingSubzoneNames} />
+      </Route>
+      {trackingV2 && (
+        <Route path={APP_PATHS.NURSERY_SITE_WITHDRAWALS}>
+          <NurserySiteWithdrawals reloadTracking={reloadTracking} />
+        </Route>
+      )}
+      {trackingV2 && (
+        <Route path={'*'}>
+          <NurserySiteWithdrawals reloadTracking={reloadTracking} />
+        </Route>
+      )}
+      {!trackingV2 && (
+        <Route path={'*'}>
+          <NurseryWithdrawalsBase />
+        </Route>
+      )}
+    </Switch>
   );
-
-  if (trackingV2) {
-    return (
-      <PlantsPrimaryPage
-        title={strings.WITHDRAWALS}
-        onSelect={onSelect}
-        pagePath={APP_PATHS.NURSERY_WITHDRAWALS_V2}
-        lastVisitedPreferenceName='seedlings.withdrawals.lastVisitedPlantingSite'
-        plantsSitePreferences={plantsSitePreferences}
-        setPlantsSitePreferences={onPreferences}
-        allowAllAsSiteSelection={true}
-        isEmptyState={!plantingSites?.length}
-        query={query.toString()}
-      >
-        {selectedPlantingSite && (
-          <NurseryPlantingsAndWithdrawals reloadTracking={reloadTracking} selectedPlantingSite={selectedPlantingSite} />
-        )}
-      </PlantsPrimaryPage>
-    );
-  }
-
-  return <NurseryWithdrawalsBase />;
 }
 
-export { NurseryReassignment, NurseryWithdrawals, NurseryWithdrawalsDetails };
+export { NurseryReassignment, NurseryWithdrawals };

--- a/src/components/Observations/ObservationsDataView.tsx
+++ b/src/components/Observations/ObservationsDataView.tsx
@@ -82,7 +82,7 @@ const AllPlantingSitesMapView = (): JSX.Element => {
   return (
     <Box textAlign='center' marginTop={6}>
       <Typography fontSize='18px' fontWeight={500} color={theme.palette.TwClrTxtSecondary}>
-        {strings.OBSERVATIONS_MAP_VIEW_PROMPT}
+        {strings.PLANTING_SITE_MAP_VIEW_PROMPT}
       </Typography>
     </Box>
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -59,7 +59,7 @@ export enum APP_PATHS {
   PLANTING_SITES_ZONE_VIEW = '/planting-sites/:plantingSiteId/zone/:zoneId',
   PLANTING_SITES_SUBZONE_VIEW = '/planting-sites/:plantingSiteId/zone/:zoneId/subzone/:subzoneId',
   NURSERY_WITHDRAWALS = '/nursery/withdrawals',
-  NURSERY_WITHDRAWALS_V2 = '/nursery/withdrawals2/:plantingSiteId',
-  NURSERY_WITHDRAWALS_DETAILS = '/nursery/withdrawals/:withdrawalId',
+  NURSERY_WITHDRAWALS_DETAILS = '/nursery/withdrawals/details/:withdrawalId',
+  NURSERY_SITE_WITHDRAWALS = '/nursery/withdrawals/:plantingSiteId',
   NURSERY_REASSIGNMENT = '/nursery/reassignment/:deliveryId',
 }

--- a/src/redux/features/plantings/plantingsSelectors.ts
+++ b/src/redux/features/plantings/plantingsSelectors.ts
@@ -90,14 +90,17 @@ export const searchPlantingProgress = createSelector(
   (plantingProgress, query, plantingCompleted, plantingSiteId) => {
     return plantingProgress?.reduce((acc, curr) => {
       const { siteId, siteName, totalPlants, reported } = curr;
+      const matchesPlantingSite =
+        plantingSiteId === undefined || plantingSiteId === -1 || siteId === plantingSiteId;
+      if (!matchesPlantingSite) {
+        return acc;
+      }
       if (reported && reported.length > 0) {
         reported?.forEach((progress) => {
           const matchesQuery = !query || regexMatch(progress.subzoneName, query);
           const matchesPlantingCompleted =
             plantingCompleted === undefined || progress.plantingCompleted === plantingCompleted;
-          const matchesPlantingSite =
-            plantingSiteId === undefined || plantingSiteId === -1 || siteId === plantingSiteId;
-          if (matchesQuery && matchesPlantingCompleted && matchesPlantingSite) {
+          if (matchesQuery && matchesPlantingCompleted) {
             acc.push({ siteId, siteName, totalPlants, ...progress });
           }
         });

--- a/src/redux/features/plantings/plantingsSelectors.ts
+++ b/src/redux/features/plantings/plantingsSelectors.ts
@@ -90,8 +90,7 @@ export const searchPlantingProgress = createSelector(
   (plantingProgress, query, plantingCompleted, plantingSiteId) => {
     return plantingProgress?.reduce((acc, curr) => {
       const { siteId, siteName, totalPlants, reported } = curr;
-      const matchesPlantingSite =
-        plantingSiteId === undefined || plantingSiteId === -1 || siteId === plantingSiteId;
+      const matchesPlantingSite = plantingSiteId === undefined || plantingSiteId === -1 || siteId === plantingSiteId;
       if (!matchesPlantingSite) {
         return acc;
       }

--- a/src/services/NurseryWithdrawalService.ts
+++ b/src/services/NurseryWithdrawalService.ts
@@ -174,7 +174,7 @@ const getWithdrawalPhotosList = async (withdrawalId: number): Promise<Response &
 /**
  * Get Filter Options
  */
-const getFilterOptions = async (organizationId: number): Promise<FieldOptionsMap> => {
+const getFilterOptions = async (organizationId: number, plantingSiteName?: string): Promise<FieldOptionsMap> => {
   const searchParams: SearchRequestPayload = {
     prefix: 'nurseryWithdrawals',
     fields: [
@@ -185,7 +185,19 @@ const getFilterOptions = async (organizationId: number): Promise<FieldOptionsMap
       'plantingSubzoneNames',
       'batchWithdrawals.batch_species_scientificName',
     ],
-    search: SearchService.convertToSearchNodePayload({}, organizationId),
+    search: SearchService.convertToSearchNodePayload(
+      plantingSiteName
+        ? [
+            {
+              operation: 'field',
+              field: 'destinationName',
+              type: 'Exact',
+              values: [plantingSiteName],
+            },
+          ]
+        : [],
+      organizationId
+    ),
     sortOrder: [{ field: 'id', direction: 'Ascending' }],
     count: 1000,
   };

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -682,7 +682,6 @@ OBSERVATIONS_DOWNLOAD_APP,"To complete observations, download the Terraware app 
 OBSERVATIONS_EMPTY_STATE_MESSAGE_1,"Observations are when you record data from a sample of monitoring plots using our mobile app in the field. This allows us to calculate mortality rates, and eventually carbon sequestration."
 OBSERVATIONS_EMPTY_STATE_MESSAGE_2,"You will be notified when it is time to take your observations (typically, the next time you end a planting season). After you've completed your first observations, you'll see the records here."
 OBSERVATIONS_EMPTY_STATE_TITLE,No Observations Yet
-OBSERVATIONS_MAP_VIEW_PROMPT,"In order to access map view, please select a single planting site."
 OBSERVATIONS_REQUIRED_BY_DATE,{0} monitoring plots require observation by {1}.,"Example: 5 monitoring plots require observation by June 30, 2023"
 OBSERVATIONS_WITH_THE_TERRAWARE_APP,Observations with the Terraware App
 OBSERVED_PLANTS_CARD_DESCRIPTION_1,This is the total number of species found in your latest observations.
@@ -775,6 +774,7 @@ PLANTING_PROGRESS_TABLE_DESCRIPTION,Use the checkboxes next to each subzone to m
 PLANTING_SEASON_END,Planting Season End
 PLANTING_SEASON_START,Planting Season Start
 PLANTING_SITE,Planting Site
+PLANTING_SITE_MAP_VIEW_PROMPT,"In order to access map view, please select a single planting site."
 PLANTING_SITE_TYPE,Planting Site Type
 PLANTING_SITE_WITH_MAP_HELP,"If you are a Terraformation partner or accelerator participant, please [contact us] to create a site with a map."
 PLANTING_SITES,Planting Sites


### PR DESCRIPTION
- fixed width/height of tab content (removed snackbar and content ref, this is handled in the primary page wrapper)
- fixed selector to apply matching site id and return earlier, avoid extra matching checks
- added map view message when selected site is All (same as in observations view)
- added non-zero component for search so list/map view selector shows up on right hand side for map view
- renamed back to links from withdrawals details and reassignment pages to saw 'Withdrawals' instead of 'Withdrawal Log'
- enhanced routing as follows:
  `/withdrawals/details/<detail-id>` goes to details
  `/withdrawas/<site-id>` goes to new withdrawals page if tracking v2 is enabled
  `/withdrawals/` goes to new withdrawals page if tracking v2 is enabled, otherwise goes to old withdrawals page
