### PR TITLE
SW-3157 Convert to new seed/weight calculator and withdraw modal logic

### DIFF
--- a/src/components/accession2/edit/QuantityModal.tsx
+++ b/src/components/accession2/edit/QuantityModal.tsx
@@ -2,14 +2,15 @@ import React, { useEffect, useState } from 'react';
 import strings from 'src/strings';
 import Button from 'src/components/common/button/Button';
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
-import { Box, Grid, useTheme } from '@mui/material';
+import { Box, Grid, useTheme, Radio, RadioGroup, FormControlLabel, Typography, Theme } from '@mui/material';
+
+import { makeStyles } from '@mui/styles';
 import { Textfield } from '@terraware/web-components';
 import { Accession } from 'src/types/Accession';
 import AccessionService from 'src/services/AccessionService';
 import useForm from 'src/utils/useForm';
 import { isUnitInPreferredSystem, Unit, usePreferredWeightUnits } from 'src/units';
 import useSnackbar from 'src/utils/useSnackbar';
-import CalculatorModal from './CalculatorModal';
 import { Dropdown } from '@terraware/web-components';
 import Link from 'src/components/common/Link';
 import EditState from './EditState';
@@ -17,6 +18,22 @@ import _ from 'lodash';
 import { useUser } from 'src/providers';
 import ConvertedValue from 'src/components/ConvertedValue';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
