### PR TITLE
Improve planting progress search

### DIFF
--- a/src/redux/features/plantings/plantingsSelectors.ts
+++ b/src/redux/features/plantings/plantingsSelectors.ts
@@ -90,7 +90,10 @@ export const searchPlantingProgress = createSelector(
             acc.push({ siteId, siteName, totalPlants, ...progress });
           }
         });
-      } else if (plantingCompleted === undefined && regexMatch(siteName, query)) {
+      } else if (
+        plantingCompleted === undefined &&
+        (siteNameSelected ? siteNameSelected === siteName : regexMatch(siteName, query))
+      ) {
         acc.push({ siteId, siteName, totalSeedlingsSent: totalPlants });
       }
       return acc;


### PR DESCRIPTION
For org with no shape files, we were allowing to write the siteName in the search field to do a fuzzy search, but if a siteName is selected in filter, then just return the exacts coincidence with the siteName selected