### PR TITLE
SW-4047 Show total plants in observations table

### DIFF
--- a/src/components/Observations/org/OrgObservationsListView.tsx
+++ b/src/components/Observations/org/OrgObservationsListView.tsx
@@ -79,6 +79,7 @@ export default function OrgObservationsListView({ observationsResults }: OrgObse
       (observationsResults ?? []).map((observation: ObservationResults) => {
         return {
           ...observation,
+          totalPlants: observation.plantingZones.reduce((acc, curr) => curr.totalPlants + acc, 0),
           plantingZones: observation.plantingZones
             .map((zone: ObservationPlantingZoneResults) => zone.plantingZoneName)
             .join('\r'),


### PR DESCRIPTION
- this was somehow missed or the schema was changed but FE was not updated
- total plants is available in the zones, use that to tally up the total in the observation row

<img width="730" alt="Terraware App 2023-08-08 17-12-30" src="https://github.com/terraware/terraware-web/assets/1865174/e8a930b3-6c5d-4fed-8511-0c87631dd45c">
