### PR TITLE
SW-4020 Use live/dead counts in species pie chart

### DIFF
--- a/src/components/PlantsV2/components/LiveDeadPlantsPerSpeciesCard.tsx
+++ b/src/components/PlantsV2/components/LiveDeadPlantsPerSpeciesCard.tsx
@@ -52,13 +52,14 @@ export default function LiveDeadPlantsPerSpeciesCard({
       );
       if (
         selectedObservationSpecies &&
-        selectedObservationSpecies.mortalityRate !== undefined &&
-        selectedObservationSpecies.mortalityRate !== null
+        selectedObservationSpecies.cumulativeDead !== undefined &&
+        selectedObservationSpecies.cumulativeDead !== null &&
+        selectedObservationSpecies.permanentLive !== undefined &&
+        selectedObservationSpecies.permanentLive !== null
       ) {
         setShowChart(true);
-        const totalPlants = selectedObservationSpecies.totalPlants;
-        const dead = Math.round((selectedObservationSpecies.mortalityRate * totalPlants) / 100);
-        const live = totalPlants - dead;
+        const dead = selectedObservationSpecies.cumulativeDead;
+        const live = selectedObservationSpecies.permanentLive;
         setValues([live, dead]);
       }
     } else {

--- a/src/components/PlantsV2/components/LiveDeadPlantsPerSpeciesCard.tsx
+++ b/src/components/PlantsV2/components/LiveDeadPlantsPerSpeciesCard.tsx
@@ -52,10 +52,7 @@ export default function LiveDeadPlantsPerSpeciesCard({
       );
       if (
         selectedObservationSpecies &&
-        selectedObservationSpecies.cumulativeDead !== undefined &&
-        selectedObservationSpecies.cumulativeDead !== null &&
-        selectedObservationSpecies.permanentLive !== undefined &&
-        selectedObservationSpecies.permanentLive !== null
+        (selectedObservationSpecies.cumulativeDead !== 0 || selectedObservationSpecies.permanentLive !== 0)
       ) {
         setShowChart(true);
         const dead = selectedObservationSpecies.cumulativeDead;


### PR DESCRIPTION
- BE API now returns live / dead counts, live specific to permanent plots
- requirement is to use those counts in the pie chart

