### PR TITLE
SW-4330-continued Allow reassign-request modal to show in full screen

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -517,6 +517,13 @@ export default function Map(props: MapProps): JSX.Element {
     return source.entities?.some((entity) => entity?.boundary?.length);
   });
 
+  const renderedPopup = useMemo<JSX.Element | null>(() => {
+    if (!popupInfo || !popupRenderer) {
+      return null;
+    }
+    return popupRenderer.render(popupInfo.properties);
+  }, [popupInfo, popupRenderer]);
+
   // keep track of map being destroyed, this is not bound by react event loop
   let destroying = false;
 
@@ -555,7 +562,7 @@ export default function Map(props: MapProps): JSX.Element {
           <AttributionControl compact={true} style={{ marginRight: '5px' }} position='top-left' />
           <ZoomToFitControl onClick={zoomToFit} />
           <MapViewControl mapViewStyle={mapViewStyle} onChangeMapViewStyle={onChangeMapViewStyle} />
-          {popupInfo && popupRenderer && (
+          {popupInfo && popupRenderer && renderedPopup && (
             <Popup
               anchor={popupRenderer.anchor ?? 'top'}
               longitude={Number(popupInfo.lng)}
@@ -570,7 +577,7 @@ export default function Map(props: MapProps): JSX.Element {
               style={popupRenderer.style}
               className={popupRenderer.className}
             >
-              {popupRenderer.render(popupInfo.properties)}
+              {renderedPopup}
             </Popup>
           )}
           {topRightMapControl && <div className={classes.topRightControl}>{topRightMapControl}</div>}

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -22,6 +22,7 @@ import {
   MapViewStyle,
   MapViewStyles,
 } from 'src/types/Map';
+import { useMapPortalContainer } from './MapRenderUtils';
 import { MapService } from 'src/services';
 import { useLocalization } from 'src/providers';
 import strings from 'src/strings';
@@ -56,6 +57,22 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontSize: '12px',
     paddingLeft: theme.spacing(0.5),
     color: theme.palette.TwClrTxt,
+  },
+  bottomLeftControl: {
+    height: 'max-content',
+    position: 'absolute',
+    left: theme.spacing(2),
+    bottom: theme.spacing(4),
+    width: 'max-content',
+    zIndex: 1000,
+  },
+  topRightControl: {
+    height: 'max-content',
+    position: 'absolute',
+    right: theme.spacing(2),
+    top: theme.spacing(2),
+    width: 'max-content',
+    zIndex: 1000,
   },
 }));
 
@@ -106,7 +123,10 @@ export default function Map(props: MapProps): JSX.Element {
     entityOptions,
     mapImages,
     hideFullScreen,
+    topRightMapControl,
+    bottomLeftMapControl,
   } = props;
+  const classes = useStyles();
   const [geoData, setGeoData] = useState<any[]>();
   const [layerIds, setLayerIds] = useState<string[]>([]);
   const [popupInfo, setPopupInfo] = useState<PopupInfo | null>(null);
@@ -553,6 +573,8 @@ export default function Map(props: MapProps): JSX.Element {
               {popupRenderer.render(popupInfo.properties)}
             </Popup>
           )}
+          {topRightMapControl && <div className={classes.topRightControl}>{topRightMapControl}</div>}
+          {bottomLeftMapControl && <div className={classes.bottomLeftControl}>{bottomLeftMapControl}</div>}
         </ReactMapGL>
       )}
     </Box>
@@ -593,10 +615,11 @@ type MapViewControlProps = {
   onChangeMapViewStyle: (style: MapViewStyle) => void;
 };
 
