### PR TITLE
SW-3998 Get exact matches for selected planting site on withdrawals page

### DIFF
--- a/src/components/NurseryWithdrawals/NurseryReassignment.tsx
+++ b/src/components/NurseryWithdrawals/NurseryReassignment.tsx
@@ -132,7 +132,11 @@ export default function NurseryReassignment(): JSX.Element {
 
   const goToWithdrawals = () => {
     const withdrawalId = query.has('fromWithdrawal') ? delivery?.withdrawalId : undefined;
-    history.push({ pathname: APP_PATHS.NURSERY_WITHDRAWALS + (withdrawalId ? `/${withdrawalId}` : '') });
+    const search = trackingV2 && !withdrawalId ? 'tab=withdrawal_history' : '';
+    const pathname = withdrawalId
+      ? APP_PATHS.NURSERY_WITHDRAWALS_DETAILS.replace(':withdrawalId', withdrawalId.toString())
+      : APP_PATHS.NURSERY_WITHDRAWALS;
+    history.push({ pathname, search });
   };
 
   const reassign = async () => {

--- a/src/components/NurseryWithdrawals/NurseryWithdrawalsTable.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawalsTable.tsx
@@ -286,6 +286,7 @@ export default function NurseryWithdrawalsTable({ selectedPlantingSite }: Nurser
           type='text'
           className={classes.searchField}
           iconRight='cancel'
+          onClickRightIcon={() => setSearchValue('')}
           value={searchValue}
           onChange={(value) => setSearchValue(value as string)}
         />

--- a/src/components/NurseryWithdrawals/NurseryWithdrawalsTable.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawalsTable.tsx
@@ -139,8 +139,10 @@ export default function NurseryWithdrawalsTable({ selectedPlantingSite }: Nurser
   };
 
   const getSearchChildren = useCallback(() => {
+    const filterValueChildren: FieldNodePayload[] = [...Object.values(filters)];
     const finalSearchValueChildren: FieldNodePayload[] = [];
     const searchValueChildren: FieldNodePayload[] = [];
+
     if (debouncedSearchTerm) {
       const fromNurseryNode: FieldNodePayload = {
         operation: 'field',
@@ -170,16 +172,14 @@ export default function NurseryWithdrawalsTable({ selectedPlantingSite }: Nurser
     }
 
     if (selectedPlantingSite && selectedPlantingSite.id !== -1) {
-      const destinationNurseryNode: FieldNodePayload = {
+      const destinationSiteNode: FieldNodePayload = {
         operation: 'field',
         field: 'destinationName',
         type: 'Exact',
         values: [selectedPlantingSite.name],
       };
-      searchValueChildren.push(destinationNurseryNode);
+      filterValueChildren.push(destinationSiteNode);
     }
-
-    const filterValueChildren: FieldNodePayload[] = [...Object.values(filters)];
 
     if (searchValueChildren.length) {
       const searchValueNodes: FieldNodePayload = {
@@ -221,10 +221,15 @@ export default function NurseryWithdrawalsTable({ selectedPlantingSite }: Nurser
     );
     if (apiSearchResults) {
       if (getRequestId('searchWithdrawals') === requestId) {
-        setSearchResults(apiSearchResults);
+        if (selectedPlantingSite?.name) {
+          // Workaround to get Exact matches on destination name
+          setSearchResults(apiSearchResults.filter((result) => result.destinationName === selectedPlantingSite.name));
+        } else {
+          setSearchResults(apiSearchResults);
+        }
       }
     }
-  }, [getSearchChildren, selectedOrganization, searchSortOrder]);
+  }, [getSearchChildren, selectedOrganization, searchSortOrder, selectedPlantingSite?.name]);
 
   useEffect(() => {
     if (siteParam) {

--- a/src/components/NurseryWithdrawals/NurseryWithdrawalsTable.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawalsTable.tsx
@@ -62,7 +62,6 @@ export default function NurseryWithdrawalsTable({ selectedPlantingSite }: Nurser
   const debouncedSearchTerm = useDebounce(searchValue, 250);
   const [filters, setFilters] = useState<Record<string, any>>({});
   const subzoneParam = query.get('subzoneName');
-  const siteParam = query.get('siteName');
   const trackingV2 = isEnabled('TrackingV2');
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -221,7 +220,7 @@ export default function NurseryWithdrawalsTable({ selectedPlantingSite }: Nurser
     );
     if (apiSearchResults) {
       if (getRequestId('searchWithdrawals') === requestId) {
-        if (selectedPlantingSite?.name) {
+        if (selectedPlantingSite?.id !== -1 && selectedPlantingSite?.name) {
           // Workaround to get Exact matches on destination name
           setSearchResults(apiSearchResults.filter((result) => result.destinationName === selectedPlantingSite.name));
         } else {
@@ -229,23 +228,7 @@ export default function NurseryWithdrawalsTable({ selectedPlantingSite }: Nurser
         }
       }
     }
-  }, [getSearchChildren, selectedOrganization, searchSortOrder, selectedPlantingSite?.name]);
-
-  useEffect(() => {
-    if (siteParam) {
-      query.delete('siteName');
-      history.replace(getLocation(location.pathname, location, query.toString()));
-      setFilters((curr) => ({
-        ...curr,
-        destinationName: {
-          field: 'destinationName',
-          operation: 'field',
-          type: 'Exact',
-          values: [siteParam],
-        },
-      }));
-    }
-  }, [siteParam, query, history, location]);
+  }, [getSearchChildren, selectedOrganization, searchSortOrder, selectedPlantingSite?.id, selectedPlantingSite?.name]);
 
   useEffect(() => {
     if (subzoneParam) {

--- a/src/components/NurseryWithdrawals/PlantingProgressList.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressList.tsx
@@ -228,10 +228,9 @@ const DetailsRenderer =
     const { column, row } = props;
 
     const createLinkToWithdrawals = () => {
-      const filterParam = row.subzoneName
-        ? `subzoneName=${encodeURIComponent(row.subzoneName)}&siteName=${encodeURIComponent(row.siteName)}`
-        : `siteName=${encodeURIComponent(row.siteName)}`;
-      const url = `${APP_PATHS.NURSERY_WITHDRAWALS}?tab=withdrawal_history&${filterParam}`;
+      const siteUrl = APP_PATHS.NURSERY_SITE_WITHDRAWALS.replace(':plantingSiteId', row.siteId.toString());
+      const filterParam = row.subzoneName ? `&subzoneName=${encodeURIComponent(row.subzoneName)}` : '';
+      const url = `${siteUrl}?tab=withdrawal_history${filterParam}`;
       return (
         <Link to={url}>
           <FormattedNumber value={row.totalSeedlingsSent} />

--- a/src/components/NurseryWithdrawals/PlantingProgressMap.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressMap.tsx
@@ -146,7 +146,7 @@ export default function PlantingProgressMap({ plantingSiteId, reloadTracking }: 
             <PlantingProgressMapDialog
               id={properties.id}
               subzoneName={properties.fullName}
-              siteName={plantingSite?.name || ''}
+              siteId={plantingSite?.id || -1}
               plantingComplete={subzonesComplete[properties.id]}
               onUpdatePlantingComplete={updatePlantingComplete}
               busy={dispatching}

--- a/src/components/NurseryWithdrawals/PlantingProgressMapDialog.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressMapDialog.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 type PlantingProgressMapDialogProps = {
   id: number;
   subzoneName: string;
-  siteName: string;
+  siteId: number;
   plantingComplete: boolean;
   onUpdatePlantingComplete: (id: number, val: boolean) => void;
   busy: boolean;
@@ -34,7 +34,7 @@ type PlantingProgressMapDialogProps = {
 export default function PlantingProgressMapDialog({
   id,
   subzoneName,
-  siteName,
+  siteId,
   plantingComplete,
   onUpdatePlantingComplete,
   busy,
@@ -47,8 +47,9 @@ export default function PlantingProgressMapDialog({
   }, [species]);
 
   const getWithdrawalHistoryLink = () => {
-    const filterParam = `subzoneName=${encodeURIComponent(subzoneName)}&siteName=${encodeURIComponent(siteName)}`;
-    const url = `${APP_PATHS.NURSERY_WITHDRAWALS}?tab=withdrawal_history&${filterParam}`;
+    const siteUrl = APP_PATHS.NURSERY_SITE_WITHDRAWALS.replace(':plantingSiteId', siteId.toString());
+    const filterParam = `subzoneName=${encodeURIComponent(subzoneName)}`;
+    const url = `${siteUrl}?tab=withdrawal_history&${filterParam}`;
     return (
       <Link className={classes.withdrawalHistoryLink} to={url}>
         {strings.SEE_WITHDRAWAL_HISTORY}


### PR DESCRIPTION
- BE returns planting sites whose names contain the selected planting site name, eg. if selected site is 'site', responses will also include 'site1' if they exist
- [see](https://terraformation.atlassian.net/browse/SW-3070) for more context
- added another layer of filtering out non-exact names within client code