### PR TITLE
SW-4101 Fix Site plant density >100%

### DIFF
--- a/src/components/common/Chart/ProgressChart.tsx
+++ b/src/components/common/Chart/ProgressChart.tsx
@@ -13,7 +13,7 @@ export default function ProgressChart({ value, target }: ProgressChartProps): JS
   return (
     <LinearProgress
       variant='determinate'
-      value={percentage}
+      value={percentage < 100 ? percentage : 100}
       valueBuffer={100}
       sx={{
         height: '32px',


### PR DESCRIPTION
If value is more than 100, MUI starts filling the progress again. Fix it to be 100% for values bigger than 100

Before:
<img width="519" alt="Screenshot 2023-08-24 at 15 30 25" src="https://github.com/terraware/terraware-web/assets/5919083/41868bd3-a25d-4525-b3b7-384c94b637ce">


After:
<img width="522" alt="Screenshot 2023-08-24 at 15 31 00" src="https://github.com/terraware/terraware-web/assets/5919083/ac517067-9d33-4413-a08f-e19aeade7fb1">
