### PR TITLE
SW-4021 Move scheduled observations notification to the observations root page

### DIFF
--- a/src/components/Observations/ObservationsDataView.tsx
+++ b/src/components/Observations/ObservationsDataView.tsx
@@ -1,19 +1,14 @@
-import { useEffect, useMemo } from 'react';
-import { Box, Grid, Typography, useTheme } from '@mui/material';
+import { useEffect } from 'react';
+import { Box, Typography, useTheme } from '@mui/material';
 import strings from 'src/strings';
 import { FieldOptionsMap } from 'src/types/Search';
 import { useAppSelector } from 'src/redux/store';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
-import {
-  searchObservations,
-  selectObservationsZoneNames,
-  selectPlantingSiteObservations,
-} from 'src/redux/features/observations/observationsSelectors';
+import { searchObservations, selectObservationsZoneNames } from 'src/redux/features/observations/observationsSelectors';
 import ListMapView from 'src/components/ListMapView';
 import Search, { SearchProps } from 'src/components/common/SearchFiltersWrapper';
 import OrgObservationsListView from './org/OrgObservationsListView';
 import ObservationMapView from './map/ObservationMapView';
-import ObservationsEventsNotification, { ObservationEvent } from './ObservationsEventsNotification';
 
 export type ObservationsDataViewProps = SearchProps & {
   setFilterOptions: (value: FieldOptionsMap) => void;
@@ -35,8 +30,6 @@ export default function ObservationsDataView(props: ObservationsDataViewProps): 
     )
   );
 
-  const upcomingObservations = useAppSelector((state) => selectPlantingSiteObservations(state, -1, 'Upcoming'));
-
   const zoneNames = useAppSelector((state) => selectObservationsZoneNames(state, selectedPlantingSiteId));
 
   useEffect(() => {
@@ -48,31 +41,19 @@ export default function ObservationsDataView(props: ObservationsDataViewProps): 
     });
   }, [setFilterOptions, zoneNames]);
 
-  const observationsEvents = useMemo<ObservationEvent[]>(() => {
-    if (!upcomingObservations) {
-      return [];
-    }
-    const now = Date.now();
-    // return observations that haven't passed
-    return upcomingObservations.filter((observation) => now <= new Date(observation.endDate).getTime());
-  }, [upcomingObservations]);
-
   return (
-    <Grid container display='flex' flexDirection='column'>
-      <ObservationsEventsNotification events={observationsEvents} />
-      <ListMapView
-        initialView='list'
-        search={<Search {...searchProps} />}
-        list={<OrgObservationsListView observationsResults={observationsResults} />}
-        map={
-          selectedPlantingSiteId === -1 ? (
-            <AllPlantingSitesMapView />
-          ) : (
-            <ObservationMapView observationsResults={observationsResults} {...searchProps} />
-          )
-        }
-      />
-    </Grid>
+    <ListMapView
+      initialView='list'
+      search={<Search {...searchProps} />}
+      list={<OrgObservationsListView observationsResults={observationsResults} />}
+      map={
+        selectedPlantingSiteId === -1 ? (
+          <AllPlantingSitesMapView />
+        ) : (
+          <ObservationMapView observationsResults={observationsResults} {...searchProps} />
+        )
+      }
+    />
   );
 }
 

--- a/src/components/Observations/ObservationsHome.tsx
+++ b/src/components/Observations/ObservationsHome.tsx
@@ -34,6 +34,7 @@ export default function ObservationsHome(props: ObservationsHomeProps): JSX.Elem
   // get upcoming observations for notifications
   const upcomingObservations = useAppSelector((state) => selectPlantingSiteObservations(state, -1, 'Upcoming'));
 
+  // observation events are to be displayed for empty states and data view states
   const observationsEvents = useMemo<ObservationEvent[]>(() => {
     if (!upcomingObservations) {
       return [];

--- a/src/components/PlantingSites/PlantingSiteView.tsx
+++ b/src/components/PlantingSites/PlantingSiteView.tsx
@@ -131,10 +131,8 @@ export default function PlantingSiteView(): JSX.Element {
           </Grid>
         )}
         {plantingSite?.boundary && !plantingSite.plantingZones && (
-          <Grid container flexGrow={1}>
-            <Grid item xs={12} display='flex'>
-              <SimplePlantingSite plantingSite={plantingSite} />
-            </Grid>
+          <Grid item xs={12}>
+            <SimplePlantingSite plantingSite={plantingSite} />
           </Grid>
         )}
       </Card>

--- a/src/components/PlantingSites/PlantingSiteView.tsx
+++ b/src/components/PlantingSites/PlantingSiteView.tsx
@@ -131,8 +131,10 @@ export default function PlantingSiteView(): JSX.Element {
           </Grid>
         )}
         {plantingSite?.boundary && !plantingSite.plantingZones && (
-          <Grid item xs={12}>
-            <SimplePlantingSite plantingSite={plantingSite} />
+          <Grid container flexGrow={1}>
+            <Grid item xs={12} display='flex'>
+              <SimplePlantingSite plantingSite={plantingSite} />
+            </Grid>
           </Grid>
         )}
       </Card>


### PR DESCRIPTION
- was previously only included in the list/map views
- move it up so it shows for the empty state as well

<img width="963" alt="Terraware App 2023-08-08 10-04-58" src="https://github.com/terraware/terraware-web/assets/1865174/17a9f1d4-0463-4d76-8dea-d8aa7ee90362">
