### PR TITLE
SW-4060 Fix issue where observations without a completed time were not clickable

### DIFF
--- a/src/redux/features/observations/observationDetailsSelectors.ts
+++ b/src/redux/features/observations/observationDetailsSelectors.ts
@@ -2,7 +2,7 @@ import { createCachedSelector } from 're-reselect';
 import { createSelector } from '@reduxjs/toolkit';
 import { RootState } from 'src/redux/rootReducer';
 import { ObservationResults, ObservationPlantingZoneResults } from 'src/types/Observations';
-import { selectMergedPlantingSiteObservations } from './observationsSelectors';
+import { selectMergedPlantingSiteObservations, ALL_STATES } from './observationsSelectors';
 import { searchResultZones } from './utils';
 
 // search observation details (search planting zone name only)
@@ -24,7 +24,7 @@ export type DetailsSearchParams = SearchParams &
 export const selectObservationDetails = createSelector(
   [
     (state, params, defaultTimeZone) =>
-      selectMergedPlantingSiteObservations(state, params.plantingSiteId, defaultTimeZone),
+      selectMergedPlantingSiteObservations(state, params.plantingSiteId, defaultTimeZone, ALL_STATES),
     (state, params, defaultTimeZone) => params,
   ],
   (observationsResults, params) =>

--- a/src/redux/features/observations/observationsSelectors.ts
+++ b/src/redux/features/observations/observationsSelectors.ts
@@ -11,6 +11,8 @@ import { selectPlantingSites } from 'src/redux/features/tracking/trackingSelecto
 import { mergeObservations, searchZones } from './utils';
 import { isAfter } from 'src/utils/dateUtils';
 
+export const ALL_STATES: ObservationState[] = ['Completed', 'Overdue', 'InProgress'];
+
 /**
  * Observations results selectors below
  */


### PR DESCRIPTION
- had made a change last week that broke this
- observation details selectors will now pass all the relevant states for selection