### PR TITLE
SW-3932 Use simple/detailed site types in dialog

### DIFF
--- a/src/components/PlantingSites/DetailedPlantingSiteHelpModal.tsx
+++ b/src/components/PlantingSites/DetailedPlantingSiteHelpModal.tsx
@@ -5,12 +5,12 @@ import { Button, DialogBox } from '@terraware/web-components';
 import TextWithLink from '../common/TextWithLink';
 import { useDocLinks } from 'src/docLinks';
 
-export type PlantingSiteWithMapHelpModalProps = {
+export type DetailedPlantingSiteHelpModalProps = {
   open: boolean;
   onClose: () => void;
 };
 
-export default function PlantingSiteWithMapHelpModal(props: PlantingSiteWithMapHelpModalProps): JSX.Element {
+export default function DetailedPlantingSiteHelpModal(props: DetailedPlantingSiteHelpModalProps): JSX.Element {
   const { open, onClose } = props;
   const docLinks = useDocLinks();
 
@@ -24,7 +24,7 @@ export default function PlantingSiteWithMapHelpModal(props: PlantingSiteWithMapH
       middleButtons={[<Button onClick={onClose} id='done' label={strings.DONE} key='button-1' />]}
     >
       <Typography>
-        <TextWithLink href={docLinks.contact_us} text={strings.PLANTING_SITE_WITH_MAP_HELP} />
+        <TextWithLink href={docLinks.contact_us} text={strings.PLANTING_SITE_CREATE_DETAILED_HELP} />
       </Typography>
     </DialogBox>
   );

--- a/src/components/PlantingSites/PlantingSiteSelectTypeModal.tsx
+++ b/src/components/PlantingSites/PlantingSiteSelectTypeModal.tsx
@@ -20,23 +20,23 @@ export default function PlantingSiteSelectTypeModal(props: PlantingSiteSelectTyp
   const { open, onNext, onClose } = props;
   const classes = useStyles();
   const theme = useTheme();
-  const [withMap, setWithMap] = useState<boolean | null>(null);
+  const [detailed, setDetailed] = useState<boolean | null>(null);
 
   const handleClose = () => {
-    setWithMap(null);
+    setDetailed(null);
     onClose();
   };
 
   const handleNext = () => {
-    onNext(withMap === false);
+    onNext(detailed === false);
     handleClose();
   };
 
   const handleTypeChange = (_: React.ChangeEvent<HTMLInputElement>, value: string) => {
-    if (value === 'withMap') {
-      setWithMap(true);
+    if (value === 'detailed') {
+      setDetailed(true);
     } else {
-      setWithMap(false);
+      setDetailed(false);
     }
   };
 
@@ -57,7 +57,7 @@ export default function PlantingSiteSelectTypeModal(props: PlantingSiteSelectTyp
           className={classes.buttonSpacing}
           key='button-1'
         />,
-        <Button onClick={handleNext} id='next' label={strings.NEXT} key='button-2' disabled={withMap === null} />,
+        <Button onClick={handleNext} id='next' label={strings.NEXT} key='button-2' disabled={detailed === null} />,
       ]}
     >
       <Typography marginBottom={theme.spacing(3)} justifyContent='center'>
@@ -74,8 +74,8 @@ export default function PlantingSiteSelectTypeModal(props: PlantingSiteSelectTyp
         {strings.PLANTING_SITE_TYPE}
       </Typography>
       <RadioGroup defaultValue={null} name='radio-buttons-group' onChange={handleTypeChange}>
-        <FormControlLabel value='withMap' control={<Radio />} label={strings.WITH_MAP} />
-        <FormControlLabel value='withoutMap' control={<Radio />} label={strings.WITHOUT_MAP} />
+        <FormControlLabel value='simple' control={<Radio />} label={strings.PLANTING_SITE_TYPE_SIMPLE} />
+        <FormControlLabel value='detailed' control={<Radio />} label={strings.PLANTING_SITE_TYPE_DETAILED} />
       </RadioGroup>
     </DialogBox>
   );

--- a/src/components/PlantingSites/PlantingSiteTypeSelect.tsx
+++ b/src/components/PlantingSites/PlantingSiteTypeSelect.tsx
@@ -1,6 +1,6 @@
 import PlantingSiteSelectTypeModal from './PlantingSiteSelectTypeModal';
 import { APP_PATHS } from 'src/constants';
-import PlantingSiteWithMapHelpModal from './PlantingSiteWithMapHelpModal';
+import DetailedPlantingSiteHelpModal from 'src/components/PlantingSites/DetailedPlantingSiteHelpModal';
 import { useHistory } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 
@@ -42,7 +42,7 @@ export default function PlantingSiteTypeSelect(props: PlantingSiteTypeSelectProp
           onClose();
         }}
       />
-      <PlantingSiteWithMapHelpModal
+      <DetailedPlantingSiteHelpModal
         open={plantingSiteTypeHelpModalOpen}
         onClose={() => {
           setPlantingSiteTypeHelpModalOpen(false);

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -778,9 +778,11 @@ PLANTING_PROGRESS_TABLE_DESCRIPTION,Use the checkboxes next to each subzone to m
 PLANTING_SEASON_END,Planting Season End
 PLANTING_SEASON_START,Planting Season Start
 PLANTING_SITE,Planting Site
+PLANTING_SITE_CREATE_DETAILED_HELP,"If you are a Terraformation partner or accelerator participant, please [contact us] to create a detailed planting site."
 PLANTING_SITE_MAP_VIEW_PROMPT,"In order to access map view, please select a single planting site."
 PLANTING_SITE_TYPE,Planting Site Type
-PLANTING_SITE_WITH_MAP_HELP,"If you are a Terraformation partner or accelerator participant, please [contact us] to create a site with a map."
+PLANTING_SITE_TYPE_DETAILED,Detailed
+PLANTING_SITE_TYPE_SIMPLE,Simple
 PLANTING_SITES,Planting Sites
 PLANTING_ZONE,Planting Zone
 PLANTING_ZONES,Planting Zones
@@ -995,8 +997,8 @@ SELECT_BATCHES,Select Batches
 SELECT_BUTTON,Select
 SELECT_PLANTING_SITE_TYPE,Select Planting Site Type
 SELECT_PLANTING_SITE_TYPE_DESCRIPTION_1,Please select which type of planting site to add.
-SELECT_PLANTING_SITE_TYPE_DESCRIPTION_2,Sites with maps allow you to track the location of plants within the site and perform live/dead monitoring. Sites without maps allow you to track how many and which species of plants have been planted on the site.
-SELECT_PLANTING_SITE_TYPE_DESCRIPTION_3,"Please note that if you create a site without a map, you won’t be able to add a map to it later on."
+SELECT_PLANTING_SITE_TYPE_DESCRIPTION_2,Detailed sites allow you to track the location of plants within the site and perform live/dead monitoring. Simple sites allow you to track how many and which species of plants have been planted on the site.
+SELECT_PLANTING_SITE_TYPE_DESCRIPTION_3,"Please note that if you create a simple site, you won’t be able to change it to a detailed site later on."
 SELECT_SEED_BANK,Select Seed Bank
 SELECT_SEED_BANK_INFO,Accessions require a seed bank storage location. Please select a seed bank.
 SEND_TO_NURSERY,Send to Nursery


### PR DESCRIPTION
Update the wording of the "select a planting site type" dialog to refer to
planting sites as "simple" and "detailed" rather than as "without map" and
"with map" to reflect the fact that we will soon allow simple planting
sites to have maps.
