### PR TITLE
SW-2223 Keep state of current org in the url

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -316,7 +316,7 @@ function AppContent() {
               <OptInFeatures refresh={reloadPreferences} />
             </Route>
           )}
-          <Route path='/'>
+          <Route path='*'>
             <Redirect to={APP_PATHS.WELCOME} />
           </Route>
         </Switch>
@@ -529,7 +529,7 @@ function AppContent() {
             <Route path={APP_PATHS.SPECIES + '/'}>
               <Redirect to={APP_PATHS.SPECIES} />
             </Route>
-            <Route path='/'>
+            <Route path='*'>
               <Redirect to={APP_PATHS.HOME} />
             </Route>
           </Switch>

--- a/src/providers/OrganizationProvider.tsx
+++ b/src/providers/OrganizationProvider.tsx
@@ -118,14 +118,14 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
           }
           if (queryOrganizationId !== orgToUse.id.toString()) {
             query.set('organizationId', orgToUse.id.toString());
-            history.push(getLocation(location.pathname, location, query.toString()));
+            history.replace(getLocation(location.pathname, location, query.toString()));
           }
         }
       }
       if (!orgToUse && queryOrganizationId) {
         // user does not belong to any orgs, clear the url param org id
         query.delete('organizationId');
-        history.push(getLocation(location.pathname, location, query.toString()));
+        history.replace(getLocation(location.pathname, location, query.toString()));
       }
     }
   }, [organizations, selectedOrganization, query, location, history, userPreferences, userBootstrapped]);


### PR DESCRIPTION
- allows us to share urls maintaining org context
- centralized handling so devs can create links in code without worrying about populating the org id
- some special handling for the welcome page alone as it switched between routing contexts
- also updated the plants primary page (used by observations, dashboard) to avoid redundant calls to get/set preferences, noticed this while debugging