### PR TITLE
SW-4249 - Improvements to plant monitoring details in reports

### DIFF
--- a/src/components/Reports/LocationSection.tsx
+++ b/src/components/Reports/LocationSection.tsx
@@ -194,6 +194,10 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
     }
   };
 
+  const estimatedPlants = useMemo(() => {
+    return latestObservation?.estimatedPlants?.toString();
+  }, [latestObservation]);
+
   const livePlants = useMemo(() => {
     return latestObservation?.species.reduce((acc, sp) => (acc = acc + sp.permanentLive), 0);
   }, [latestObservation]);
@@ -537,7 +541,7 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
                   className={classes.infoCardStyle}
                 />
               </Grid>
-              {!latestObservation.estimatedPlants?.toString() && (
+              {!estimatedPlants && (
                 <Grid item xs={smallItemGridWidth()}>
                   <OverviewItemCard
                     isEditable={false}
@@ -561,11 +565,7 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
                 <OverviewItemCard
                   isEditable={false}
                   title={strings.EST_TOTAL_PLANTS_PLANTING_DENSITY_AREA}
-                  contents={
-                    latestObservation.estimatedPlants?.toString()
-                      ? `${latestObservation.estimatedPlants?.toString()} ${strings.PLANTS_PER_HECTARE}`
-                      : ''
-                  }
+                  contents={estimatedPlants ? `${estimatedPlants} ${strings.PLANTS_PER_HECTARE}` : ''}
                   className={classes.infoCardStyle}
                 />
               </Grid>

--- a/src/components/Reports/LocationSection.tsx
+++ b/src/components/Reports/LocationSection.tsx
@@ -226,10 +226,15 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
   }, [plantingSite]);
 
   const plantingDensityForZones = useMemo(() => {
+    const zoneNameWithDensities: string[] = [];
     if (plantingSite && plantingDensity) {
-      const zoneNameWithDensities = plantingSite.plantingZones?.map(
-        (zone) => `${zone.name}: ${plantingDensity[zone.name]}`
-      );
+      plantingSite.plantingZones?.reduce((acc, zone) => {
+        if (plantingDensity[zone.name] !== '') {
+          zoneNameWithDensities.push(`${zone.name}: ${plantingDensity[zone.name]}`);
+        }
+        return acc;
+      }, zoneNameWithDensities);
+
       return (
         (
           <Box>

--- a/src/components/Reports/LocationSection.tsx
+++ b/src/components/Reports/LocationSection.tsx
@@ -129,7 +129,7 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
     if (plantingSite) {
       dispatch(requestSiteReportedPlants(plantingSite.id));
     }
-  }, [plantingSite]);
+  }, [plantingSite, dispatch]);
 
   useEffect(() => {
     if (plantingSite) {

--- a/src/components/Reports/LocationSection.tsx
+++ b/src/components/Reports/LocationSection.tsx
@@ -22,7 +22,10 @@ import { requestObservations, requestObservationsResults } from 'src/redux/featu
 import { selectPlantingSite, selectSiteReportedPlants } from 'src/redux/features/tracking/trackingSelectors';
 import { requestSpecies } from 'src/redux/features/species/speciesThunks';
 import { requestPlantings } from 'src/redux/features/plantings/plantingsThunks';
-import { requestPlantingSitesSearchResults } from 'src/redux/features/tracking/trackingThunks';
+import {
+  requestPlantingSitesSearchResults,
+  requestSiteReportedPlants,
+} from 'src/redux/features/tracking/trackingThunks';
 import isEnabled from 'src/features';
 
 type PlantingSiteSpecies = {
@@ -121,6 +124,12 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
       dispatch(requestPlantingSitesSearchResults(selectedOrganization.id));
     }
   }, [dispatch, selectedOrganization, trackingV2]);
+
+  useEffect(() => {
+    if (plantingSite) {
+      dispatch(requestSiteReportedPlants(plantingSite.id));
+    }
+  }, [plantingSite]);
 
   useEffect(() => {
     if (plantingSite) {
@@ -528,27 +537,35 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
                   className={classes.infoCardStyle}
                 />
               </Grid>
-              <Grid item xs={smallItemGridWidth()}>
-                <OverviewItemCard
-                  isEditable={false}
-                  title={strings.PLANTING_PROGRESS_PERCENT}
-                  contents={reportedPlants?.progressPercent || ''}
-                  className={classes.infoCardStyle}
-                />
-              </Grid>
-              <Grid item xs={smallItemGridWidth()}>
-                <OverviewItemCard
-                  isEditable={false}
-                  title={strings.PLANTING_DENSITY_OF_PLANTED_ZONES}
-                  contents={plantingDensityForZones}
-                  className={classes.infoCardStyle}
-                />
-              </Grid>
+              {!latestObservation.estimatedPlants?.toString() && (
+                <Grid item xs={smallItemGridWidth()}>
+                  <OverviewItemCard
+                    isEditable={false}
+                    title={strings.PLANTING_PROGRESS_PERCENT}
+                    contents={reportedPlants?.progressPercent || ''}
+                    className={classes.infoCardStyle}
+                  />
+                </Grid>
+              )}
+              {plantingDensityForZones && (
+                <Grid item xs={smallItemGridWidth()}>
+                  <OverviewItemCard
+                    isEditable={false}
+                    title={strings.PLANTING_DENSITY_OF_PLANTED_ZONES}
+                    contents={plantingDensityForZones}
+                    className={classes.infoCardStyle}
+                  />
+                </Grid>
+              )}
               <Grid item xs={smallItemGridWidth()}>
                 <OverviewItemCard
                   isEditable={false}
                   title={strings.EST_TOTAL_PLANTS_PLANTING_DENSITY_AREA}
-                  contents={latestObservation.estimatedPlants?.toString() || ''}
+                  contents={
+                    latestObservation.estimatedPlants?.toString()
+                      ? `${latestObservation.estimatedPlants?.toString()} ${strings.PLANTS_PER_HECTARE}`
+                      : ''
+                  }
                   className={classes.infoCardStyle}
                 />
               </Grid>

--- a/src/components/Reports/LocationSection.tsx
+++ b/src/components/Reports/LocationSection.tsx
@@ -235,14 +235,14 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
         return acc;
       }, zoneNameWithDensities);
 
-      return (
-        (
-          <Box>
-            {zoneNameWithDensities?.map((zd, index) => (
-              <Box key={`zone-${index}`}>{zd}</Box>
-            ))}
-          </Box>
-        ) || ''
+      return zoneNameWithDensities.length ? (
+        <Box>
+          {zoneNameWithDensities.map((zd, index) => (
+            <Box key={`zone-${index}`}>{zd}</Box>
+          ))}
+        </Box>
+      ) : (
+        ''
       );
     }
     return '';

--- a/src/components/Reports/LocationSection.tsx
+++ b/src/components/Reports/LocationSection.tsx
@@ -126,10 +126,10 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
   }, [dispatch, selectedOrganization, trackingV2]);
 
   useEffect(() => {
-    if (plantingSite) {
+    if (plantingSite?.id) {
       dispatch(requestSiteReportedPlants(plantingSite.id));
     }
-  }, [plantingSite, dispatch]);
+  }, [plantingSite?.id, dispatch]);
 
   useEffect(() => {
     if (plantingSite) {
@@ -196,7 +196,7 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
 
   const estimatedPlants = useMemo(() => {
     return latestObservation?.estimatedPlants?.toString();
-  }, [latestObservation]);
+  }, [latestObservation?.estimatedPlants]);
 
   const livePlants = useMemo(() => {
     return latestObservation?.species.reduce((acc, sp) => (acc = acc + sp.permanentLive), 0);

--- a/src/components/Reports/LocationSection.tsx
+++ b/src/components/Reports/LocationSection.tsx
@@ -17,6 +17,7 @@ import {
   selectCurrentObservation,
   selectLatestObservation,
   selectNextObservation,
+  selectObservation,
 } from 'src/redux/features/observations/observationsSelectors';
 import { requestObservations, requestObservationsResults } from 'src/redux/features/observations/observationsThunks';
 import { selectPlantingSite, selectSiteReportedPlants } from 'src/redux/features/tracking/trackingSelectors';
@@ -106,8 +107,14 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
   const currentObservation = useAppSelector((state) =>
     selectCurrentObservation(state, location.id, defaultTimeZone.get().id)
   );
+  const currentObservationData = useAppSelector((state) =>
+    selectObservation(state, location.id, Number(currentObservation?.observationId))
+  );
   const nextObservation = useAppSelector((state) =>
     selectNextObservation(state, location.id, defaultTimeZone.get().id)
+  );
+  const nextObservationData = useAppSelector((state) =>
+    selectObservation(state, location.id, Number(nextObservation?.observationId))
   );
   const latestObservation = useAppSelector((state) =>
     selectLatestObservation(state, location.id, defaultTimeZone.get().id)
@@ -247,6 +254,16 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
     }
     return '';
   }, [plantingSite, plantingDensity]);
+
+  const currentNextObservationDates = useMemo(() => {
+    if (currentObservationData) {
+      return `${currentObservationData.startDate} - ${currentObservationData.endDate}`;
+    }
+    if (nextObservationData) {
+      return `${nextObservationData.startDate} - ${nextObservationData.endDate}`;
+    }
+    return '';
+  }, [currentObservationData, nextObservationData]);
 
   return (
     <>
@@ -492,9 +509,7 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
                 <OverviewItemCard
                   isEditable={false}
                   title={strings.CURRENT_NEXT_OBSERVATION}
-                  contents={`${currentObservation ? currentObservation?.startDate : ''} - ${
-                    nextObservation ? nextObservation?.startDate : ''
-                  }`}
+                  contents={currentNextObservationDates}
                   className={classes.infoCardStyle}
                 />
               </Grid>


### PR DESCRIPTION
Fixes in this PR include: 
- Planting progress is not populating at all
- Planting progress should not be shown when we have planting density for the whole site
- Planting density per zone should not be shown if we don’t have any values
- Planting density should be labeled with the units (Plants/ha)