### PR TITLE
SW-4010 Fix stale withdrawal numbers in planting progress map popup

### DIFF
--- a/src/components/NurseryWithdrawals/PlantingProgressMap.tsx
+++ b/src/components/NurseryWithdrawals/PlantingProgressMap.tsx
@@ -79,7 +79,9 @@ export default function PlantingProgressMap({ plantingSiteId, reloadTracking }: 
   }, [plantingSite]);
 
   useEffect(() => {
-    dispatch(requestSitePopulation(org.selectedOrganization.id, plantingSiteId));
+    if (plantingSiteId !== -1) {
+      dispatch(requestSitePopulation(org.selectedOrganization.id, plantingSiteId));
+    }
   }, [dispatch, org.selectedOrganization.id, plantingSiteId]);
 
   useEffect(() => {


### PR DESCRIPTION
- this was a race condition in the planting progress map component
- removed race condition by skipping the dispatch on site id -1 (which was probably not intended anyways)
- in many cases the response from dispatching on -1 was completing after the actual selected site's dispatch, and yielding no results
- also created https://terraformation.atlassian.net/browse/SW-4044 for longer term cleanup