### PR TITLE
Move sub-locations fetch/create functions into SubLocationService

### DIFF
--- a/src/components/InventoryV2/BatchSummary.tsx
+++ b/src/components/InventoryV2/BatchSummary.tsx
@@ -2,7 +2,7 @@ import { Grid, useTheme } from '@mui/material';
 import strings from 'src/strings';
 import { Batch } from 'src/types/Batch';
 import OverviewItemCard from '../common/OverviewItemCard';
-import { SeedBankService } from 'src/services';
+import { SubLocationService } from 'src/services';
 import { useEffect, useState } from 'react';
 
 interface BatchSummaryProps {
@@ -17,7 +17,7 @@ export default function BatchSummary(props: BatchSummaryProps): JSX.Element {
   useEffect(() => {
     const setLocations = async () => {
       if (batch?.facilityId) {
-        const response = await SeedBankService.getSubLocations(Number(batch.facilityId));
+        const response = await SubLocationService.getSubLocations(Number(batch.facilityId));
         if (response.requestSucceeded) {
           const nurserySLs: string[] = [];
           batch.subLocationIds.forEach((subLocId) => {

--- a/src/components/NewSeedBank/index.tsx
+++ b/src/components/NewSeedBank/index.tsx
@@ -9,7 +9,7 @@ import useForm from 'src/utils/useForm';
 import PageForm from '../common/PageForm';
 import { getAllSeedBanks } from 'src/utils/organization';
 import { Facility } from 'src/types/Facility';
-import { FacilityService, SeedBankService, SubLocationService } from 'src/services';
+import { FacilityService, SubLocationService } from 'src/services';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import PageSnackbar from 'src/components/PageSnackbar';
 import useSnackbar from 'src/utils/useSnackbar';
@@ -92,7 +92,7 @@ export default function SeedBankView(): JSX.Element {
      * Find existing locations and pick out the ones to delete, create and update.
      * Use bulk API to delete, create, update.
      */
-    const response = await SeedBankService.getSubLocations(facilityId);
+    const response = await SubLocationService.getSubLocations(facilityId);
     if (response.requestSucceeded) {
       const { subLocations } = response;
       const toDelete = _.differenceWith(subLocations, editedSubLocations, isEqual);
@@ -113,7 +113,7 @@ export default function SeedBankView(): JSX.Element {
       }
       if (toCreate.length) {
         promises.push(
-          SeedBankService.createSubLocations(
+          SubLocationService.createSubLocations(
             facilityId,
             toCreate.map((l) => l.name as string)
           )

--- a/src/components/SeedBank/SubLocations.tsx
+++ b/src/components/SeedBank/SubLocations.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Box, Grid, Typography } from '@mui/material';
 import strings from 'src/strings';
-import { SeedBankService } from 'src/services';
+import { SubLocationService } from 'src/services';
 import { DEFAULT_SUB_LOCATIONS, PartialSubLocation } from 'src/types/Facility';
 import { useLocalization } from 'src/providers';
 import Table from 'src/components/common/table';
@@ -42,7 +42,7 @@ export default function SubLocations({ seedBankId, onEdit }: SublocationsProps):
 
   useEffect(() => {
     const fetchSubLocations = async () => {
-      const response = await SeedBankService.getSubLocations(seedBankId!);
+      const response = await SubLocationService.getSubLocations(seedBankId!);
       if (response.requestSucceeded) {
         if (activeLocale) {
           const collator = new Intl.Collator(activeLocale);

--- a/src/components/accession2/edit/EditLocationModal.tsx
+++ b/src/components/accession2/edit/EditLocationModal.tsx
@@ -9,7 +9,7 @@ import { getAllSeedBanks } from 'src/utils/organization';
 import { Accession } from 'src/types/Accession';
 import AccessionService from 'src/services/AccessionService';
 import useForm from 'src/utils/useForm';
-import { SeedBankService } from 'src/services';
+import { SubLocationService } from 'src/services';
 import { FacilitySelector, SubLocationSelector } from '../properties';
 import useSnackbar from 'src/utils/useSnackbar';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
@@ -43,7 +43,7 @@ export default function EditLocationModal(props: EditLocationModalProps): JSX.El
   useEffect(() => {
     const setLocations = async () => {
       if (record.facilityId && activeLocale) {
-        const response = await SeedBankService.getSubLocations(record.facilityId);
+        const response = await SubLocationService.getSubLocations(record.facilityId);
         if (response.requestSucceeded) {
           const collator = new Intl.Collator(activeLocale);
           setSubLocations(response.subLocations.sort((a, b) => collator.compare(a.name, b.name)));

--- a/src/components/accession2/properties/SeedBank2Selector.tsx
+++ b/src/components/accession2/properties/SeedBank2Selector.tsx
@@ -5,7 +5,7 @@ import { AccessionPostRequestBody } from 'src/services/SeedBankService';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import { getAllSeedBanks } from 'src/utils/organization';
 import { Facility, SubLocation } from 'src/types/Facility';
-import { SeedBankService } from 'src/services';
+import { SubLocationService } from 'src/services';
 import { SubLocationSelector, FacilitySelector } from './';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
 
@@ -35,7 +35,7 @@ export default function SeedBank2Selector(props: SeedBank2SelectorProps): JSX.El
   useEffect(() => {
     const setLocation = async () => {
       if (record.facilityId && activeLocale) {
-        const response = await SeedBankService.getSubLocations(record.facilityId);
+        const response = await SubLocationService.getSubLocations(record.facilityId);
         if (response.requestSucceeded) {
           const collator = new Intl.Collator(activeLocale);
           setSubLocations(response.subLocations.sort((a, b) => collator.compare(a.name, b.name)));

--- a/src/services/SeedBankService.ts
+++ b/src/services/SeedBankService.ts
@@ -1,18 +1,15 @@
 import { paths } from 'src/api/types/generated-schema';
 import strings from 'src/strings';
-import { SubLocation } from 'src/types/Facility';
 import HttpService, { Response } from './HttpService';
 import SearchService, { SearchRequestPayload } from './SearchService';
 import { SearchCriteria, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
 import { GetUploadStatusResponsePayload, UploadFileResponse } from 'src/types/File';
-import { getPromisesResponse } from './utils';
 
 /**
  * Seed bank related services
  */
 
 const SUMMARY_ENDPOINT = '/api/v1/seedbank/summary';
-const SUB_LOCATIONS_ENDPOINT = '/api/v1/facilities/{facilityId}/subLocations';
 const ACCESSIONS_ENDPOINT = '/api/v2/seedbank/accessions';
 const FIELD_VALUES_ENDPOINT = '/api/v1/seedbank/values';
 const ACCESSIONS_TEMPLATE_ENDPOINT = '/api/v2/seedbank/accessions/uploads/template';
@@ -22,9 +19,6 @@ const ACCESSIONS_UPLOAD_RESOLVE_ENDPOINT = '/api/v2/seedbank/accessions/uploads/
 
 type ValuesPostRequestBody = paths[typeof FIELD_VALUES_ENDPOINT]['post']['requestBody']['content']['application/json'];
 type ValuesPostResponse = paths[typeof FIELD_VALUES_ENDPOINT]['post']['responses'][200]['content']['application/json'];
-
-type StorageLocationsResponsePayload =
-  paths[typeof SUB_LOCATIONS_ENDPOINT]['get']['responses'][200]['content']['application/json'];
 
 export type FieldValuesMap = ValuesPostResponse['results'];
 export const DEFAULT_SEED_SEARCH_FILTERS = {};
@@ -45,16 +39,6 @@ export type Summary = {
 };
 export type SummaryResponse = Response & Summary;
 
-export type SubLocationsData = {
-  subLocations: SubLocation[];
-};
-export type SubLocationsResponse = Response & SubLocationsData;
-
-export type SubLocationData = {
-  subLocation?: SubLocation;
-};
-export type SubLocationResponse = Response & SubLocationData;
-
 export type AccessionPostRequestBody =
   paths[typeof ACCESSIONS_ENDPOINT]['post']['requestBody']['content']['application/json'];
 
@@ -68,8 +52,6 @@ export type AccessionsSearchParams = {
   searchCriteria?: SearchCriteria;
   sortOrder?: SearchSortOrder;
 };
-
-const httpSubLocations = HttpService.root(SUB_LOCATIONS_ENDPOINT);
 
 /**
  * Seed bank summary
@@ -241,47 +223,6 @@ const resolveAccessionsUpload = async (uploadId: number, overwriteExisting: bool
   });
 };
 
-/*
- * Returns all the sub-locations associated with a given facility or null if the API call failed.
- */
-const getSubLocations = async (facilityId: number): Promise<SubLocationsResponse> => {
-  const response: SubLocationsResponse = await httpSubLocations.get<StorageLocationsResponsePayload, SubLocationsData>(
-    {
-      urlReplacements: {
-        '{facilityId}': facilityId.toString(),
-      },
-    },
-    (data) => ({ subLocations: data?.subLocations ?? [] })
-  );
-
-  return response;
-};
-
-/**
- * Create a single sub-location
- */
-const createSubLocation = async (facilityId: number, name: string): Promise<SubLocationResponse> => {
-  const response: Response = await httpSubLocations.post({
-    urlReplacements: {
-      '{facilityId}': facilityId.toString(),
-    },
-    entity: { name },
-  });
-
-  return {
-    ...response,
-    subLocation: response.data?.subLocation,
-  };
-};
-
-/**
- * Create one or more sub-locations
- */
-const createSubLocations = async (facilityId: number, names: string[]): Promise<(SubLocationResponse | null)[]> => {
-  const promises = names.map((name) => createSubLocation(facilityId, name));
-  return getPromisesResponse<SubLocationResponse>(promises);
-};
-
 /**
  * Exported functions
  */
@@ -296,9 +237,6 @@ const SeedBankService = {
   uploadAccessions,
   getAccessionsUploadStatus,
   resolveAccessionsUpload,
-  getSubLocations,
-  createSubLocation,
-  createSubLocations,
 };
 
 export default SeedBankService;


### PR DESCRIPTION
- I had originally created them under SeedBankService (since seedbanks alone referred to sublocations)
- move these functions into the newly created SubLocationService and update all callers
- plan is to use these functions in the nurseries details view updates