-const MapViewControl = ({ mapViewStyle, onChangeMapViewStyle }: MapViewControlProps): JSX.Element => {
+const MapViewControl = ({ mapViewStyle, onChangeMapViewStyle }: MapViewControlProps): JSX.Element | null => {
   const classes = useStyles();
   const theme = useTheme();
   const { activeLocale } = useLocalization();
+  const mapPortalContainer = useMapPortalContainer();
 
   const setMapStyle = (item: DropdownItem) => {
     const style: MapViewStyle = item.value === 'Outdoors' ? 'Outdoors' : 'Satellite';
@@ -612,6 +635,10 @@ const MapViewControl = ({ mapViewStyle, onChangeMapViewStyle }: MapViewControlPr
       { label: strings.SATELLITE, value: 'Satellite' },
     ];
   }, [activeLocale]);
+
+  if (mapPortalContainer) {
+    return null;
+  }
 
   return (
     <Box

--- a/src/components/Map/MapRenderUtils.tsx
+++ b/src/components/Map/MapRenderUtils.tsx
@@ -1,3 +1,5 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useMap } from 'react-map-gl';
 import { makeStyles } from '@mui/styles';
 import { Box, Typography, useTheme } from '@mui/material';
 import { MapPopupRenderer, MapSourceProperties } from 'src/types/Map';
@@ -49,6 +51,28 @@ export function useSpeciesPlantsRenderer(subzonesWithPlants: any): MapPopupRende
       );
     },
   };
