### PR TITLE
SW-3993 Quantity not accurate with nursery filter

### DIFF
--- a/src/components/Inventory/index.tsx
+++ b/src/components/Inventory/index.tsx
@@ -166,8 +166,7 @@ export default function Inventory(props: InventoryProps): JSX.Element {
 
     let updatedResult: InventoryResultWithFacilityNames[] | undefined = [];
     if (filters.facilityIds && filters.facilityIds.length) {
-      const nextResults: InventoryResultWithFacilityNames[] = [];
-      apiSearchResults?.reduce((acc, result) => {
+      const nextResults = apiSearchResults?.reduce((acc, result) => {
         const resultTyped = result as FacilityInventoryResult;
         const indexFound = acc.findIndex((res) => res.species_id === resultTyped.species_id);
 
@@ -203,10 +202,10 @@ export default function Inventory(props: InventoryProps): JSX.Element {
           acc.push(transformedResult);
         }
         return acc;
-      }, nextResults);
+      }, [] as InventoryResultWithFacilityNames[]);
 
       // format results
-      updatedResult = nextResults.map((uR) => {
+      updatedResult = nextResults?.map((uR) => {
         return {
           ...uR,
           germinatingQuantity: numericFormatter.format(uR.germinatingQuantity),

--- a/src/components/Inventory/index.tsx
+++ b/src/components/Inventory/index.tsx
@@ -167,13 +167,13 @@ export default function Inventory(props: InventoryProps): JSX.Element {
     let updatedResult: InventoryResultWithFacilityNames[] | undefined = [];
     if (filters.facilityIds && filters.facilityIds.length) {
       const nextResults: InventoryResultWithFacilityNames[] = [];
-      apiSearchResults?.forEach((result) => {
+      apiSearchResults?.reduce((acc, result) => {
         const resultTyped = result as FacilityInventoryResult;
-        const indexFound = nextResults.findIndex((res) => res.species_id === resultTyped.species_id);
+        const indexFound = acc.findIndex((res) => res.species_id === resultTyped.species_id);
 
         if (indexFound !== undefined && indexFound !== -1) {
-          const existingSpecies = nextResults[indexFound];
-          nextResults[indexFound] = {
+          const existingSpecies = acc[indexFound];
+          acc[indexFound] = {
             ...existingSpecies,
             germinatingQuantity: (
               Number(existingSpecies.germinatingQuantity) + Number(resultTyped['germinatingQuantity(raw)'])
@@ -200,19 +200,20 @@ export default function Inventory(props: InventoryProps): JSX.Element {
             facilityInventories: resultTyped.facility_name,
           };
 
-          nextResults.push(transformedResult);
-
-          // format results
-          updatedResult = nextResults.map((uR) => {
-            return {
-              ...uR,
-              germinatingQuantity: numericFormatter.format(uR.germinatingQuantity),
-              notReadyQuantity: numericFormatter.format(uR.notReadyQuantity),
-              readyQuantity: numericFormatter.format(uR.readyQuantity),
-              totalQuantity: numericFormatter.format(uR.totalQuantity),
-            };
-          });
+          acc.push(transformedResult);
         }
+        return acc;
+      }, nextResults);
+
+      // format results
+      updatedResult = nextResults.map((uR) => {
+        return {
+          ...uR,
+          germinatingQuantity: numericFormatter.format(uR.germinatingQuantity),
+          notReadyQuantity: numericFormatter.format(uR.notReadyQuantity),
+          readyQuantity: numericFormatter.format(uR.readyQuantity),
+          totalQuantity: numericFormatter.format(uR.totalQuantity),
+        };
       });
     } else {
       updatedResult = apiSearchResults?.map((result) => {

--- a/src/services/NurseryInventoryService.ts
+++ b/src/services/NurseryInventoryService.ts
@@ -24,6 +24,19 @@ export const BE_SORTED_FIELDS = [
   'totalQuantity',
 ];
 
+export const INVENTORY_FIELDS = [...BE_SORTED_FIELDS, 'species_commonName', 'totalQuantity(raw)'];
+
+export const FACILITY_SPECIFIC_FIELDS = [
+  'species_id',
+  'species_scientificName',
+  'species_commonName',
+  'facility_name',
+  'germinatingQuantity(raw)',
+  'readyQuantity(raw)',
+  'notReadyQuantity(raw)',
+  'totalQuantity(raw)',
+];
+
 /**
  * exported types
  */
@@ -133,50 +146,22 @@ const searchInventory = async ({
 }: SearchInventoryParams): Promise<SearchResponseElement[] | null> => {
   let params: SearchNodePayload;
   const forSpecificFacilities = !!facilityIds && !!facilityIds.length;
-  if (forSpecificFacilities) {
-    params = {
-      prefix: 'inventories.facilityInventories',
-      fields: [
-        'species_id',
-        'species_scientificName',
-        'species_commonName',
-        'facility_name',
-        'germinatingQuantity(raw)',
-        'readyQuantity(raw)',
-        'notReadyQuantity(raw)',
-        'totalQuantity(raw)',
+  params = {
+    prefix: forSpecificFacilities ? 'inventories.facilityInventories' : 'inventories',
+    fields: forSpecificFacilities ? FACILITY_SPECIFIC_FIELDS : INVENTORY_FIELDS,
+    sortOrder: searchSortOrder ? [searchSortOrder] : undefined,
+    search: {
+      operation: 'and',
+      children: [
+        {
+          operation: 'field',
+          field: 'organization_id',
+          values: [organizationId],
+        },
       ],
-      sortOrder: searchSortOrder ? [searchSortOrder] : undefined,
-      search: {
-        operation: 'and',
-        children: [
-          {
-            operation: 'field',
-            field: 'organization_id',
-            values: [organizationId],
-          },
-        ],
-      },
-      count: 0,
-    };
-  } else {
-    params = {
-      prefix: 'inventories',
-      fields: [...BE_SORTED_FIELDS, 'species_commonName', 'totalQuantity(raw)'],
-      sortOrder: searchSortOrder ? [searchSortOrder] : undefined,
-      search: {
-        operation: 'and',
-        children: [
-          {
-            operation: 'field',
-            field: 'organization_id',
-            values: [organizationId],
-          },
-        ],
-      },
-      count: 0,
-    };
-  }
+    },
+    count: 0,
+  };
 
   const searchValueChildren: FieldNodePayload[] = [];
 


### PR DESCRIPTION
Allow searching inventories by different nurseries and getting its corresponding quantities. Previously we were getting the totals for all nurseries, not considering nursery filter.

Query executed to the backend changes depending on if nurseries are selected or not. From backend, response comes by species id, so sum all same species id quantities to show the number of each quantity for selected nurseries (and not total as before)

This PR requires a backend change: https://github.com/terraware/terraware-server/pull/1326

