### PR TITLE
SW-4028 Use 'contain' object fit for thumbnail images

### DIFF
--- a/src/components/common/PhotosList.tsx
+++ b/src/components/common/PhotosList.tsx
@@ -11,7 +11,7 @@ type StyleProps = {
 
 const useStyles = makeStyles(() => ({
   thumbnail: {
-    objectFit: 'cover',
+    objectFit: 'contain',
     display: 'flex',
     width: (props: StyleProps) => (props.isMobile ? '105px' : '220px'),
     height: '120px',


### PR DESCRIPTION
- this will use correct aspect ratio to display thumbnail, with the downside that there will be horizontal empty space for portrait images