+import Icon from 'src/components/common/icon/Icon';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  addIcon: {
+    fill: theme.palette.TwClrIcnBrand,
+    height: '20px',
+    width: '20px',
+  },
+  units: {
+    marginLeft: theme.spacing(0.5),
+  },
+  subset: {
+    borderTop: `1px solid ${theme.palette.TwClrBrdrTertiary}`,
+    paddingTop: theme.spacing(2),
+  },
+}));
 
 export interface QuantityModalProps {
   open: boolean;
@@ -31,14 +48,21 @@ export default function QuantityModal(props: QuantityModalProps): JSX.Element {
   const { onClose, open, accession, reload, statusEdit } = props;
 
   const [record, setRecord, onChange] = useForm(accession);
-  const [isCalculatorOpened, setIsCalculatorOpened] = useState(false);
+  const [isSubsetOpen, setIsSubsetOpen] = useState(false);
   const [quantityError, setQuantityError] = useState(false);
   const theme = useTheme();
   const snackbar = useSnackbar();
   const preferredUnits = usePreferredWeightUnits();
   const { userPreferences } = useUser();
   const { isMobile } = useDeviceInfo();
+  const [isByWeight, setIsByWeight] = useState(!(accession.remainingQuantity?.units === 'Seeds'));
 
+  const [subsetError, setSubsetError] = useState('');
+  const [subsetWeightError, setSubsetWeightError] = useState('');
+
+  const [subsetCountError, setSubsetCountError] = useState('');
+  const [totalWeightError, setTotalWeightError] = useState('');
+  const classes = useStyles();
   const validate = () => {
     const quantity = parseFloat(record.remainingQuantity?.quantity as unknown as string);
     if (isNaN(quantity) || quantity < 0) {
@@ -88,17 +112,6 @@ export default function QuantityModal(props: QuantityModalProps): JSX.Element {
     }
   };
 
-  const onChangeUnit = (newValue: string) => {
-    if (record) {
-      setRecord({
-        ...record,
-        remainingQuantity: {
-          quantity: record.remainingQuantity?.quantity || 0,
-          units: newValue as Unit['value'],
-        },
-      });
-    }
-  };
   const gridSize = () => (isMobile ? 12 : 6);
 
   const onChangeStatus = (id: string, value: unknown) => {
@@ -107,33 +120,70 @@ export default function QuantityModal(props: QuantityModalProps): JSX.Element {
 
   const onCloseHandler = () => {
     setRecord(accession);
+    setIsSubsetOpen(false);
+    setIsByWeight(!(record.remainingQuantity?.units === 'Seeds'));
     onClose();
   };
 
-  const openCalculator = () => {
-    setIsCalculatorOpened(true);
+  const showSubset = () => {
+    setIsSubsetOpen(true);
+  };
+
+  const onChangeQuantityBy = (_: React.ChangeEvent<HTMLInputElement>, value: string) => {
+    if (value === 'count') {
+      setIsByWeight(false);
+    } else if (value === 'weight') {
+      setIsByWeight(true);
+    }
+  };
+
+  const onChangeRemainingQuantityUnit = (newValue: string) => {
+    setTotalWeightError('');
+    if (record) {
+      setRecord({
+        ...record,
+        remainingQuantity: { quantity: record.remainingQuantity?.quantity || 0, units: newValue as Unit['value'] },
+      });
+    }
+  };
+
+  const onChangeSubsetWeight = (value: any) => {
+    setSubsetWeightError('');
+    setSubsetError('');
+    setRecord({
+      ...record,
+      subsetWeight: { quantity: value, units: record.subsetWeight?.units || 'Grams' },
+    });
+  };
+
+  const onChangeSubsetUnit = (newValue: string) => {
+    setSubsetWeightError('');
+    setSubsetError('');
+    setRecord({
+      ...record,
+      subsetWeight: { quantity: record.subsetWeight?.quantity || 0, units: newValue as Unit['value'] },
+    });
+  };
+
+  const onChangeSubsetCount = (value: number) => {
+    setSubsetCountError('');
+    onChange('subsetCount', value);
   };
 
   const hasChanged =
     (!statusEdit || accession.state !== record.state) &&
     (!_.isEqual(accession.remainingQuantity, record.remainingQuantity) ||
-      !_.isEqual(accession.estimatedCount, record.estimatedCount));
+      !_.isEqual(accession.estimatedCount, record.estimatedCount) ||
+      !_.isEqual(accession.subsetCount, record.subsetCount) ||
+      !_.isEqual(accession.subsetWeight?.units, record.subsetWeight?.units) ||
+      !_.isEqual(accession.subsetWeight?.quantity, record.subsetWeight?.quantity));
 
   return (
     <>
-      <CalculatorModal
-        open={isCalculatorOpened}
-        onClose={() => setIsCalculatorOpened(false)}
-        record={record}
-        setRecord={setRecord}
-        onChange={onChange}
-        reload={reload}
-        onPrevious={() => setIsCalculatorOpened(false)}
-      />
       <DialogBox
         scrolled={true}
         onClose={onCloseHandler}
-        open={open && !isCalculatorOpened}
+        open={open}
         title={props.title}
         size='medium'
         middleButtons={[
@@ -161,81 +211,144 @@ export default function QuantityModal(props: QuantityModalProps): JSX.Element {
         )}
         <Grid container spacing={2}>
           <Grid item xs={12} textAlign='left'>
-            <Textfield
-              label={strings.SEED_COUNT}
-              id='seedsQuantity'
-              onChange={(value) => onChangeRemainingQuantity('seedsQuantity', Number(value))}
-              type='number'
-              value={
-                record.remainingQuantity?.units === 'Seeds'
-                  ? record.remainingQuantity?.quantity.toString()
-                  : record.estimatedCount?.toString()
-              }
-              errorText={
-                quantityError
-                  ? record.remainingQuantity?.quantity
-                    ? strings.INVALID_VALUE
-                    : strings.REQUIRED_FIELD
-                  : ''
-              }
-              disabledCharacters={[',', '.', '-']}
-            />
-          </Grid>
-          <Grid
-            item
-            xs={12}
-            display='flex'
-            flexDirection={isMobile ? 'column' : 'row'}
-            textAlign='left'
-            alignItems='end'
-          >
-            <Grid item xs={gridSize()} marginTop={theme.spacing(2)} width='100%'>
-              <Textfield
-                label={strings.OR_SEED_WEIGHT}
-                id='quantity'
-                onChange={(value) => onChangeRemainingQuantity('quantity', value)}
-                type='number'
-                value={record.remainingQuantity?.units !== 'Seeds' ? record.remainingQuantity?.quantity : ''}
-              />
-            </Grid>
-            <Grid
-              item
-              xs={gridSize()}
-              marginTop={theme.spacing(2)}
-              marginLeft={isMobile ? '0px' : theme.spacing(0.5)}
-              width='100%'
+            <Typography color={theme.palette.TwClrTxtSecondary} display='flex' fontSize={14}>
+              {strings.SEED_QUANTITY_BY}
+            </Typography>
+            <RadioGroup
+              name='radio-buttons-seed-quantity-by'
+              defaultValue={accession.remainingQuantity?.units === 'Seeds' ? 'count' : 'weight'}
+              onChange={onChangeQuantityBy}
             >
-              <Dropdown
-                options={preferredUnits}
-                placeholder={strings.SELECT}
-                onChange={onChangeUnit}
-                selectedValue={record.remainingQuantity?.units}
-                fullWidth={true}
-              />
-            </Grid>
+              <Grid item xs={12} textAlign='left' display='flex' flexDirection='row'>
+                <FormControlLabel value='count' control={<Radio />} label={strings.COUNT} />
+                <FormControlLabel value='weight' control={<Radio />} label={strings.WEIGHT} />
+              </Grid>
+            </RadioGroup>
           </Grid>
           <Grid item xs={12} textAlign='left'>
-            {record.remainingQuantity?.units &&
-              record.remainingQuantity?.units !== 'Seeds' &&
-              !isUnitInPreferredSystem(
-                record.remainingQuantity.units,
-                userPreferences.preferredWeightSystem as string
-              ) && (
+            {!isByWeight ? (
+              <Textfield
+                label={strings.SEED_COUNT}
+                id='seedsQuantity'
+                onChange={(value) => onChangeRemainingQuantity('seedsQuantity', Number(value))}
+                type='number'
+                value={
+                  record.remainingQuantity?.units === 'Seeds'
+                    ? record.remainingQuantity?.quantity.toString()
+                    : record.estimatedCount?.toString()
+                }
+                errorText={
+                  quantityError
+                    ? record.remainingQuantity?.quantity
+                      ? strings.INVALID_VALUE
+                      : strings.REQUIRED_FIELD
+                    : ''
+                }
+                disabledCharacters={[',', '.', '-']}
+                required={true}
+              />
+            ) : (
+              <Box display='flex' textAlign='left' alignItems='end'>
+                <Textfield
+                  label={strings.TOTAL_WEIGHT}
+                  id='remainingQuantity'
+                  onChange={(value) => onChangeRemainingQuantity('weight', value as number)}
+                  type='number'
+                  min={0}
+                  disabledCharacters={['-']}
+                  value={
+                    record.remainingQuantity?.units === 'Seeds'
+                      ? record.estimatedWeight?.quantity.toString()
+                      : record.remainingQuantity?.quantity.toString()
+                  }
+                  errorText={totalWeightError}
+                />
+                <Box height={totalWeightError ? '85px' : 'auto'}>
+                  <Dropdown
+                    options={preferredUnits}
+                    placeholder={strings.SELECT}
+                    onChange={onChangeRemainingQuantityUnit}
+                    selectedValue={
+                      record.remainingQuantity?.units === 'Seeds'
+                        ? record.estimatedWeight?.units
+                        : record.remainingQuantity?.units
+                    }
+                    fullWidth={true}
+                    className={classes.units}
+                  />
+                </Box>
+              </Box>
+            )}
+          </Grid>
+          {record.remainingQuantity?.units &&
+            record.remainingQuantity?.units !== 'Seeds' &&
+            !isUnitInPreferredSystem(
+              record.remainingQuantity.units,
+              userPreferences.preferredWeightSystem as string
+            ) && (
+              <Grid item xs={12} textAlign='left'>
                 <ConvertedValue
                   quantity={record.remainingQuantity.quantity}
                   unit={record.remainingQuantity.units}
                   showTooltip={true}
                 />
-              )}
-          </Grid>
-          <Grid item xs={12} sx={{ marginTop: theme.spacing(2) }}>
-            {!isCalculatorOpened ? (
+              </Grid>
+            )}
+          <Grid item xs={12}>
+            {!isSubsetOpen ? (
               <Box display='flex' justifyContent='flex-start'>
-                <Link id='addNotes' onClick={openCalculator} fontSize='16px'>
-                  {`${strings.WEIGHT_TO_COUNT_CALCULATOR}`}
+                <Link id='addNotes' onClick={showSubset} fontSize='16px'>
+                  <Box display='flex' alignItems='center'>
+                    <Icon name='iconAdd' className={classes.addIcon} />
+                    &nbsp;{`${strings.ADD_SUBSET_WEIGHT_AND_COUNT}`}
+                  </Box>
                 </Link>
               </Box>
-            ) : null}
+            ) : (
+              <Box className={classes.subset}>
+                <Grid container item justifyContent='space-between'>
+                  <Grid container item xs={isMobile ? 12 : 7} spacing={1}>
+                    <Grid item xs={8}>
+                      <Textfield
+                        label={strings.SUBSET_WEIGHT}
+                        id='subsetWeight'
+                        onChange={(value) => onChangeSubsetWeight(value)}
+                        type='number'
+                        min={0}
+                        disabledCharacters={['-']}
+                        value={record.subsetWeight?.quantity}
+                        errorText={subsetError || subsetWeightError}
+                        tooltipTitle={strings.ENTER_SUBSET_WEIGHT_AND_COUNT}
+                      />
+                    </Grid>
+                    <Grid item xs={4}>
+                      <Box height={subsetWeightError ? '85px' : subsetError ? '65px' : 'auto'} paddingTop='24px'>
+                        <Dropdown
+                          label=''
+                          options={preferredUnits}
+                          placeholder={strings.SELECT}
+                          onChange={onChangeSubsetUnit}
+                          selectedValue={record.subsetWeight?.units}
+                          fullWidth={true}
+                        />
+                      </Box>
+                    </Grid>
+                  </Grid>
+                  <Grid item xs={isMobile ? 12 : 4} paddingTop={isMobile ? '4px' : '0px'}>
+                    <Textfield
+                      label={strings.SUBSET_COUNT}
+                      id='subsetCount'
+                      onChange={(value) => onChangeSubsetCount(value as number)}
+                      type='number'
+                      min={0}
+                      disabledCharacters={['.', ',', '-']}
+                      value={record.subsetCount}
+                      errorText={subsetCountError}
+                    />
+                  </Grid>
+                </Grid>
+              </Box>
+            )}
           </Grid>
         </Grid>
       </DialogBox>

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -62,6 +62,7 @@ ADD_SEEDLING_BATCH,Add Seedling Batch
 ADD_SPECIES,Add Species
 ADD_SPECIES_MANUALLY_DESCRIPTION,"Enter scientific name and other optional fields manually, one species at a time."
 ADD_SUB_LOCATION,Add Sub-Location
+ADD_SUBSET_WEIGHT_AND_COUNT,Add Subset Weight And Count
 ADD_TEST,Add Test
 ADD_VIABILITY,Add Viability
 ADD_VIABILITY_TEST,Add Viability Test
@@ -84,6 +85,7 @@ ALL_SEEDS_WITHDRAWN_MSG,"As all seeds have been withdrawn, new withdrawals are d
 ALL_SENSORS_FOUND,All sensors found.
 ALREADY_INVITED_PERSON_ERROR,It looks like you have already added or invited this person. Please enter a unique email address or go to the existing person’s profile.
 AMOUNT_REMAINING,Amount ({0} remaining)
+AMOUNT_EST_COUNT,Amount (Est. Count)
 APPLY,Apply
 APPLY_FILTERS,Apply Filters
 APPLY_RESULT,Apply Result
@@ -311,6 +313,7 @@ END_DRYING_REMINDER,End-Drying Reminder
 END_DRYING_REMINDER_OFF,End-drying Reminder Off
 ENDANGERED,Endangered
 ENTER_SIX_DIGIT_KEY,Enter 6-digit key
+ENTER_SUBSET_WEIGHT_AND_COUNT,"Enter Subset Weight and Count ratio to determine approximate seed count when withdrawing by weight from a count quantity. (Conversely, the ratio will determine approximate remaining quantity when withdrawing by count from a weight quantity.) These fields are useful when counting tiny seeds is not practical and only required if you intend to withdraw from this accession to a nursery."
 ENVIRONMENTAL_NOTES,Environmental Notes
 ENVIRONMENTAL_NOTES_PLACEHOLDER,"Important notes about landscape, climate, and environmental conditions"
 EST_READY_DATE,Est. Ready Date
@@ -1005,6 +1008,7 @@ SEED_COLLECTION_DETAIL,Seed Details
 SEED_COLLECTION_DETAIL_DESC,Enter this accession’s seed information below.
 SEED_COUNT,Seed Count
 SEED_DASHBOARD,Seed Dashboard
+SEED_QUANTITY_BY,Seed Quantity By
 SEED_STORAGE_BEHAVIOR,Seed Storage Behavior
 SEED_TYPE,Seed Type
 SEED_WEIGHT,Seed Weight
@@ -1128,8 +1132,9 @@ SUB_LOCATIONS,Sub-Locations
 SUBMITTED,Submitted
 SUBMITTED_BY,Submitted By
 SUBSET_COUNT,Subset Count
-SUBSET_WEIGHT,Weight of Seed Subset
+SUBSET_WEIGHT,Subset Weight
 SUBSET_WEIGHT_ERROR,Subset weight should be less than seed weight
+SUBSET_WEIGHT_REQUIRED,"You must enter in a subset weight and count in order to determine approximate seed count when withdrawing to a nursery. This can be done by editing the quantity of this accession."
 SUBSHRUB,Subshrub
 SUBSTRATE,Substrate
 SUBTITLE_GET_STARTED,"To get started, please create your organization now. You'll also be able to set up and manage information on people and species."
@@ -1165,6 +1170,7 @@ TEST_METHOD,Test Method
 TEST_METHOD_REQUIRED,Test Method *
 TEST_TYPE,Test Type
 TESTING_STAFF,Testing Staff
+TILDE,"~"
 TIME,Time
 TIME_PERIOD,Time Period
 TIME_ZONE,Time Zone
@@ -1241,6 +1247,7 @@ TOTAL_PLANTS_PLANTED_HELPER_TEXT,Species not classified as “trees” in the sp
 TOTAL_QUANTITY,Total Quantity
 TOTAL_READY_QUANTITY,Total Ready Quantity
 TOTAL_SEED_COUNT,Total Seed Count
+TOTAL_SEED_WEIGHT,Total Seed Weight
 TOTAL_SEEDLINGS_SENT,Total Seedlings Sent
 TOTAL_SEEDS_COUNT_ESTIMATION,Total Seeds Count Estimation
 TOTAL_SEEDS_GERMINATED,Total Seeds Germinated
@@ -1313,6 +1320,7 @@ VIEW_SITES_ZONES_SUBZONES,"View Sites, Zones, and Subzones on a map."
 VINE,Vine,A type of plant.
 WAITING_TO_DOWNLOAD,Waiting to download...
 WATTS_VALUE,{0}W
+WEIGHT,Weight
 WEIGHT_GRAMS,Weight (g)
 WEIGHT_KILOGRAMS,Weight (kg)
 WEIGHT_MILLIGRAMS,Weight (mg)
@@ -1330,6 +1338,7 @@ WILD_IN_SITU_DESCRIPTION,Plants that occur naturally in wild areas and were not 
 WITH_MAP,With Map
 WITHDRAW,Withdraw
 WITHDRAW_ALL,Withdraw all
+WITHDRAW_BY,Withdraw By
 WITHDRAW_DATE_REQUIRED,Withdraw Date *
 WITHDRAW_FROM_BATCHES,Withdraw from Batches
 WITHDRAW_INSTRUCTIONS,Select a withdrawal purpose and enter the quantities from each batch to withdraw.

--- a/src/units.ts
+++ b/src/units.ts
@@ -75,6 +75,7 @@ export function getUnitsForSystem(system: string) {
 }
 
 export function convertValue(value: number, unit: string) {
+  //We are just switching between imperial and metric, but don't care about the output unit
   switch (unit) {
     case 'Grams': {
       return `${(value * 0.035274).toFixed(2)} ${getUnitName('Ounces')}`;
@@ -93,6 +94,110 @@ export function convertValue(value: number, unit: string) {
     }
     default: {
       return `${value} ${getUnitName(unit)}`;
+    }
+  }
+}
+
+export function convertUnits(value: number, unit: string, outputUnit: string) {
+  //We want to switch between specific units
+  switch (unit) {
+    case 'Grams': {
+      switch (outputUnit) {
+        case 'Ounces': {
+          return value * 0.035274;
+        }
+        case 'Pounds': {
+          return value * 0.002204;
+        }
+        case 'Milligrams': {
+          return value * 1000;
+        }
+        case 'Kilograms': {
+          return value * 0.001;
+        }
+        default: {
+          return value;
+        }
+      }
+    }
+    case 'Kilograms': {
+      switch (outputUnit) {
+        case 'Ounces': {
+          return value * 35.274;
+        }
+        case 'Pounds': {
+          return value * 2.20462;
+        }
+        case 'Milligrams': {
+          return value * 1000000;
+        }
+        case 'Grams': {
+          return value * 1000;
+        }
+        default: {
+          return value;
+        }
+      }
+    }
+    case 'Milligrams': {
+      switch (outputUnit) {
+        case 'Ounces': {
+          return value * 0.035274;
+        }
+        case 'Pounds': {
+          return value * 2.20462e-6;
+        }
+        case 'Grams': {
+          return value * 0.001;
+        }
+        case 'Kilograms': {
+          return value * 0.000001;
+        }
+        default: {
+          return value;
+        }
+      }
+    }
+    case 'Pounds': {
+      switch (outputUnit) {
+        case 'Ounces': {
+          return value * 0.035274;
+        }
+        case 'Grams': {
+          return value * 0.035274;
+        }
+        case 'Milligrams': {
+          return value * 0.035274;
+        }
+        case 'Kilograms': {
+          return value * 0.035274;
+        }
+        default: {
+          return value;
+        }
+      }
+    }
+    case 'Ounces': {
+      switch (outputUnit) {
+        case 'Grams': {
+          return value * 28.3495;
+        }
+        case 'Pounds': {
+          return value * 0.0625;
+        }
+        case 'Milligrams': {
+          return value * 28349.5;
+        }
+        case 'Kilograms': {
+          return value * 0.0283495;
+        }
+        default: {
+          return value;
+        }
+      }
+    }
+    default: {
+      return 0;
     }
   }
 }


### PR DESCRIPTION
If a user has both a subset weight and subset count allow them to withdraw in either seeds or weight.  For nursery transfers and viability test convert all weight withdrawals to seed count.  Otherwise perform withdrawal in the units selected.
<img width="488" alt="Screen Shot 2023-10-11 at 12 12 15 PM" src="https://github.com/terraware/terraware-web/assets/104874529/fa405675-7a00-4b4b-95bf-7d3e6419091f">
<img width="489" alt="Screen Shot 2023-10-11 at 12 12 23 PM" src="https://github.com/terraware/terraware-web/assets/104874529/395c9206-2f68-4f65-8c4b-ed4cd2e4d951">
<img width="485" alt="Screen Shot 2023-10-11 at 12 12 31 PM" src="https://github.com/terraware/terraware-web/assets/104874529/9fc650f2-de8b-453e-9a78-220fbcb38c33">
<img width="489" alt="Screen Shot 2023-10-11 at 12 12 58 PM" src="https://github.com/terraware/terraware-web/assets/104874529/76bcea70-e5c4-44a7-bedd-6b54dfe907b9">
<img width="485" alt="Screen Shot 2023-10-11 at 12 13 13 PM" src="https://github.com/terraware/terraware-web/assets/104874529/9951add4-20bf-48bc-bafc-54a519dc0e19">
<img width="485" alt="Screen Shot 2023-10-11 at 12 17 45 PM" src="https://github.com/terraware/terraware-web/assets/104874529/68b4646c-8017-4471-b1bf-101711b00846">
