### PR TITLE
SW-3271 Show all errors on species list upload failure

### DIFF
--- a/src/components/common/ImportModal.tsx
+++ b/src/components/common/ImportModal.tsx
@@ -121,7 +121,7 @@ export default function ImportSpeciesModal(props: ImportSpeciesModalProps): JSX.
   const [file, setFile] = useState<File>();
   const inputRef = useRef<HTMLInputElement>(null);
   const divRef = useRef<HTMLDivElement>(null);
-  const [error, setError] = useState<string>();
+  const [error, setError] = useState<JSX.Element>();
   const [loading, setLoading] = useState(false);
   const [fileStatus, setFileStatus] = useState<GetUploadStatusResponsePayload>();
   const [uploadInterval, setUploadInterval] = useState<NodeJS.Timer>();
@@ -156,11 +156,22 @@ export default function ImportSpeciesModal(props: ImportSpeciesModalProps): JSX.
 
   useEffect(() => {
     const getErrors = () => {
-      let errors = strings.DATA_IMPORT_FAILED;
-      if (fileStatus?.details.errors && fileStatus?.details.errors[0]) {
-        errors += ': ' + fileStatus?.details.errors[0].message;
-      }
-      return errors;
+      return (
+        <div className={classes.warningContent} key='import-error-1'>
+          {strings.DATA_IMPORT_FAILED}
+          <ul>
+            {fileStatus?.details.errors?.map((err, index) => (
+              <li key={`import-error-item-${index}`}>
+                {strings.formatString(
+                  strings.DATA_IMPORT_ROW_MESSAGE,
+                  `${err.position}`,
+                  err.message || strings.GENERIC_ERROR
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      );
     };
 
     const clearUploadInterval = () => {
@@ -183,7 +194,7 @@ export default function ImportSpeciesModal(props: ImportSpeciesModalProps): JSX.
       clearUploadInterval();
       setWarning(true);
     }
-  }, [fileStatus, uploadInterval]);
+  }, [fileStatus, uploadInterval, classes]);
 
   const dropHandler = (event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -219,7 +230,7 @@ export default function ImportSpeciesModal(props: ImportSpeciesModalProps): JSX.
       }
       if (response) {
         if (response.requestSucceeded === false) {
-          setError(strings.DATA_IMPORT_FAILED);
+          setError(<>{strings.DATA_IMPORT_FAILED}</>);
         } else {
           if (response.id) {
             setUploadId(response.id);

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -206,6 +206,7 @@ DASHBOARD_MESSAGE,Your seeds dashboard will automatically populate with data as 
 DASHBOARD_MESSAGE_TITLE,Add Accessions to See Data
 DATA_CHECK_COMPLETED,Database check complete. No errors were found!
 DATA_CHECK_WITH_PROBLEMS,Database check complete. {0} potential errors were found.
+DATA_IMPORT_ROW_MESSAGE,Row {0}: {1},{0} is a number referring to a row in a spreadsheet file; {1} is an error message related to the row.
 DATA_IMPORT_FAILED,Data import failed
 DATE,Date
 DATE_ADDED,Date Added


### PR DESCRIPTION
Currently, if the user uploads a species list CSV that has validation failures, we
show an error dialog that only includes the first failure and doesn't say where in
the file the offending row is.

Update the dialog so it shows all the errors and says which row each one is on.
