### PR TITLE
SW-4049 Fix map zoom into boundary when switching site in observations page

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -208,7 +208,10 @@ export default function Map(props: MapProps): JSX.Element {
       });
       if (coordinates.length > 0) {
         const bbox = MapService.getBoundingBox([coordinates]);
-        map.fitBounds([bbox.lowerLeft, bbox.upperRight], { padding: 20, linear: true });
+        // this is a hack to allow zooming to geometry while data is being updated, otherwise the zoom was not taking effect
+        setTimeout(() => {
+          map.fitBounds([bbox.lowerLeft, bbox.upperRight], { padding: 20, linear: true });
+        }, 0);
       }
     },
     [geoData]


### PR DESCRIPTION
- this happens a lot of the time where the zoom does not take effect, even though it is being called
- suspect this could be a react event vs non-react underlying map implementation event latency issue, unsure
- added a set timeout of 0 so the zoom happens on next time slice, open to other suggestions
- see before/after gifs

### before
![screencast 2023-08-16 16-04-25](https://github.com/terraware/terraware-web/assets/1865174/49081d38-cd0c-4f0f-b34c-6af6cd20729e)

### after
![screencast 2023-08-16 16-02-59](https://github.com/terraware/terraware-web/assets/1865174/2f2608c4-64b9-4b9f-85bf-b9ec2b247923)
