### PR TITLE
SW-4073 Show total plants in observations details page regardless of planting complete state

### DIFF
--- a/src/components/Observations/common/AggregatedPlantsStats.tsx
+++ b/src/components/Observations/common/AggregatedPlantsStats.tsx
@@ -14,7 +14,6 @@ export type AggregatedPlantsStatsProps = {
   plantingDensity?: number;
   mortalityRate?: number;
   species?: ObservationSpeciesResults[];
-  isSite?: boolean;
 };
 
 export default function AggregatedPlantsStats({
@@ -23,18 +22,13 @@ export default function AggregatedPlantsStats({
   plantingDensity,
   mortalityRate,
   species,
-  isSite,
 }: AggregatedPlantsStatsProps): JSX.Element {
   const { isMobile } = useDeviceInfo();
   const infoCardGridSize = isMobile ? 12 : 3;
   const chartGridSize = isMobile ? 12 : 6;
 
   const getData = () => [
-    {
-      label: strings.PLANTS,
-      value: totalPlants,
-      toolTip: isSite ? strings.PLANTS_MISSING_TOOLTIP : '',
-    },
+    { label: strings.PLANTS, value: totalPlants },
     { label: strings.SPECIES, value: totalSpecies },
     {
       label: strings.PLANTING_DENSITY,

--- a/src/components/Observations/details/index.tsx
+++ b/src/components/Observations/details/index.tsx
@@ -133,7 +133,7 @@ export default function ObservationDetails(props: ObservationDetailsProps): JSX.
       <ObservationStatusSummaryMessage statusSummary={statusSummary} />
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <AggregatedPlantsStats {...(details ?? {})} isSite />
+          <AggregatedPlantsStats {...(details ?? {})} />
         </Grid>
         <Grid item xs={12}>
           <Card flushMobile>

--- a/src/components/Observations/org/OrgObservationsListView.tsx
+++ b/src/components/Observations/org/OrgObservationsListView.tsx
@@ -79,10 +79,6 @@ export default function OrgObservationsListView({ observationsResults }: OrgObse
       (observationsResults ?? []).map((observation: ObservationResults) => {
         return {
           ...observation,
-          totalPlants:
-            observation.state === 'Completed'
-              ? observation.plantingZones.reduce((acc, curr) => curr.totalPlants + acc, 0)
-              : 0,
           plantingZones: observation.plantingZones
             .map((zone: ObservationPlantingZoneResults) => zone.plantingZoneName)
             .join('\r'),

--- a/src/redux/features/observations/utils.ts
+++ b/src/redux/features/observations/utils.ts
@@ -148,6 +148,7 @@ export const mergeObservations = (
           site.timeZone ?? defaultTimeZone
         ),
         species: mergeSpecies(observation.species, species),
+        totalPlants: observation.plantingZones.reduce((acc, curr) => acc + curr.totalPlants, 0),
       };
     });
 };

--- a/src/types/Observations.ts
+++ b/src/types/Observations.ts
@@ -21,6 +21,7 @@ export type ObservationResults = Omit<ObservationResultsPayload, 'species'> &
     plantingSiteName: string;
     plantingZones: ObservationPlantingZoneResults[];
     species: ObservationSpeciesResults[];
+    totalPlants: number;
   };
 
 // zone level results -> contains a list of subzone level results


### PR DESCRIPTION
- introduced total plants data member (looks like observation details no longer has a total plants field in the BE)
- sum total plants in the selector
- removed tooltip