### PR TITLE
SW-4330 Add 'Outdoors' map view style option

### DIFF
--- a/src/components/Map/MapRenderUtils.tsx
+++ b/src/components/Map/MapRenderUtils.tsx
@@ -1,3 +1,5 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useMap } from 'react-map-gl';
 import { makeStyles } from '@mui/styles';
 import { Box, Typography, useTheme } from '@mui/material';
 import { MapPopupRenderer, MapSourceProperties } from 'src/types/Map';
@@ -49,6 +51,28 @@ export function useSpeciesPlantsRenderer(subzonesWithPlants: any): MapPopupRende
       );
     },
   };
+}
+
+/**
+ * Full screen map container ref for Portals
+ */
+export function useMapPortalContainer(): Element | undefined {
+  const { current: map } = useMap();
+  const [container, setContainer] = useState<Element | undefined>();
+
+  const updateContainer = useCallback(() => {
+    if (window.document.fullscreenElement?.attributes?.getNamedItem('class')?.value === 'mapboxgl-map') {
+      setContainer(window.document.fullscreenElement);
+    } else {
+      setContainer(undefined);
+    }
+  }, [setContainer]);
+
+  useEffect(updateContainer);
+
+  map?.on('resize', updateContainer);
+
+  return container;
 }
 
 /**

--- a/src/components/Map/PlantingSiteMap.tsx
+++ b/src/components/Map/PlantingSiteMap.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Box, CircularProgress, Theme, useTheme } from '@mui/material';
+import { Box, CircularProgress, useTheme } from '@mui/material';
 import useSnackbar from 'src/utils/useSnackbar';
 import GenericMap from './GenericMap';
 import {
@@ -15,7 +15,6 @@ import {
 import { MapService } from 'src/services';
 import _ from 'lodash';
 import { MapLayer } from 'src/components/common/MapLayerSelect';
-import { makeStyles } from '@mui/styles';
 import { getRgbaFromHex } from 'src/utils/color';
 
 const mapImages = [
@@ -24,25 +23,6 @@ const mapImages = [
     url: '/assets/mortality-rate-indicator.png',
   },
 ];
-
-const useStyles = makeStyles((theme: Theme) => ({
-  bottomLeftControl: {
-    height: 'max-content',
-    position: 'absolute',
-    left: theme.spacing(2),
-    bottom: theme.spacing(4),
-    width: 'max-content',
-    zIndex: 1000,
-  },
-  topRightControl: {
-    height: 'max-content',
-    position: 'absolute',
-    right: theme.spacing(2),
-    top: theme.spacing(2),
-    width: 'max-content',
-    zIndex: 1000,
-  },
-}));
 
 export type PlantingSiteMapProps = {
   mapData: MapData;
@@ -54,26 +34,13 @@ export type PlantingSiteMapProps = {
   focusEntities?: MapEntityId[];
   // layers to be displayed on map
   layers?: MapLayer[];
-  bottomLeftMapControl?: React.ReactNode;
-  topRightMapControl?: React.ReactNode;
   showMortalityRateFill?: boolean;
 } & MapControl;
 
 export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Element | null {
-  const {
-    mapData,
-    style,
-    contextRenderer,
-    highlightEntities,
-    focusEntities,
-    layers,
-    bottomLeftMapControl,
-    topRightMapControl,
-    showMortalityRateFill,
-  } = props;
+  const { mapData, style, contextRenderer, highlightEntities, focusEntities, layers, showMortalityRateFill } = props;
   const { ...controlProps }: MapControl = props;
   const theme = useTheme();
-  const classes = useStyles();
   const snackbar = useSnackbar();
   const [mapOptions, setMapOptions] = useState<MapOptions>();
 
@@ -274,8 +241,6 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
         mapImages={mapImages}
         {...controlProps}
       />
-      {topRightMapControl && <div className={classes.topRightControl}>{topRightMapControl}</div>}
-      {bottomLeftMapControl && <div className={classes.bottomLeftControl}>{bottomLeftMapControl}</div>}
     </Box>
   );
 }

--- a/src/components/Observations/map/ObservationMapView.tsx
+++ b/src/components/Observations/map/ObservationMapView.tsx
@@ -117,7 +117,7 @@ export default function ObservationMapView({
 
   const hasSearchCriteria = search.trim() || filterZoneNames.length;
 
-  const contextRenderer = (properties: MapSourceProperties): JSX.Element => {
+  const contextRenderer = (properties: MapSourceProperties): JSX.Element | null => {
     let entity: any;
     if (properties.type === 'site') {
       entity = selectedObservation;
@@ -129,6 +129,10 @@ export default function ObservationMapView({
         ?.flatMap((z) => z.plantingSubzones)
         ?.flatMap((sz) => sz.monitoringPlots)
         ?.find((p) => p.monitoringPlotId === properties.id);
+    }
+
+    if (!entity) {
+      return null;
     }
 
     return (

--- a/src/components/Observations/map/TooltipContents.tsx
+++ b/src/components/Observations/map/TooltipContents.tsx
@@ -6,6 +6,7 @@ import { Button } from '@terraware/web-components';
 import strings from 'src/strings';
 import { ObservationState, ObservationMonitoringPlotResultsPayload } from 'src/types/Observations';
 import ReplaceObservationPlotModal from 'src/components/Observations/replacePlot/ReplaceObservationPlotModal';
+import { useMapPortalContainer } from 'src/components/Map/MapRenderUtils';
 
 const useStyles = makeStyles(() => ({
   button: {
@@ -27,6 +28,7 @@ export default function TooltipContents(props: TooltipContentsProps): JSX.Elemen
   const { monitoringPlot, observationId, observationState, title } = props;
   const theme = useTheme();
   const classes = useStyles();
+  const mapPortalContainer = useMapPortalContainer();
   const [showReplacePlotModal, setShowReplacePlotModal] = useState<boolean>(false);
 
   const observationInProgress = observationState === 'InProgress';
@@ -40,7 +42,7 @@ export default function TooltipContents(props: TooltipContentsProps): JSX.Elemen
   return (
     <>
       {showReplacePlotModal && observationId && monitoringPlot && (
-        <Portal>
+        <Portal container={mapPortalContainer}>
           <ReplaceObservationPlotModal
             onClose={() => setShowReplacePlotModal(false)}
             observationId={observationId}

--- a/src/components/Observations/replacePlot/ReplaceObservationPlotModal.tsx
+++ b/src/components/Observations/replacePlot/ReplaceObservationPlotModal.tsx
@@ -11,7 +11,7 @@ import { requestReplaceObservationPlot } from 'src/redux/features/observations/o
 import { requestObservationsResults } from 'src/redux/features/observations/observationsThunks';
 
 export interface ReplaceObservationPlotModalProps {
-  onClose: () => void;
+  onClose: (replaced?: boolean) => void;
   observationId: number;
   monitoringPlot: ObservationMonitoringPlotResultsPayload;
 }
@@ -65,7 +65,7 @@ export default function ReplaceObservationPlotModal(props: ReplaceObservationPlo
     } else if (result.status === 'success') {
       // TODO: display page message on what was replaced by parsing results.{added,removed}MonitoringPlotIds
       dispatch(requestObservationsResults(selectedOrganization.id));
-      onClose();
+      onClose(true);
     }
   }, [dispatch, onClose, result, selectedOrganization.id, snackbar]);
 
@@ -73,7 +73,7 @@ export default function ReplaceObservationPlotModal(props: ReplaceObservationPlo
     <>
       {result?.status === 'pending' && <BusySpinner withSkrim={true} />}
       <DialogBox
-        onClose={onClose}
+        onClose={() => onClose(false)}
         open={true}
         title={strings.REQUEST_REASSIGNMENT}
         size='medium'
@@ -82,7 +82,7 @@ export default function ReplaceObservationPlotModal(props: ReplaceObservationPlo
             id='cancelReplaceObservationPlot'
             label={strings.CANCEL}
             type='passive'
-            onClick={onClose}
+            onClick={() => onClose(false)}
             priority='secondary'
             key='button-1'
           />,

--- a/src/components/common/MapLayerSelect/index.tsx
+++ b/src/components/common/MapLayerSelect/index.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Icon, PopoverMultiSelect } from '@terraware/web-components';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material';
+import { useMapPortalContainer } from 'src/components/Map/MapRenderUtils';
 
 export type MapLayer = 'Planting Site' | 'Zones' | 'Sub-Zones' | 'Monitoring Plots';
 
@@ -29,12 +30,17 @@ export default function MapLayerSelect({
   initialSelection,
   onUpdateSelection,
   menuSections,
-}: MapLayerSelectProps): JSX.Element {
+}: MapLayerSelectProps): JSX.Element | null {
   const classes = useStyles();
+  const mapPortalContainer = useMapPortalContainer();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const handleClick = (event?: React.MouseEvent<HTMLButtonElement, MouseEvent> | undefined) => {
     setAnchorEl(event?.currentTarget ?? null);
   };
+
+  if (mapPortalContainer) {
+    return null;
+  }
 
   return (
     <>

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -741,6 +741,7 @@ ORTHODOX,Orthodox
 OTHER,Other
 OUNCES,Ounces
 OUT_PLANTING,Out-planting
+OUTDOORS,Outdoors
 OUTPLANT,Outplant
 OUTPLANTS_REQUIRE_READY_SEEDLINGS,"Outplants require batches with seedlings that are ""ready."""
 OUTSTANDING,Outstanding
@@ -958,6 +959,7 @@ RUN_A_DATABASE_CHECK,Run a Database Check
 S_SEED_COUNT,seed count
 SAND,Sand
 SAND_PETRI_DISH,Sand Petri Dish
+SATELLITE,Satellite
 SAVE,Save
 SAVE_ACCESSION_ERROR,An error occurred when saving the accession.
 SAVE_AND_NEXT,Save and Next

--- a/src/types/Map.ts
+++ b/src/types/Map.ts
@@ -1,5 +1,5 @@
 // flattened info for shapes relating to planting site data
-
+import React from 'react';
 import mapboxgl from 'mapbox-gl';
 
 export type MapGeometry = number[][][][];
@@ -93,7 +93,7 @@ export type MapOptions = {
  * Render a popup based on properties
  */
 export type MapPopupRenderer = {
-  render: (properties: MapSourceProperties) => JSX.Element;
+  render: (properties: MapSourceProperties) => JSX.Element | null;
   style?: object;
   className?: string;
   anchor?: mapboxgl.Anchor;
@@ -131,6 +131,10 @@ export type MapData = Record<MapObject, MapSourceBaseData | undefined>;
 export type MapControl = {
   // hide the full screen control
   hideFullScreen?: boolean;
+
+  // custom map controls
+  topRightMapControl?: React.ReactNode;
+  bottomLeftMapControl?: React.ReactNode;
 };
 
 /**

--- a/src/types/Map.ts
+++ b/src/types/Map.ts
@@ -132,3 +132,12 @@ export type MapControl = {
   // hide the full screen control
   hideFullScreen?: boolean;
 };
+
+/**
+ * Map view style
+ */
+export type MapViewStyle = 'Outdoors' | 'Satellite';
+export const MapViewStyles: Record<MapViewStyle, string> = {
+  Outdoors: 'mapbox://styles/mapbox/outdoors-v12?optimize=true',
+  Satellite: 'mapbox://styles/mapbox/satellite-v9?optimize=true',
+};


### PR DESCRIPTION
- Added switcher on top left for Outdoors/Satellite, not using an IControl at this point, being consistent with how we added the layers and zoom-to-fit controls
- update map view style based on selection
- currently storing selection in localStorage, not distinguished by site id or any other key
- we should discuss best approach for storing this preference (site wide option vs user specific option vs user/site option, etc.)
- outstanding issue is the selector is not clickable in full screen mode because the popover is not viewable in full screen mode (not part of the dom hierarchy).. i could switch this to a radio button

<img width="746" alt="Terraware App 2023-10-19 12-31-57" src="https://github.com/terraware/terraware-web/assets/1865174/369baf3d-6867-4a4d-8909-6bfc1451c12c">
