### PR TITLE
SW-4124 Move Mapbox info pop-up to the top

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -471,14 +471,14 @@ export default function Map(props: MapProps): JSX.Element {
         >
           {mapSources}
           <NavigationControl showCompass={false} style={navControlStyle} position='bottom-right' />
-          <AttributionControl compact={true} style={{ marginRight: '5px' }} />
+          <AttributionControl compact={true} style={{ marginRight: '5px' }} position='top-left' />
           <Box
             style={{
               width: 28,
               height: 28,
               backgroundColor: `${theme.palette.TwClrBaseWhite}`,
               position: 'absolute',
-              bottom: '120px',
+              bottom: '84px',
               right: '5px',
               zIndex: 10,
               borderRadius: '4px',


### PR DESCRIPTION
When screen is small (some mobiles), the info text wraps into two lines and it also shows under the buttons. To fix this, move the info botton to the top

<img width="373" alt="Screenshot 2023-08-31 at 12 45 50" src="https://github.com/terraware/terraware-web/assets/5919083/cf9f2fdb-d67e-4d83-b8ba-5559ac6fd22a">
