### PR TITLE
SW-4255 / SW-4256 UI to schedule/reschedule observations

### DIFF
--- a/src/components/Observations/ObservationsEventsNotification.tsx
+++ b/src/components/Observations/ObservationsEventsNotification.tsx
@@ -9,6 +9,7 @@ import { getLongDate } from 'src/utils/dateFormatter';
 export type ObservationEvent = {
   startDate: string;
   plantingSiteName: string;
+  plantingSiteId: number;
 };
 
 export type ObservationsEventsNotificationProps = {

--- a/src/components/Observations/index.tsx
+++ b/src/components/Observations/index.tsx
@@ -21,6 +21,7 @@ import ObservationsHome from './ObservationsHome';
 import ObservationDetails from './details';
 import ObservationPlantingZoneDetails from './zone';
 import ObservationMonitoringPlotDetails from './plot';
+import { ScheduleObservation, RescheduleObservation } from './schedule';
 
 /**
  * This page will route to the correct component based on url params
@@ -116,6 +117,12 @@ const ObservationsWrapper = (): JSX.Element => {
 
   return (
     <Switch>
+      <Route path={APP_PATHS.RESCHEDULE_OBSERVATION}>
+        <RescheduleObservation />
+      </Route>
+      <Route path={APP_PATHS.SCHEDULE_OBSERVATION}>
+        <ScheduleObservation />
+      </Route>
       <Route path={APP_PATHS.OBSERVATION_MONITORING_PLOT_DETAILS}>
         <ObservationMonitoringPlotDetails />
       </Route>

--- a/src/components/Observations/org/ActionsMenu.tsx
+++ b/src/components/Observations/org/ActionsMenu.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { MenuItem, MenuList, Popover, Typography, useTheme } from '@mui/material';
+import { APP_PATHS } from 'src/constants';
+import { Button, Tooltip } from '@terraware/web-components';
+import { ObservationState } from 'src/types/Observations';
+import strings from 'src/strings';
+
+type ActionsMenuProps = {
+  observationId: number;
+  state: ObservationState;
+};
+
+const ActionsMenu = ({ observationId, state }: ActionsMenuProps): JSX.Element => {
+  const theme = useTheme();
+  const history = useHistory();
+  const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLButtonElement | null>(null);
+  const openMenu = Boolean(menuAnchorEl);
+
+  const openMenuHandler = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setMenuAnchorEl(event.currentTarget);
+  };
+
+  const closeMenuHandler = () => {
+    setMenuAnchorEl(null);
+  };
+
+  const goToReschedule = () => {
+    history.push(APP_PATHS.RESCHEDULE_OBSERVATION.replace(':observationId', observationId.toString()));
+  };
+
+  return (
+    <>
+      <Popover
+        open={openMenu}
+        anchorEl={menuAnchorEl}
+        onClose={closeMenuHandler}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+      >
+        <MenuList sx={{ padding: theme.spacing(2, 0) }}>
+          <MenuItem
+            id='reschedule'
+            onClick={goToReschedule}
+            sx={{ padding: theme.spacing(1, 2) }}
+            disabled={state !== 'Overdue'}
+          >
+            <Typography color={theme.palette.TwClrBaseGray800} paddingLeft={1}>
+              {strings.RESCHEDULE}
+            </Typography>
+          </MenuItem>
+        </MenuList>
+      </Popover>
+      <Tooltip title={strings.MORE_OPTIONS}>
+        <Button
+          onClick={(event) => event && openMenuHandler(event)}
+          icon='menuVertical'
+          type='passive'
+          priority='ghost'
+          size='medium'
+        />
+      </Tooltip>
+    </>
+  );
+};
+
+export default ActionsMenu;

--- a/src/components/Observations/org/OrgObservationsListView.tsx
+++ b/src/components/Observations/org/OrgObservationsListView.tsx
@@ -62,6 +62,11 @@ const columns = (): TableColumnType[] => [
     name: strings.MORTALITY_RATE,
     type: 'number',
   },
+  {
+    key: 'actionsMenu',
+    name: '',
+    type: 'string',
+  },
 ];
 
 export type OrgObservationsListViewProps = {

--- a/src/components/Observations/org/OrgObservationsRenderer.tsx
+++ b/src/components/Observations/org/OrgObservationsRenderer.tsx
@@ -7,6 +7,7 @@ import Link from 'src/components/common/Link';
 import { TextTruncated } from '@terraware/web-components';
 import { getShortDate } from 'src/utils/dateFormatter';
 import { ObservationState, getStatus } from 'src/types/Observations';
+import ActionsMenu from './ActionsMenu';
 import strings from 'src/strings';
 
 const COLUMN_WIDTH = 250;
@@ -61,6 +62,10 @@ const OrgObservationsRenderer =
 
     if (column.key === 'mortalityRate') {
       return <CellRenderer {...props} value={value !== undefined && value !== null ? `${value}%` : ''} />;
+    }
+
+    if (column.key === 'actionsMenu') {
+      return <CellRenderer {...props} value={<ActionsMenu observationId={row.observationId} state={row.state} />} />;
     }
 
     return <CellRenderer {...props} />;

--- a/src/components/Observations/schedule/RescheduleObservation.tsx
+++ b/src/components/Observations/schedule/RescheduleObservation.tsx
@@ -52,13 +52,15 @@ export default function ScheduleObservation(): JSX.Element {
   }, []);
 
   useEffect(() => {
-    const siteId = observations?.find((observation) => observation.id.toString() === observationId)?.plantingSiteId;
-    const plantingSite = plantingSitesResult?.find((ps) => ps.id === siteId);
+    const observation = observations?.find((data) => data.id.toString() === observationId);
+    const plantingSite = plantingSitesResult?.find((ps) => ps.id === observation?.plantingSiteId);
     if (!observationId || (observations?.length && plantingSitesResult?.length && !plantingSite)) {
       goToObservations();
-    } else if (plantingSite) {
+    } else if (plantingSite && observation) {
       setPlantingSites([plantingSite]);
       setPlantingSiteId(plantingSite.id);
+      setStartDate(observation?.startDate);
+      setEndDate(observation?.endDate);
     }
   }, [goToObservations, observationId, plantingSitesResult, observations]);
 

--- a/src/components/Observations/schedule/RescheduleObservation.tsx
+++ b/src/components/Observations/schedule/RescheduleObservation.tsx
@@ -1,0 +1,95 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useHistory, useParams } from 'react-router-dom';
+import { APP_PATHS } from 'src/constants';
+import strings from 'src/strings';
+import { useAppSelector, useAppDispatch } from 'src/redux/store';
+import { useOrganization } from 'src/providers';
+import { PlantingSite } from 'src/types/Tracking';
+import { selectObservations } from 'src/redux/features/observations/observationsSelectors';
+import { selectPlantingSites } from 'src/redux/features/tracking/trackingSelectors';
+import { selectRescheduleObservation } from 'src/redux/features/observations/observationsSelectors';
+import { requestRescheduleObservation } from 'src/redux/features/observations/observationsAsyncThunks';
+import { requestObservations, requestObservationsResults } from 'src/redux/features/observations/observationsThunks';
+import useSnackbar from 'src/utils/useSnackbar';
+import ScheduleObservationForm from './ScheduleObservationForm';
+
+export default function ScheduleObservation(): JSX.Element {
+  const history = useHistory();
+  const snackbar = useSnackbar();
+  const dispatch = useAppDispatch();
+  const { selectedOrganization } = useOrganization();
+  const [validate, setValidate] = useState(false);
+  const [plantingSiteId, setPlantingSiteId] = useState<number>();
+  const [startDate, setStartDate] = useState<string>();
+  const [endDate, setEndDate] = useState<string>();
+  const [hasErrors, setHasErrors] = useState<boolean>(false);
+  const [requestId, setRequestId] = useState<string>('');
+  const [plantingSites, setPlantingSites] = useState<PlantingSite[]>([]);
+  const { observationId } = useParams<{ observationId: string }>();
+
+  const plantingSitesResult = useAppSelector(selectPlantingSites);
+  const observations = useAppSelector(selectObservations);
+  const result = useAppSelector((state) => selectRescheduleObservation(state, requestId));
+
+  const rescheduleObservation = async () => {
+    setValidate(true);
+    if (!hasErrors && observationId && startDate && endDate) {
+      const dispatched = dispatch(
+        requestRescheduleObservation({
+          observationId: Number(observationId),
+          request: { startDate, endDate },
+        })
+      );
+      setRequestId(dispatched.requestId);
+    }
+    return Promise.resolve(true);
+  };
+
+  const goToObservations = useCallback(() => history.push(APP_PATHS.OBSERVATIONS), [history]);
+
+  const onErrors = useCallback((errors: boolean) => {
+    setHasErrors(errors);
+  }, []);
+
+  useEffect(() => {
+    const siteId = observations?.find((observation) => observation.id.toString() === observationId)?.plantingSiteId;
+    const plantingSite = plantingSitesResult?.find((ps) => ps.id === siteId);
+    if (!observationId || (observations?.length && plantingSitesResult?.length && !plantingSite)) {
+      goToObservations();
+    } else if (plantingSite) {
+      setPlantingSites([plantingSite]);
+      setPlantingSiteId(plantingSite.id);
+    }
+  }, [goToObservations, observationId, plantingSitesResult, observations]);
+
+  useEffect(() => {
+    if (result?.status === 'error') {
+      snackbar.toastError();
+    } else if (result?.status === 'success') {
+      snackbar.toastSuccess(strings.OBSERVATION_RESCHEDULED);
+      dispatch(requestObservations(selectedOrganization.id));
+      dispatch(requestObservationsResults(selectedOrganization.id));
+      goToObservations();
+    }
+  }, [dispatch, goToObservations, selectedOrganization.id, snackbar, result?.status]);
+
+  return (
+    <ScheduleObservationForm
+      title={strings.RESCHEDULE_OBSERVATION}
+      plantingSites={plantingSites}
+      plantingSiteId={plantingSiteId}
+      onPlantingSiteId={(id) => setPlantingSiteId(id)}
+      startDate={startDate}
+      onStartDate={(date) => setStartDate(date)}
+      endDate={endDate}
+      onEndDate={(date) => setEndDate(date)}
+      validate={validate}
+      onErrors={onErrors}
+      cancelID='cancelRescheduleObservation'
+      saveID='rescheduleObservation'
+      onCancel={() => goToObservations()}
+      onSave={rescheduleObservation}
+      status={result?.status}
+    />
+  );
+}

--- a/src/components/Observations/schedule/ScheduleObservation.tsx
+++ b/src/components/Observations/schedule/ScheduleObservation.tsx
@@ -1,0 +1,78 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { APP_PATHS } from 'src/constants';
+import strings from 'src/strings';
+import { useAppSelector, useAppDispatch } from 'src/redux/store';
+import { useOrganization } from 'src/providers';
+import { selectObservationSchedulableSites } from 'src/redux/features/observations/observationsUtilsSelectors';
+import { selectScheduleObservation } from 'src/redux/features/observations/observationsSelectors';
+import { requestPlantings } from 'src/redux/features/plantings/plantingsThunks';
+import { requestScheduleObservation } from 'src/redux/features/observations/observationsAsyncThunks';
+import { requestObservations } from 'src/redux/features/observations/observationsThunks';
+import useSnackbar from 'src/utils/useSnackbar';
+import ScheduleObservationForm from './ScheduleObservationForm';
+
+export default function ScheduleObservation(): JSX.Element {
+  const history = useHistory();
+  const snackbar = useSnackbar();
+  const dispatch = useAppDispatch();
+  const { selectedOrganization } = useOrganization();
+  const [validate, setValidate] = useState(false);
+  const [plantingSiteId, setPlantingSiteId] = useState<number>();
+  const [startDate, setStartDate] = useState<string>();
+  const [endDate, setEndDate] = useState<string>();
+  const [hasErrors, setHasErrors] = useState<boolean>(false);
+  const [requestId, setRequestId] = useState<string>('');
+
+  const plantingSites = useAppSelector(selectObservationSchedulableSites) ?? [];
+  const result = useAppSelector((state) => selectScheduleObservation(state, requestId));
+
+  const scheduleObservation = async () => {
+    setValidate(true);
+    if (!hasErrors && plantingSiteId && startDate && endDate) {
+      const dispatched = dispatch(requestScheduleObservation({ plantingSiteId, startDate, endDate }));
+      setRequestId(dispatched.requestId);
+    }
+    return Promise.resolve(true);
+  };
+
+  const goToObservations = useCallback(() => history.push(APP_PATHS.OBSERVATIONS), [history]);
+
+  const onErrors = useCallback((errors: boolean) => {
+    setHasErrors(errors);
+  }, []);
+
+  useEffect(() => {
+    dispatch(requestPlantings(selectedOrganization.id));
+  }, [dispatch, selectedOrganization.id]);
+
+  useEffect(() => {
+    if (result?.status === 'error') {
+      snackbar.toastError();
+    } else if (result?.status === 'success') {
+      snackbar.toastSuccess(strings.OBSERVATION_SCHEDULED);
+      dispatch(requestObservations(selectedOrganization.id));
+      goToObservations();
+    }
+  }, [dispatch, goToObservations, selectedOrganization.id, snackbar, result?.status]);
+
+  return (
+    <ScheduleObservationForm
+      title={strings.SCHEDULE_OBSERVATION}
+      plantingSites={plantingSites}
+      plantingSiteId={plantingSiteId}
+      onPlantingSiteId={(id) => setPlantingSiteId(id)}
+      startDate={startDate}
+      onStartDate={(date) => setStartDate(date)}
+      endDate={endDate}
+      onEndDate={(date) => setEndDate(date)}
+      validate={validate}
+      onErrors={onErrors}
+      cancelID='cancelScheduleObservation'
+      saveID='scheduleObservation'
+      onCancel={() => goToObservations()}
+      onSave={scheduleObservation}
+      status={result?.status}
+    />
+  );
+}

--- a/src/components/Observations/schedule/ScheduleObservationForm.tsx
+++ b/src/components/Observations/schedule/ScheduleObservationForm.tsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Box, Grid, Typography, useTheme } from '@mui/material';
+import { DateTime } from 'luxon';
+import { BusySpinner, Dropdown, DatePicker } from '@terraware/web-components';
+import strings from 'src/strings';
+import { PlantingSite } from 'src/types/Tracking';
+import { Statuses } from 'src/redux/features/asyncUtils';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
+import PageSnackbar from 'src/components/PageSnackbar';
+import PageForm from 'src/components/common/PageForm';
+import TfMain from 'src/components/common/TfMain';
+import Card from 'src/components/common/Card';
+
+export type ScheduleObservationFormProps = {
+  title: string;
+  plantingSites: PlantingSite[];
+  onPlantingSiteId: (siteId: number) => void;
+  onStartDate: (value: string) => void;
+  onEndDate: (value: string) => void;
+  plantingSiteId?: number;
+  startDate?: string;
+  endDate?: string;
+  validate?: boolean;
+  onErrors: (hasErrors: boolean) => void;
+  status?: Statuses;
+  onCancel: () => void;
+  onSave: () => void;
+  saveID: string;
+  cancelID: string;
+};
+
+export default function ScheduleObservationForm({
+  title,
+  plantingSites,
+  onPlantingSiteId,
+  onStartDate,
+  onEndDate,
+  plantingSiteId,
+  startDate,
+  endDate,
+  validate,
+  onErrors,
+  status,
+  onCancel,
+  onSave,
+  saveID,
+  cancelID,
+}: ScheduleObservationFormProps): JSX.Element {
+  const { isMobile } = useDeviceInfo();
+  const theme = useTheme();
+  const [startDateError, setStartDateError] = useState<string>();
+  const [endDateError, setEndDateError] = useState<string>();
+
+  const gridSize = () => {
+    if (isMobile) {
+      return 12;
+    }
+    return 6;
+  };
+
+  useEffect(() => {
+    let startError: string = '';
+    let endError: string = '';
+    if (!startDate) {
+      startError = strings.REQUIRED_FIELD;
+    }
+    if (!endDate) {
+      endError = strings.REQUIRED_FIELD;
+    }
+    if (startDate && endDate) {
+      const today = DateTime.now().startOf('day');
+      const oneYearFromToday = today.plus({ years: 1 }).toMillis();
+      const start = new Date(startDate).getTime();
+      const end = new Date(endDate).getTime();
+      const twoMonthsFromStart = DateTime.fromMillis(start).plus({ months: 2 }).toMillis();
+      if (start < today.toMillis() || start > oneYearFromToday) {
+        // start should be between today and one year from today
+        startError = strings.INVALID_DATE;
+      } else if (end < start || end > twoMonthsFromStart) {
+        // end should be between start and two months from start
+        endError = strings.INVALID_DATE;
+      }
+    }
+    setStartDateError(startError);
+    setEndDateError(endError);
+    const hasErrors: boolean = startError || endError || !plantingSiteId ? true : false;
+    onErrors(hasErrors);
+  }, [plantingSiteId, startDate, endDate, onErrors]);
+
+  const sites = useMemo(
+    () =>
+      plantingSites.map((site) => ({
+        label: site.name,
+        value: site.id.toString(),
+      })),
+    [plantingSites]
+  );
+
+  return (
+    <TfMain>
+      {status === 'pending' && <BusySpinner withSkrim={true} />}
+      <PageForm cancelID={cancelID} saveID={saveID} onCancel={onCancel} onSave={onSave}>
+        <Box marginBottom={theme.spacing(4)} paddingLeft={theme.spacing(3)}>
+          <Typography fontSize='24px' fontWeight={600}>
+            {title}
+          </Typography>
+          <PageSnackbar />
+        </Box>
+        <Card style={{ maxWidth: '568px', margin: 'auto' }}>
+          <Grid container spacing={3}>
+            <Grid item xs={12}>
+              <Dropdown
+                id='site'
+                label={strings.PLANTING_SITE}
+                onChange={(id) => onPlantingSiteId(Number(id))}
+                options={sites}
+                selectedValue={plantingSiteId?.toString()}
+                errorText={validate && !plantingSiteId ? strings.REQUIRED_FIELD : ''}
+                fullWidth
+              />
+            </Grid>
+            <Grid item xs={gridSize()}>
+              <DatePicker
+                id='startDate'
+                label={strings.OBSERVATION_START_DATE}
+                value={startDate ?? ''}
+                onChange={(value) => onStartDate(value as string)}
+                aria-label='date-picker'
+                errorText={validate ? startDateError : ''}
+              />
+            </Grid>
+            <Grid item xs={gridSize()}>
+              <DatePicker
+                id='endDate'
+                label={strings.OBSERVATION_END_DATE}
+                value={endDate ?? ''}
+                onChange={(value) => onEndDate(value as string)}
+                aria-label='date-picker'
+                errorText={validate ? endDateError : ''}
+              />
+            </Grid>
+            <Typography
+              fontSize='14px'
+              fontWeight={400}
+              lineHeight='20px'
+              color={theme.palette.TwClrBrdrInfo}
+              padding={theme.spacing(1, 3)}
+            >
+              {strings.OBSERVATION_PERIOD_WARN}
+            </Typography>
+          </Grid>
+        </Card>
+      </PageForm>
+    </TfMain>
+  );
+}

--- a/src/components/Observations/schedule/index.tsx
+++ b/src/components/Observations/schedule/index.tsx
@@ -1,0 +1,4 @@
+import ScheduleObservation from './ScheduleObservation';
+import RescheduleObservation from './RescheduleObservation';
+
+export { ScheduleObservation, RescheduleObservation };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,8 @@ export enum APP_PATHS {
   INVENTORY_ITEM = '/inventory/:speciesId',
   INVENTORY_WITHDRAW = '/inventory/withdraw',
   OBSERVATIONS = '/observations',
+  SCHEDULE_OBSERVATION = '/observations/schedule',
+  RESCHEDULE_OBSERVATION = '/observations/schedule/:observationId',
   OBSERVATIONS_SITE = '/observations/:plantingSiteId',
   OBSERVATION_DETAILS = '/observations/:plantingSiteId/results/:observationId',
   OBSERVATION_PLANTING_ZONE_DETAILS = '/observations/:plantingSiteId/results/:observationId/zone/:plantingZoneId',

--- a/src/redux/features/observations/observationsUtilsSelectors.tsx
+++ b/src/redux/features/observations/observationsUtilsSelectors.tsx
@@ -1,0 +1,46 @@
+import { createSelector } from '@reduxjs/toolkit';
+import { selectPlantingSites } from 'src/redux/features/tracking/trackingSelectors';
+import { selectPlantings } from 'src/redux/features/plantings/plantingsSelectors';
+import { selectPlantingSiteObservations } from './observationsSelectors';
+
+export const selectUpcomingObservations = createSelector(
+  [(state) => selectPlantingSiteObservations(state, -1, 'Upcoming')],
+  (upcomingObservations) => {
+    if (!upcomingObservations) {
+      return [];
+    }
+    const now = Date.now();
+    // return observations that haven't passed
+    return upcomingObservations.filter((observation) => now <= new Date(observation.endDate).getTime());
+  }
+);
+
+export const selectObservationSchedulableSites = createSelector(
+  [
+    (state) => selectUpcomingObservations(state),
+    (state) => selectPlantingSites(state),
+    (state) => selectPlantings(state),
+  ],
+  (upcomingObservations, plantingSites, plantings) => {
+    // map sites with plantings
+    const sitesWithPlantings = (plantings ?? []).reduce((acc, planting) => {
+      const siteId = planting.plantingSite.id;
+      const numPlants = planting['numPlants(raw)'];
+      acc[siteId] = (acc[siteId] ?? 0) + Number(numPlants);
+      return acc;
+    }, {} as Record<string, number>);
+
+    // find sites with zones
+    const sitesWithZones = (plantingSites ?? []).filter((site) => site.plantingZones?.length);
+
+    // find sites that have zones and plantings
+    const sitesWithZonesAndPlantings = sitesWithZones.filter((site) => sitesWithPlantings[site.id.toString()] > 0);
+
+    // find sites with zones and plantings that don't have an upcoming observation
+    const observationSchedulableSites = sitesWithZonesAndPlantings.filter(
+      (site) => !upcomingObservations.find((observation) => observation.plantingSiteId === site.id)
+    );
+
+    return observationSchedulableSites;
+  }
+);

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -683,9 +683,14 @@ NURSERY_MEDIA,Nursery Media
 NURSERY_MORTALITY_RATE,Nursery Mortality Rate
 NURSERY_REQUIRED,Nursery *
 NURSERY_TRANSFER,Nursery Transfer
+OBSERVATION_END_DATE,Observation End Date
 OBSERVATION_EVENT_SCHEDULED,Observation event is scheduled for {0} for planting site(s): {1},"Example: Observation event is scheduled for June 1, 2023 for planting site(s): Site-A, Site-B"
 OBSERVATION_IN_PROGRESS,Observation in Progress
 OBSERVATION_OVERDUE,Observation Overdue
+OBSERVATION_PERIOD_WARN,Observation period cannot exceed two months.
+OBSERVATION_RESCHEDULED,Observation rescheduled!
+OBSERVATION_SCHEDULED,Observation scheduled!
+OBSERVATION_START_DATE,Observation Start Date
 OBSERVATION_STATUS,Observation Status
 OBSERVATION_STATUS_OUTSTANDING,Outstanding,Remaining to be done
 OBSERVATIONS,Observations
@@ -920,6 +925,8 @@ REQUEST_FEATURE,Request Feature
 REQUIRED,Required
 REQUIRED_FIELD,Required field
 REQUIRED_VALUE_AND_UNITS_FIELD,Value and units required
+RESCHEDULE,Reschedule
+RESCHEDULE_OBSERVATION,Reschedule Observation
 RESET,Reset
 REVIEW_ERRORS,Review Errors
 REVIEW_YOUR_ACCOUNT_SETTING,Review your account setting
@@ -941,6 +948,7 @@ SAVING,Saving...
 SCARIFY,Scarify
 SCHEDULE_DATE_INFO,Schedule a date by selecting a future date.
 SCHEDULE_DATE_TO_MOVE,Schedule Date to Move from Racks to Dry Cabinets
+SCHEDULE_OBSERVATION,Schedule Observation
 SCHEDULE_WITHDRAWAL,Schedule Withdrawal
 SCHEDULED,(Scheduled)
 SCHEDULED_FOR,Scheduled for


### PR DESCRIPTION
- show buttons to schedule/reschedule as per requirements in PRD
- same for validation of dates
- a bunch of refactor to enable reuse of selectors
- this PR is built on top of two other PRs https://github.com/terraware/terraware-web/pull/1718 and https://github.com/terraware/terraware-web/pull/1719

<img width="1472" alt="Screen Shot 2023-09-26 at 3 56 22 PM" src="https://github.com/terraware/terraware-web/assets/1865174/c16dc338-59f7-40cf-81a3-49b47fd944dc">

<img width="741" alt="Terraware App 2023-09-26 15-58-41" src="https://github.com/terraware/terraware-web/assets/1865174/11bafa10-3b9e-4bb5-9a98-1599ec6fd4a7">

<img width="756" alt="Terraware App 2023-09-26 15-57-19" src="https://github.com/terraware/terraware-web/assets/1865174/25986781-7336-46f0-ba38-2425cc2e9589">

<img width="761" alt="Terraware App 2023-09-26 15-57-04" src="https://github.com/terraware/terraware-web/assets/1865174/9756c6dd-c476-482c-9525-8db4d732c1ba">

<img width="763" alt="Terraware App 2023-09-26 15-56-46" src="https://github.com/terraware/terraware-web/assets/1865174/e88d4763-cf05-4f6a-b12e-0d07dfca88d0">

<img width="744" alt="Terraware App 2023-09-26 15-56-35" src="https://github.com/terraware/terraware-web/assets/1865174/9b47ed57-8478-4404-89d4-530be592ef47">
