### PR TITLE
SW-4045 Add support for InProgress and Overdue observations in the Observations page

### DIFF
--- a/src/components/Observations/ObservationsDataView.tsx
+++ b/src/components/Observations/ObservationsDataView.tsx
@@ -4,6 +4,7 @@ import strings from 'src/strings';
 import { useLocalization } from 'src/providers';
 import { FieldOptionsMap } from 'src/types/Search';
 import { ObservationState } from 'src/types/Observations';
+import { PlantingSite } from 'src/types/Tracking';
 import { useAppSelector } from 'src/redux/store';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 import { searchObservations, selectObservationsZoneNames } from 'src/redux/features/observations/observationsSelectors';
@@ -15,10 +16,11 @@ import ObservationMapView from './map/ObservationMapView';
 export type ObservationsDataViewProps = SearchProps & {
   setFilterOptions: (value: FieldOptionsMap) => void;
   selectedPlantingSiteId: number;
+  selectedPlantingSite?: PlantingSite;
 };
 
 export default function ObservationsDataView(props: ObservationsDataViewProps): JSX.Element {
-  const { selectedPlantingSiteId, setFilterOptions } = props;
+  const { selectedPlantingSiteId, selectedPlantingSite, setFilterOptions } = props;
   const { ...searchProps }: SearchProps = props;
   const defaultTimeZone = useDefaultTimeZone();
   const { activeLocale } = useLocalization();
@@ -80,10 +82,14 @@ export default function ObservationsDataView(props: ObservationsDataViewProps): 
       search={<Search {...searchProps} />}
       list={<OrgObservationsListView observationsResults={observationsResults} />}
       map={
-        selectedPlantingSiteId === -1 ? (
-          <AllPlantingSitesMapView />
+        selectedPlantingSite ? (
+          <ObservationMapView
+            observationsResults={observationsResults}
+            selectedPlantingSite={selectedPlantingSite}
+            {...searchProps}
+          />
         ) : (
-          <ObservationMapView observationsResults={observationsResults} {...searchProps} />
+          <AllPlantingSitesMapView />
         )
       }
     />

--- a/src/components/Observations/ObservationsDataView.tsx
+++ b/src/components/Observations/ObservationsDataView.tsx
@@ -82,7 +82,7 @@ export default function ObservationsDataView(props: ObservationsDataViewProps): 
       search={<Search {...searchProps} />}
       list={<OrgObservationsListView observationsResults={observationsResults} />}
       map={
-        selectedPlantingSite ? (
+        selectedPlantingSite && selectedPlantingSiteId !== -1 ? (
           <ObservationMapView
             observationsResults={observationsResults}
             selectedPlantingSite={selectedPlantingSite}

--- a/src/components/Observations/ObservationsHome.tsx
+++ b/src/components/Observations/ObservationsHome.tsx
@@ -73,7 +73,11 @@ export default function ObservationsHome(props: ObservationsHomeProps): JSX.Elem
         {observationsResults === undefined ? (
           <CircularProgress sx={{ margin: 'auto' }} />
         ) : selectedPlantingSite && observationsResults?.length ? (
-          <ObservationsDataView selectedPlantingSiteId={selectedPlantingSite.id} {...props} />
+          <ObservationsDataView
+            selectedPlantingSiteId={selectedPlantingSite.id}
+            selectedPlantingSite={selectedPlantingSite}
+            {...props}
+          />
         ) : (
           <Card style={{ margin: '56px auto 0', borderRadius: '24px', height: 'fit-content' }}>
             <EmptyStateContent

--- a/src/components/Observations/ObservationsHome.tsx
+++ b/src/components/Observations/ObservationsHome.tsx
@@ -24,7 +24,7 @@ export default function ObservationsHome(props: ObservationsHomeProps): JSX.Elem
   const [plantsSitePreferences, setPlantsSitePreferences] = useState<Record<string, unknown>>();
   const plantingSites = useAppSelector(selectPlantingSites);
   const observationsResults = useAppSelector((state) =>
-    selectPlantingSiteObservationsResults(state, selectedPlantingSite?.id)
+    selectPlantingSiteObservationsResults(state, selectedPlantingSite?.id ?? -1, ['Completed', 'InProgress', 'Overdue'])
   );
 
   const onSelect = useCallback((site: PlantingSite) => setSelectedPlantingSite(site), [setSelectedPlantingSite]);

--- a/src/components/Observations/index.tsx
+++ b/src/components/Observations/index.tsx
@@ -74,10 +74,16 @@ const ObservationsWrapper = (): JSX.Element => {
   const [filters, setFilters] = useState<Record<string, any>>({});
   const [filterOptions, setFilterOptions] = useState<FieldOptionsMap>({});
 
-  const filterColumns = useMemo<FilterField[]>(
-    () => (activeLocale ? [{ name: 'zone', label: strings.ZONE, type: 'multiple_selection' }] : []),
-    [activeLocale]
-  );
+  const filterColumns = useMemo<FilterField[]>(() => {
+    if (activeLocale) {
+      return [
+        { name: 'zone', label: strings.ZONE, type: 'multiple_selection' },
+        { name: 'status', label: strings.STATUS, type: 'multiple_selection' },
+      ];
+    } else {
+      return [];
+    }
+  }, [activeLocale]);
 
   const setFilterOptionsCallback = useCallback((value: FieldOptionsMap) => setFilterOptions(value), []);
 
@@ -94,6 +100,21 @@ const ObservationsWrapper = (): JSX.Element => {
     }),
     [filters, filterColumns, filterOptions, search]
   );
+
+  // reset status filter values to default on locale change
+  useEffect(() => {
+    if (activeLocale) {
+      setFilters((prev) => ({
+        ...prev,
+        status: {
+          field: 'status',
+          operation: 'field',
+          type: 'Exact',
+          values: [strings.COMPLETED],
+        },
+      }));
+    }
+  }, [activeLocale]);
 
   return (
     <Switch>

--- a/src/components/Observations/map/ObservationMapView.tsx
+++ b/src/components/Observations/map/ObservationMapView.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { ObservationResults } from 'src/types/Observations';
 import { Box, Theme } from '@mui/material';
+import { PlantingSite } from 'src/types/Tracking';
 import PlantingSiteMapLegend from 'src/components/common/PlantingSiteMapLegend';
 import { PlantingSiteMap } from 'src/components/Map';
 import { MapEntityId, MapObject, MapSourceBaseData, MapSourceProperties } from 'src/types/Map';
@@ -23,12 +24,14 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 type ObservationMapViewProps = SearchProps & {
   observationsResults?: ObservationResults[];
+  selectedPlantingSite: PlantingSite;
 };
 
 export default function ObservationMapView({
   observationsResults,
   search,
   filtersProps,
+  selectedPlantingSite,
 }: ObservationMapViewProps): JSX.Element {
   const classes = useStyles();
 
@@ -65,7 +68,11 @@ export default function ObservationMapView({
     [observationsResults, selectedObservationDate]
   );
 
-  const [plantingSiteMapData, setPlantingSiteMapData] = useState<MapSourceBaseData | undefined>();
+  const plantingSiteMapData: MapSourceBaseData | undefined = useMemo(
+    () => MapService.getMapDataFromPlantingSite(selectedPlantingSite)?.site,
+    [selectedPlantingSite]
+  );
+
   const mapData: Record<MapObject, MapSourceBaseData | undefined> = useMemo(() => {
     if (!selectedObservationDate || !selectedObservation) {
       return {
@@ -79,12 +86,6 @@ export default function ObservationMapView({
 
     return MapService.getMapDataFromObservation(selectedObservation);
   }, [selectedObservation, selectedObservationDate, plantingSiteMapData]);
-
-  useEffect(() => {
-    if (!plantingSiteMapData && mapData.site) {
-      setPlantingSiteMapData(mapData.site);
-    }
-  }, [mapData, plantingSiteMapData]);
 
   const filterZoneNames = useMemo(() => filtersProps?.filters.zone?.values ?? [], [filtersProps?.filters.zone?.values]);
 

--- a/src/components/Observations/map/ObservationMapView.tsx
+++ b/src/components/Observations/map/ObservationMapView.tsx
@@ -33,8 +33,9 @@ export default function ObservationMapView({
   const classes = useStyles();
 
   const observationsDates = useMemo(() => {
-    return observationsResults
-      ?.map((obs) => obs.completedDate)
+    const uniqueDates = new Set(observationsResults?.map((obs) => obs.completedDate || obs.startDate));
+
+    return Array.from(uniqueDates)
       ?.filter((time) => time)
       ?.map((time) => time!)
       ?.sort((a, b) => (Date.parse(a!) > Date.parse(b!) ? 1 : -1));
@@ -56,7 +57,11 @@ export default function ObservationMapView({
   }, [observationsDates]);
 
   const selectedObservation = useMemo(
-    () => observationsResults?.find((obs) => obs.completedDate === selectedObservationDate),
+    () =>
+      observationsResults?.find((obs) => {
+        const dateToCheck = obs.state === 'Completed' ? obs.completedDate : obs.startDate;
+        return dateToCheck === selectedObservationDate;
+      }),
     [observationsResults, selectedObservationDate]
   );
 
@@ -124,7 +129,7 @@ export default function ObservationMapView({
 
     return (
       <TooltipContents
-        observationInProgress={selectedObservation?.state === 'InProgress'}
+        observationState={selectedObservation?.state}
         title={`${properties.name}${properties.type === 'temporaryPlot' ? ` (${strings.TEMPORARY})` : ''}`}
         numPlants={entity?.totalPlants}
         numSpecies={entity?.totalSpecies}

--- a/src/components/Observations/map/TooltipContents.tsx
+++ b/src/components/Observations/map/TooltipContents.tsx
@@ -1,9 +1,10 @@
 import { Box, Typography, useTheme } from '@mui/material';
 import strings from 'src/strings';
+import { ObservationState } from 'src/types/Observations';
 
 type TooltipContentsProps = {
   title: string;
-  observationInProgress: boolean;
+  observationState?: ObservationState;
   numPlants?: number;
   numSpecies?: number;
   plantingDensity?: number;
@@ -11,8 +12,11 @@ type TooltipContentsProps = {
 };
 
 export default function TooltipContents(props: TooltipContentsProps): JSX.Element {
-  const { title, observationInProgress, numPlants, numSpecies, plantingDensity, percentMortality } = props;
+  const { title, observationState, numPlants, numSpecies, plantingDensity, percentMortality } = props;
   const theme = useTheme();
+
+  const observationInProgress = observationState === 'InProgress';
+  const observationOverdue = observationState === 'Overdue';
 
   return (
     <Box display='flex' flexDirection='column' padding={theme.spacing(1)}>
@@ -21,6 +25,8 @@ export default function TooltipContents(props: TooltipContentsProps): JSX.Elemen
       </Typography>
       {observationInProgress ? (
         <Typography>{strings.OBSERVATION_IN_PROGRESS}</Typography>
+      ) : observationOverdue ? (
+        <Typography>{strings.OBSERVATION_OVERDUE}</Typography>
       ) : (
         <>
           <Typography fontSize='16px' fontWeight={400}>

--- a/src/components/Observations/org/OrgObservationsRenderer.tsx
+++ b/src/components/Observations/org/OrgObservationsRenderer.tsx
@@ -44,7 +44,8 @@ const OrgObservationsRenderer =
     }
 
     if (column.key === 'completedDate') {
-      return <CellRenderer {...props} value={createLinkToSiteObservation(getShortDate(value as string, locale))} />;
+      const dateValue: string = (value as string) || (row.startDate as string);
+      return <CellRenderer {...props} value={createLinkToSiteObservation(getShortDate(dateValue, locale))} />;
     }
 
     if (column.key === 'state') {

--- a/src/redux/features/observations/observationsSelectors.ts
+++ b/src/redux/features/observations/observationsSelectors.ts
@@ -30,7 +30,7 @@ export const selectPlantingSiteObservationsResults = createCachedSelector(
       const matchesSite = plantingSiteId === -1 || observationResults.plantingSiteId === plantingSiteId;
       const matchesState =
         (!status?.length && observationResults.state === 'Completed') ||
-        status?.indexOf(observationResults.state) !== -1;
+        (status && status.indexOf(observationResults.state) !== -1);
       return matchesSite && matchesState;
     });
   }

--- a/src/redux/features/observations/utils.ts
+++ b/src/redux/features/observations/utils.ts
@@ -138,7 +138,8 @@ export const mergeObservations = (
         ...observation,
         plantingSiteName: site.name,
         boundary: site.boundary,
-        completedDate: getDateDisplayValue(observation.completedTime!, site.timeZone),
+        completedDate: observation.completedTime ? getDateDisplayValue(observation.completedTime, site.timeZone) : '',
+        startDate: getDateDisplayValue(observation.startDate, site.timeZone),
         plantingZones: mergeZones(
           observation.plantingZones,
           zones,

--- a/src/redux/features/observations/utils.ts
+++ b/src/redux/features/observations/utils.ts
@@ -241,17 +241,14 @@ const mergeSpecies = (
   return speciesObservations
     .filter(
       (speciesObservation: ObservationSpeciesResultsPayload) =>
-        speciesObservation.speciesId || speciesObservation.speciesName
+        species[speciesObservation.speciesId ?? -1] || speciesObservation.speciesName
     )
     .map(
       (speciesObservation: ObservationSpeciesResultsPayload): ObservationSpeciesResults => ({
         ...speciesObservation,
-        speciesCommonName: speciesObservation.speciesId
-          ? species[speciesObservation.speciesId].commonName ?? ''
-          : speciesObservation.speciesName,
-        speciesScientificName: speciesObservation.speciesId
-          ? species[speciesObservation.speciesId].scientificName ?? ''
-          : '',
+        speciesCommonName:
+          species[speciesObservation.speciesId ?? -1]?.commonName ?? speciesObservation.speciesName ?? '',
+        speciesScientificName: species[speciesObservation.speciesId ?? -1]?.scientificName ?? '',
       })
     );
 };

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -674,6 +674,7 @@ NURSERY_REQUIRED,Nursery *
 NURSERY_TRANSFER,Nursery Transfer
 OBSERVATION_EVENT_SCHEDULED,Observation event is scheduled for {0} for planting site(s): {1},"Example: Observation event is scheduled for June 1, 2023 for planting site(s): Site-A, Site-B"
 OBSERVATION_IN_PROGRESS,Observation in Progress
+OBSERVATION_OVERDUE,Observation Overdue
 OBSERVATION_STATUS,Observation Status
 OBSERVATION_STATUS_OUTSTANDING,Outstanding,Remaining to be done
 OBSERVATIONS,Observations


### PR DESCRIPTION
- to satisfy PRD requirement allowing users to see which observations are not completed, check out zones, monitoring plots info, etc.

<img width="816" alt="Terraware App 2023-08-09 11-05-37" src="https://github.com/terraware/terraware-web/assets/1865174/e378ff89-f90d-4020-91fb-27d508ac5744">

<img width="709" alt="Terraware App 2023-08-09 11-06-05" src="https://github.com/terraware/terraware-web/assets/1865174/bbde7aaa-5331-4b79-b31c-187cb2feecab">

<img width="799" alt="Terraware App 2023-08-09 11-06-45" src="https://github.com/terraware/terraware-web/assets/1865174/5ea30378-5ee1-4019-b076-395e78173392">
