### PR TITLE
SW-4022 Adjust padding and alignment for site selector in plants primary page

### DIFF
--- a/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
+++ b/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
@@ -55,7 +55,7 @@ export default function PlantsPrimaryPageView({
     <TfMain backgroundImageVisible={isEmptyState}>
       <PageHeaderWrapper nextElement={contentRef.current}>
         <Grid item xs={12} paddingLeft={theme.spacing(3)} marginBottom={theme.spacing(4)}>
-          <Grid item xs={12} display={isMobile ? 'block' : 'flex'}>
+          <Grid item xs={12} display={isMobile ? 'block' : 'flex'} alignItems='center'>
             <Typography sx={{ fontSize: '24px', fontWeight: 600, alignItems: 'center' }}>{title}</Typography>
             {plantingSites.length > 0 && (
               <>
@@ -69,7 +69,7 @@ export default function PlantsPrimaryPageView({
                     }}
                   />
                 )}
-                <Box display='flex' alignItems='center' paddingTop={isMobile ? 2 : 0}>
+                <Box display='flex' alignItems='center' padding={theme.spacing(2, 0)}>
                   <Typography sx={{ paddingRight: 1, fontSize: '16px', fontWeight: 500 }}>
                     {strings.PLANTING_SITE}
                   </Typography>


### PR DESCRIPTION
- the selector top was being cut off (since the outline was extending beyond the container)
- added a top/bottom padding and aligned peers by 'center'

<img width="430" alt="Terraware App 2023-08-09 16-19-32" src="https://github.com/terraware/terraware-web/assets/1865174/4d047a6c-d5ae-4b52-9dcc-48ac351fdc81">

<img width="232" alt="Terraware App 2023-08-09 16-20-15" src="https://github.com/terraware/terraware-web/assets/1865174/b1f11886-44ac-4a69-b4fe-d0fe180bc04f">
