### PR TITLE
SW-3998 Filter down withdrawals results based on matching destination names

### DIFF
--- a/src/components/NurseryWithdrawals/NurseryWithdrawalsTable.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawalsTable.tsx
@@ -195,10 +195,17 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
     );
     if (apiSearchResults) {
       if (getRequestId('searchWithdrawals') === requestId) {
-        setSearchResults(apiSearchResults);
+        const destinationFilter = filters.destinationName?.values ?? [];
+        if (destinationFilter.length) {
+          setSearchResults(
+            apiSearchResults.filter((result) => destinationFilter.indexOf(result.destinationName) !== -1)
+          );
+        } else {
+          setSearchResults(apiSearchResults);
+        }
       }
     }
-  }, [getSearchChildren, selectedOrganization, searchSortOrder]);
+  }, [getSearchChildren, selectedOrganization, searchSortOrder, filters]);
 
   useEffect(() => {
     if (siteParam) {


### PR DESCRIPTION
- 'Exact' search for destination names will also return any destination that contains the filter name, ex. 'test' will also return 'test1'
- Add another layer of filtering on destination names to avoid showing non-matching destinations

### Before

<img width="859" alt="Terraware App 2023-08-08 12-27-40" src="https://github.com/terraware/terraware-web/assets/1865174/55a4679a-e820-40d3-a054-9cc6564c30d3">

### After

<img width="858" alt="Terraware App 2023-08-08 12-27-12" src="https://github.com/terraware/terraware-web/assets/1865174/57cf9ec6-01f6-48bc-9313-b979f563fc0e">

