### PR TITLE
SW-4080 Use consistent styling for photos thumbnail viewer

### DIFF
--- a/src/components/NurseryWithdrawals/NurseryReassignment.tsx
+++ b/src/components/NurseryWithdrawals/NurseryReassignment.tsx
@@ -222,7 +222,7 @@ export default function NurseryReassignment(): JSX.Element {
         <Box>
           <BackToLink
             id='back'
-            to={APP_PATHS.NURSERY_WITHDRAWALS}
+            to={`${APP_PATHS.NURSERY_WITHDRAWALS}?tab=withdrawal_history`}
             className={classes.backToWithdrawals}
             name={strings.WITHDRAWAL_LOG}
           />

--- a/src/components/NurseryWithdrawals/NurseryWithdrawalsDetails.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawalsDetails.tsx
@@ -164,7 +164,7 @@ export default function NurseryWithdrawalsDetails({
           <Box>
             <BackToLink
               id='back'
-              to={APP_PATHS.NURSERY_WITHDRAWALS}
+              to={`${APP_PATHS.NURSERY_WITHDRAWALS}?tab=withdrawal_history`}
               className={classes.backToWithdrawals}
               name={strings.WITHDRAWAL_LOG}
             />

--- a/src/components/NurseryWithdrawals/WithdrawalDetails/sections/Photos.tsx
+++ b/src/components/NurseryWithdrawals/WithdrawalDetails/sections/Photos.tsx
@@ -1,9 +1,9 @@
-import { Box, Typography, useTheme } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import strings from 'src/strings';
 import { useEffect, useState } from 'react';
 import { NurseryWithdrawalService } from 'src/services';
 import useSnackbar from 'src/utils/useSnackbar';
-import { ViewPhotosDialog } from '@terraware/web-components';
+import PhotosList from 'src/components/common/PhotosList';
 
 const NURSERY_WITHDRAWAL_PHOTO_ENDPOINT = '/api/v1/nursery/withdrawals/{withdrawalId}/photos/{photoId}';
 
@@ -12,11 +12,8 @@ type PhotosSectionProps = {
 };
 
 export default function Photos({ withdrawalId }: PhotosSectionProps): JSX.Element {
-  const theme = useTheme();
   const snackbar = useSnackbar();
   const [photoUrls, setPhotoUrls] = useState<string[]>([]);
-  const [photosModalOpened, setPhotosModalOpened] = useState(false);
-  const [selectedSlide, setSelectedSlide] = useState(0);
 
   useEffect(() => {
     const getPhotos = async () => {
@@ -45,38 +42,11 @@ export default function Photos({ withdrawalId }: PhotosSectionProps): JSX.Elemen
 
   return (
     <>
-      <ViewPhotosDialog
-        photos={photoUrls.map((url) => ({ url }))}
-        open={photosModalOpened}
-        onClose={() => setPhotosModalOpened(false)}
-        initialSelectedSlide={selectedSlide}
-        nextButtonLabel={strings.NEXT}
-        prevButtonLabel={strings.PREVIOUS}
-        title={strings.PHOTOS}
-      />
       <Typography fontSize='20px' fontWeight={600}>
         {strings.PHOTOS}
       </Typography>
       <Box display='flex' flexWrap='wrap'>
-        {photoUrls.map((photoUrl, index) => (
-          <Box
-            key={index}
-            marginRight={theme.spacing(3)}
-            marginTop={theme.spacing(2)}
-            maxWidth='500px'
-            overflow='hidden'
-            sx={{ cursor: 'pointer' }}
-          >
-            <img
-              src={`${photoUrl}?maxHeight=250`}
-              alt={`${index}`}
-              onClick={() => {
-                setSelectedSlide(index);
-                setPhotosModalOpened(true);
-              }}
-            />
-          </Box>
-        ))}
+        <PhotosList photoUrls={photoUrls} />
       </Box>
     </>
   );

--- a/src/components/Reports/ViewPhotos.tsx
+++ b/src/components/Reports/ViewPhotos.tsx
@@ -6,6 +6,7 @@ import { Button, ViewPhotosDialog } from '@terraware/web-components';
 import { makeStyles } from '@mui/styles';
 import { ReportPhoto } from 'src/types/Report';
 import strings from 'src/strings';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
 
 type PhotosSectionProps = {
   reportId: number;
@@ -22,6 +23,13 @@ const useStyles = makeStyles((theme: Theme) => ({
     right: -10,
     backgroundColor: theme.palette.TwClrBgDanger,
   },
+  thumbnail: {
+    margin: 'auto auto',
+    objectFit: 'contain',
+    display: 'flex',
+    maxWidth: '120px',
+    maxHeight: '120px',
+  },
 }));
 
 export default function ViewPhotos({ reportId, onPhotoRemove, editable }: PhotosSectionProps): JSX.Element {
@@ -31,6 +39,7 @@ export default function ViewPhotos({ reportId, onPhotoRemove, editable }: Photos
   const [photosModalOpened, setPhotosModalOpened] = useState(false);
   const [selectedSlide, setSelectedSlide] = useState(0);
   const classes = useStyles();
+  const { isMobile } = useDeviceInfo();
 
   useEffect(() => {
     const getPhotos = async () => {
@@ -80,15 +89,16 @@ export default function ViewPhotos({ reportId, onPhotoRemove, editable }: Photos
         prevButtonLabel={strings.PREVIOUS}
         title={strings.PHOTOS}
       />
-      <Box display='flex' flexWrap='wrap'>
+      <Box display='flex' flexWrap='wrap' flexDirection='row'>
         {photos.map((photo, index) => (
           <Box
             key={index}
+            display='flex'
             position='relative'
-            marginRight={theme.spacing(3)}
-            marginTop={theme.spacing(2)}
-            maxWidth='400px'
-            sx={{ cursor: 'pointer' }}
+            height={122}
+            width={122}
+            marginRight={isMobile ? 2 : 3}
+            marginTop={1}
             border={`1px solid ${theme.palette.TwClrBrdrTertiary}`}
           >
             {editable && (
@@ -100,7 +110,8 @@ export default function ViewPhotos({ reportId, onPhotoRemove, editable }: Photos
               />
             )}
             <img
-              src={`${photo.url}?maxHeight=122&maxWidth=122`}
+              className={classes.thumbnail}
+              src={`${photo.url}?maxHeight=120&maxWidth=120`}
               alt={`${index}`}
               onClick={() => {
                 setSelectedSlide(index);

--- a/src/components/accession2/view/DetailPanel.tsx
+++ b/src/components/accession2/view/DetailPanel.tsx
@@ -1,7 +1,7 @@
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import { Button, Icon, ViewPhotosDialog } from '@terraware/web-components';
-import { useEffect, useState } from 'react';
+import { Button, Icon } from '@terraware/web-components';
+import { useEffect, useMemo, useState } from 'react';
 import { Accession } from 'src/types/Accession';
 import strings from 'src/strings';
 import { LocationService } from 'src/services';
@@ -11,6 +11,7 @@ import useDeviceInfo from 'src/utils/useDeviceInfo';
 import Accession2EditModal from '../edit/Accession2EditModal';
 import { isContributor } from 'src/utils/organization';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
+import PhotosList from 'src/components/common/PhotosList';
 
 type DetailPanelProps = {
   accession?: Accession;
@@ -56,8 +57,6 @@ export default function DetailPanel(props: DetailPanelProps): JSX.Element {
 
   const gridLeftSide = isMobile ? 12 : 2;
   const gridRightSide = isMobile ? 12 : 10;
-  const [photosModalOpened, setPhotosModalOpened] = useState(false);
-  const [selectedSlide, setSelectedSlide] = useState(0);
   const [openEditAccessionModal, setOpenEditAccessionModal] = useState(false);
   const [countries, setCountries] = useState<Country[]>();
   const classes = useStyles();
@@ -112,6 +111,11 @@ export default function DetailPanel(props: DetailPanelProps): JSX.Element {
 
   const spaceFiller = () => <Box sx={{ marginLeft: 1, height: '24px', width: 2 }} />;
 
+  const photoUrls = useMemo(
+    () => accession?.photoFilenames?.map((file) => `/api/v1/seedbank/accessions/${accession.id}/photos/${file}`) ?? [],
+    [accession?.photoFilenames, accession?.id]
+  );
+
   return accession ? (
     <>
       {openEditAccessionModal && (
@@ -122,19 +126,6 @@ export default function DetailPanel(props: DetailPanelProps): JSX.Element {
           reload={reload}
         />
       )}
-      <ViewPhotosDialog
-        photos={
-          accession.photoFilenames?.map((file) => ({
-            url: `/api/v1/seedbank/accessions/${accession.id}/photos/${file}`,
-          })) || []
-        }
-        open={photosModalOpened}
-        onClose={() => setPhotosModalOpened(false)}
-        initialSelectedSlide={selectedSlide}
-        nextButtonLabel={strings.NEXT}
-        prevButtonLabel={strings.PREVIOUS}
-        title={strings.PHOTOS}
-      />
       <Grid container>
         <Grid item xs={9}>
           <Grid item xs={12} sx={headerStyle}>
@@ -217,20 +208,7 @@ export default function DetailPanel(props: DetailPanelProps): JSX.Element {
               {strings.PHOTOS}
             </Grid>
             <Grid item xs={gridRightSide} sx={valueStyle} display='flex'>
-              {accession.photoFilenames?.map((file, index) => {
-                return (
-                  <Box paddingRight={theme.spacing(2)} key={`photo-${index}`}>
-                    <img
-                      src={`/api/v1/seedbank/accessions/${accession.id}/photos/${file}?maxHeight=100`}
-                      alt=''
-                      onClick={() => {
-                        setSelectedSlide(index);
-                        setPhotosModalOpened(true);
-                      }}
-                    />
-                  </Box>
-                );
-              })}
+              <PhotosList photoUrls={photoUrls} />
             </Grid>
           </Grid>
         </Grid>

--- a/src/components/common/PhotosList.tsx
+++ b/src/components/common/PhotosList.tsx
@@ -5,16 +5,14 @@ import { ViewPhotosDialog } from '@terraware/web-components';
 import strings from 'src/strings';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 
-type StyleProps = {
-  isMobile: boolean;
-};
-
 const useStyles = makeStyles(() => ({
   thumbnail: {
+    margin: 'auto auto',
     objectFit: 'contain',
     display: 'flex',
-    width: (props: StyleProps) => (props.isMobile ? '105px' : '220px'),
-    height: '120px',
+    maxWidth: '120px',
+    maxHeight: '120px',
+    cursor: 'pointer',
   },
 }));
 
@@ -28,7 +26,7 @@ export default function PhotosList({ photoUrls, initialSlide }: PhotosListProps)
   const [selectedSlide, setSelectedSlide] = useState<number>(initialSlide ?? 0);
   const [photosModalOpened, setPhotosModalOpened] = useState<boolean>(false);
   const theme = useTheme();
-  const classes = useStyles({ isMobile });
+  const classes = useStyles();
 
   return (
     <>
@@ -41,15 +39,17 @@ export default function PhotosList({ photoUrls, initialSlide }: PhotosListProps)
         prevButtonLabel={strings.PREVIOUS}
         title={strings.PHOTOS}
       />
-      <Box display='flex' flexWrap='wrap'>
+      <Box display='flex' flexDirection='row' flexWrap='wrap' marginBottom={2}>
         {photoUrls.map((photoUrl, index) => (
           <Box
             key={index}
-            marginRight={theme.spacing(isMobile ? 2 : 3)}
-            marginTop={theme.spacing(2)}
-            width={isMobile ? '105px' : '220px'}
-            height='120px'
-            sx={{ cursor: 'pointer' }}
+            display='flex'
+            position='relative'
+            height={122}
+            width={122}
+            marginRight={isMobile ? 2 : 3}
+            marginTop={1}
+            border={`1px solid ${theme.palette.TwClrBrdrTertiary}`}
           >
             <img
               className={classes.thumbnail}


### PR DESCRIPTION
- Port styles from photo uploader in web-components
- Updated PhotosList component in terraware web
- Reused PhotosList in withdrawals and accessions (already being used in observations)
- Updated Reports photos thumbnails to be consistent (could not use PhotosList here due to custom behavior, editing)
- Also fixed the back-to link from withdrawals details to go back to withdrawal history

<img width="698" alt="Terraware App 2023-08-22 16-20-21" src="https://github.com/terraware/terraware-web/assets/1865174/fa7d695f-d9fb-49ca-bb68-78633648681d">

<img width="888" alt="Terraware App 2023-08-22 16-05-01" src="https://github.com/terraware/terraware-web/assets/1865174/5be40651-20d1-47ec-956e-2ad4b814f6a0">

<img width="902" alt="Terraware App 2023-08-22 15-49-41" src="https://github.com/terraware/terraware-web/assets/1865174/aa57c4e2-bd85-42ab-bc76-1cb4636a4447">

<img width="899" alt="Terraware App 2023-08-22 15-48-02" src="https://github.com/terraware/terraware-web/assets/1865174/c969d220-e89c-46fa-8180-197cd6f1e408">
