### PR TITLE
SW-4051 Show scientific names instead of common in plot species charts 

### DIFF
--- a/src/components/Observations/common/SpeciesMortalityRateChart.tsx
+++ b/src/components/Observations/common/SpeciesMortalityRateChart.tsx
@@ -20,7 +20,7 @@ export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesT
       const { speciesCommonName, speciesName, speciesScientificName, mortalityRate } = speciesData;
 
       if (mortalityRate !== undefined && mortalityRate !== null) {
-        const label: string = speciesName || speciesScientificName || speciesCommonName || '';
+        const label: string = speciesScientificName || speciesName || '';
         const value: number = mortalityRate;
         data.labels.push(label);
         data.values.push(value);

--- a/src/components/Observations/common/SpeciesMortalityRateChart.tsx
+++ b/src/components/Observations/common/SpeciesMortalityRateChart.tsx
@@ -20,7 +20,7 @@ export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesT
       const { speciesCommonName, speciesName, speciesScientificName, mortalityRate } = speciesData;
 
       if (mortalityRate !== undefined && mortalityRate !== null) {
-        const label: string = speciesName ?? speciesCommonName ?? speciesScientificName;
+        const label: string = speciesName || speciesScientificName || speciesCommonName || '';
         const value: number = mortalityRate;
         data.labels.push(label);
         data.values.push(value);

--- a/src/components/Observations/common/SpeciesMortalityRateChart.tsx
+++ b/src/components/Observations/common/SpeciesMortalityRateChart.tsx
@@ -17,7 +17,7 @@ export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesT
     const data: Data = { labels: [], values: [] };
 
     species?.forEach((speciesData) => {
-      const { speciesCommonName, speciesName, speciesScientificName, mortalityRate } = speciesData;
+      const { speciesName, speciesScientificName, mortalityRate } = speciesData;
 
       if (mortalityRate !== undefined && mortalityRate !== null) {
         const label: string = speciesScientificName || speciesName || '';

--- a/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
+++ b/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
@@ -19,7 +19,7 @@ export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesT
     species?.forEach((speciesData) => {
       const { speciesCommonName, speciesName, speciesScientificName, totalPlants } = speciesData;
 
-      const label: string = speciesName || speciesScientificName || speciesCommonName || '';
+      const label: string = speciesScientificName || speciesName || '';
 
       data.labels.push(label);
       data.values.push(totalPlants);

--- a/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
+++ b/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
@@ -19,7 +19,7 @@ export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesT
     species?.forEach((speciesData) => {
       const { speciesCommonName, speciesName, speciesScientificName, totalPlants } = speciesData;
 
-      const label: string = speciesName ?? speciesCommonName ?? speciesScientificName;
+      const label: string = speciesName || speciesScientificName || speciesCommonName || '';
 
       data.labels.push(label);
       data.values.push(totalPlants);

--- a/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
+++ b/src/components/Observations/common/SpeciesTotalPlantsChart.tsx
@@ -17,7 +17,7 @@ export default function SpeciesTotalPlantsChart({ minHeight, species }: SpeciesT
     const data: Data = { labels: [], values: [] };
 
     species?.forEach((speciesData) => {
-      const { speciesCommonName, speciesName, speciesScientificName, totalPlants } = speciesData;
+      const { speciesName, speciesScientificName, totalPlants } = speciesData;
       const label: string = speciesScientificName || speciesName || '';
 
       data.labels.push(label);


### PR DESCRIPTION
- cleaned up earlier fix, removed commonName since it isn't relevant
