### PR TITLE
SW-4372 Create batch details modal without keeping state of previous batch selection

### DIFF
--- a/src/components/Inventory/view/BatchDetailsModal.tsx
+++ b/src/components/Inventory/view/BatchDetailsModal.tsx
@@ -21,7 +21,6 @@ import { useNumberFormatter } from 'src/utils/useNumber';
 import { useUser } from 'src/providers';
 
 export interface BatchDetailsModalProps {
-  open: boolean;
   onClose: () => void;
   reload: () => void;
   selectedBatch: any;
@@ -32,7 +31,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
   const numberFormatter = useNumberFormatter();
   const { user } = useUser();
   const { selectedOrganization } = useOrganization();
-  const { onClose, open, reload, selectedBatch, speciesId } = props;
+  const { onClose, reload, selectedBatch, speciesId } = props;
 
   const [record, setRecord, onChange] = useForm(selectedBatch);
   const snackbar = useSnackbar();
@@ -136,7 +135,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
     if (foundFacility) {
       setFacility(foundFacility);
     }
-  }, [selectedBatch, speciesId, setRecord, selectedOrganization, open]);
+  }, [selectedBatch, speciesId, setRecord, selectedOrganization]);
 
   const MANDATORY_FIELDS = [
     'facilityId',
@@ -209,7 +208,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
       {record && (
         <DialogBox
           onClose={onCloseHandler}
-          open={open}
+          open={true}
           title={record.id === -1 ? strings.ADD_SEEDLING_BATCH : strings.SEEDLING_BATCH_DETAILS}
           size='large'
           middleButtons={[

--- a/src/components/Inventory/view/InventorySeedlingsTable.tsx
+++ b/src/components/Inventory/view/InventorySeedlingsTable.tsx
@@ -241,16 +241,17 @@ export default function InventorySeedslingsTable(props: InventorySeedslingsTable
           padding: theme.spacing(3),
         }}
       >
-        <BatchDetailsModal
-          open={openNewBatchModal}
-          reload={reloadData}
-          onClose={() => {
-            onUpdateOpenBatch(null);
-            setOpenNewBatchModal(false);
-          }}
-          speciesId={speciesId}
-          selectedBatch={selectedBatch}
-        />
+        {openNewBatchModal && (
+          <BatchDetailsModal
+            reload={reloadData}
+            onClose={() => {
+              onUpdateOpenBatch(null);
+              setOpenNewBatchModal(false);
+            }}
+            speciesId={speciesId}
+            selectedBatch={selectedBatch}
+          />
+        )}
         <DeleteBatchesModal
           open={openDeleteModal}
           onClose={() => setOpenDeleteModal(false)}


### PR DESCRIPTION
- don't use the `open` modal parameter, which required us to clean the modal state across batch selections
- conditionally show/render the batch details modal when user clicks on a batch
- this approach is cleaner and we won't have to add a bunch of logic in the modal to update the fields