### PR TITLE
SW-4064 Fix mortality rate display issues in plants dashboard

### DIFF
--- a/src/components/PlantsV2/components/HighestAndLowestMortalityRateSpeciesCard.tsx
+++ b/src/components/PlantsV2/components/HighestAndLowestMortalityRateSpeciesCard.tsx
@@ -58,14 +58,25 @@ export default function HighestAndLowestMortalityRateSpeciesCard({
               <Typography fontSize='24px' fontWeight={600}>
                 <FormattedNumber value={highestMortalityRate || 0} />%
               </Typography>
+              {(!lowestSpecies || lowestSpecies === highestSpecies) && (
+                <Typography
+                  fontWeight={400}
+                  fontSize='12px'
+                  lineHeight='16px'
+                  color={theme.palette.gray[800]}
+                  marginTop={2}
+                >
+                  {strings.SINGLE_SPECIES_MORTALITY_RATE_MESSAGE}
+                </Typography>
+              )}
             </>
           )}
-          <Divider sx={{ marginY: theme.spacing(2) }} />
-          <Typography fontSize='12px' fontWeight={400}>
-            {strings.LOWEST}
-          </Typography>
-          {lowestSpecies && (
+          {lowestSpecies && lowestSpecies !== highestSpecies && (
             <>
+              <Divider sx={{ marginY: theme.spacing(2) }} />
+              <Typography fontSize='12px' fontWeight={400}>
+                {strings.LOWEST}
+              </Typography>
               <Typography fontSize='24px' fontWeight={600} paddingY={theme.spacing(2)}>
                 {lowestSpecies}
               </Typography>

--- a/src/components/PlantsV2/components/HighestAndLowestMortalityRateSpeciesCard.tsx
+++ b/src/components/PlantsV2/components/HighestAndLowestMortalityRateSpeciesCard.tsx
@@ -64,7 +64,7 @@ export default function HighestAndLowestMortalityRateSpeciesCard({
           <Typography fontSize='12px' fontWeight={400}>
             {strings.LOWEST}
           </Typography>
-          {lowestSpecies && lowestSpecies !== highestSpecies && (
+          {lowestSpecies && (
             <>
               <Typography fontSize='24px' fontWeight={600} paddingY={theme.spacing(2)}>
                 {lowestSpecies}

--- a/src/components/PlantsV2/components/HighestAndLowestMortalityRateSpeciesCard.tsx
+++ b/src/components/PlantsV2/components/HighestAndLowestMortalityRateSpeciesCard.tsx
@@ -1,7 +1,6 @@
 import OverviewItemCard from 'src/components/common/OverviewItemCard';
 import strings from 'src/strings';
 import { Box, Divider, Typography, useTheme } from '@mui/material';
-import { selectSpecies } from 'src/redux/features/species/speciesSelectors';
 import { useAppSelector } from 'src/redux/store';
 import FormattedNumber from 'src/components/common/FormattedNumber';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
@@ -15,7 +14,6 @@ export default function HighestAndLowestMortalityRateSpeciesCard({
   plantingSiteId,
 }: HighestAndLowestMortalityRateSpeciesCardProps): JSX.Element {
   const theme = useTheme();
-  const species = useAppSelector(selectSpecies);
   const defaultTimeZone = useDefaultTimeZone();
   const observation = useAppSelector((state) =>
     selectLatestObservation(state, plantingSiteId, defaultTimeZone.get().id)
@@ -27,7 +25,7 @@ export default function HighestAndLowestMortalityRateSpeciesCard({
   observation?.species.forEach((sp) => {
     if (sp.mortalityRate !== undefined && sp.mortalityRate !== null && sp.mortalityRate >= highestMortalityRate) {
       highestMortalityRate = sp.mortalityRate;
-      highestSpecies = species?.find((iSpecies) => iSpecies.id === sp.speciesId)?.scientificName ?? '';
+      highestSpecies = sp.speciesScientificName || sp.speciesName || '';
     }
   });
 
@@ -37,7 +35,7 @@ export default function HighestAndLowestMortalityRateSpeciesCard({
   observation?.species.forEach((sp) => {
     if (sp.mortalityRate !== undefined && sp.mortalityRate !== null && sp.mortalityRate <= lowestMortalityRate) {
       lowestMortalityRate = sp.mortalityRate;
-      lowestSpecies = species?.find((iSpecies) => iSpecies.id === sp.speciesId)?.scientificName ?? '';
+      lowestSpecies = sp.speciesScientificName || sp.speciesName || '';
     }
   });
 

--- a/src/components/PlantsV2/components/HighestAndLowestMortalityRateSpeciesCard.tsx
+++ b/src/components/PlantsV2/components/HighestAndLowestMortalityRateSpeciesCard.tsx
@@ -64,7 +64,7 @@ export default function HighestAndLowestMortalityRateSpeciesCard({
           <Typography fontSize='12px' fontWeight={400}>
             {strings.LOWEST}
           </Typography>
-          {lowestSpecies && (
+          {lowestSpecies && lowestSpecies !== highestSpecies && (
             <>
               <Typography fontSize='24px' fontWeight={600} paddingY={theme.spacing(2)}>
                 {lowestSpecies}

--- a/src/components/PlantsV2/components/HighestAndLowestMortalityRateZonesCard.tsx
+++ b/src/components/PlantsV2/components/HighestAndLowestMortalityRateZonesCard.tsx
@@ -95,7 +95,7 @@ export default function TotalMortalityRateCard({
           <Typography fontSize='12px' fontWeight={400}>
             {strings.LOWEST}
           </Typography>
-          {lowestPlantingZone && lowestPlantingZone.plantingZoneId !== highestPlantingZone?.plantingZoneId && (
+          {lowestPlantingZone && (
             <>
               <Typography fontSize='24px' fontWeight={600} paddingY={theme.spacing(2)}>
                 {lowestPlantingZone.plantingZoneName}

--- a/src/components/PlantsV2/components/HighestAndLowestMortalityRateZonesCard.tsx
+++ b/src/components/PlantsV2/components/HighestAndLowestMortalityRateZonesCard.tsx
@@ -89,14 +89,25 @@ export default function TotalMortalityRateCard({
               <Typography fontSize='24px' fontWeight={600}>
                 <FormattedNumber value={highestMortalityRate || 0} />%
               </Typography>
+              {(!lowestPlantingZone || lowestPlantingZone.plantingZoneId === highestPlantingZone.plantingZoneId) && (
+                <Typography
+                  fontWeight={400}
+                  fontSize='12px'
+                  lineHeight='16px'
+                  color={theme.palette.gray[800]}
+                  marginTop={2}
+                >
+                  {strings.SINGLE_ZONE_MORTALITY_RATE_MESSAGE}
+                </Typography>
+              )}
             </>
           )}
-          <Divider sx={{ marginY: theme.spacing(2) }} />
-          <Typography fontSize='12px' fontWeight={400}>
-            {strings.LOWEST}
-          </Typography>
-          {lowestPlantingZone && (
+          {lowestPlantingZone && lowestPlantingZone.plantingZoneId !== highestPlantingZone?.plantingZoneId && (
             <>
+              <Divider sx={{ marginY: theme.spacing(2) }} />
+              <Typography fontSize='12px' fontWeight={400}>
+                {strings.LOWEST}
+              </Typography>
               <Typography fontSize='24px' fontWeight={600} paddingY={theme.spacing(2)}>
                 {lowestPlantingZone.plantingZoneName}
               </Typography>

--- a/src/components/PlantsV2/components/HighestAndLowestMortalityRateZonesCard.tsx
+++ b/src/components/PlantsV2/components/HighestAndLowestMortalityRateZonesCard.tsx
@@ -33,8 +33,16 @@ export default function TotalMortalityRateCard({
   let lowestZoneId: number;
   observation?.plantingZones.forEach((zone) => {
     if (zone.mortalityRate !== undefined && zone.mortalityRate !== null && zone.mortalityRate <= lowestMortalityRate) {
-      lowestMortalityRate = zone.mortalityRate;
-      lowestZoneId = zone.plantingZoneId;
+      // if the mortality rate is 0, check that the plots are not all temporary plots (in which case we won't consider this zone)
+      if (
+        zone.mortalityRate !== 0 ||
+        zone.plantingSubzones.some((plantingSubzone) =>
+          plantingSubzone.monitoringPlots.some((plot) => plot.isPermanent)
+        )
+      ) {
+        lowestMortalityRate = zone.mortalityRate;
+        lowestZoneId = zone.plantingZoneId;
+      }
     }
   });
 

--- a/src/components/PlantsV2/components/HighestAndLowestMortalityRateZonesCard.tsx
+++ b/src/components/PlantsV2/components/HighestAndLowestMortalityRateZonesCard.tsx
@@ -95,7 +95,7 @@ export default function TotalMortalityRateCard({
           <Typography fontSize='12px' fontWeight={400}>
             {strings.LOWEST}
           </Typography>
-          {lowestPlantingZone && (
+          {lowestPlantingZone && lowestPlantingZone.plantingZoneId !== highestPlantingZone?.plantingZoneId && (
             <>
               <Typography fontSize='24px' fontWeight={600} paddingY={theme.spacing(2)}>
                 {lowestPlantingZone.plantingZoneName}

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -1329,3 +1329,5 @@ ZONE_LEVEL_DATA_MAP_TITLE,What does the planting site look like based on what we
 ZONE_LEVEL_DATA_MAP_TITLE_WITH_OBSERVATION,What does the planting site look like as of {0}?
 ZONE_REQUIRED,Zone *
 ZONES,Zones
+SINGLE_ZONE_MORTALITY_RATE_MESSAGE,"You have only 1 zone with a mortality rate right now. Once there are more, the zone with the lowest mortality rate will appear."
+SINGLE_SPECIES_MORTALITY_RATE_MESSAGE,"You have only 1 species with a mortality rate right now. Once there are more, the species with the lowest mortality rate will appear."


### PR DESCRIPTION
- show species name as provided in the observation instead of looking up by id, we may have unknown species entered by user
- show mortality rate of '0' only if the monitoring plot has permanent plots
- hide lowest zone/species mortality rate and use info blurb if highest and lowest are the same (see screenshot)

<img width="311" alt="Terraware App 2023-08-16 11-37-14" src="https://github.com/terraware/terraware-web/assets/1865174/7026c92e-aa43-4beb-aa6e-300f9a454424">
