### PR TITLE
SW-4034 Show other/can't-tell species in observations bar charts

### DIFF
--- a/src/redux/features/observations/utils.ts
+++ b/src/redux/features/observations/utils.ts
@@ -246,9 +246,11 @@ const mergeSpecies = (
       (speciesObservation: ObservationSpeciesResultsPayload): ObservationSpeciesResults => ({
         ...speciesObservation,
         speciesCommonName: speciesObservation.speciesId
-          ? species[speciesObservation.speciesId].commonName
+          ? species[speciesObservation.speciesId].commonName ?? ''
           : speciesObservation.speciesName,
-        speciesScientificName: speciesObservation.speciesId ? species[speciesObservation.speciesId].scientificName : '',
+        speciesScientificName: speciesObservation.speciesId
+          ? species[speciesObservation.speciesId].scientificName ?? ''
+          : '',
       })
     );
 };

--- a/src/redux/features/observations/utils.ts
+++ b/src/redux/features/observations/utils.ts
@@ -238,12 +238,17 @@ const mergeSpecies = (
   species: Record<number, SpeciesValue>
 ): ObservationSpeciesResults[] => {
   return speciesObservations
-    .filter((speciesObservation: ObservationSpeciesResultsPayload) => species[speciesObservation.speciesId ?? -1])
+    .filter(
+      (speciesObservation: ObservationSpeciesResultsPayload) =>
+        speciesObservation.speciesId || speciesObservation.speciesName
+    )
     .map(
       (speciesObservation: ObservationSpeciesResultsPayload): ObservationSpeciesResults => ({
         ...speciesObservation,
-        speciesCommonName: species[speciesObservation.speciesId ?? -1].commonName,
-        speciesScientificName: species[speciesObservation.speciesId ?? -1].scientificName,
+        speciesCommonName: speciesObservation.speciesId
+          ? species[speciesObservation.speciesId].commonName
+          : speciesObservation.speciesName,
+        speciesScientificName: speciesObservation.speciesId ? species[speciesObservation.speciesId].scientificName : '',
       })
     );
 };


### PR DESCRIPTION
- fix merge/species util to factor in those species, were previously being filtered out

<img width="828" alt="Terraware App 2023-08-08 18-03-05" src="https://github.com/terraware/terraware-web/assets/1865174/d37539c9-194e-445c-a0e4-867c67df1090">