+}
+
+/**
+ * Full screen map container ref for Portals
+ */
+export function useMapPortalContainer(): Element | undefined {
+  const { current: map } = useMap();
+  const [container, setContainer] = useState<Element | undefined>();
+
+  const updateContainer = useCallback(() => {
+    if (window.document.fullscreenElement?.attributes?.getNamedItem('class')?.value === 'mapboxgl-map') {
+      setContainer(window.document.fullscreenElement);
+    } else {
+      setContainer(undefined);
+    }
+  }, [setContainer]);
+
+  useEffect(updateContainer);
+
+  map?.on('resize', updateContainer);
+
+  return container;
 }
 
 /**

--- a/src/components/Map/PlantingSiteMap.tsx
+++ b/src/components/Map/PlantingSiteMap.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Box, CircularProgress, Theme, useTheme } from '@mui/material';
+import { Box, CircularProgress, useTheme } from '@mui/material';
 import useSnackbar from 'src/utils/useSnackbar';
 import GenericMap from './GenericMap';
 import {
@@ -15,7 +15,6 @@ import {
 import { MapService } from 'src/services';
 import _ from 'lodash';
 import { MapLayer } from 'src/components/common/MapLayerSelect';
-import { makeStyles } from '@mui/styles';
 import { getRgbaFromHex } from 'src/utils/color';
 
 const mapImages = [
@@ -24,25 +23,6 @@ const mapImages = [
     url: '/assets/mortality-rate-indicator.png',
   },
 ];
-
-const useStyles = makeStyles((theme: Theme) => ({
-  bottomLeftControl: {
-    height: 'max-content',
-    position: 'absolute',
-    left: theme.spacing(2),
-    bottom: theme.spacing(4),
-    width: 'max-content',
-    zIndex: 1000,
-  },
-  topRightControl: {
-    height: 'max-content',
-    position: 'absolute',
-    right: theme.spacing(2),
-    top: theme.spacing(2),
-    width: 'max-content',
-    zIndex: 1000,
-  },
-}));
 
 export type PlantingSiteMapProps = {
   mapData: MapData;
@@ -54,26 +34,13 @@ export type PlantingSiteMapProps = {
   focusEntities?: MapEntityId[];
   // layers to be displayed on map
   layers?: MapLayer[];
-  bottomLeftMapControl?: React.ReactNode;
-  topRightMapControl?: React.ReactNode;
   showMortalityRateFill?: boolean;
 } & MapControl;
 
 export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Element | null {
-  const {
-    mapData,
-    style,
-    contextRenderer,
-    highlightEntities,
-    focusEntities,
-    layers,
-    bottomLeftMapControl,
-    topRightMapControl,
-    showMortalityRateFill,
-  } = props;
+  const { mapData, style, contextRenderer, highlightEntities, focusEntities, layers, showMortalityRateFill } = props;
   const { ...controlProps }: MapControl = props;
   const theme = useTheme();
-  const classes = useStyles();
   const snackbar = useSnackbar();
   const [mapOptions, setMapOptions] = useState<MapOptions>();
 
@@ -274,8 +241,6 @@ export default function PlantingSiteMap(props: PlantingSiteMapProps): JSX.Elemen
         mapImages={mapImages}
         {...controlProps}
       />
-      {topRightMapControl && <div className={classes.topRightControl}>{topRightMapControl}</div>}
-      {bottomLeftMapControl && <div className={classes.bottomLeftControl}>{bottomLeftMapControl}</div>}
     </Box>
   );
 }

--- a/src/components/Observations/map/ObservationMapView.tsx
+++ b/src/components/Observations/map/ObservationMapView.tsx
@@ -117,7 +117,7 @@ export default function ObservationMapView({
 
   const hasSearchCriteria = search.trim() || filterZoneNames.length;
 
-  const contextRenderer = (properties: MapSourceProperties): JSX.Element => {
+  const contextRenderer = (properties: MapSourceProperties): JSX.Element | null => {
     let entity: any;
     if (properties.type === 'site') {
       entity = selectedObservation;
@@ -129,6 +129,10 @@ export default function ObservationMapView({
         ?.flatMap((z) => z.plantingSubzones)
         ?.flatMap((sz) => sz.monitoringPlots)
         ?.find((p) => p.monitoringPlotId === properties.id);
+    }
+
+    if (!entity) {
+      return null;
     }
 
     return (

--- a/src/components/Observations/map/TooltipContents.tsx
+++ b/src/components/Observations/map/TooltipContents.tsx
@@ -6,6 +6,7 @@ import { Button } from '@terraware/web-components';
 import strings from 'src/strings';
 import { ObservationState, ObservationMonitoringPlotResultsPayload } from 'src/types/Observations';
 import ReplaceObservationPlotModal from 'src/components/Observations/replacePlot/ReplaceObservationPlotModal';
+import { useMapPortalContainer } from 'src/components/Map/MapRenderUtils';
 
 const useStyles = makeStyles(() => ({
   button: {
@@ -27,6 +28,7 @@ export default function TooltipContents(props: TooltipContentsProps): JSX.Elemen
   const { monitoringPlot, observationId, observationState, title } = props;
   const theme = useTheme();
   const classes = useStyles();
+  const mapPortalContainer = useMapPortalContainer();
   const [showReplacePlotModal, setShowReplacePlotModal] = useState<boolean>(false);
 
   const observationInProgress = observationState === 'InProgress';
@@ -40,7 +42,7 @@ export default function TooltipContents(props: TooltipContentsProps): JSX.Elemen
   return (
     <>
       {showReplacePlotModal && observationId && monitoringPlot && (
-        <Portal>
+        <Portal container={mapPortalContainer}>
           <ReplaceObservationPlotModal
             onClose={() => setShowReplacePlotModal(false)}
             observationId={observationId}

--- a/src/components/Observations/replacePlot/ReplaceObservationPlotModal.tsx
+++ b/src/components/Observations/replacePlot/ReplaceObservationPlotModal.tsx
@@ -11,7 +11,7 @@ import { requestReplaceObservationPlot } from 'src/redux/features/observations/o
 import { requestObservationsResults } from 'src/redux/features/observations/observationsThunks';
 
 export interface ReplaceObservationPlotModalProps {
-  onClose: () => void;
+  onClose: (replaced?: boolean) => void;
   observationId: number;
   monitoringPlot: ObservationMonitoringPlotResultsPayload;
 }
@@ -65,7 +65,7 @@ export default function ReplaceObservationPlotModal(props: ReplaceObservationPlo
     } else if (result.status === 'success') {
       // TODO: display page message on what was replaced by parsing results.{added,removed}MonitoringPlotIds
       dispatch(requestObservationsResults(selectedOrganization.id));
-      onClose();
+      onClose(true);
     }
   }, [dispatch, onClose, result, selectedOrganization.id, snackbar]);
 
@@ -73,7 +73,7 @@ export default function ReplaceObservationPlotModal(props: ReplaceObservationPlo
     <>
       {result?.status === 'pending' && <BusySpinner withSkrim={true} />}
       <DialogBox
-        onClose={onClose}
+        onClose={() => onClose(false)}
         open={true}
         title={strings.REQUEST_REASSIGNMENT}
         size='medium'
@@ -82,7 +82,7 @@ export default function ReplaceObservationPlotModal(props: ReplaceObservationPlo
             id='cancelReplaceObservationPlot'
             label={strings.CANCEL}
             type='passive'
-            onClick={onClose}
+            onClick={() => onClose(false)}
             priority='secondary'
             key='button-1'
           />,

--- a/src/components/common/MapLayerSelect/index.tsx
+++ b/src/components/common/MapLayerSelect/index.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Icon, PopoverMultiSelect } from '@terraware/web-components';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material';
+import { useMapPortalContainer } from 'src/components/Map/MapRenderUtils';
 
 export type MapLayer = 'Planting Site' | 'Zones' | 'Sub-Zones' | 'Monitoring Plots';
 
@@ -29,12 +30,17 @@ export default function MapLayerSelect({
   initialSelection,
   onUpdateSelection,
   menuSections,
-}: MapLayerSelectProps): JSX.Element {
+}: MapLayerSelectProps): JSX.Element | null {
   const classes = useStyles();
+  const mapPortalContainer = useMapPortalContainer();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const handleClick = (event?: React.MouseEvent<HTMLButtonElement, MouseEvent> | undefined) => {
     setAnchorEl(event?.currentTarget ?? null);
   };
+
+  if (mapPortalContainer) {
+    return null;
+  }
 
   return (
     <>

--- a/src/types/Map.ts
+++ b/src/types/Map.ts
@@ -93,7 +93,7 @@ export type MapOptions = {
  * Render a popup based on properties
  */
 export type MapPopupRenderer = {
-  render: (properties: MapSourceProperties) => JSX.Element;
+  render: (properties: MapSourceProperties) => JSX.Element | null;
   style?: object;
   className?: string;
   anchor?: mapboxgl.Anchor;

--- a/src/types/Map.ts
+++ b/src/types/Map.ts
@@ -1,5 +1,5 @@
 // flattened info for shapes relating to planting site data
-
+import React from 'react';
 import mapboxgl from 'mapbox-gl';
 
 export type MapGeometry = number[][][][];
@@ -131,6 +131,10 @@ export type MapData = Record<MapObject, MapSourceBaseData | undefined>;
 export type MapControl = {
   // hide the full screen control
   hideFullScreen?: boolean;
+
+  // custom map controls
+  topRightMapControl?: React.ReactNode;
+  bottomLeftMapControl?: React.ReactNode;
 };
 
 /**


### PR DESCRIPTION
- Created a custom hook that informs when a map is in fullscreen and which container to use for modal portals
- Integrated this hook with map tooltip so reassign request modal shows in full screen mode as well (uses the full screen container as the parent for the modal)
- popovers (such as layers and outdoors-vs-satellite) are still not functional, added a change to not render these in fullscreen mode for now (since they won't work)
- will follow up later with a web-component change if we can get popovers to work
- refactored the top-right/bottom-left control components to be rendered inside of the map hierarchy otherwise they get hidden in fullscreen mode, top-right for now is not rendered until popovers work, the bottom-left observation date slider now works in fullscreen mode

<img width="738" alt="Screen Shot 2023-10-23 at 11 32 22 AM 2023-10-23 11-34-12" src="https://github.com/terraware/terraware-web/assets/1865174/4d63983d-a958-428b-9bf5-84654573cad1">
