### PR TITLE
SW-4123 Deterministically load mapbox worker class static js code

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,16 +69,6 @@ import { getRgbaFromHex } from 'src/utils/color';
 import PlantsDashboardV2 from 'src/components/PlantsV2';
 import PlantingSites from 'src/components/PlantingSites';
 
-/**
- * The following is needed to deal with a mapbox bug
- * See: https://docs.mapbox.com/mapbox-gl-js/guides/install/#transpiling
- */
-import mapboxgl from 'mapbox-gl';
-const mapboxImpl: any = mapboxgl;
-// @tslint
-// eslint-disable-next-line import/no-webpack-loader-syntax
-mapboxImpl.workerClass = require('worker-loader!mapbox-gl/dist/mapbox-gl-csp-worker').default; /* tslint:disable-line */
-
 interface StyleProps {
   isDesktop?: boolean;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,16 @@ import { getRgbaFromHex } from 'src/utils/color';
 import PlantsDashboardV2 from 'src/components/PlantsV2';
 import PlantingSites from 'src/components/PlantingSites';
 
+/**
+ * The following is needed to deal with a mapbox bug
+ * See: https://docs.mapbox.com/mapbox-gl-js/guides/install/#transpiling
+ */
+import mapboxgl from 'mapbox-gl';
+const mapboxImpl: any = mapboxgl;
+// @tslint
+// eslint-disable-next-line import/no-webpack-loader-syntax
+mapboxImpl.workerClass = require('worker-loader!mapbox-gl/dist/mapbox-gl-csp-worker').default; /* tslint:disable-line */
+
 interface StyleProps {
   isDesktop?: boolean;
 }

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -4,20 +4,10 @@ import 'mapbox-gl/dist/mapbox-gl.css';
 import ReactMapGL, { AttributionControl, Layer, MapRef, NavigationControl, Popup, Source } from 'react-map-gl';
 import { MapSource, MapEntityId, MapEntityOptions, MapOptions, MapPopupRenderer, MapGeometry } from 'src/types/Map';
 import { MapService } from 'src/services';
-
-/**
- * The following is needed to deal with a mapbox bug
- * See: https://docs.mapbox.com/mapbox-gl-js/guides/install/#transpiling
- */
-import mapboxgl from 'mapbox-gl';
 import MapBanner from './MapBanner';
 import { useIsVisible } from 'src/hooks/useIsVisible';
 import useSnackbar from 'src/utils/useSnackbar';
 import { Icon } from '@terraware/web-components';
-const mapboxImpl: any = mapboxgl;
-// @tslint
-// eslint-disable-next-line import/no-webpack-loader-syntax
-mapboxImpl.workerClass = require('worker-loader!mapbox-gl/dist/mapbox-gl-csp-worker').default; /* tslint:disable-line */
 
 type FeatureStateId = Record<string, Record<string, number | undefined>>;
 


### PR DESCRIPTION
- currently the static js code is loaded when we instantiate the map component (when user visits a page with a map component)
- the js code is chunked as part of the build and looks something like this `https://staging.terraware.io/static/js/mapbox-gl-csp-worker.35e7015c.worker.js`
- note that the hash `35e7015c` changes across builds
- lets assume a user loads terraware and doesn't visit a page with a map component
- lets assume a new code commit was deployed to staging, the mapbox-gl-csp-worker.<old-hash>.worker.js is no longer available, we instead have a `mapbox-gl-csp-worker.<new-hash>.worker.js`
- if the user now visits a page with a map component in the older session, it will try to load the mapbox-gl-csp-worker.<old-hash>.worker.js and won't find it, leading to errors and potentially incorrect behavior
- fix is to load the mapbox-gl-csp-worker js file as part of the main App.tsx load, this avoids loading stale files
- the other option to explore is if we even need this worker class anymore (terraware web will need to switch to creating es6 builds which would be a nice thing to do anyways)