### PR TITLE
SW-3932 Extract Mapbox token fetching into hook

### DIFF
--- a/src/components/Map/GenericMap.tsx
+++ b/src/components/Map/GenericMap.tsx
@@ -1,9 +1,7 @@
-import React, { useEffect, useState, useCallback } from 'react';
 import { Box, CircularProgress } from '@mui/material';
-import { MapService } from 'src/services';
-import useSnackbar from 'src/utils/useSnackbar';
 import Map, { MapImage } from './Map';
 import { MapEntityOptions, MapOptions, MapPopupRenderer } from 'src/types/Map';
+import useMapboxToken from 'src/utils/useMapboxToken';
 
 const DUMMY_MAP_OPTIONS: MapOptions = {
   bbox: {
@@ -30,37 +28,7 @@ export default function GenericMap({
   entityOptions,
   mapImages,
 }: GenericMapProps): JSX.Element | null {
-  const snackbar = useSnackbar();
-  const [token, setToken] = useState<string>();
-  const [mapId, setMapId] = useState<string>();
-  const [tokenPromise, setTokenPromise] = useState<Promise<void>>();
-
-  // fetch token
-  const fetchMapboxToken = useCallback(async () => {
-    const response = await MapService.getMapboxToken();
-    if (response.requestSucceeded) {
-      setToken(response.token);
-      setMapId(Date.now().toString());
-    } else {
-      snackbar.toastError();
-    }
-  }, [snackbar]);
-
-  const refreshToken = useCallback(() => {
-    const promise = fetchMapboxToken();
-    setTokenPromise(promise);
-  }, [fetchMapboxToken]);
-
-  const getToken = useCallback(() => {
-    if (tokenPromise) {
-      return;
-    }
-    refreshToken();
-  }, [tokenPromise, refreshToken]);
-
-  useEffect(() => {
-    getToken();
-  }, [getToken]);
+  const { token, mapId, refreshToken } = useMapboxToken();
 
   if (!token) {
     return (

--- a/src/utils/useMapboxToken.ts
+++ b/src/utils/useMapboxToken.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useState } from 'react';
+import { MapService } from 'src/services';
+import useSnackbar from 'src/utils/useSnackbar';
+
+interface MapboxToken {
+  /**
+   * Identifier to pass to the ReactMapGL component. Updated every time a new token is fetched;
+   * passing this to the map component forces the map to be re-rendered using the new token.
+   */
+  mapId?: string;
+
+  /**
+   * Callback that forces the token to be refreshed. Typically called from an error handler if the
+   * Mapbox API returns HTTP 401.
+   */
+  refreshToken: () => void;
+
+  /** API token. Undefined if the request to fetch the token is still in progress. */
+  token?: string;
+}
+
+export default function useMapboxToken(): MapboxToken {
+  const snackbar = useSnackbar();
+  const [token, setToken] = useState<string>();
+  const [mapId, setMapId] = useState<string>();
+  const [tokenPromise, setTokenPromise] = useState<Promise<void>>();
+
+  // fetch token
+  const fetchMapboxToken = useCallback(async () => {
+    const response = await MapService.getMapboxToken();
+    if (response.requestSucceeded) {
+      setToken(response.token);
+      setMapId(Date.now().toString());
+    } else {
+      snackbar.toastError();
+    }
+  }, [snackbar]);
+
+  const refreshToken = useCallback(() => {
+    const promise = fetchMapboxToken();
+    setTokenPromise(promise);
+  }, [fetchMapboxToken]);
+
+  const getToken = useCallback(() => {
+    if (tokenPromise) {
+      return;
+    }
+    refreshToken();
+  }, [tokenPromise, refreshToken]);
+
+  useEffect(() => {
+    getToken();
+  }, [getToken]);
+
+  return { mapId, refreshToken, token };
+}


### PR DESCRIPTION
In preparation for adding a new React component that renders maps, move the logic
for fetching and refreshing Mapbox API tokens into a reusable hook.
