### PR TITLE
Revert "SW-4034 Show other/can't-tell species in observations bar charts (#1646)"

### DIFF
--- a/src/redux/features/observations/utils.ts
+++ b/src/redux/features/observations/utils.ts
@@ -238,19 +238,12 @@ const mergeSpecies = (
   species: Record<number, SpeciesValue>
 ): ObservationSpeciesResults[] => {
   return speciesObservations
-    .filter(
-      (speciesObservation: ObservationSpeciesResultsPayload) =>
-        speciesObservation.speciesId || speciesObservation.speciesName
-    )
+    .filter((speciesObservation: ObservationSpeciesResultsPayload) => species[speciesObservation.speciesId ?? -1])
     .map(
       (speciesObservation: ObservationSpeciesResultsPayload): ObservationSpeciesResults => ({
         ...speciesObservation,
-        speciesCommonName: speciesObservation.speciesId
-          ? species[speciesObservation.speciesId].commonName ?? ''
-          : speciesObservation.speciesName,
-        speciesScientificName: speciesObservation.speciesId
-          ? species[speciesObservation.speciesId].scientificName ?? ''
-          : '',
+        speciesCommonName: species[speciesObservation.speciesId ?? -1].commonName,
+        speciesScientificName: species[speciesObservation.speciesId ?? -1].scientificName,
       })
     );
 };


### PR DESCRIPTION

This reverts commit 96a6c2f05ea57191f5edfa61ed989895856323df.

Reverting this change, have a cleaner fix in another PR.