### PR TITLE
SW-4016 Do Not Add Actual Density Series if All Values are Null

### DIFF
--- a/src/components/PlantsV2/components/PlantingDensityPerZoneCard.tsx
+++ b/src/components/PlantsV2/components/PlantingDensityPerZoneCard.tsx
@@ -65,7 +65,7 @@ export default function PlantingDensityPerZoneCard({ plantingSiteId }: PlantingD
       },
     ];
 
-    if (observation && actuals?.length) {
+    if (observation && actuals?.length && !actuals?.every((val) => val === null)) {
       datasets.push({
         label: strings.PLANTING_DENSITY,
         values: actuals,


### PR DESCRIPTION
This will avoid the case where an observation has been completed, but no zone has had all its subzones marked as complete, resulting in a series of `null`s in the actual planting density dataset.