### PR TITLE
SW-4096 Use latest observations data in plants dashboard

### DIFF
--- a/src/redux/features/observations/observationsSelectors.ts
+++ b/src/redux/features/observations/observationsSelectors.ts
@@ -159,7 +159,7 @@ export const selectLatestObservation = createCachedSelector(
       return undefined;
     }
     const result = observationsResults.reduce((prev, curr) => {
-      if (isAfter(prev.completedDate, curr.completedDate)) {
+      if (isAfter(prev.completedTime, curr.completedTime)) {
         return prev;
       }
       return curr;


### PR DESCRIPTION
- we were sorting by `completedDate` (yyyy-mm-dd format), there were 2 observations on that date, the earlier one was used
- sort by `completedTime` instead which has millisecond level granularity