### PR TITLE
SW-3932 Update editable map instructions

### DIFF
--- a/src/components/Map/EditableMap.tsx
+++ b/src/components/Map/EditableMap.tsx
@@ -87,6 +87,9 @@ export default function EditableMap({ boundary, onBoundaryChanged, style }: Edit
     >
       {firstVisible && (
         <>
+          <Typography fontSize='16px' margin={theme.spacing(1, 0)} minHeight='4em'>
+            {instructionsForMode(mode)}
+          </Typography>
           <ReactMapGL
             key={mapId}
             onError={onMapError}
@@ -106,9 +109,6 @@ export default function EditableMap({ boundary, onBoundaryChanged, style }: Edit
           >
             <EditableMapDraw boundary={boundary} onBoundaryChanged={onBoundaryChanged} setMode={setMode} />
           </ReactMapGL>
-          <Typography fontSize='16px' margin={theme.spacing(1, 0)} minHeight='3em'>
-            {instructionsForMode(mode)}
-          </Typography>
         </>
       )}
     </Box>

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -528,7 +528,7 @@ MANAGER,Manager
 MANAGER_INFO,"A manager can do the above as well as edit data entries for seeds and manage outplant withdrawals, planting sites and species."
 MAP,Map
 MAP_EDITOR_DRAWING_ADDITIONAL_FEATURE,"Add points to your new boundary by clicking on the map. To finish drawing, complete the boundary by either double-clicking or by clicking on the starting point again. The original boundary will be replaced by the new one when you finish drawing."
-MAP_EDITOR_DRAWING_FIRST_FEATURE,"Add points to your boundary by clicking on the map. To finish drawing, complete the boundary by either double-clicking or by clicking on the starting point again."
+MAP_EDITOR_DRAWING_FIRST_FEATURE,"Add points to your boundary by zooming in to where your planting site is, and then clicking on the map. To finish drawing, complete the boundary by either double-clicking or by clicking on the starting point again."
 MAP_EDITOR_EDITING_FEATURE,"Click and drag a corner of the boundary to adjust its position. Click the midpoint between two corners to add another one. To remove a corner, click on it and then click the {trash} button. When finished, click outside the boundary."
 MAP_EDITOR_NO_FEATURES,"Start drawing the boundary of your planting site. When finished, click on the starting point or double-click to complete the boundary."
 MAP_EDITOR_NO_SELECTION,"Click on your planting site's boundary if you want to adjust its position or its shape. To replace the boundary with a new one, click the {polygon} button.",{polygon} will be replaced with a symbol.


### PR DESCRIPTION
Based on user feedback, update the instructions for the planting site map editor
to tell people to zoom in first, and move the instructions above the map.
