### PR TITLE
SW-4330-followup Add map style dropdown and fullscreen button to editable map view

### DIFF
--- a/src/components/Map/EditableMap.tsx
+++ b/src/components/Map/EditableMap.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import ReactMapGL, { LngLatBoundsLike, MapRef } from 'react-map-gl';
+import ReactMapGL, { FullscreenControl, LngLatBoundsLike, MapRef } from 'react-map-gl';
 import EditableMapDraw, { MapEditorMode } from 'src/components/Map/EditableMapDraw';
 import useMapboxToken from 'src/utils/useMapboxToken';
 import { Box, Typography, useTheme } from '@mui/material';
@@ -7,6 +7,8 @@ import { useIsVisible } from 'src/hooks/useIsVisible';
 import bbox from '@turf/bbox';
 import { MultiPolygon } from 'geojson';
 import strings from 'src/strings';
+import { MapViewStyles } from 'src/types/Map';
+import MapViewStyleControl, { useMapViewStyle } from './MapViewStyleControl';
 
 export type EditableMapProps = {
   boundary?: MultiPolygon;
@@ -50,6 +52,7 @@ export default function EditableMap({ boundary, onBoundaryChanged, style }: Edit
   const mapRef = useRef<MapRef | null>(null);
   const visible = useIsVisible(containerRef);
   const theme = useTheme();
+  const [mapViewStyle, onChangeMapViewStyle] = useMapViewStyle();
 
   useEffect(() => {
     // `firstVisible` detects when the box containing the map is first visible in the viewport. The map should only be
@@ -95,7 +98,7 @@ export default function EditableMap({ boundary, onBoundaryChanged, style }: Edit
             onError={onMapError}
             ref={mapRef}
             mapboxAccessToken={token}
-            mapStyle='mapbox://styles/mapbox/satellite-v9?optimize=true'
+            mapStyle={MapViewStyles[mapViewStyle]}
             style={{
               position: 'relative',
               width: '100%',
@@ -107,6 +110,8 @@ export default function EditableMap({ boundary, onBoundaryChanged, style }: Edit
             }}
             initialViewState={initialViewState}
           >
+            <FullscreenControl position='top-left' />
+            <MapViewStyleControl mapViewStyle={mapViewStyle} onChangeMapViewStyle={onChangeMapViewStyle} />
             <EditableMapDraw boundary={boundary} onBoundaryChanged={onBoundaryChanged} setMode={setMode} />
           </ReactMapGL>
         </>

--- a/src/components/Map/MapRenderUtils.tsx
+++ b/src/components/Map/MapRenderUtils.tsx
@@ -61,7 +61,7 @@ export function useMapPortalContainer(): Element | undefined {
   const [container, setContainer] = useState<Element | undefined>();
 
   const updateContainer = useCallback(() => {
-    if (window.document.fullscreenElement?.attributes?.getNamedItem('class')?.value === 'mapboxgl-map') {
+    if (window.document.fullscreenElement?.attributes?.getNamedItem('class')?.value?.includes('mapboxgl-map')) {
       setContainer(window.document.fullscreenElement);
     } else {
       setContainer(undefined);

--- a/src/components/Map/MapViewStyleControl.tsx
+++ b/src/components/Map/MapViewStyleControl.tsx
@@ -1,0 +1,106 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { Box, Theme, useTheme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { MapViewStyle } from 'src/types/Map';
+import { DropdownItem, PopoverMenu } from '@terraware/web-components';
+import { useMapPortalContainer } from './MapRenderUtils';
+import { useLocalization } from 'src/providers';
+import strings from 'src/strings';
+
+export const useMapViewStyle = (): [MapViewStyle, (style: MapViewStyle) => void] => {
+  const [mapViewStyle, setMapViewStyle] = useState<MapViewStyle>(
+    localStorage.getItem('mapViewStyle') === 'Outdoors' ? 'Outdoors' : 'Satellite'
+  );
+
+  const onChangeMapViewStyle = useCallback(
+    (viewStyle: MapViewStyle) => {
+      setMapViewStyle(viewStyle);
+      localStorage.setItem('mapViewStyle', viewStyle);
+    },
+    [setMapViewStyle]
+  );
+
+  return useMemo<[MapViewStyle, (style: MapViewStyle) => void]>(
+    () => [mapViewStyle, onChangeMapViewStyle],
+    [mapViewStyle, onChangeMapViewStyle]
+  );
+};
+
+const useStyles = makeStyles((theme: Theme) => ({
+  viewControl: {
+    '& .MuiButtonBase-root': {
+      padding: 0,
+    },
+    '& .MuiButtonBase-root.MuiMenuItem-root': {
+      fontSize: '12px',
+    },
+    '& svg': {
+      marginLeft: 0,
+    },
+  },
+  viewControlSelected: {
+    fontSize: '12px',
+    paddingLeft: theme.spacing(0.5),
+    color: theme.palette.TwClrTxt,
+  },
+}));
+
+export type MapViewStyleControlProps = {
+  mapViewStyle?: MapViewStyle;
+  onChangeMapViewStyle: (style: MapViewStyle) => void;
+};
+
+const MapViewStyleControl = ({ mapViewStyle, onChangeMapViewStyle }: MapViewStyleControlProps): JSX.Element | null => {
+  const classes = useStyles();
+  const theme = useTheme();
+  const { activeLocale } = useLocalization();
+  const mapPortalContainer = useMapPortalContainer();
+
+  const setMapViewStyle = (item: DropdownItem) => {
+    const style: MapViewStyle = item.value === 'Outdoors' ? 'Outdoors' : 'Satellite';
+    onChangeMapViewStyle(style);
+  };
+
+  const viewOptions = useMemo<DropdownItem[]>(() => {
+    if (!activeLocale) {
+      return [];
+    }
+    return [
+      { label: strings.OUTDOORS, value: 'Outdoors' },
+      { label: strings.SATELLITE, value: 'Satellite' },
+    ];
+  }, [activeLocale]);
+
+  if (mapPortalContainer) {
+    return null;
+  }
+
+  return (
+    <Box
+      sx={{
+        position: 'absolute',
+        top: '10px',
+        left: '45px',
+        zIndex: 10,
+        height: 28,
+        backgroundColor: `${theme.palette.TwClrBaseWhite}`,
+        borderRadius: '4px',
+        display: 'flex',
+        alignItems: 'center',
+      }}
+      className={classes.viewControl}
+    >
+      <PopoverMenu
+        anchor={
+          <span className={classes.viewControlSelected}>
+            {mapViewStyle === 'Outdoors' ? strings.OUTDOORS : strings.SATELLITE}
+          </span>
+        }
+        menuSections={[viewOptions]}
+        onClick={setMapViewStyle}
+      />
+    </Box>
+  );
+};
+
+export default MapViewStyleControl;


### PR DESCRIPTION
- extracted out the map view style component for reuse
- added a react hook to share the set/get map view style properties, for reuse
- added map view style and fullscreen controls to the editable map view
- the color contrast can be off in outdoors view sometimes

<img width="924" alt="Terraware App 2023-10-31 09-56-16" src="https://github.com/terraware/terraware-web/assets/1865174/efad2c86-5fcd-4d92-918d-049f45397dff">
