### PR TITLE
SW-3932 Map view for simple planting sites

### DIFF
--- a/src/components/PlantingSites/PlantingSiteCreate.tsx
+++ b/src/components/PlantingSites/PlantingSiteCreate.tsx
@@ -23,6 +23,7 @@ import Card from 'src/components/common/Card';
 import isEnabled from 'src/features';
 import { getMonth } from 'src/utils/dateFormatter';
 import { useLocalization } from 'src/providers';
+import SimplePlantingSite from 'src/components/PlantingSites/SimplePlantingSite';
 
 type CreatePlantingSiteProps = {
   reloadPlantingSites: () => void;
@@ -212,11 +213,16 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
                       </>
                     )}
                   </Grid>
-                  {record?.boundary && (
+                  {record?.boundary && record?.plantingZones && (
                     <Grid container flexGrow={1}>
                       <Grid item xs={12} display='flex'>
                         <BoundariesAndZones plantingSite={record} />
                       </Grid>
+                    </Grid>
+                  )}
+                  {record?.boundary && !record.plantingZones && (
+                    <Grid item xs={12}>
+                      <SimplePlantingSite plantingSite={record} />
                     </Grid>
                   )}
                 </Card>

--- a/src/components/PlantingSites/PlantingSiteView.tsx
+++ b/src/components/PlantingSites/PlantingSiteView.tsx
@@ -17,6 +17,7 @@ import Card from 'src/components/common/Card';
 import isEnabled from 'src/features';
 import { getMonth } from 'src/utils/dateFormatter';
 import { useLocalization } from 'src/providers';
+import SimplePlantingSite from 'src/components/PlantingSites/SimplePlantingSite';
 
 const useStyles = makeStyles((theme: Theme) => ({
   titleWithButton: {
@@ -122,11 +123,16 @@ export default function PlantingSiteView(): JSX.Element {
             </>
           )}
         </Grid>
-        {plantingSite?.boundary && (
+        {plantingSite?.boundary && plantingSite.plantingZones && (
           <Grid container flexGrow={1}>
             <Grid item xs={12} display='flex'>
               <BoundariesAndZones plantingSite={plantingSite} />
             </Grid>
+          </Grid>
+        )}
+        {plantingSite?.boundary && !plantingSite.plantingZones && (
+          <Grid item xs={12}>
+            <SimplePlantingSite plantingSite={plantingSite} />
           </Grid>
         )}
       </Card>

--- a/src/components/PlantingSites/SimplePlantingSite.tsx
+++ b/src/components/PlantingSites/SimplePlantingSite.tsx
@@ -1,0 +1,23 @@
+import { Box, Typography, useTheme } from '@mui/material';
+import strings from 'src/strings';
+import { PlantingSite } from 'src/types/Tracking';
+import SimplePlantingSiteMap from 'src/components/PlantsV2/components/SimplePlantingSiteMap';
+
+type SimplePlantingSiteProps = {
+  plantingSite: PlantingSite;
+};
+
+export default function SimplePlantingSite({ plantingSite }: SimplePlantingSiteProps): JSX.Element {
+  const theme = useTheme();
+
+  return (
+    <>
+      <Box padding={theme.spacing(3, 0, 0, 0)}>
+        <Typography fontSize='16px' fontWeight={600} margin={theme.spacing(3, 0)}>
+          {strings.SITE_MAP}
+        </Typography>
+      </Box>
+      {plantingSite.boundary && <SimplePlantingSiteMap plantingSiteId={plantingSite.id} />}
+    </>
+  );
+}

--- a/src/components/PlantsV2/components/SimplePlantingSiteMap.tsx
+++ b/src/components/PlantsV2/components/SimplePlantingSiteMap.tsx
@@ -1,0 +1,32 @@
+import { Box, CircularProgress } from '@mui/material';
+import { useMemo } from 'react';
+import { useAppSelector } from 'src/redux/store';
+import { selectPlantingSite } from 'src/redux/features/tracking/trackingSelectors';
+import { PlantingSiteMap } from 'src/components/Map';
+import { MapService } from 'src/services';
+
+type SimplePlantingSiteMapProps = {
+  plantingSiteId: number;
+};
+
+export default function SimplePlantingSiteMap({ plantingSiteId }: SimplePlantingSiteMapProps): JSX.Element {
+  const plantingSite = useAppSelector((state) => selectPlantingSite(state, plantingSiteId));
+
+  const mapData = useMemo(() => {
+    if (!plantingSite?.boundary) {
+      return undefined;
+    }
+
+    return MapService.getMapDataFromPlantingSite(plantingSite);
+  }, [plantingSite]);
+
+  if (plantingSite?.boundary) {
+    return <PlantingSiteMap mapData={mapData!} style={{ borderRadius: '24px' }} layers={['Planting Site']} />;
+  } else {
+    return (
+      <Box sx={{ position: 'fixed', top: '50%', left: '50%' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+}

--- a/src/components/PlantsV2/index.tsx
+++ b/src/components/PlantsV2/index.tsx
@@ -3,7 +3,7 @@ import strings from 'src/strings';
 import { PlantingSite } from 'src/types/Tracking';
 import { APP_PATHS } from 'src/constants';
 import PlantsPrimaryPage from 'src/components/PlantsPrimaryPage';
-import { Box, Grid, Typography } from '@mui/material';
+import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { requestSitePopulation, requestSiteReportedPlants } from 'src/redux/features/tracking/trackingThunks';
 import { useLocalization, useOrganization } from 'src/providers';
@@ -33,6 +33,7 @@ import PlantingSiteDensityCard from 'src/components/PlantsV2/components/Planting
 import { requestPlantings } from 'src/redux/features/plantings/plantingsThunks';
 import FormattedNumber from '../common/FormattedNumber';
 import ObservedNumberOfSpeciesCard from 'src/components/PlantsV2/components/ObservedNumberOfSpeciesCard';
+import SimplePlantingSiteMap from 'src/components/PlantsV2/components/SimplePlantingSiteMap';
 
 export default function PlantsDashboardV2(): JSX.Element {
   const org = useOrganization();
@@ -42,6 +43,7 @@ export default function PlantsDashboardV2(): JSX.Element {
   const [plantsDashboardPreferences, setPlantsDashboardPreferences] = useState<Record<string, unknown>>();
   const locale = useLocalization();
   const history = useHistory();
+  const theme = useTheme();
 
   const onSelect = useCallback((site: PlantingSite) => setSelectedPlantingSiteId(site.id), [setSelectedPlantingSiteId]);
   const onPreferences = useCallback(
@@ -182,8 +184,29 @@ export default function PlantsDashboardV2(): JSX.Element {
     </>
   );
 
+  const renderSimpleSiteMap = () => (
+    <>
+      {sectionHeader(strings.SITE_MAP)}
+      <Grid item xs={12}>
+        <Box
+          sx={{
+            background: theme.palette.TwClrBg,
+            borderRadius: '24px',
+            padding: theme.spacing(3),
+            gap: theme.spacing(3),
+          }}
+        >
+          <SimplePlantingSiteMap plantingSiteId={selectedPlantingSiteId} />
+        </Box>
+      </Grid>
+    </>
+  );
+
   const hasPolygons =
     !!plantingSiteResult && !!plantingSiteResult.boundary && plantingSiteResult.boundary.coordinates?.length > 0;
+
+  const hasPlantingZones =
+    !!plantingSiteResult && !!plantingSiteResult.plantingZones && plantingSiteResult.plantingZones.length > 0;
 
   const getObservationHectares = () => {
     const numMonitoringPlots =
@@ -229,7 +252,8 @@ export default function PlantsDashboardV2(): JSX.Element {
             </>
           )}
           {hasObservations && renderTotalPlantsAndSpecies()}
-          {hasPolygons && renderZoneLevelData()}
+          {hasPlantingZones && renderZoneLevelData()}
+          {hasPolygons && !hasPlantingZones && renderSimpleSiteMap()}
         </Grid>
       ) : (
         <Box sx={{ margin: '0 auto', maxWidth: '800px', padding: '48px', width: isMobile ? 'auto' : '800px' }}>

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -1031,6 +1031,7 @@ SILVOPASTURE,Silvopasture
 SITE,Site
 SITE_DETAIL,Site Detail
 SITE_LOCATION,Site Location
+SITE_MAP,Site Map
 SNACKBAR_MSG_CHANGES_SAVED,Changes saved just now.
 SNACKBAR_MSG_NEW_SPECIES_ADDED,New species added just now.
 SNACKBAR_MSG_PLANT_DELETED,Plant deleted just now.


### PR DESCRIPTION
For planting sites with site boundaries but without planting zones or subzones
(which we refer to as "simple" planting sites), show a map view that doesn't
mention zones and subzones.

There is currently no way to create a simple planting site from the UI; that
will be added in a later change.
