### PR TITLE
SW-4376 Distinguish status changes from quantity edits

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -107,6 +107,10 @@ export interface paths {
     put: operations["updateBatch"];
     delete: operations["deleteBatch"];
   };
+  "/api/v1/nursery/batches/{id}/changeStatuses": {
+    /** There must be enough seedlings available to move to the next status. */
+    post: operations["changeBatchStatuses"];
+  };
   "/api/v1/nursery/batches/{id}/quantities": {
     /** This should not be used to record withdrawals; use the withdrawal API for that. */
     put: operations["updateBatchQuantities"];
@@ -722,6 +726,15 @@ export interface components {
        * @example EPSG:4326
        */
       name: string;
+    };
+    ChangeBatchStatusRequestPayload: {
+      /** @description Which status change to apply. */
+      operation: "GerminatingToNotReady" | "NotReadyToReady";
+      /**
+       * Format: int32
+       * @description Number of seedlings to move from one status to the next.
+       */
+      quantity: number;
     };
     CompletePlotObservationRequestPayload: {
       conditions: (
@@ -4139,6 +4152,39 @@ export interface operations {
         content: {
           "application/json": components["schemas"]["SimpleSuccessResponsePayload"];
         };
+      };
+    };
+  };
+  /** There must be enough seedlings available to move to the next status. */
+  changeBatchStatuses: {
+    parameters: {
+      path: {
+        id: number;
+      };
+    };
+    responses: {
+      /** The requested operation succeeded. */
+      200: {
+        content: {
+          "application/json": components["schemas"]["BatchResponsePayload"];
+        };
+      };
+      /** The requested resource was not found. */
+      404: {
+        content: {
+          "application/json": components["schemas"]["SimpleErrorResponsePayload"];
+        };
+      };
+      /** The requested resource has a newer version and was not updated. */
+      412: {
+        content: {
+          "application/json": components["schemas"]["SimpleErrorResponsePayload"];
+        };
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ChangeBatchStatusRequestPayload"];
       };
     };
   };

--- a/src/components/Inventory/view/ChangeQuantityModal.tsx
+++ b/src/components/Inventory/view/ChangeQuantityModal.tsx
@@ -41,7 +41,8 @@ export default function ChangeQuantityModal(props: ChangeQuantityModalProps): JS
       return;
     }
     setSaving(true);
-    const response = await NurseryBatchService.updateBatchQuantities({ ...record, version: row.version });
+    const operation = type === 'germinating' ? 'GerminatingToNotReady' : 'NotReadyToReady';
+    const response = await NurseryBatchService.changeBatchStatuses(record, { operation, quantity: movedValue });
     setSaving(false);
     if (response.requestSucceeded) {
       if (reload) {

--- a/src/services/NurseryBatchService.ts
+++ b/src/services/NurseryBatchService.ts
@@ -9,6 +9,7 @@ import { SearchNodePayload, SearchResponseElement, SearchSortOrder } from 'src/t
  */
 
 const BATCHES_ENDPOINT = '/api/v1/nursery/batches';
+const BATCH_CHANGE_STATUSES_ENDPOINT = '/api/v1/nursery/batches/{id}/changeStatuses';
 const BATCH_ID_ENDPOINT = '/api/v1/nursery/batches/{id}';
 const BATCH_QUANTITIES_ENDPOINT = '/api/v1/nursery/batches/{id}/quantities';
 
@@ -53,6 +54,8 @@ export type BatchData = {
   batch: Batch | null;
 };
 
+export type ChangeBatchStatusesRequestPayload =
+  paths[typeof BATCH_CHANGE_STATUSES_ENDPOINT]['post']['requestBody']['content']['application/json'];
 export type UpdateBatchRequestPayload =
   paths[typeof BATCH_ID_ENDPOINT]['put']['requestBody']['content']['application/json'];
 export type UpdateBatchQuantitiesRequestPayload =
@@ -253,9 +256,22 @@ const updateBatchQuantities = async (batch: Batch): Promise<Response> => {
 };
 
 /**
+ * Change the statuses of seedlings in a batch
+ */
+const changeBatchStatuses = async (batch: Batch, entity: ChangeBatchStatusesRequestPayload): Promise<Response> => {
+  return await HttpService.root(BATCH_CHANGE_STATUSES_ENDPOINT).post({
+    entity,
+    urlReplacements: {
+      '{id}': batch.id.toString(),
+    },
+  });
+};
+
+/**
  * Exported functions
  */
 const NurseryBatchService = {
+  changeBatchStatuses,
   createBatch,
   getBatch,
   getBatches,


### PR DESCRIPTION
Calculating germination and loss rates will require that we distinguish between
the user overwriting the quantities of a batch and the user moving seedlings from
one status to another.

Update the "change status" dialog so it calls a newly-added API endpoint for
changing seedling statuses.
