### PR TITLE
SW-3740 Remove recoil usage from species list page

### DIFF
--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -1,12 +1,10 @@
 import { Container, Grid, Popover, Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useRecoilState } from 'recoil';
 import Button from 'src/components/common/button/Button';
 import EmptyMessage from 'src/components/common/EmptyMessage';
 import { OrderPreserveableTable as Table } from 'src/components/common/table';
 import { TableColumnType } from 'src/components/common/table/types';
-import speciesAtom from 'src/state/species';
 import strings from 'src/strings';
 import { Species } from 'src/types/Species';
 import TfMain from 'src/components/common/TfMain';
@@ -40,6 +38,9 @@ import FilterGroup, { FilterField } from 'src/components/common/FilterGroup';
 import { SpeciesService } from 'src/services';
 import OptionsMenu from 'src/components/common/OptionsMenu';
 import _ from 'lodash';
+import useQuery from 'src/utils/useQuery';
+import { useHistory } from 'react-router';
+import { APP_PATHS } from 'src/constants';
 
 type SpeciesListProps = {
   reloadData: () => void;
@@ -149,10 +150,11 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
   const [importSpeciesModalOpen, setImportSpeciesModalOpen] = useState(false);
   const [checkDataModalOpen, setCheckDataModalOpen] = useState(false);
   const snackbar = useSnackbar();
-  const [speciesState, setSpeciesState] = useRecoilState(speciesAtom);
   const [searchValue, setSearchValue] = useState('');
   const debouncedSearchTerm = useDebounce(searchValue, 250);
   const [results, setResults] = useState<SpeciesSearchResultRow[]>();
+  const query = useQuery();
+  const history = useHistory();
 
   const [filterAnchorEl, setFilterAnchorEl] = useState<null | HTMLElement>(null);
   const handleFilterClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -498,11 +500,13 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
   }, [columns, setSelectedColumns, activeLocale]);
 
   useEffect(() => {
-    if (speciesState?.checkData) {
-      setSpeciesState({ checkData: false });
+    const shouldCheckData = query.get('checkData');
+    if (shouldCheckData) {
+      query.delete('checkData');
       setCheckDataModalOpen(true);
+      history.replace({ pathname: APP_PATHS.SPECIES, search: query.toString() });
     }
-  }, [setCheckDataModalOpen, speciesState, setSpeciesState]);
+  }, [query, setCheckDataModalOpen, history]);
 
   useEffect(() => {
     onApplyFilters();

--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -500,7 +500,7 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
   }, [columns, setSelectedColumns, activeLocale]);
 
   useEffect(() => {
-    const shouldCheckData = query.get('checkData');
+    const shouldCheckData = query.has('checkData');
     if (shouldCheckData) {
       query.delete('checkData');
       setCheckDataModalOpen(true);

--- a/src/components/emptyStatePages/EmptyStatePage.tsx
+++ b/src/components/emptyStatePages/EmptyStatePage.tsx
@@ -5,10 +5,8 @@ import PageHeader from 'src/components/seeds/PageHeader';
 import { APP_PATHS } from 'src/constants';
 import strings from 'src/strings';
 import AddSpeciesModal from '../Species/AddSpeciesModal';
-import { useSetRecoilState } from 'recoil';
 import ImportSpeciesModal, { downloadCsvTemplate } from '../Species/ImportSpeciesModal';
 import TfMain from '../common/TfMain';
-import speciesAtom from 'src/state/species';
 import { Container, Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import useSnackbar from 'src/utils/useSnackbar';
@@ -74,7 +72,6 @@ export default function EmptyStatePage({
   const classes = useStyles({ isMobile });
   const history = useHistory();
   const snackbar = useSnackbar();
-  const setSpeciesState = useSetRecoilState(speciesAtom);
 
   const goToNewLocation = () => {
     const newLocation = {
@@ -234,8 +231,7 @@ export default function EmptyStatePage({
       if (reloadData) {
         reloadData();
       }
-      setSpeciesState({ checkData: true });
-      history.push(APP_PATHS.SPECIES);
+      history.push({ pathname: APP_PATHS.SPECIES, search: '?checkData=true' });
     }
     setAddSpeciesModalOpened(false);
     if (snackbarMessage) {
@@ -248,8 +244,7 @@ export default function EmptyStatePage({
       if (reloadData) {
         reloadData();
       }
-      setSpeciesState({ checkData: true });
-      history.push(APP_PATHS.SPECIES);
+      history.push({ pathname: APP_PATHS.SPECIES, search: '?checkData=true' });
     }
     setImportSpeciesModalOpened(false);
     if (snackbarMessage) {

--- a/src/components/emptyStatePages/EmptyStatePage.tsx
+++ b/src/components/emptyStatePages/EmptyStatePage.tsx
@@ -231,7 +231,7 @@ export default function EmptyStatePage({
       if (reloadData) {
         reloadData();
       }
-      history.push({ pathname: APP_PATHS.SPECIES, search: '?checkData=true' });
+      history.push({ pathname: APP_PATHS.SPECIES, search: '?checkData' });
     }
     setAddSpeciesModalOpened(false);
     if (snackbarMessage) {
@@ -244,7 +244,7 @@ export default function EmptyStatePage({
       if (reloadData) {
         reloadData();
       }
-      history.push({ pathname: APP_PATHS.SPECIES, search: '?checkData=true' });
+      history.push({ pathname: APP_PATHS.SPECIES, search: '?checkData' });
     }
     setImportSpeciesModalOpened(false);
     if (snackbarMessage) {

--- a/src/state/species.ts
+++ b/src/state/species.ts
@@ -1,7 +1,0 @@
-import { atom } from 'recoil';
-
-export interface SpeciesState {
-  checkData: boolean;
-}
-
-export default atom<SpeciesState>({ key: 'species', default: { checkData: false } });


### PR DESCRIPTION
Recoil was used to show the review errors modal in species list when coming from the empty state.
Remove recoil usage and replace it using a query param to show the modal in those cases.