### PR TITLE
SW-4240 Add 'Terraformation Contact' semantics in FE

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -40,8 +40,8 @@ export interface paths {
     post: operations["deviceUnresponsive"];
   };
   "/api/v1/facilities": {
-    get: operations["listAllFacilities_1"];
-    post: operations["createFacility_1"];
+    get: operations["listAllFacilities"];
+    post: operations["createFacility"];
   };
   "/api/v1/facilities/{facilityId}": {
     get: operations["getFacility"];
@@ -52,25 +52,10 @@ export interface paths {
   };
   "/api/v1/facilities/{facilityId}/configured": {
     /** After connecting a device manager and finishing any necessary configuration of the facility's devices, send this request to enable processing of timeseries values and alerts from the device manager. Only valid if the facility's connection state is `Connected`. */
-    post: operations["postConfigured_1"];
+    post: operations["postConfigured"];
   };
   "/api/v1/facilities/{facilityId}/devices": {
     get: operations["listFacilityDevices"];
-  };
-  "/api/v1/facility": {
-    get: operations["listAllFacilities"];
-    post: operations["createFacility"];
-  };
-  "/api/v1/facility/{facilityId}": {
-    get: operations["getFacility_1"];
-    put: operations["updateFacility_1"];
-  };
-  "/api/v1/facility/{facilityId}/alert/send": {
-    post: operations["sendFacilityAlert_1"];
-  };
-  "/api/v1/facility/{facilityId}/configured": {
-    /** After connecting a device manager and finishing any necessary configuration of the facility's devices, send this request to enable processing of timeseries values and alerts from the device manager. Only valid if the facility's connection state is `Connected`. */
-    post: operations["postConfigured"];
   };
   "/api/v1/facility/{facilityId}/devices": {
     get: operations["listFacilityDevices_1"];
@@ -563,7 +548,12 @@ export interface components {
     };
     AddOrganizationUserRequestPayload: {
       email: string;
-      role: "Contributor" | "Manager" | "Admin" | "Owner";
+      role:
+        | "Contributor"
+        | "Manager"
+        | "Admin"
+        | "Owner"
+        | "Terraformation Contact";
     };
     AllFieldValuesPayload: {
       /** @description If true, the list of values is too long to return in its entirety and "values" is a partial list. */
@@ -1785,6 +1775,11 @@ export interface components {
       status: components["schemas"]["SuccessOrError"];
       /**
        * Format: int32
+       * @description Total number of monitoring plots that haven't been completed yet across all current observations.
+       */
+      totalIncompletePlots: number;
+      /**
+       * Format: int32
        * @description Total number of monitoring plots that haven't been claimed yet across all current observations.
        */
       totalUnclaimedPlots: number;
@@ -2012,6 +2007,16 @@ export interface components {
       id: number;
       /**
        * Format: int32
+       * @description Total number of monitoring plots that haven't been completed yet. Includes both claimed and unclaimed plots.
+       */
+      numIncompletePlots: number;
+      /**
+       * Format: int32
+       * @description Total number of monitoring plots in observation, regardless of status.
+       */
+      numPlots: number;
+      /**
+       * Format: int32
        * @description Total number of monitoring plots that haven't been claimed yet.
        */
       numUnclaimedPlots: number;
@@ -2154,7 +2159,12 @@ export interface components {
       id: number;
       name: string;
       /** @description The current user's role in the organization. */
-      role: "Contributor" | "Manager" | "Admin" | "Owner";
+      role:
+        | "Contributor"
+        | "Manager"
+        | "Admin"
+        | "Owner"
+        | "Terraformation Contact";
       /**
        * @description Time zone name in IANA tz database format
        * @example America/New_York
@@ -2167,7 +2177,12 @@ export interface components {
       totalUsers: number;
     };
     OrganizationRolePayload: {
-      role: "Contributor" | "Manager" | "Admin" | "Owner";
+      role:
+        | "Contributor"
+        | "Manager"
+        | "Admin"
+        | "Owner"
+        | "Terraformation Contact";
       /**
        * Format: int32
        * @description Total number of users in the organization with this role.
@@ -2187,7 +2202,12 @@ export interface components {
       id: number;
       /** @description The user's last name. Not present if the user has been added to the organization but has not signed up for an account yet. */
       lastName?: string;
-      role: "Contributor" | "Manager" | "Admin" | "Owner";
+      role:
+        | "Contributor"
+        | "Manager"
+        | "Admin"
+        | "Owner"
+        | "Terraformation Contact";
     };
     PlantingPayload: {
       /** Format: int64 */
@@ -2994,7 +3014,12 @@ export interface components {
       timeZone?: string;
     };
     UpdateOrganizationUserRequestPayload: {
-      role: "Contributor" | "Manager" | "Admin" | "Owner";
+      role:
+        | "Contributor"
+        | "Manager"
+        | "Admin"
+        | "Owner"
+        | "Terraformation Contact";
     };
     UpdatePlantingSiteRequestPayload: {
       /** @description Site boundary. Ignored if this is a detailed planting site. */
@@ -3472,7 +3497,7 @@ export interface operations {
       };
     };
   };
-  listAllFacilities_1: {
+  listAllFacilities: {
     responses: {
       /** OK */
       200: {
@@ -3482,7 +3507,7 @@ export interface operations {
       };
     };
   };
-  createFacility_1: {
+  createFacility: {
     responses: {
       /** OK */
       200: {
@@ -3559,7 +3584,7 @@ export interface operations {
     };
   };
   /** After connecting a device manager and finishing any necessary configuration of the facility's devices, send this request to enable processing of timeseries values and alerts from the device manager. Only valid if the facility's connection state is `Connected`. */
-  postConfigured_1: {
+  postConfigured: {
     parameters: {
       path: {
         facilityId: number;
@@ -3595,114 +3620,6 @@ export interface operations {
       };
       /** The facility does not exist or is not accessible by the current user. */
       404: {
-        content: {
-          "application/json": components["schemas"]["SimpleErrorResponsePayload"];
-        };
-      };
-    };
-  };
-  listAllFacilities: {
-    responses: {
-      /** OK */
-      200: {
-        content: {
-          "application/json": components["schemas"]["ListFacilitiesResponse"];
-        };
-      };
-    };
-  };
-  createFacility: {
-    responses: {
-      /** OK */
-      200: {
-        content: {
-          "application/json": components["schemas"]["CreateFacilityResponsePayload"];
-        };
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateFacilityRequestPayload"];
-      };
-    };
-  };
-  getFacility_1: {
-    parameters: {
-      path: {
-        facilityId: number;
-      };
-    };
-    responses: {
-      /** OK */
-      200: {
-        content: {
-          "application/json": components["schemas"]["GetFacilityResponse"];
-        };
-      };
-    };
-  };
-  updateFacility_1: {
-    parameters: {
-      path: {
-        facilityId: number;
-      };
-    };
-    responses: {
-      /** OK */
-      200: {
-        content: {
-          "application/json": components["schemas"]["SimpleSuccessResponsePayload"];
-        };
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateFacilityRequestPayload"];
-      };
-    };
-  };
-  sendFacilityAlert_1: {
-    parameters: {
-      path: {
-        facilityId: number;
-      };
-    };
-    responses: {
-      /** The requested operation succeeded. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["SimpleSuccessResponsePayload"];
-        };
-      };
-      /** The request was received, but the user is still configuring or placing sensors, so no notification has been generated. */
-      202: {
-        content: {
-          "application/json": components["schemas"]["SimpleSuccessResponsePayload"];
-        };
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["SendFacilityAlertRequestPayload"];
-      };
-    };
-  };
-  /** After connecting a device manager and finishing any necessary configuration of the facility's devices, send this request to enable processing of timeseries values and alerts from the device manager. Only valid if the facility's connection state is `Connected`. */
-  postConfigured: {
-    parameters: {
-      path: {
-        facilityId: number;
-      };
-    };
-    responses: {
-      /** The requested operation succeeded. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["SimpleSuccessResponsePayload"];
-        };
-      };
-      /** The facility's device manager was not in the process of being configured. */
-      409: {
         content: {
           "application/json": components["schemas"]["SimpleErrorResponsePayload"];
         };

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -6,7 +6,6 @@ import NavItem from 'src/components/common/Navbar/NavItem';
 import NavSection from 'src/components/common/Navbar/NavSection';
 import { APP_PATHS } from 'src/constants';
 import strings from 'src/strings';
-import { OrganizationRole } from 'src/types/Organization';
 import { NurseryWithdrawalService } from 'src/services';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import NavFooter from './common/Navbar/NavFooter';
@@ -14,6 +13,7 @@ import { useOrganization } from 'src/providers/hooks';
 import LocaleSelector from './LocaleSelector';
 import isEnabled from '../features';
 import ReportService, { Reports } from 'src/services/ReportService';
+import { isAdmin } from 'src/utils/organization';
 
 type NavBarProps = {
   setShowNavBar: React.Dispatch<React.SetStateAction<boolean>>;
@@ -28,7 +28,6 @@ export default function NavBar({
   hasPlantingSites,
 }: NavBarProps): JSX.Element | null {
   const { selectedOrganization } = useOrganization();
-  const [role, setRole] = useState<OrganizationRole>();
   const [showNurseryWithdrawals, setShowNurseryWithdrawals] = useState<boolean>(false);
   const [reports, setReports] = useState<Reports>([]);
   const { isDesktop } = useDeviceInfo();
@@ -81,7 +80,6 @@ export default function NavBar({
   useEffect(() => {
     setShowNurseryWithdrawals(false);
     if (selectedOrganization) {
-      setRole(selectedOrganization.role);
       checkNurseryWithdrawals();
     }
   }, [selectedOrganization, checkNurseryWithdrawals]);
@@ -217,7 +215,7 @@ export default function NavBar({
           />
         </>
       )}
-      {role && ['Admin', 'Owner'].includes(role) && (
+      {isAdmin(selectedOrganization) && (
         <>
           <NavSection title={strings.SETTINGS.toUpperCase()} />
           <NavItem

--- a/src/components/Nurseries/index.tsx
+++ b/src/components/Nurseries/index.tsx
@@ -18,6 +18,7 @@ import PageHeaderWrapper from '../common/PageHeaderWrapper';
 import Table from 'src/components/common/table';
 import { useTimeZones } from 'src/providers';
 import { setTimeZone, useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
+import { isAdmin } from 'src/utils/organization';
 
 const columns = (): TableColumnType[] => [
   { key: 'name', name: strings.NAME, type: 'string' },
@@ -87,7 +88,7 @@ export default function NurseriesList({ organization }: NurseriesListProps): JSX
             </Typography>
           </Grid>
           <Grid item xs={3} sx={{ textAlign: 'right' }}>
-            {['Admin', 'Owner'].includes(organization.role) &&
+            {isAdmin(organization) &&
               (isMobile ? (
                 <Button id='new-nursery' icon='plus' onClick={goToNewNursery} size='medium' />
               ) : (

--- a/src/components/People/TableCellRenderer.tsx
+++ b/src/components/People/TableCellRenderer.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { APP_PATHS } from 'src/constants';
-import CellRenderer, { TableRowType } from '../common/table/TableCellRenderer';
-import { RendererProps } from '../common/table/types';
-import Link from '../common/Link';
+import CellRenderer, { TableRowType } from 'src/components/common/table/TableCellRenderer';
+import { RendererProps } from 'src/components/common/table/types';
+import Link from 'src/components/common/Link';
+import { isTfContact } from 'src/utils/organization';
 
 export default function Renderer(props: RendererProps<TableRowType>): JSX.Element {
   const { column, row, value, index } = props;
@@ -14,7 +15,7 @@ export default function Renderer(props: RendererProps<TableRowType>): JSX.Elemen
     return <Link to={personLocation.pathname}>{iValue as React.ReactNode}</Link>;
   };
 
-  if (column.key === 'email') {
+  if (column.key === 'email' && !isTfContact(row.role)) {
     return <CellRenderer index={index} column={column} value={createLinkToPerson(value)} row={row} />;
   }
 

--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -287,7 +287,7 @@ export default function PeopleList(): JSX.Element {
   };
 
   const hasRemovableUsers = useMemo(
-    () => selectedPeopleRows.some((row) => row.role !== 'Terraformation Contact'),
+    () => selectedPeopleRows.some((row) => !isTfContact(row.role)),
     [selectedPeopleRows]
   );
 

--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -251,7 +251,13 @@ export default function PeopleList(): JSX.Element {
   const deleteOrgHandler = async () => {
     if (user) {
       let allRemoved = true;
-      const otherUsers = selectedPeopleRows.filter((person) => person.id !== user.id && !isTfContact(person.role));
+      const keepOneOwnerId = selectedPeopleRows.filter((person) => person.role === 'Owner')[0].id.toString();
+      const otherUsers = selectedPeopleRows.filter(
+        (person) =>
+          person.id.toString() !== user.id.toString() &&
+          !isTfContact(person.role) &&
+          person.id.toString() !== keepOneOwnerId
+      );
       if (otherUsers.length) {
         const promises: Promise<Response>[] = [];
         otherUsers.forEach((person) => {

--- a/src/components/SeedBanks/index.tsx
+++ b/src/components/SeedBanks/index.tsx
@@ -20,6 +20,7 @@ import useDeviceInfo from 'src/utils/useDeviceInfo';
 import PageHeaderWrapper from '../common/PageHeaderWrapper';
 import { useTimeZones } from 'src/providers';
 import { setTimeZone, useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
+import { isAdmin } from 'src/utils/organization';
 
 const useStyles = makeStyles((theme: Theme) => ({
   title: {
@@ -119,7 +120,7 @@ export default function SeedBanksList({ organization }: SeedBanksListProps): JSX
                 <h1 className={classes.title}>{strings.SEED_BANKS}</h1>
               </Grid>
               <Grid item xs={4} className={classes.centered}>
-                {['Admin', 'Owner'].includes(organization.role) &&
+                {isAdmin(organization) &&
                   (isMobile ? (
                     <Button id='new-facility' icon='plus' onClick={goToNewSeedBank} size='medium' />
                   ) : (

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -1138,6 +1138,7 @@ TEMPERATURE_AND_HUMIDITY_SENSOR_DATA,Temperature & Humidity Sensor Data
 TEMPLATES,Templates
 TEMPORARY,Temporary
 TEMPORARY_PLOTS,Temporary Plots
+TERRAFORMATION_CONTACT,Terraformation Contact
 TEST,Test
 TEST_DATE_REQUIRED,Test Date *
 TEST_METHOD,Test Method

--- a/src/types/Organization.ts
+++ b/src/types/Organization.ts
@@ -15,9 +15,9 @@ export type Organization = {
   canSubmitReports?: boolean;
 };
 
-export type HighOrganizationRoles = 'Admin' | 'Owner';
+export type HighOrganizationRoles = 'Admin' | 'Owner' | 'Terraformation Contact';
 
-export const HighOrganizationRolesValues = ['Admin', 'Owner'];
+export const HighOrganizationRolesValues = ['Admin', 'Owner', 'Terraformation Contact'];
 
 // Manager role included here so we don't get type issues with the server response,
 // which could contain a user with a manger role.
@@ -33,6 +33,8 @@ export function roleName(role: OrganizationRole) {
       return strings.CONTRIBUTOR;
     case 'Manager':
       return strings.MANAGER;
+    case 'Terraformation Contact':
+      return strings.TERRAFORMATION_CONTACT;
   }
 }
 

--- a/src/utils/organization.tsx
+++ b/src/utils/organization.tsx
@@ -1,5 +1,5 @@
 import { Facility, FacilityType } from 'src/types/Facility';
-import { HighOrganizationRolesValues, Organization } from 'src/types/Organization';
+import { HighOrganizationRolesValues, Organization, OrganizationRole } from 'src/types/Organization';
 import { OrganizationUser } from 'src/types/User';
 
 export const getFacilitiesByType = (organization: Organization, type: FacilityType, locale?: string) => {
@@ -23,6 +23,8 @@ export const getSeedBank = (organization: Organization, facilityId: number): Fac
 export const isAdmin = (organization: Organization | undefined) => {
   return HighOrganizationRolesValues.includes(organization?.role || '');
 };
+
+export const isTfContact = (role: OrganizationRole | undefined) => role === 'Terraformation Contact';
 
 export const isContributor = (roleHolder: Organization | OrganizationUser | undefined) => {
   return roleHolder?.role === 'Contributor';


### PR DESCRIPTION
- show TF contact role string value in people table if there is such a user
- disallow deletion/edit of TF contact
- adding TF Contact as a role is disallowed by default since we hard-code the roles and TF Contact was not there
- note: these capture the basic requirements for TF contact jira, there may be a follow up task around UX (jira created for design)
- this PR is dependent on BE PRs https://github.com/terraware/terraware-server/pull/1370 & https://github.com/terraware/terraware-server/pull/1372
- another outstanding issue is how delete org works when there is a Tf contact, this may be unrelated to FE and completely handled with BE but currently not done
- fixed another issue where we show a warning when all removable users are selected (the org's total users includes non humans, such as devices, the comparison failed in most cases, fixed that)

<img width="850" alt="Terraware App 2023-09-20 15-36-30" src="https://github.com/terraware/terraware-web/assets/1865174/7e490e70-1f9e-449f-b9be-0ad019c2e3c1">

<img width="781" alt="Terraware App 2023-09-20 15-18-30" src="https://github.com/terraware/terraware-web/assets/1865174/61209e00-fe49-44f7-a3f8-daff9648177d">

<img width="849" alt="Terraware App 2023-09-20 15-16-35" src="https://github.com/terraware/terraware-web/assets/1865174/604766b1-e885-4adb-898a-4768cefba40c">

