### PR TITLE
SW-4402 Allow upcoming observations to be rescheduled 

### DIFF
--- a/src/components/Observations/ObservationsEventsNotification.tsx
+++ b/src/components/Observations/ObservationsEventsNotification.tsx
@@ -66,14 +66,16 @@ export default function ObservationsEventsNotification({ events }: ObservationsE
               <Box marginBottom={3}>
                 {eventsInfo.map((event, index) => (
                   <Box key={index} display='flex'>
-                    {event.infoPrefix}&nbsp;
-                    {event.eventDetails.map((data, eventDetailsIndex) => (
-                      <Box key={eventDetailsIndex} display='flex'>
-                        <Typography>{data.detail.plantingSiteName}&nbsp;(</Typography>
-                        <Link to={data.rescheduleUrl}>{strings.RESCHEDULE}</Link>
-                        <Typography>){eventDetailsIndex < event.eventDetails.length - 1 ? ', ' : ''}&nbsp;</Typography>
-                      </Box>
-                    ))}
+                    <Typography sx={{ whiteSpace: 'pre-wrap' }}>
+                      {event.infoPrefix}&nbsp;
+                      {event.eventDetails.map((data, eventDetailsIndex) => (
+                        <>
+                          {data.detail.plantingSiteName}&nbsp; (
+                          <Link to={data.rescheduleUrl}>{strings.RESCHEDULE}</Link>)
+                          {eventDetailsIndex < event.eventDetails.length - 1 ? ',' : ''}&nbsp;
+                        </>
+                      ))}
+                    </Typography>
                   </Box>
                 ))}
               </Box>

--- a/src/components/Observations/org/OrgObservationsRenderer.tsx
+++ b/src/components/Observations/org/OrgObservationsRenderer.tsx
@@ -74,7 +74,7 @@ const OrgObservationsRenderer =
         <TableRowPopupMenu
           menuItems={[
             {
-              disabled: row.state !== 'Overdue',
+              disabled: row.state === 'Completed' || row.hasObservedPermanentPlots || row.hasObservedTemporaryPlots,
               label: strings.RESCHEDULE,
               onClick: () => {
                 goToRescheduleObservation(row.observationId);

--- a/src/redux/features/observations/utils.ts
+++ b/src/redux/features/observations/utils.ts
@@ -152,6 +152,7 @@ export const mergeObservations = (
         species: mergeSpecies(observation.species, species),
         totalPlants: observation.plantingZones.reduce((acc, curr) => acc + curr.totalPlants, 0),
         hasObservedPermanentPlots: mergedZones.some((zone) => zone.hasObservedPermanentPlots),
+        hasObservedTemporaryPlots: mergedZones.some((zone) => zone.hasObservedTemporaryPlots),
       };
     });
 };
@@ -202,6 +203,9 @@ const mergeZones = (
         status,
         hasObservedPermanentPlots: zoneObservation.plantingSubzones.some((plantingSubzone) =>
           plantingSubzone.monitoringPlots.some((plot) => plot.isPermanent && plot.completedTime)
+        ),
+        hasObservedTemporaryPlots: zoneObservation.plantingSubzones.some((plantingSubzone) =>
+          plantingSubzone.monitoringPlots.some((plot) => !plot.isPermanent && plot.completedTime)
         ),
       };
     });

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -694,7 +694,7 @@ NURSERY_MORTALITY_RATE,Nursery Mortality Rate
 NURSERY_REQUIRED,Nursery *
 NURSERY_TRANSFER,Nursery Transfer
 OBSERVATION_END_DATE,Observation End Date
-OBSERVATION_EVENT_SCHEDULED,Observation event is scheduled for {0} for planting site(s): {1},"Example: Observation event is scheduled for June 1, 2023 for planting site(s): Site-A, Site-B"
+OBSERVATION_EVENT_SCHEDULED,Observation event is scheduled for {0} for planting site(s):,"Example: Observation event is scheduled for June 1, 2023 for planting site(s): "
 OBSERVATION_IN_PROGRESS,Observation in Progress
 OBSERVATION_OVERDUE,Observation Overdue
 OBSERVATION_PERIOD_WARN,Observation period cannot exceed two months.

--- a/src/types/Observations.ts
+++ b/src/types/Observations.ts
@@ -33,6 +33,7 @@ export type ObservationResults = Omit<ObservationResultsPayload, 'species'> &
     species: ObservationSpeciesResults[];
     totalPlants: number;
     hasObservedPermanentPlots: boolean;
+    hasObservedTemporaryPlots: boolean;
   };
 
 // zone level results -> contains a list of subzone level results
@@ -45,6 +46,7 @@ export type ObservationPlantingZoneResults = ObservationPlantingZoneResultsPaylo
     species: ObservationSpeciesResults[];
     status?: MonitoringPlotStatus;
     hasObservedPermanentPlots: boolean;
+    hasObservedTemporaryPlots: boolean;
   };
 
 // subzone level results -> contains lists of both species level results and monitoring plot level results


### PR DESCRIPTION
- also change criteria for which observations in the table can be rescheduled (in-progress/overdue and no observed plots)
- added a hasObservedTemporaryPlots to capture whether any type of plot was observed (in tandem with hasObservedPermanentPlots)
- refactor layout of page message that shows upcoming observations for reschedule, the site names have permalinks now and had to be constructed programmatically (removed from the string representation)

<img width="902" alt="Terraware App 2023-11-01 08-46-48" src="https://github.com/terraware/terraware-web/assets/1865174/04366018-2233-4f65-b64d-26da9772fc8b">

<img width="209" alt="Terraware App 2023-11-01 09-12-29" src="https://github.com/terraware/terraware-web/assets/1865174/e9210eff-9cb9-4218-bf25-45bc1412594e">
