### PR TITLE
SW-4009 Add % and plants/ha labels to per-zone progress/density charts

### DIFF
--- a/src/components/PlantsV2/components/PlantingDensityPerZoneCard.tsx
+++ b/src/components/PlantsV2/components/PlantingDensityPerZoneCard.tsx
@@ -101,6 +101,7 @@ export default function PlantingDensityPerZoneCard({ plantingSiteId }: PlantingD
               chartData={chartData}
               customTooltipTitles={tooltipTitles}
               maxWidth='100%'
+              yAxisLabel={strings.PLANTS_PER_HECTARE}
             />
           </Box>
           <Typography fontSize='12px' fontWeight={400}>

--- a/src/components/PlantsV2/components/PlantingProgressPerZoneCard.tsx
+++ b/src/components/PlantsV2/components/PlantingProgressPerZoneCard.tsx
@@ -57,6 +57,7 @@ export default function PlantingProgressPerZoneCard({ plantingSiteId }: Planting
               customTooltipTitles={tooltipTitles}
               maxWidth='100%'
               yLimits={{ min: 0, max: 100 }}
+              yAxisLabel='%'
             />
           </Box>
           <Typography fontSize='12px' fontWeight={400} marginBottom={theme.spacing(1.5)}>

--- a/src/components/common/Chart/BarChart.tsx
+++ b/src/components/common/Chart/BarChart.tsx
@@ -1,18 +1,6 @@
-import { AnnotationPluginOptions } from 'chartjs-plugin-annotation/types/options';
-import Chart, { ChartData } from './Chart';
+import Chart, { BaseChartProps } from './Chart';
 
-export interface BarChartProps {
-  chartId: string;
-  chartData?: ChartData;
-  customTooltipTitles?: string[];
-  minHeight?: string;
-  maxWidth?: string;
-  barWidth?: number;
-  elementColor?: string;
-  barAnnotations?: AnnotationPluginOptions;
-  yLimits?: { min?: number; max?: number };
-  showLegend?: boolean;
-}
+export type BarChartProps = BaseChartProps;
 
 export default function BarChart(props: BarChartProps): JSX.Element | null {
   return <Chart {...props} type='bar' />;

--- a/src/components/common/Chart/PieChart.tsx
+++ b/src/components/common/Chart/PieChart.tsx
@@ -1,17 +1,6 @@
-import { AnnotationPluginOptions } from 'chartjs-plugin-annotation/types/options';
-import Chart, { ChartData } from './Chart';
+import Chart, { BaseChartProps } from './Chart';
 
-export interface PieChartProps {
-  chartId: string;
-  chartData?: ChartData;
-  customTooltipTitles?: string[];
-  minHeight?: string;
-  maxWidth?: string;
-  barWidth?: number;
-  barAnnotations?: AnnotationPluginOptions;
-  yLimits?: { min?: number; max?: number };
-  showLegend?: boolean;
-}
+export type PieChartProps = Omit<BaseChartProps, 'elementColor | xAxisLabel | yAxisLabel'>;
 
 export default function PieChart(props: PieChartProps): JSX.Element | null {
   return <Chart {...props} type='pie' showLegend={true} />;

--- a/src/components/common/Chart/ProgressChart.tsx
+++ b/src/components/common/Chart/ProgressChart.tsx
@@ -1,5 +1,6 @@
 import { LinearProgress, useTheme } from '@mui/material';
-type ProgressChartProps = {
+
+export type ProgressChartProps = {
   value: number;
   target: number;
 };

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,0 +1,1 @@
+export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };


### PR DESCRIPTION
- also cleaned up the props a bit
- this is sorta wip but could be finished (waiting on comments in jira)

<img width="857" alt="Terraware App 2023-08-08 11-27-36" src="https://github.com/terraware/terraware-web/assets/1865174/07b7e53d-69de-4a97-94e7-786e17c5cd5a">
