### PR TITLE
Add primary action button to PlantsPrimaryPage

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,6 +2,7 @@ import type { Preview } from '@storybook/react';
 import { StyledEngineProvider, ThemeProvider } from '@mui/material';
 import { MemoryRouter } from 'react-router';
 import { Provider } from 'react-redux';
+import { store } from '../src/redux/store';
 
 const preview: Preview = {
   parameters: {

--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -315,12 +315,14 @@ export interface paths {
   };
   "/api/v1/tracking/observations": {
     get: operations["listObservations"];
+    post: operations["scheduleObservation"];
   };
   "/api/v1/tracking/observations/results": {
     get: operations["listObservationResults"];
   };
   "/api/v1/tracking/observations/{observationId}": {
     get: operations["getObservation"];
+    put: operations["rescheduleObservation"];
   };
   "/api/v1/tracking/observations/{observationId}/plots": {
     get: operations["listAssignedPlots"];
@@ -2442,9 +2444,43 @@ export interface components {
       speciesName?: string;
       status: "Live" | "Dead" | "Existing";
     };
+    RescheduleObservationRequestPayload: {
+      /**
+       * Format: date
+       * @description The end date for this observation, should be limited to 2 months from the start date .
+       */
+      endDate: string;
+      /**
+       * Format: date
+       * @description The start date for this observation, can be up to a year from the date this schedule request occurs on.
+       */
+      startDate: string;
+    };
     ResolveUploadRequestPayload: {
       /** @description If true, the data for entries that already exist will be overwritten with the values in the uploaded file. If false, only entries that don't already exist will be imported. */
       overwriteExisting: boolean;
+    };
+    ScheduleObservationRequestPayload: {
+      /**
+       * Format: date
+       * @description The end date for this observation, should be limited to 2 months from the start date .
+       */
+      endDate: string;
+      /**
+       * Format: int64
+       * @description Which planting site this observation needs to be scheduled for.
+       */
+      plantingSiteId: number;
+      /**
+       * Format: date
+       * @description The start date for this observation, can be up to a year from the date this schedule request occurs on.
+       */
+      startDate: string;
+    };
+    ScheduleObservationResponsePayload: {
+      /** Format: int64 */
+      id: number;
+      status: components["schemas"]["SuccessOrError"];
     };
     /** @description A search criterion. The search will return results that match this criterion. The criterion can be composed of other search criteria to form arbitrary Boolean search expressions. TYPESCRIPT-OVERRIDE-TYPE-WITH-ANY */
     SearchNodePayload: any;
@@ -5520,6 +5556,21 @@ export interface operations {
       };
     };
   };
+  scheduleObservation: {
+    responses: {
+      /** OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ScheduleObservationResponsePayload"];
+        };
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ScheduleObservationRequestPayload"];
+      };
+    };
+  };
   listObservationResults: {
     parameters: {
       query: {
@@ -5550,6 +5601,26 @@ export interface operations {
         content: {
           "application/json": components["schemas"]["GetObservationResponsePayload"];
         };
+      };
+    };
+  };
+  rescheduleObservation: {
+    parameters: {
+      path: {
+        observationId: number;
+      };
+    };
+    responses: {
+      /** OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["SimpleSuccessResponsePayload"];
+        };
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["RescheduleObservationRequestPayload"];
       };
     };
   };

--- a/src/components/Observations/ObservationsEventsNotification.tsx
+++ b/src/components/Observations/ObservationsEventsNotification.tsx
@@ -9,6 +9,7 @@ import { getLongDate } from 'src/utils/dateFormatter';
 export type ObservationEvent = {
   startDate: string;
   plantingSiteName: string;
+  plantingSiteId: number;
 };
 
 export type ObservationsEventsNotificationProps = {

--- a/src/components/Observations/index.tsx
+++ b/src/components/Observations/index.tsx
@@ -21,6 +21,7 @@ import ObservationsHome from './ObservationsHome';
 import ObservationDetails from './details';
 import ObservationPlantingZoneDetails from './zone';
 import ObservationMonitoringPlotDetails from './plot';
+import { ScheduleObservation, RescheduleObservation } from './schedule';
 
 /**
  * This page will route to the correct component based on url params
@@ -116,6 +117,12 @@ const ObservationsWrapper = (): JSX.Element => {
 
   return (
     <Switch>
+      <Route path={APP_PATHS.RESCHEDULE_OBSERVATION}>
+        <RescheduleObservation />
+      </Route>
+      <Route path={APP_PATHS.SCHEDULE_OBSERVATION}>
+        <ScheduleObservation />
+      </Route>
       <Route path={APP_PATHS.OBSERVATION_MONITORING_PLOT_DETAILS}>
         <ObservationMonitoringPlotDetails />
       </Route>

--- a/src/components/Observations/org/ActionsMenu.tsx
+++ b/src/components/Observations/org/ActionsMenu.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { MenuItem, MenuList, Popover, Typography, useTheme } from '@mui/material';
+import { APP_PATHS } from 'src/constants';
+import { Button, Tooltip } from '@terraware/web-components';
+import { ObservationState } from 'src/types/Observations';
+import strings from 'src/strings';
+
+type ActionsMenuProps = {
+  observationId: number;
+  state: ObservationState;
+};
+
+const ActionsMenu = ({ observationId, state }: ActionsMenuProps): JSX.Element => {
+  const theme = useTheme();
+  const history = useHistory();
+  const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLButtonElement | null>(null);
+  const openMenu = Boolean(menuAnchorEl);
+
+  const openMenuHandler = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setMenuAnchorEl(event.currentTarget);
+  };
+
+  const closeMenuHandler = () => {
+    setMenuAnchorEl(null);
+  };
+
+  const goToReschedule = () => {
+    history.push(APP_PATHS.RESCHEDULE_OBSERVATION.replace(':observationId', observationId.toString()));
+  };
+
+  return (
+    <>
+      <Popover
+        open={openMenu}
+        anchorEl={menuAnchorEl}
+        onClose={closeMenuHandler}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+      >
+        <MenuList sx={{ padding: theme.spacing(2, 0) }}>
+          <MenuItem
+            id='reschedule'
+            onClick={goToReschedule}
+            sx={{ padding: theme.spacing(1, 2) }}
+            disabled={state !== 'Overdue'}
+          >
+            <Typography color={theme.palette.TwClrBaseGray800} paddingLeft={1}>
+              {strings.RESCHEDULE}
+            </Typography>
+          </MenuItem>
+        </MenuList>
+      </Popover>
+      <Tooltip title={strings.MORE_OPTIONS}>
+        <Button
+          onClick={(event) => event && openMenuHandler(event)}
+          icon='menuVertical'
+          type='passive'
+          priority='ghost'
+          size='medium'
+        />
+      </Tooltip>
+    </>
+  );
+};
+
+export default ActionsMenu;

--- a/src/components/Observations/org/OrgObservationsListView.tsx
+++ b/src/components/Observations/org/OrgObservationsListView.tsx
@@ -62,6 +62,11 @@ const columns = (): TableColumnType[] => [
     name: strings.MORTALITY_RATE,
     type: 'number',
   },
+  {
+    key: 'actionsMenu',
+    name: '',
+    type: 'string',
+  },
 ];
 
 export type OrgObservationsListViewProps = {

--- a/src/components/Observations/org/OrgObservationsRenderer.tsx
+++ b/src/components/Observations/org/OrgObservationsRenderer.tsx
@@ -7,6 +7,7 @@ import Link from 'src/components/common/Link';
 import { TextTruncated } from '@terraware/web-components';
 import { getShortDate } from 'src/utils/dateFormatter';
 import { ObservationState, getStatus } from 'src/types/Observations';
+import ActionsMenu from './ActionsMenu';
 import strings from 'src/strings';
 
 const COLUMN_WIDTH = 250;
@@ -61,6 +62,10 @@ const OrgObservationsRenderer =
 
     if (column.key === 'mortalityRate') {
       return <CellRenderer {...props} value={value !== undefined && value !== null ? `${value}%` : ''} />;
+    }
+
+    if (column.key === 'actionsMenu') {
+      return <CellRenderer {...props} value={<ActionsMenu observationId={row.observationId} state={row.state} />} />;
     }
 
     return <CellRenderer {...props} />;

--- a/src/components/Observations/schedule/RescheduleObservation.tsx
+++ b/src/components/Observations/schedule/RescheduleObservation.tsx
@@ -1,0 +1,97 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useHistory, useParams } from 'react-router-dom';
+import { APP_PATHS } from 'src/constants';
+import strings from 'src/strings';
+import { useAppSelector, useAppDispatch } from 'src/redux/store';
+import { useOrganization } from 'src/providers';
+import { PlantingSite } from 'src/types/Tracking';
+import { selectObservations } from 'src/redux/features/observations/observationsSelectors';
+import { selectPlantingSites } from 'src/redux/features/tracking/trackingSelectors';
+import { selectRescheduleObservation } from 'src/redux/features/observations/observationsSelectors';
+import { requestRescheduleObservation } from 'src/redux/features/observations/observationsAsyncThunks';
+import { requestObservations, requestObservationsResults } from 'src/redux/features/observations/observationsThunks';
+import useSnackbar from 'src/utils/useSnackbar';
+import ScheduleObservationForm from './ScheduleObservationForm';
+
+export default function ScheduleObservation(): JSX.Element {
+  const history = useHistory();
+  const snackbar = useSnackbar();
+  const dispatch = useAppDispatch();
+  const { selectedOrganization } = useOrganization();
+  const [validate, setValidate] = useState(false);
+  const [plantingSiteId, setPlantingSiteId] = useState<number>();
+  const [startDate, setStartDate] = useState<string>();
+  const [endDate, setEndDate] = useState<string>();
+  const [hasErrors, setHasErrors] = useState<boolean>(false);
+  const [requestId, setRequestId] = useState<string>('');
+  const [plantingSites, setPlantingSites] = useState<PlantingSite[]>([]);
+  const { observationId } = useParams<{ observationId: string }>();
+
+  const plantingSitesResult = useAppSelector(selectPlantingSites);
+  const observations = useAppSelector(selectObservations);
+  const result = useAppSelector((state) => selectRescheduleObservation(state, requestId));
+
+  const rescheduleObservation = async () => {
+    setValidate(true);
+    if (!hasErrors && observationId && startDate && endDate) {
+      const dispatched = dispatch(
+        requestRescheduleObservation({
+          observationId: Number(observationId),
+          request: { startDate, endDate },
+        })
+      );
+      setRequestId(dispatched.requestId);
+    }
+    return Promise.resolve(true);
+  };
+
+  const goToObservations = useCallback(() => history.push(APP_PATHS.OBSERVATIONS), [history]);
+
+  const onErrors = useCallback((errors: boolean) => {
+    setHasErrors(errors);
+  }, []);
+
+  useEffect(() => {
+    const observation = observations?.find((data) => data.id.toString() === observationId);
+    const plantingSite = plantingSitesResult?.find((ps) => ps.id === observation?.plantingSiteId);
+    if (!observationId || (observations?.length && plantingSitesResult?.length && !plantingSite)) {
+      goToObservations();
+    } else if (plantingSite && observation) {
+      setPlantingSites([plantingSite]);
+      setPlantingSiteId(plantingSite.id);
+      setStartDate(observation?.startDate);
+      setEndDate(observation?.endDate);
+    }
+  }, [goToObservations, observationId, plantingSitesResult, observations]);
+
+  useEffect(() => {
+    if (result?.status === 'error') {
+      snackbar.toastError();
+    } else if (result?.status === 'success') {
+      snackbar.toastSuccess(strings.OBSERVATION_RESCHEDULED);
+      dispatch(requestObservations(selectedOrganization.id));
+      dispatch(requestObservationsResults(selectedOrganization.id));
+      goToObservations();
+    }
+  }, [dispatch, goToObservations, selectedOrganization.id, snackbar, result?.status]);
+
+  return (
+    <ScheduleObservationForm
+      title={strings.RESCHEDULE_OBSERVATION}
+      plantingSites={plantingSites}
+      plantingSiteId={plantingSiteId}
+      onPlantingSiteId={(id) => setPlantingSiteId(id)}
+      startDate={startDate}
+      onStartDate={(date) => setStartDate(date)}
+      endDate={endDate}
+      onEndDate={(date) => setEndDate(date)}
+      validate={validate}
+      onErrors={onErrors}
+      cancelID='cancelRescheduleObservation'
+      saveID='rescheduleObservation'
+      onCancel={() => goToObservations()}
+      onSave={rescheduleObservation}
+      status={result?.status}
+    />
+  );
+}

--- a/src/components/Observations/schedule/ScheduleObservation.tsx
+++ b/src/components/Observations/schedule/ScheduleObservation.tsx
@@ -1,0 +1,78 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { APP_PATHS } from 'src/constants';
+import strings from 'src/strings';
+import { useAppSelector, useAppDispatch } from 'src/redux/store';
+import { useOrganization } from 'src/providers';
+import { selectObservationSchedulableSites } from 'src/redux/features/observations/observationsUtilsSelectors';
+import { selectScheduleObservation } from 'src/redux/features/observations/observationsSelectors';
+import { requestPlantings } from 'src/redux/features/plantings/plantingsThunks';
+import { requestScheduleObservation } from 'src/redux/features/observations/observationsAsyncThunks';
+import { requestObservations } from 'src/redux/features/observations/observationsThunks';
+import useSnackbar from 'src/utils/useSnackbar';
+import ScheduleObservationForm from './ScheduleObservationForm';
+
+export default function ScheduleObservation(): JSX.Element {
+  const history = useHistory();
+  const snackbar = useSnackbar();
+  const dispatch = useAppDispatch();
+  const { selectedOrganization } = useOrganization();
+  const [validate, setValidate] = useState(false);
+  const [plantingSiteId, setPlantingSiteId] = useState<number>();
+  const [startDate, setStartDate] = useState<string>();
+  const [endDate, setEndDate] = useState<string>();
+  const [hasErrors, setHasErrors] = useState<boolean>(false);
+  const [requestId, setRequestId] = useState<string>('');
+
+  const plantingSites = useAppSelector(selectObservationSchedulableSites) ?? [];
+  const result = useAppSelector((state) => selectScheduleObservation(state, requestId));
+
+  const scheduleObservation = async () => {
+    setValidate(true);
+    if (!hasErrors && plantingSiteId && startDate && endDate) {
+      const dispatched = dispatch(requestScheduleObservation({ plantingSiteId, startDate, endDate }));
+      setRequestId(dispatched.requestId);
+    }
+    return Promise.resolve(true);
+  };
+
+  const goToObservations = useCallback(() => history.push(APP_PATHS.OBSERVATIONS), [history]);
+
+  const onErrors = useCallback((errors: boolean) => {
+    setHasErrors(errors);
+  }, []);
+
+  useEffect(() => {
+    dispatch(requestPlantings(selectedOrganization.id));
+  }, [dispatch, selectedOrganization.id]);
+
+  useEffect(() => {
+    if (result?.status === 'error') {
+      snackbar.toastError();
+    } else if (result?.status === 'success') {
+      snackbar.toastSuccess(strings.OBSERVATION_SCHEDULED);
+      dispatch(requestObservations(selectedOrganization.id));
+      goToObservations();
+    }
+  }, [dispatch, goToObservations, selectedOrganization.id, snackbar, result?.status]);
+
+  return (
+    <ScheduleObservationForm
+      title={strings.SCHEDULE_OBSERVATION}
+      plantingSites={plantingSites}
+      plantingSiteId={plantingSiteId}
+      onPlantingSiteId={(id) => setPlantingSiteId(id)}
+      startDate={startDate}
+      onStartDate={(date) => setStartDate(date)}
+      endDate={endDate}
+      onEndDate={(date) => setEndDate(date)}
+      validate={validate}
+      onErrors={onErrors}
+      cancelID='cancelScheduleObservation'
+      saveID='scheduleObservation'
+      onCancel={() => goToObservations()}
+      onSave={scheduleObservation}
+      status={result?.status}
+    />
+  );
+}

--- a/src/components/Observations/schedule/ScheduleObservationForm.tsx
+++ b/src/components/Observations/schedule/ScheduleObservationForm.tsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Box, Grid, Typography, useTheme } from '@mui/material';
+import { DateTime } from 'luxon';
+import { BusySpinner, Dropdown, DatePicker } from '@terraware/web-components';
+import strings from 'src/strings';
+import { PlantingSite } from 'src/types/Tracking';
+import { Statuses } from 'src/redux/features/asyncUtils';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
+import PageSnackbar from 'src/components/PageSnackbar';
+import PageForm from 'src/components/common/PageForm';
+import TfMain from 'src/components/common/TfMain';
+import Card from 'src/components/common/Card';
+
+export type ScheduleObservationFormProps = {
+  title: string;
+  plantingSites: PlantingSite[];
+  onPlantingSiteId: (siteId: number) => void;
+  onStartDate: (value: string) => void;
+  onEndDate: (value: string) => void;
+  plantingSiteId?: number;
+  startDate?: string;
+  endDate?: string;
+  validate?: boolean;
+  onErrors: (hasErrors: boolean) => void;
+  status?: Statuses;
+  onCancel: () => void;
+  onSave: () => void;
+  saveID: string;
+  cancelID: string;
+};
+
+export default function ScheduleObservationForm({
+  title,
+  plantingSites,
+  onPlantingSiteId,
+  onStartDate,
+  onEndDate,
+  plantingSiteId,
+  startDate,
+  endDate,
+  validate,
+  onErrors,
+  status,
+  onCancel,
+  onSave,
+  saveID,
+  cancelID,
+}: ScheduleObservationFormProps): JSX.Element {
+  const { isMobile } = useDeviceInfo();
+  const theme = useTheme();
+  const [startDateError, setStartDateError] = useState<string>();
+  const [endDateError, setEndDateError] = useState<string>();
+
+  const gridSize = () => {
+    if (isMobile) {
+      return 12;
+    }
+    return 6;
+  };
+
+  useEffect(() => {
+    let startError: string = '';
+    let endError: string = '';
+    if (!startDate) {
+      startError = strings.REQUIRED_FIELD;
+    }
+    if (!endDate) {
+      endError = strings.REQUIRED_FIELD;
+    }
+    if (startDate && endDate) {
+      const today = DateTime.now().startOf('day');
+      const oneYearFromToday = today.plus({ years: 1 }).toMillis();
+      const start = new Date(startDate).getTime();
+      const end = new Date(endDate).getTime();
+      const twoMonthsFromStart = DateTime.fromMillis(start).plus({ months: 2 }).toMillis();
+      if (start < today.toMillis() || start > oneYearFromToday) {
+        // start should be between today and one year from today
+        startError = strings.INVALID_DATE;
+      } else if (end < start || end > twoMonthsFromStart) {
+        // end should be between start and two months from start
+        endError = strings.INVALID_DATE;
+      }
+    }
+    setStartDateError(startError);
+    setEndDateError(endError);
+    const hasErrors: boolean = startError || endError || !plantingSiteId ? true : false;
+    onErrors(hasErrors);
+  }, [plantingSiteId, startDate, endDate, onErrors]);
+
+  const sites = useMemo(
+    () =>
+      plantingSites.map((site) => ({
+        label: site.name,
+        value: site.id.toString(),
+      })),
+    [plantingSites]
+  );
+
+  return (
+    <TfMain>
+      {status === 'pending' && <BusySpinner withSkrim={true} />}
+      <PageForm cancelID={cancelID} saveID={saveID} onCancel={onCancel} onSave={onSave}>
+        <Box marginBottom={theme.spacing(4)} paddingLeft={theme.spacing(3)}>
+          <Typography fontSize='24px' fontWeight={600}>
+            {title}
+          </Typography>
+          <PageSnackbar />
+        </Box>
+        <Card style={{ maxWidth: '568px', margin: 'auto' }}>
+          <Grid container spacing={3}>
+            <Grid item xs={12}>
+              <Dropdown
+                id='site'
+                label={strings.PLANTING_SITE}
+                onChange={(id) => onPlantingSiteId(Number(id))}
+                options={sites}
+                selectedValue={plantingSiteId?.toString()}
+                errorText={validate && !plantingSiteId ? strings.REQUIRED_FIELD : ''}
+                fullWidth
+              />
+            </Grid>
+            <Grid item xs={gridSize()}>
+              <DatePicker
+                id='startDate'
+                label={strings.OBSERVATION_START_DATE}
+                value={startDate ?? ''}
+                onChange={(value) => onStartDate(value as string)}
+                aria-label='date-picker'
+                errorText={validate ? startDateError : ''}
+              />
+            </Grid>
+            <Grid item xs={gridSize()}>
+              <DatePicker
+                id='endDate'
+                label={strings.OBSERVATION_END_DATE}
+                value={endDate ?? ''}
+                onChange={(value) => onEndDate(value as string)}
+                aria-label='date-picker'
+                errorText={validate ? endDateError : ''}
+              />
+            </Grid>
+            <Typography
+              fontSize='14px'
+              fontWeight={400}
+              lineHeight='20px'
+              color={theme.palette.TwClrBrdrInfo}
+              padding={theme.spacing(1, 3)}
+            >
+              {strings.OBSERVATION_PERIOD_WARN}
+            </Typography>
+          </Grid>
+        </Card>
+      </PageForm>
+    </TfMain>
+  );
+}

--- a/src/components/Observations/schedule/index.tsx
+++ b/src/components/Observations/schedule/index.tsx
@@ -1,0 +1,4 @@
+import ScheduleObservation from './ScheduleObservation';
+import RescheduleObservation from './RescheduleObservation';
+
+export { ScheduleObservation, RescheduleObservation };

--- a/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
+++ b/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
@@ -64,7 +64,19 @@ export default function PlantsPrimaryPageView({
       <PageHeaderWrapper nextElement={contentRef.current}>
         <Grid item xs={12} paddingLeft={theme.spacing(3)} marginBottom={theme.spacing(4)}>
           <Grid item xs={12} display={isMobile ? 'block' : 'flex'} alignItems='center'>
-            <Typography sx={{ fontSize: '24px', fontWeight: 600, alignItems: 'center' }}>{title}</Typography>
+            <Box display='flex' alignItems='center'>
+              <Typography sx={{ fontSize: '24px', fontWeight: 600, alignItems: 'center' }}>{title}</Typography>
+              {actionButton && isMobile && (
+                <Box marginLeft='auto' display='flex'>
+                  <Button
+                    id={`${actionButton.title}_id}`}
+                    icon={actionButton.icon}
+                    onClick={actionButton.onClick}
+                    size='medium'
+                  />
+                </Box>
+              )}
+            </Box>
             {plantingSites.length > 0 && (
               <>
                 {!isMobile && (
@@ -91,17 +103,11 @@ export default function PlantsPrimaryPageView({
                 </Box>
               </>
             )}
-            {actionButton && (
-              <Box
-                marginLeft='auto'
-                display='flex'
-                width={isMobile ? '50px' : 'auto'}
-                height={isMobile ? '50px' : 'auto'}
-              >
+            {actionButton && !isMobile && (
+              <Box marginLeft='auto' display='flex'>
                 <Button
                   id={`${actionButton.title}_id}`}
-                  icon={isMobile ? actionButton.icon : undefined}
-                  label={isMobile ? undefined : actionButton.title}
+                  label={actionButton.title}
                   onClick={actionButton.onClick}
                   size='medium'
                 />

--- a/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
+++ b/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
@@ -2,11 +2,17 @@ import React, { useMemo, useRef } from 'react';
 import strings from 'src/strings';
 import TfMain from 'src/components/common/TfMain';
 import { Box, CircularProgress, Grid, Typography, useTheme } from '@mui/material';
-import { Dropdown } from '@terraware/web-components';
+import { Button, Dropdown, IconName } from '@terraware/web-components';
 import { PlantingSite } from 'src/types/Tracking';
 import { useDeviceInfo } from '@terraware/web-components/utils';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import PageSnackbar from 'src/components/PageSnackbar';
+
+export type ButtonProps = {
+  title: string;
+  onClick: () => void;
+  icon: IconName;
+};
 
 export type PlantsPrimaryPageViewProps = {
   title: string;
@@ -16,6 +22,7 @@ export type PlantsPrimaryPageViewProps = {
   selectedPlantingSiteId?: number;
   onSelect: (plantingSite: PlantingSite) => void; // planting site selected, id of -1 refers to All
   isEmptyState?: boolean; // optional boolean to indicate this is an empty state view
+  actionButton?: ButtonProps;
 };
 
 export default function PlantsPrimaryPageView({
@@ -26,6 +33,7 @@ export default function PlantsPrimaryPageView({
   selectedPlantingSiteId,
   onSelect,
   isEmptyState,
+  actionButton,
 }: PlantsPrimaryPageViewProps): JSX.Element {
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
@@ -82,6 +90,22 @@ export default function PlantsPrimaryPageView({
                   />
                 </Box>
               </>
+            )}
+            {actionButton && (
+              <Box
+                marginLeft='auto'
+                display='flex'
+                width={isMobile ? '50px' : 'auto'}
+                height={isMobile ? '50px' : 'auto'}
+              >
+                <Button
+                  id={`${actionButton.title}_id}`}
+                  icon={isMobile ? actionButton.icon : undefined}
+                  label={isMobile ? undefined : actionButton.title}
+                  onClick={actionButton.onClick}
+                  size='medium'
+                />
+              </Box>
             )}
           </Grid>
           {text && (

--- a/src/components/PlantsPrimaryPage/index.tsx
+++ b/src/components/PlantsPrimaryPage/index.tsx
@@ -5,7 +5,7 @@ import { useHistory, useParams } from 'react-router-dom';
 import useSnackbar from 'src/utils/useSnackbar';
 import { PreferencesService, TrackingService } from 'src/services';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
-import PlantsPrimaryPageView from './PlantsPrimaryPageView';
+import PlantsPrimaryPageView, { ButtonProps } from './PlantsPrimaryPageView';
 
 export type PlantsPrimaryPageProps = {
   title: string;
@@ -20,6 +20,7 @@ export type PlantsPrimaryPageProps = {
   isEmptyState?: boolean; // optional boolean to indicate this is an empty state view
   // this is to allow redux based components to pass in already selected data
   plantingSitesData?: PlantingSite[];
+  actionButton?: ButtonProps;
 };
 
 const allSitesOption = (organizationId: number): PlantingSite => ({
@@ -40,6 +41,7 @@ export default function PlantsPrimaryPage({
   allowAllAsSiteSelection,
   isEmptyState,
   plantingSitesData,
+  actionButton,
 }: PlantsPrimaryPageProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const [selectedPlantingSite, setSelectedPlantingSite] = useState<PlantingSite>();
@@ -140,6 +142,7 @@ export default function PlantsPrimaryPage({
       selectedPlantingSiteId={selectedPlantingSite?.id}
       onSelect={setActivePlantingSite}
       isEmptyState={isEmptyState}
+      actionButton={actionButton}
     />
   );
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,8 @@ export enum APP_PATHS {
   INVENTORY_ITEM = '/inventory/:speciesId',
   INVENTORY_WITHDRAW = '/inventory/withdraw',
   OBSERVATIONS = '/observations',
+  SCHEDULE_OBSERVATION = '/observations/schedule',
+  RESCHEDULE_OBSERVATION = '/observations/schedule/:observationId',
   OBSERVATIONS_SITE = '/observations/:plantingSiteId',
   OBSERVATION_DETAILS = '/observations/:plantingSiteId/results/:observationId',
   OBSERVATION_PLANTING_ZONE_DETAILS = '/observations/:plantingSiteId/results/:observationId/zone/:plantingZoneId',

--- a/src/redux/features/asyncUtils.ts
+++ b/src/redux/features/asyncUtils.ts
@@ -1,0 +1,17 @@
+import { ActionReducerMapBuilder, AsyncThunk, CaseReducers } from '@reduxjs/toolkit';
+
+export type Statuses = 'pending' | 'success' | 'error';
+
+export type Status = { status: Statuses };
+
+export const buildReducers =
+  (asyncThunk: AsyncThunk<any, any, any>) => (builder: CaseReducers<any, any> | ActionReducerMapBuilder<any>) =>
+    (builder as any)
+      .addCase(asyncThunk.pending, setStatus('pending'))
+      .addCase(asyncThunk.fulfilled, setStatus('success'))
+      .addCase(asyncThunk.rejected, setStatus('error'));
+
+const setStatus = (status: Statuses) => (state: any, action: any) => {
+  const requestId = action.meta.requestId;
+  state[requestId] = { status };
+};

--- a/src/redux/features/observations/observationsAsyncThunks.ts
+++ b/src/redux/features/observations/observationsAsyncThunks.ts
@@ -1,0 +1,33 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { ObservationsService, Response } from 'src/services';
+import { ScheduleObservationRequestPayload, RescheduleObservationRequestPayload } from 'src/types/Observations';
+import strings from 'src/strings';
+
+export const requestScheduleObservation = createAsyncThunk(
+  'scheduleObservation',
+  async (request: ScheduleObservationRequestPayload, { rejectWithValue }) => {
+    const response: Response = await ObservationsService.scheduleObservation(request);
+    if (response.requestSucceeded) {
+      return true;
+    }
+
+    return rejectWithValue(response.error || strings.GENERIC_ERROR);
+  }
+);
+
+export type RescheduleRequest = {
+  observationId: number;
+  request: RescheduleObservationRequestPayload;
+};
+
+export const requestRescheduleObservation = createAsyncThunk(
+  'rescheduleObservation',
+  async ({ observationId, request }: RescheduleRequest, { rejectWithValue }) => {
+    const response: Response = await ObservationsService.rescheduleObservation(observationId, request);
+    if (response.requestSucceeded) {
+      return true;
+    }
+
+    return rejectWithValue(response.error || strings.GENERIC_ERROR);
+  }
+);

--- a/src/redux/features/observations/observationsSelectors.ts
+++ b/src/redux/features/observations/observationsSelectors.ts
@@ -169,6 +169,14 @@ export const selectLatestObservation = createCachedSelector(
     observationsResults?.filter((result: ObservationResults) => result.completedTime)?.[0]
 )((state: RootState, plantingSiteId: number, defaultTimeZoneId: string) => `${plantingSiteId}-${defaultTimeZoneId}`);
 
+// scheduling selectors
+
+export const selectScheduleObservation = (state: RootState, requestId: string) =>
+  (state.scheduleObservation as any)[requestId];
+
+export const selectRescheduleObservation = (state: RootState, requestId: string) =>
+  (state.rescheduleObservation as any)[requestId];
+
 // get the current observation for a planting site
 export const selectCurrentObservation = createCachedSelector(
   (state: RootState, plantingSiteId: number, defaultTimeZoneId: string) =>

--- a/src/redux/features/observations/observationsSlice.ts
+++ b/src/redux/features/observations/observationsSlice.ts
@@ -1,5 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Observation, ObservationResultsPayload } from 'src/types/Observations';
+import { requestScheduleObservation, requestRescheduleObservation } from './observationsAsyncThunks';
+import { buildReducers, Status } from 'src/redux/features/asyncUtils';
 
 // Define a type for the slice state
 type ResultsData = {
@@ -58,7 +60,7 @@ type PlantingSiteData = Record<number, ResultsData>;
 
 const plantingSiteInitialResultsState: PlantingSiteData = {};
 
-export const plantingSiteObservationsResultsSlice = createSlice({
+const plantingSiteObservationsResultsSlice = createSlice({
   name: 'plantingSiteObservationsResultsSlice',
   initialState: plantingSiteInitialResultsState,
   reducers: {
@@ -71,3 +73,24 @@ export const plantingSiteObservationsResultsSlice = createSlice({
 
 export const { setPlantingSiteObservationsResultsAction } = plantingSiteObservationsResultsSlice.actions;
 export const plantingSiteObservationsResultsReducer = plantingSiteObservationsResultsSlice.reducer;
+
+type SchedulingState = Record<string, Status>;
+
+const initialSchedulingState: SchedulingState = {};
+
+const scheduleObservationSlice = createSlice({
+  name: 'scheduleObservation',
+  initialState: initialSchedulingState,
+  reducers: {},
+  extraReducers: buildReducers(requestScheduleObservation),
+});
+
+const rescheduleObservationSlice = createSlice({
+  name: 'rescheduleObservation',
+  initialState: initialSchedulingState,
+  reducers: {},
+  extraReducers: buildReducers(requestRescheduleObservation),
+});
+
+export const scheduleObservationReducer = scheduleObservationSlice.reducer;
+export const rescheduleObservationReducer = rescheduleObservationSlice.reducer;

--- a/src/redux/features/observations/observationsUtilsSelectors.tsx
+++ b/src/redux/features/observations/observationsUtilsSelectors.tsx
@@ -1,0 +1,46 @@
+import { createSelector } from '@reduxjs/toolkit';
+import { selectPlantingSites } from 'src/redux/features/tracking/trackingSelectors';
+import { selectPlantings } from 'src/redux/features/plantings/plantingsSelectors';
+import { selectPlantingSiteObservations } from './observationsSelectors';
+
+export const selectUpcomingObservations = createSelector(
+  [(state) => selectPlantingSiteObservations(state, -1, 'Upcoming')],
+  (upcomingObservations) => {
+    if (!upcomingObservations) {
+      return [];
+    }
+    const now = Date.now();
+    // return observations that haven't passed
+    return upcomingObservations.filter((observation) => now <= new Date(observation.endDate).getTime());
+  }
+);
+
+export const selectObservationSchedulableSites = createSelector(
+  [
+    (state) => selectUpcomingObservations(state),
+    (state) => selectPlantingSites(state),
+    (state) => selectPlantings(state),
+  ],
+  (upcomingObservations, plantingSites, plantings) => {
+    // map sites with plantings
+    const sitesWithPlantings = (plantings ?? []).reduce((acc, planting) => {
+      const siteId = planting.plantingSite.id;
+      const numPlants = planting['numPlants(raw)'];
+      acc[siteId] = (acc[siteId] ?? 0) + Number(numPlants);
+      return acc;
+    }, {} as Record<string, number>);
+
+    // find sites with zones
+    const sitesWithZones = (plantingSites ?? []).filter((site) => site.plantingZones?.length);
+
+    // find sites that have zones and plantings
+    const sitesWithZonesAndPlantings = sitesWithZones.filter((site) => sitesWithPlantings[site.id.toString()] > 0);
+
+    // find sites with zones and plantings that don't have an upcoming observation
+    const observationSchedulableSites = sitesWithZonesAndPlantings.filter(
+      (site) => !upcomingObservations.find((observation) => observation.plantingSiteId === site.id)
+    );
+
+    return observationSchedulableSites;
+  }
+);

--- a/src/redux/features/plantings/plantingsSlice.ts
+++ b/src/redux/features/plantings/plantingsSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { requestUpdatePlantingCompleted, requestUpdatePlantingsCompleted } from './plantingsAsyncThunks';
+import { buildReducers, Status } from 'src/redux/features/asyncUtils';
 
 // Define a type for the slice state
 export type PlantingSearchData = {
@@ -38,50 +39,20 @@ export const plantingsSlice = createSlice({
 
 type UpdateData = Record<string, Status>;
 
-type Status = { status: 'pending' | 'success' | 'error' };
-
 const initialUpdateState: UpdateData = {};
 
-export const updatePlantingCompletedSlice = createSlice({
+const updatePlantingCompletedSlice = createSlice({
   name: 'updatePlantingCompleted',
   initialState: initialUpdateState,
   reducers: {},
-  extraReducers: (builder) => {
-    builder
-      .addCase(requestUpdatePlantingCompleted.pending, (state, action) => {
-        const requestId = action.meta.requestId;
-        state[requestId] = { status: 'pending' };
-      })
-      .addCase(requestUpdatePlantingCompleted.fulfilled, (state, action) => {
-        const requestId = action.meta.requestId;
-        state[requestId] = { status: 'success' };
-      })
-      .addCase(requestUpdatePlantingCompleted.rejected, (state, action) => {
-        const requestId = action.meta.requestId;
-        state[requestId] = { status: 'error' };
-      });
-  },
+  extraReducers: buildReducers(requestUpdatePlantingCompleted),
 });
 
-export const updatePlantingsCompletedSlice = createSlice({
+const updatePlantingsCompletedSlice = createSlice({
   name: 'updatePlantingsCompleted',
   initialState: initialUpdateState,
   reducers: {},
-  extraReducers: (builder) => {
-    builder
-      .addCase(requestUpdatePlantingsCompleted.pending, (state, action) => {
-        const requestId = action.meta.requestId;
-        state[requestId] = { status: 'pending' };
-      })
-      .addCase(requestUpdatePlantingsCompleted.fulfilled, (state, action) => {
-        const requestId = action.meta.requestId;
-        state[requestId] = { status: 'success' };
-      })
-      .addCase(requestUpdatePlantingsCompleted.rejected, (state, action) => {
-        const requestId = action.meta.requestId;
-        state[requestId] = { status: 'error' };
-      });
-  },
+  extraReducers: buildReducers(requestUpdatePlantingsCompleted), // planting(s) plural
 });
 
 export const { setPlantingsAction } = plantingsSlice.actions;

--- a/src/redux/rootReducer.ts
+++ b/src/redux/rootReducer.ts
@@ -4,6 +4,8 @@ import {
   observationsReducer,
   observationsResultsReducer,
   plantingSiteObservationsResultsReducer,
+  scheduleObservationReducer,
+  rescheduleObservationReducer,
 } from './features/observations/observationsSlice';
 import {
   plantingsReducer,
@@ -38,6 +40,8 @@ export const reducers = {
   snackbar: snackbarReducer,
   message: messageReducer,
   userAnalytics: userAnalyticsReducer,
+  scheduleObservation: scheduleObservationReducer,
+  rescheduleObservation: rescheduleObservationReducer,
 };
 const combinedReducers = combineReducers(reducers);
 

--- a/src/services/ObservationsService.ts
+++ b/src/services/ObservationsService.ts
@@ -1,6 +1,11 @@
 import { paths } from 'src/api/types/generated-schema';
 import HttpService, { Response } from './HttpService';
-import { Observation, ObservationResultsPayload } from 'src/types/Observations';
+import {
+  Observation,
+  ObservationResultsPayload,
+  ScheduleObservationRequestPayload,
+  RescheduleObservationRequestPayload,
+} from 'src/types/Observations';
 
 /**
  * Tracking observations related services
@@ -8,6 +13,7 @@ import { Observation, ObservationResultsPayload } from 'src/types/Observations';
 
 const OBSERVATIONS_RESULTS_ENDPOINT = '/api/v1/tracking/observations/results';
 const OBSERVATIONS_ENDPOINT = '/api/v1/tracking/observations';
+const OBSERVATION_ENDPOINT = '/api/v1/tracking/observations/{observationId}';
 
 type ObservationsResultsResponsePayload =
   paths[typeof OBSERVATIONS_RESULTS_ENDPOINT]['get']['responses'][200]['content']['application/json'];
@@ -28,6 +34,7 @@ export type ObservationsData = {
 
 const httpObservationsResults = HttpService.root(OBSERVATIONS_RESULTS_ENDPOINT);
 const httpObservations = HttpService.root(OBSERVATIONS_ENDPOINT);
+const httpObservation = HttpService.root(OBSERVATION_ENDPOINT);
 
 /**
  * List all observations results
@@ -69,12 +76,28 @@ const listObservations = async (organizationId: number): Promise<ObservationsDat
   return response;
 };
 
+const scheduleObservation = async (request: ScheduleObservationRequestPayload): Promise<Response> =>
+  await httpObservations.post({ entity: request });
+
+const rescheduleObservation = async (
+  observationId: number,
+  request: RescheduleObservationRequestPayload
+): Promise<Response> =>
+  await httpObservation.put({
+    urlReplacements: {
+      '{observationId}': observationId.toString(),
+    },
+    entity: request,
+  });
+
 /**
  * Exported functions
  */
 const ObservationsService = {
   listObservationsResults,
   listObservations,
+  scheduleObservation,
+  rescheduleObservation,
 };
 
 export default ObservationsService;

--- a/src/stories/PlantsPrimaryPage.stories.tsx
+++ b/src/stories/PlantsPrimaryPage.stories.tsx
@@ -20,6 +20,7 @@ export default {
 };
 
 export const Default = PlantsPrimaryPageViewTemplate.bind({});
+export const ActionButton = PlantsPrimaryPageViewTemplate.bind({});
 
 Default.args = {
   title: 'Cloudforest Sites',
@@ -30,4 +31,9 @@ Default.args = {
     { name: 'Congo', id: 3, organizationId: 1 },
   ],
   selectedPlantingSiteId: 99,
+};
+
+ActionButton.args = {
+  ...Default.args,
+  actionButton: { title: 'Plant Tree', icon: 'plus', onClick: () => window.alert('You planted a tree!!') },
 };

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -691,9 +691,14 @@ NURSERY_MEDIA,Nursery Media
 NURSERY_MORTALITY_RATE,Nursery Mortality Rate
 NURSERY_REQUIRED,Nursery *
 NURSERY_TRANSFER,Nursery Transfer
+OBSERVATION_END_DATE,Observation End Date
 OBSERVATION_EVENT_SCHEDULED,Observation event is scheduled for {0} for planting site(s): {1},"Example: Observation event is scheduled for June 1, 2023 for planting site(s): Site-A, Site-B"
 OBSERVATION_IN_PROGRESS,Observation in Progress
 OBSERVATION_OVERDUE,Observation Overdue
+OBSERVATION_PERIOD_WARN,Observation period cannot exceed two months.
+OBSERVATION_RESCHEDULED,Observation rescheduled!
+OBSERVATION_SCHEDULED,Observation scheduled!
+OBSERVATION_START_DATE,Observation Start Date
 OBSERVATION_STATUS,Observation Status
 OBSERVATION_STATUS_OUTSTANDING,Outstanding,Remaining to be done
 OBSERVATIONS,Observations
@@ -930,6 +935,8 @@ REQUEST_FEATURE,Request Feature
 REQUIRED,Required
 REQUIRED_FIELD,Required field
 REQUIRED_VALUE_AND_UNITS_FIELD,Value and units required
+RESCHEDULE,Reschedule
+RESCHEDULE_OBSERVATION,Reschedule Observation
 RESET,Reset
 REVIEW_ERRORS,Review Errors
 REVIEW_YOUR_ACCOUNT_SETTING,Review your account setting
@@ -951,6 +958,7 @@ SAVING,Saving...
 SCARIFY,Scarify
 SCHEDULE_DATE_INFO,Schedule a date by selecting a future date.
 SCHEDULE_DATE_TO_MOVE,Schedule Date to Move from Racks to Dry Cabinets
+SCHEDULE_OBSERVATION,Schedule Observation
 SCHEDULE_WITHDRAWAL,Schedule Withdrawal
 SCHEDULED,(Scheduled)
 SCHEDULED_FOR,Scheduled for

--- a/src/types/Observations.ts
+++ b/src/types/Observations.ts
@@ -5,6 +5,9 @@ import strings from 'src/strings';
 // basic information on a single observation (excluding observation results)
 export type Observation = components['schemas']['ObservationPayload'];
 
+export type ScheduleObservationRequestPayload = components['schemas']['ScheduleObservationRequestPayload'];
+export type RescheduleObservationRequestPayload = components['schemas']['RescheduleObservationRequestPayload'];
+
 // "Upcoming" | "InProgress" | "Completed" | "Overdue"
 export type ObservationState = Observation['state'];
 


### PR DESCRIPTION
- to support schedule observation use-case
- fixed storybook not loading due to `store` not defined
- added a story to capture the primary action button

<img width="724" alt="PlantsPrimaryPageView - Action Button ⋅ Storybook 2023-09-26 10-39-15" src="https://github.com/terraware/terraware-web/assets/1865174/4bc56a72-12bb-40f7-9f63-b4dd719775a0">
