### PR TITLE
SW-4319 Redux/service/types for replacing an observation monitoring plot

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -344,6 +344,10 @@ export interface paths {
   "/api/v1/tracking/observations/{observationId}/plots/{plotId}/release": {
     post: operations["releaseMonitoringPlot"];
   };
+  "/api/v1/tracking/observations/{observationId}/plots/{plotId}/replace": {
+    /** Additional monitoring plots may be replaced as well, e.g., if the requested plot is part of a permanent cluster. In some cases, the requested plot will be removed from the observation but not replaced with a different one. */
+    post: operations["replaceObservationPlot"];
+  };
   "/api/v1/tracking/observations/{observationId}/results": {
     /** Some information is only available once all plots have been completed. */
     get: operations["getObservationResults"];
@@ -2443,6 +2447,17 @@ export interface components {
       /** @description If certainty is Other, the optional user-supplied name of the species. Ignored if certainty is Known or Unknown. */
       speciesName?: string;
       status: "Live" | "Dead" | "Existing";
+    };
+    ReplaceObservationPlotRequestPayload: {
+      duration: "Temporary" | "LongTerm";
+      justification: string;
+    };
+    ReplaceObservationPlotResponsePayload: {
+      /** @description IDs of monitoring plots that were added to the observation. Empty if no plots were added. */
+      addedMonitoringPlotIds: number[];
+      /** @description IDs of monitoring plots that were removed from the observation. Will usually include the requested plot ID, but may be empty if the replacement request couldn't be satisfied. */
+      removedMonitoringPlotIds: number[];
+      status: components["schemas"]["SuccessOrError"];
     };
     RescheduleObservationRequestPayload: {
       /**
@@ -5764,6 +5779,34 @@ export interface operations {
         content: {
           "application/json": components["schemas"]["SimpleErrorResponsePayload"];
         };
+      };
+    };
+  };
+  /** Additional monitoring plots may be replaced as well, e.g., if the requested plot is part of a permanent cluster. In some cases, the requested plot will be removed from the observation but not replaced with a different one. */
+  replaceObservationPlot: {
+    parameters: {
+      path: {
+        observationId: number;
+        plotId: number;
+      };
+    };
+    responses: {
+      /** The requested operation succeeded. */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ReplaceObservationPlotResponsePayload"];
+        };
+      };
+      /** The observation does not exist or does not have the requested monitoring plot. */
+      404: {
+        content: {
+          "application/json": components["schemas"]["SimpleErrorResponsePayload"];
+        };
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ReplaceObservationPlotRequestPayload"];
       };
     };
   };

--- a/src/redux/features/asyncUtils.ts
+++ b/src/redux/features/asyncUtils.ts
@@ -2,16 +2,22 @@ import { ActionReducerMapBuilder, AsyncThunk, CaseReducers } from '@reduxjs/tool
 
 export type Statuses = 'pending' | 'success' | 'error';
 
-export type Status = { status: Statuses };
+export type StatusT<T> = { status: Statuses; data?: T };
+
+export type Status = StatusT<unknown>; // when data is not relevant in the response
 
 export const buildReducers =
-  (asyncThunk: AsyncThunk<any, any, any>) => (builder: CaseReducers<any, any> | ActionReducerMapBuilder<any>) =>
+  <T>(asyncThunk: AsyncThunk<any, any, any>) =>
+  (builder: CaseReducers<any, any> | ActionReducerMapBuilder<any>) =>
     (builder as any)
-      .addCase(asyncThunk.pending, setStatus('pending'))
-      .addCase(asyncThunk.fulfilled, setStatus('success'))
-      .addCase(asyncThunk.rejected, setStatus('error'));
+      .addCase(asyncThunk.pending, setStatus<T>('pending'))
+      .addCase(asyncThunk.fulfilled, setStatus<T>('success'))
+      .addCase(asyncThunk.rejected, setStatus<T>('error'));
 
-const setStatus = (status: Statuses) => (state: any, action: any) => {
-  const requestId = action.meta.requestId;
-  state[requestId] = { status };
-};
+const setStatus =
+  <T>(status: Statuses) =>
+  (state: any, action: any) => {
+    const requestId = action.meta.requestId;
+    const data: T = action.payload as T;
+    state[requestId] = { status, data };
+  };

--- a/src/redux/features/observations/observationsAsyncThunks.ts
+++ b/src/redux/features/observations/observationsAsyncThunks.ts
@@ -1,6 +1,11 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { ObservationsService, Response } from 'src/services';
-import { ScheduleObservationRequestPayload, RescheduleObservationRequestPayload } from 'src/types/Observations';
+import {
+  ScheduleObservationRequestPayload,
+  ReplaceObservationPlotRequestPayload,
+  ReplaceObservationPlotResponsePayload,
+  RescheduleObservationRequestPayload,
+} from 'src/types/Observations';
 import strings from 'src/strings';
 
 export const requestScheduleObservation = createAsyncThunk(
@@ -26,6 +31,29 @@ export const requestRescheduleObservation = createAsyncThunk(
     const response: Response = await ObservationsService.rescheduleObservation(observationId, request);
     if (response.requestSucceeded) {
       return true;
+    }
+
+    return rejectWithValue(response.error || strings.GENERIC_ERROR);
+  }
+);
+
+export type ReplaceObservationPlotRequest = {
+  observationId: number;
+  plotId: number;
+  request: ReplaceObservationPlotRequestPayload;
+};
+
+export const requestReplaceObservationPlot = createAsyncThunk(
+  'replaceObservationPlot',
+  async ({ observationId, plotId, request }: ReplaceObservationPlotRequest, { rejectWithValue }) => {
+    const response: Response & ReplaceObservationPlotResponsePayload = await ObservationsService.replaceObservationPlot(
+      observationId,
+      plotId,
+      request
+    );
+    if (response.requestSucceeded) {
+      const { addedMonitoringPlotIds, removedMonitoringPlotIds } = response;
+      return { addedMonitoringPlotIds, removedMonitoringPlotIds };
     }
 
     return rejectWithValue(response.error || strings.GENERIC_ERROR);

--- a/src/redux/features/observations/observationsSelectors.ts
+++ b/src/redux/features/observations/observationsSelectors.ts
@@ -177,6 +177,11 @@ export const selectScheduleObservation = (state: RootState, requestId: string) =
 export const selectRescheduleObservation = (state: RootState, requestId: string) =>
   (state.rescheduleObservation as any)[requestId];
 
+// replace observation plot selectors
+
+export const selectReplaceObservationPlot = (state: RootState, requestId: string) =>
+  (state.replaceObservationPlot as any)[requestId];
+
 // get the current observation for a planting site
 export const selectCurrentObservation = createCachedSelector(
   (state: RootState, plantingSiteId: number, defaultTimeZoneId: string) =>

--- a/src/redux/features/observations/observationsSlice.ts
+++ b/src/redux/features/observations/observationsSlice.ts
@@ -1,7 +1,11 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { Observation, ObservationResultsPayload } from 'src/types/Observations';
-import { requestScheduleObservation, requestRescheduleObservation } from './observationsAsyncThunks';
-import { buildReducers, Status } from 'src/redux/features/asyncUtils';
+import { Observation, ObservationResultsPayload, ReplaceObservationPlotResponsePayload } from 'src/types/Observations';
+import {
+  requestScheduleObservation,
+  requestReplaceObservationPlot,
+  requestRescheduleObservation,
+} from './observationsAsyncThunks';
+import { buildReducers, Status, StatusT } from 'src/redux/features/asyncUtils';
 
 // Define a type for the slice state
 type ResultsData = {
@@ -74,6 +78,8 @@ const plantingSiteObservationsResultsSlice = createSlice({
 export const { setPlantingSiteObservationsResultsAction } = plantingSiteObservationsResultsSlice.actions;
 export const plantingSiteObservationsResultsReducer = plantingSiteObservationsResultsSlice.reducer;
 
+// Schedule/Reschedule observation
+
 type SchedulingState = Record<string, Status>;
 
 const initialSchedulingState: SchedulingState = {};
@@ -94,3 +100,18 @@ const rescheduleObservationSlice = createSlice({
 
 export const scheduleObservationReducer = scheduleObservationSlice.reducer;
 export const rescheduleObservationReducer = rescheduleObservationSlice.reducer;
+
+// Replace observation plot
+
+type ReplaceObservationPlotState = Record<string, StatusT<ReplaceObservationPlotResponsePayload>>;
+
+const initialReplaceObservationPlotState: ReplaceObservationPlotState = {};
+
+const replaceObservationPlotSlice = createSlice({
+  name: 'replaceObservationPlot',
+  initialState: initialReplaceObservationPlotState,
+  reducers: {},
+  extraReducers: buildReducers<ReplaceObservationPlotResponsePayload>(requestReplaceObservationPlot),
+});
+
+export const replaceObservationPlotReducer = replaceObservationPlotSlice.reducer;

--- a/src/redux/rootReducer.ts
+++ b/src/redux/rootReducer.ts
@@ -5,6 +5,7 @@ import {
   observationsResultsReducer,
   plantingSiteObservationsResultsReducer,
   scheduleObservationReducer,
+  replaceObservationPlotReducer,
   rescheduleObservationReducer,
 } from './features/observations/observationsSlice';
 import {
@@ -42,6 +43,7 @@ export const reducers = {
   userAnalytics: userAnalyticsReducer,
   scheduleObservation: scheduleObservationReducer,
   rescheduleObservation: rescheduleObservationReducer,
+  replaceObservationPlot: replaceObservationPlotReducer,
 };
 const combinedReducers = combineReducers(reducers);
 

--- a/src/services/ObservationsService.ts
+++ b/src/services/ObservationsService.ts
@@ -3,8 +3,10 @@ import HttpService, { Response } from './HttpService';
 import {
   Observation,
   ObservationResultsPayload,
-  ScheduleObservationRequestPayload,
+  ReplaceObservationPlotRequestPayload,
+  ReplaceObservationPlotResponsePayload,
   RescheduleObservationRequestPayload,
+  ScheduleObservationRequestPayload,
 } from 'src/types/Observations';
 
 /**
@@ -14,6 +16,7 @@ import {
 const OBSERVATIONS_RESULTS_ENDPOINT = '/api/v1/tracking/observations/results';
 const OBSERVATIONS_ENDPOINT = '/api/v1/tracking/observations';
 const OBSERVATION_ENDPOINT = '/api/v1/tracking/observations/{observationId}';
+const REPLACE_OBSERVATION_PLOT_ENDPOINT = '/api/v1/tracking/observations/{observationId}/plots/{plotId}/replace';
 
 type ObservationsResultsResponsePayload =
   paths[typeof OBSERVATIONS_RESULTS_ENDPOINT]['get']['responses'][200]['content']['application/json'];
@@ -90,14 +93,35 @@ const rescheduleObservation = async (
     entity: request,
   });
 
+const replaceObservationPlot = async (
+  observationId: number,
+  plotId: number,
+  request: ReplaceObservationPlotRequestPayload
+): Promise<Response & ReplaceObservationPlotResponsePayload> => {
+  const serverResponse: Response = await HttpService.root(REPLACE_OBSERVATION_PLOT_ENDPOINT).post({
+    urlReplacements: {
+      '{observationId}': observationId.toString(),
+      '{plotId}': plotId.toString(),
+    },
+    entity: request,
+  });
+
+  return {
+    ...serverResponse,
+    addedMonitoringPlotIds: serverResponse.data?.addedMonitoringPlotIds ?? [],
+    removedMonitoringPlotIds: serverResponse.data?.removedMonitoringPlotIds ?? [],
+  };
+};
+
 /**
  * Exported functions
  */
 const ObservationsService = {
   listObservationsResults,
   listObservations,
-  scheduleObservation,
+  replaceObservationPlot,
   rescheduleObservation,
+  scheduleObservation,
 };
 
 export default ObservationsService;

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -521,6 +521,7 @@ LOCATION_REQUIRED,Location *
 LOCATIONS,Locations
 LOCKED,Locked
 LOG_OUT,Log Out
+LONG_TERM_PERMANENT,Long-Term/Permanent
 LOSS_RATE,Loss Rate
 LOWEST,Lowest
 MANAGER,Manager

--- a/src/types/Observations.ts
+++ b/src/types/Observations.ts
@@ -11,6 +11,13 @@ export type RescheduleObservationRequestPayload = components['schemas']['Resched
 // "Upcoming" | "InProgress" | "Completed" | "Overdue"
 export type ObservationState = Observation['state'];
 
+// plot replacement
+export type ReplaceObservationPlotRequestPayload = components['schemas']['ReplaceObservationPlotRequestPayload'];
+export type ReplaceObservationPlotResponseFullPayload = components['schemas']['ReplaceObservationPlotResponsePayload'];
+export type ReplaceObservationPlotResponsePayload = Omit<ReplaceObservationPlotResponseFullPayload, 'status'>;
+// "Temporary" | "LongTerm"
+export type ReplaceObservationPlotDuration = ReplaceObservationPlotRequestPayload['duration'];
+
 type Boundary = {
   boundary: MultiPolygon;
 };
@@ -88,6 +95,17 @@ export const getPlotStatus = (status?: MonitoringPlotStatus): string => {
       return strings.IN_PROGRESS;
     case 'Outstanding':
       return strings.OBSERVATION_STATUS_OUTSTANDING;
+    default:
+      return '';
+  }
+};
+
+export const getReplaceObservationPlotDuration = (duration: ReplaceObservationPlotDuration): string => {
+  switch (duration) {
+    case 'Temporary':
+      return strings.TEMPORARY;
+    case 'LongTerm':
+      return strings.LONG_TERM_PERMANENT;
     default:
       return '';
   }


### PR DESCRIPTION
- Generated types using branch `replace-api` from [PR](https://github.com/terraware/terraware-server/pull/1397)
- Added service functions
- Added redux
- Refactored `buildReducers` to accept a type, to store data other than just the request status (new use-case)
- Added strings and a type/util to return string for plot replacement duration