### PR TITLE
SW-4050 Fix overlapping bars in reported plants by species chart

### DIFF
--- a/src/components/PlantsV2/components/PlantsReportedPerSpeciesCard.tsx
+++ b/src/components/PlantsV2/components/PlantsReportedPerSpeciesCard.tsx
@@ -81,18 +81,17 @@ export default function PlantsReportedPerSpeciesCard({
             {strings.REPORTED_PLANTS_PER_SPECIES_CARD_TITLE}
           </Typography>
           <Box>
-            {values !== undefined && (
-              <BarChart
-                elementColor={theme.palette.TwClrBasePurple300}
-                chartId='plantsBySpecies'
-                chartData={chartData}
-                customTooltipTitles={tooltipTitles}
-                maxWidth='100%'
-                minHeight='127px'
-                yLimits={!values.length ? { min: 0, max: 200 } : undefined}
-                barWidth={0}
-              />
-            )}
+            <BarChart
+              key={values?.length}
+              elementColor={theme.palette.TwClrBasePurple300}
+              chartId='plantsBySpecies'
+              chartData={chartData}
+              customTooltipTitles={tooltipTitles}
+              maxWidth='100%'
+              minHeight='127px'
+              yLimits={!values?.length ? { min: 0, max: 200 } : undefined}
+              barWidth={0}
+            />
           </Box>
         </Box>
       }

--- a/src/components/PlantsV2/components/PlantsReportedPerSpeciesCard.tsx
+++ b/src/components/PlantsV2/components/PlantsReportedPerSpeciesCard.tsx
@@ -82,7 +82,7 @@ export default function PlantsReportedPerSpeciesCard({
           </Typography>
           <Box>
             <BarChart
-              key={values?.length}
+              key={`${plantingSiteId}_${values?.length}`}
               elementColor={theme.palette.TwClrBasePurple300}
               chartId='plantsBySpecies'
               chartData={chartData}

--- a/src/components/PlantsV2/components/PlantsReportedPerSpeciesCard.tsx
+++ b/src/components/PlantsV2/components/PlantsReportedPerSpeciesCard.tsx
@@ -88,6 +88,7 @@ export default function PlantsReportedPerSpeciesCard({
               maxWidth='100%'
               minHeight='127px'
               yLimits={!values?.length ? { min: 0, max: 200 } : undefined}
+              barWidth={0}
             />
           </Box>
         </Box>

--- a/src/components/PlantsV2/components/PlantsReportedPerSpeciesCard.tsx
+++ b/src/components/PlantsV2/components/PlantsReportedPerSpeciesCard.tsx
@@ -21,6 +21,7 @@ export default function PlantsReportedPerSpeciesCard({
   const [labels, setLabels] = useState<string[]>();
   const [values, setValues] = useState<number[]>();
   const [tooltipTitles, setTooltipTitles] = useState<string[]>();
+
   useEffect(() => {
     if (populationSelector) {
       const speciesQuantities: Record<string, number> = {};
@@ -80,16 +81,18 @@ export default function PlantsReportedPerSpeciesCard({
             {strings.REPORTED_PLANTS_PER_SPECIES_CARD_TITLE}
           </Typography>
           <Box>
-            <BarChart
-              elementColor={theme.palette.TwClrBasePurple300}
-              chartId='plantsBySpecies'
-              chartData={chartData}
-              customTooltipTitles={tooltipTitles}
-              maxWidth='100%'
-              minHeight='127px'
-              yLimits={!values?.length ? { min: 0, max: 200 } : undefined}
-              barWidth={0}
-            />
+            {values !== undefined && (
+              <BarChart
+                elementColor={theme.palette.TwClrBasePurple300}
+                chartId='plantsBySpecies'
+                chartData={chartData}
+                customTooltipTitles={tooltipTitles}
+                maxWidth='100%'
+                minHeight='127px'
+                yLimits={!values.length ? { min: 0, max: 200 } : undefined}
+                barWidth={0}
+              />
+            )}
           </Box>
         </Box>
       }


### PR DESCRIPTION
- use 'flex' bar width
- bar charts are not updating with data changes, using a key property to re-create the bar chart when we have update values, fixes the y-values race condition of creating bar chart before we have all the data

<img width="204" alt="Terraware App 2023-08-15 16-48-34" src="https://github.com/terraware/terraware-web/assets/1865174/a6d7140e-855c-44e7-8a4c-0fde9bd52aab">

