### PR TITLE
SW-4010 Try Changing Dispatch to Improve Initial Map Load

### DIFF
--- a/src/components/NurseryWithdrawals/PlantingProgressMap.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressMap.tsx
@@ -7,8 +7,6 @@ import { PlantingSiteMap } from 'src/components/Map';
 import { Typography, useTheme } from '@mui/material';
 import PlantingProgressMapDialog from './PlantingProgressMapDialog';
 import { makeStyles } from '@mui/styles';
-import { requestSitePopulation } from 'src/redux/features/tracking/trackingThunks';
-import { useOrganization } from 'src/providers';
 import {
   selectUpdatePlantingCompleted,
   selectZonesHaveStatistics,
@@ -39,7 +37,6 @@ export default function PlantingProgressMap({ plantingSiteId, reloadTracking }: 
   const classes = useStyles();
   const dispatch = useAppDispatch();
   const snackbar = useSnackbar();
-  const org = useOrganization();
   const defaultTimeZone = useDefaultTimeZone();
   const plantingSite = useAppSelector((state) => selectPlantingSite(state, plantingSiteId));
   const [mapData, setMapData] = useState<MapData | undefined>();
@@ -77,10 +74,6 @@ export default function PlantingProgressMap({ plantingSiteId, reloadTracking }: 
       });
     return result;
   }, [plantingSite]);
-
-  useEffect(() => {
-    dispatch(requestSitePopulation(org.selectedOrganization.id, plantingSiteId));
-  }, [dispatch, org.selectedOrganization.id, plantingSiteId]);
 
   useEffect(() => {
     if (updateStatus) {

--- a/src/components/NurseryWithdrawals/PlantingProgressTabContent.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressTabContent.tsx
@@ -15,6 +15,7 @@ import PlantingSiteSelector from 'src/components/common/PlantingSiteSelector';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { requestObservationsResults } from 'src/redux/features/observations/observationsThunks';
 import { selectPlantingSitesNames } from 'src/redux/features/tracking/trackingSelectors';
+import { requestSitePopulation } from 'src/redux/features/tracking/trackingThunks';
 
 const initialView: View = 'list';
 
@@ -36,7 +37,8 @@ export default function PlantingProgress({ reloadTracking }: PlantingProgressPro
 
   useEffect(() => {
     dispatch(requestObservationsResults(selectedOrganization.id));
-  }, [dispatch, selectedOrganization.id]);
+    dispatch(requestSitePopulation(selectedOrganization.id, selectedPlantingSiteId));
+  }, [dispatch, selectedOrganization.id, selectedPlantingSiteId]);
 
   const filterColumns = useMemo<FilterField[]>(
     () =>
@@ -78,7 +80,8 @@ export default function PlantingProgress({ reloadTracking }: PlantingProgressPro
   const reloadTrackingAndObservations = useCallback(() => {
     reloadTracking();
     dispatch(requestObservationsResults(selectedOrganization.id));
-  }, [selectedOrganization.id, dispatch, reloadTracking]);
+    dispatch(requestSitePopulation(selectedOrganization.id, selectedPlantingSiteId));
+  }, [selectedOrganization.id, selectedPlantingSiteId, dispatch, reloadTracking]);
 
   const plantingSitesNames = useAppSelector((state) => selectPlantingSitesNames(state));
 


### PR DESCRIPTION
In some cases users were seeing map tooltips with no data populated for plant counts on initial map load. This change moves the dispatch for that data to the containing component to see whether that causes the data to be in place at the correct time for those instances.