### PR TITLE
Fix font size in Reschedule link

### DIFF
--- a/src/components/Observations/ObservationsEventsNotification.tsx
+++ b/src/components/Observations/ObservationsEventsNotification.tsx
@@ -71,8 +71,10 @@ export default function ObservationsEventsNotification({ events }: ObservationsE
                       {event.eventDetails.map((data, eventDetailsIndex) => (
                         <>
                           {data.detail.plantingSiteName}&nbsp; (
-                          <Link to={data.rescheduleUrl}>{strings.RESCHEDULE}</Link>)
-                          {eventDetailsIndex < event.eventDetails.length - 1 ? ',' : ''}&nbsp;
+                          <Link fontSize={16} to={data.rescheduleUrl}>
+                            {strings.RESCHEDULE}
+                          </Link>
+                          ){eventDetailsIndex < event.eventDetails.length - 1 ? ',' : ''}&nbsp;
                         </>
                       ))}
                     </Typography>


### PR DESCRIPTION
- use font size 16 for Reschedule link

<img width="172" alt="Terraware App 2023-11-01 13-32-49" src="https://github.com/terraware/terraware-web/assets/1865174/8fceb04e-7bb4-416b-b624-b91d229f5a1b">
