### PR TITLE
SW-4072 Observations details table backgrounds should extend to scrolled region

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import { Species } from './types/Species';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { requestPlantingSites } from 'src/redux/features/tracking/trackingThunks';
 import { selectPlantingSites } from 'src/redux/features/tracking/trackingSelectors';
+import { selectHasObservationsResults } from 'src/redux/features/observations/observationsSelectors';
 import MyAccount from './components/MyAccount';
 import Monitoring from './components/Monitoring';
 import SeedBanks from './components/SeedBanks';
@@ -172,6 +173,7 @@ function AppContent() {
 
   const history = useHistory();
   const [species, setSpecies] = useState<Species[]>([]);
+  const hasObservationsResults: boolean = useAppSelector(selectHasObservationsResults);
   const plantingSites: PlantingSite[] | undefined = useAppSelector(selectPlantingSites);
   const [plantingSubzoneNames, setPlantingSubzoneNames] = useState<Record<number, string>>({});
   const [showNavBar, setShowNavBar] = useState(true);
@@ -290,7 +292,7 @@ function AppContent() {
       (location.pathname.startsWith(APP_PATHS.INVENTORY) && (!selectedOrgHasNurseries() || !selectedOrgHasSpecies())) ||
       (location.pathname.startsWith(APP_PATHS.SEED_BANKS) && !selectedOrgHasSeedBanks()) ||
       (location.pathname.startsWith(APP_PATHS.NURSERIES) && !selectedOrgHasNurseries()) ||
-      location.pathname.startsWith(APP_PATHS.OBSERVATIONS) ||
+      (location.pathname.startsWith(APP_PATHS.OBSERVATIONS) && !hasObservationsResults) ||
       (location.pathname.startsWith(APP_PATHS.PLANTING_SITES) && !selectedOrgHasPlantingSites())
     ) {
       return true;

--- a/src/components/Observations/details/index.tsx
+++ b/src/components/Observations/details/index.tsx
@@ -136,7 +136,7 @@ export default function ObservationDetails(props: ObservationDetailsProps): JSX.
           <AggregatedPlantsStats {...(details ?? {})} isSite />
         </Grid>
         <Grid item xs={12}>
-          <Card flushMobile>
+          <Card flushMobile style={{ display: 'flex', flexDirection: 'column', flexGrow: 1, minWidth: 'fit-content' }}>
             <Search {...searchProps} />
             <Box marginTop={2}>
               <Table

--- a/src/components/Observations/zone/index.tsx
+++ b/src/components/Observations/zone/index.tsx
@@ -105,7 +105,7 @@ export default function ObservationPlantingZone(): JSX.Element {
           <AggregatedPlantsStats {...(plantingZone ?? {})} />
         </Grid>
         <Grid item xs={12}>
-          <Card flushMobile>
+          <Card flushMobile style={{ display: 'flex', flexDirection: 'column', flexGrow: 1, minWidth: 'fit-content' }}>
             <Search search={search} onSearch={(value: string) => onSearch(value)} filtersProps={filtersProps} />
             <Box marginTop={2}>
               <Table

--- a/src/redux/features/observations/observationsSelectors.ts
+++ b/src/redux/features/observations/observationsSelectors.ts
@@ -18,6 +18,10 @@ export const ALL_STATES: ObservationState[] = ['Completed', 'Overdue', 'InProgre
  */
 export const selectObservationsResults = (state: RootState) => state.observationsResults?.observations;
 export const selectObservationsResultsError = (state: RootState) => state.observationsResults?.error;
+export const selectHasObservationsResults = (state: RootState) => {
+  const results = selectObservationsResults(state);
+  return results !== undefined && results.filter((result) => result.state !== 'Upcoming').length > 0;
+};
 
 export const selectPlantingSiteObservationsResults = createCachedSelector(
   (state: RootState, plantingSiteId: number, status?: ObservationState[]) => selectObservationsResults(state),


### PR DESCRIPTION
- fix styles of container
- also make the navbar bg translucent when there are observations, navbar was always transparent for observations and scrolling the table showed overlapping content in the navbar