### PR TITLE
Clean up search API payload types

### DIFF
--- a/scripts/openapi-typescript-formatter.js
+++ b/scripts/openapi-typescript-formatter.js
@@ -13,7 +13,7 @@ import fs from 'fs';
       // access to that within the formatter function. Instead, we check for a
       // keyword that's hardcoded on the server side.
       if (node.description != null && node.description.includes('TYPESCRIPT-OVERRIDE-TYPE-WITH-ANY')) {
-        return 'any';
+        return '{operation: "and" | "field" | "not" | "or"; [key: string]: any;}';
       }
       if (node.description != null && node.description.includes('GEOMETRY-FIX-TYPE-ON-CLIENT-SIDE')) {
         console.log(node);

--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -2812,7 +2812,7 @@ export interface components {
       status: components["schemas"]["SuccessOrError"];
     };
     /** @description A search criterion. The search will return results that match this criterion. The criterion can be composed of other search criteria to form arbitrary Boolean search expressions. TYPESCRIPT-OVERRIDE-TYPE-WITH-ANY */
-    SearchNodePayload: any;
+    SearchNodePayload: {operation: "and" | "field" | "not" | "or"; [key: string]: any;};
     SearchRequestPayload: {
       /**
        * Format: int32

--- a/src/components/Inventory/view/InventorySeedlingsTable.tsx
+++ b/src/components/Inventory/view/InventorySeedlingsTable.tsx
@@ -4,7 +4,7 @@ import { Typography, Grid, Box, useTheme } from '@mui/material';
 import { Button, DropdownItem, TableColumnType } from '@terraware/web-components';
 import strings from 'src/strings';
 import useDebounce from 'src/utils/useDebounce';
-import { SearchResponseElement, SearchSortOrder } from 'src/types/Search';
+import { FieldNodePayload, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
 import BatchesCellRenderer from './BatchesCellRenderer';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import useForm from 'src/utils/useForm';
@@ -65,7 +65,7 @@ export default function InventorySeedslingsTable(props: InventorySeedslingsTable
   const getSearchFields = useCallback(() => {
     // Skip fuzzy search on empty strings since the query will be
     // expensive and results will be the same as not adding the fuzzy search
-    const fields = debouncedSearchTerm
+    const fields: FieldNodePayload[] = debouncedSearchTerm
       ? [
           {
             operation: 'field',

--- a/src/components/NurseryWithdrawals/NurseryWithdrawalsTable.tsx
+++ b/src/components/NurseryWithdrawals/NurseryWithdrawalsTable.tsx
@@ -9,7 +9,15 @@ import { APP_PATHS } from 'src/constants';
 import useQuery from 'src/utils/useQuery';
 import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
 import { NurseryWithdrawalService } from 'src/services';
-import { FieldNodePayload, FieldOptionsMap, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
+import {
+  AndNodePayload,
+  FieldNodePayload,
+  FieldOptionsMap,
+  OrNodePayload,
+  SearchNodePayload,
+  SearchResponseElement,
+  SearchSortOrder,
+} from 'src/types/Search';
 import WithdrawalLogRenderer from './WithdrawalLogRenderer';
 import useDebounce from 'src/utils/useDebounce';
 import { getRequestId, setRequestId } from 'src/utils/requestsId';
@@ -125,7 +133,7 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   };
 
   const getSearchChildren = useCallback(() => {
-    const finalSearchValueChildren: FieldNodePayload[] = [];
+    const finalSearchValueChildren: SearchNodePayload[] = [];
     const searchValueChildren: FieldNodePayload[] = [];
     if (debouncedSearchTerm) {
       const fromNurseryNode: FieldNodePayload = {
@@ -153,16 +161,16 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
       searchValueChildren.push(speciesNameNode);
     }
 
-    const filterValueChildren: FieldNodePayload[] = [...Object.values(filters)];
+    const filterValueChildren: SearchNodePayload[] = [...Object.values(filters)];
 
     if (searchValueChildren.length) {
-      const searchValueNodes: FieldNodePayload = {
+      const searchValueNodes: OrNodePayload = {
         operation: 'or',
         children: searchValueChildren,
       };
 
       if (filterValueChildren.length) {
-        const filterValueNodes: FieldNodePayload = {
+        const filterValueNodes: AndNodePayload = {
           operation: 'and',
           children: filterValueChildren,
         };
@@ -175,7 +183,7 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
         finalSearchValueChildren.push(searchValueNodes);
       }
     } else if (filterValueChildren.length) {
-      const filterValueNodes: FieldNodePayload = {
+      const filterValueNodes: AndNodePayload = {
         operation: 'and',
         children: filterValueChildren,
       };
@@ -185,7 +193,7 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   }, [filters, debouncedSearchTerm]);
 
   const onApplyFilters = useCallback(async () => {
-    const searchChildren: FieldNodePayload[] = getSearchChildren();
+    const searchChildren: SearchNodePayload[] = getSearchChildren();
     const requestId = Math.random().toString();
     setRequestId('searchWithdrawals', requestId);
     const apiSearchResults = await NurseryWithdrawalService.listNurseryWithdrawals(

--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -22,7 +22,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 import PageHeaderWrapper from '../common/PageHeaderWrapper';
 import TextField from '../common/Textfield/Textfield';
 import useDebounce from 'src/utils/useDebounce';
-import { SearchNodePayload } from 'src/types/Search';
+import { OrNodePayload, SearchRequestPayload } from 'src/types/Search';
 import { SearchService } from 'src/services';
 import { getRequestId, setRequestId } from 'src/utils/requestsId';
 import { useUser, useOrganization, useLocalization } from 'src/providers/hooks';
@@ -83,7 +83,7 @@ export default function PeopleList(): JSX.Element {
 
   const search = useCallback(
     async (searchTerm: string, skipTfContact = false) => {
-      const searchField = searchTerm
+      const searchField: OrNodePayload | null = searchTerm
         ? {
             operation: 'or',
             children: [
@@ -93,7 +93,7 @@ export default function PeopleList(): JSX.Element {
           }
         : null;
 
-      const params: SearchNodePayload = {
+      const params: SearchRequestPayload = {
         prefix: 'members',
         fields: ['user_id', 'user_firstName', 'user_lastName', 'user_email', 'roleName', 'createdTime'],
         search: {

--- a/src/components/PlantingSites/PlantingSitesList.tsx
+++ b/src/components/PlantingSites/PlantingSitesList.tsx
@@ -3,7 +3,7 @@ import { Box, CircularProgress, Grid, Typography } from '@mui/material';
 import { Button, theme } from '@terraware/web-components';
 import { useDeviceInfo } from '@terraware/web-components/utils';
 import { TrackingService } from 'src/services';
-import { SearchResponseElement, SearchSortOrder } from 'src/types/Search';
+import { OrNodePayload, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
 import strings from 'src/strings';
 import useDebounce from 'src/utils/useDebounce';
 import PageSnackbar from 'src/components/PageSnackbar';
@@ -32,7 +32,7 @@ export default function PlantingSitesList(): JSX.Element {
   const { isMobile } = useDeviceInfo();
 
   const onSearch = useCallback(async () => {
-    const searchField = debouncedSearchTerm
+    const searchField: OrNodePayload | undefined = debouncedSearchTerm
       ? {
           operation: 'or',
           children: [

--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -12,8 +12,14 @@ import PageSnackbar from 'src/components/PageSnackbar';
 import AddSpeciesModal from './AddSpeciesModal';
 import DeleteSpeciesModal from './DeleteSpeciesModal';
 import TextField from '../common/Textfield/Textfield';
-import SearchService, { SearchRequestPayload } from 'src/services/SearchService';
-import { FieldNodePayload, FieldOptionsMap, SearchNodePayload, SearchSortOrder } from 'src/types/Search';
+import SearchService from 'src/services/SearchService';
+import {
+  FieldNodePayload,
+  FieldOptionsMap,
+  SearchNodePayload,
+  SearchRequestPayload,
+  SearchSortOrder,
+} from 'src/types/Search';
 import useForm from 'src/utils/useForm';
 import Icon from '../common/icon/Icon';
 import ImportSpeciesModal from './ImportSpeciesModal';
@@ -370,7 +376,7 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
   const { isMobile } = useDeviceInfo();
 
   const getParams = useCallback(() => {
-    const params: SearchNodePayload = {
+    const params: SearchRequestPayload = {
       prefix: 'species',
       fields: [...BE_SORTED_FIELDS, 'id', 'rare', 'ecosystemTypes.ecosystemType', 'organization_id'],
       search: {
@@ -459,7 +465,7 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
 
   const onApplyFilters = useCallback(
     async (reviewErrors?: boolean) => {
-      const params: SearchNodePayload = getParams();
+      const params: SearchRequestPayload = getParams();
 
       if (species) {
         // organization id filter will always exist
@@ -571,9 +577,6 @@ export default function SpeciesList({ reloadData, species }: SpeciesListProps): 
 
   const downloadReportHandler = async () => {
     const params = getParams();
-    if (!params.search.children.length) {
-      params.search = null;
-    }
     params.fields = CSV_FIELDS;
     const apiResponse = await SearchService.searchCsv(params);
 

--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -13,12 +13,7 @@ import AddSpeciesModal from './AddSpeciesModal';
 import DeleteSpeciesModal from './DeleteSpeciesModal';
 import TextField from '../common/Textfield/Textfield';
 import SearchService from 'src/services/SearchService';
-import {
-  FieldNodePayload,
-  FieldOptionsMap,
-  SearchRequestPayload,
-  SearchSortOrder,
-} from 'src/types/Search';
+import { FieldNodePayload, FieldOptionsMap, SearchRequestPayload, SearchSortOrder } from 'src/types/Search';
 import useForm from 'src/utils/useForm';
 import Icon from '../common/icon/Icon';
 import ImportSpeciesModal from './ImportSpeciesModal';

--- a/src/components/Species/index.tsx
+++ b/src/components/Species/index.tsx
@@ -16,7 +16,6 @@ import SearchService from 'src/services/SearchService';
 import {
   FieldNodePayload,
   FieldOptionsMap,
-  SearchNodePayload,
   SearchRequestPayload,
   SearchSortOrder,
 } from 'src/types/Search';

--- a/src/components/seeds/database/Filters.tsx
+++ b/src/components/seeds/database/Filters.tsx
@@ -137,7 +137,7 @@ export default function Filters(props: Props): JSX.Element {
     const result: PillListItem<string>[] = [];
     const preExpFilterPill: PillListItem<string> = filters[preExpFilterKey] && {
       id: preExpFilterKey,
-      label: preExpFilterColumn.name,
+      label: preExpFilterColumn.name as string,
       value: filters[preExpFilterKey].values.join(', '),
     };
     if (preExpFilterPill) {

--- a/src/redux/features/plantings/plantingsThunks.ts
+++ b/src/redux/features/plantings/plantingsThunks.ts
@@ -6,7 +6,7 @@ import { setPlantingsAction } from './plantingsSlice';
 export const requestPlantings = (organizationId: number) => {
   return async (dispatch: Dispatch, _getState: () => RootState) => {
     try {
-      const response = await PlantingsService.listPlantings(organizationId, []);
+      const response = await PlantingsService.listPlantings(organizationId, {});
       const plantings = response?.flatMap((r) => (r as any).delivery.plantings);
       dispatch(setPlantingsAction({ plantings }));
     } catch (e) {

--- a/src/services/FacilityService.ts
+++ b/src/services/FacilityService.ts
@@ -2,7 +2,7 @@ import strings from 'src/strings';
 import { paths } from 'src/api/types/generated-schema';
 import { Organization } from 'src/types/Organization';
 import { Facility, FacilityType } from 'src/types/Facility';
-import { SearchNodePayload } from 'src/types/Search';
+import { OrNodePayload, SearchRequestPayload } from 'src/types/Search';
 import SearchService from './SearchService';
 import HttpService, { Response } from './HttpService';
 import { getAllSeedBanks, getAllNurseries } from 'src/utils/organization';
@@ -112,7 +112,7 @@ const updateFacility = async (facility: Facility): Promise<Response> => {
  */
 const getFacilities = async ({ type, organizationId, query }: FacilitySearchParams): Promise<Facilities> => {
   const typeVal = type === 'Seed Bank' ? strings.SEED_BANK : strings.NURSERY;
-  const searchField = query
+  const searchField: OrNodePayload | null = query
     ? {
         operation: 'or',
         children: [
@@ -122,7 +122,7 @@ const getFacilities = async ({ type, organizationId, query }: FacilitySearchPara
       }
     : null;
 
-  const params: SearchNodePayload = {
+  const params: SearchRequestPayload = {
     prefix: 'facilities',
     fields: [
       'id',

--- a/src/services/LocationService.ts
+++ b/src/services/LocationService.ts
@@ -1,7 +1,7 @@
 import { paths } from 'src/api/types/generated-schema';
 import { Country } from 'src/types/Country';
 import HttpService, { Response } from './HttpService';
-import SearchService, { SearchRequestPayload } from './SearchService';
+import SearchService, { RawSearchRequestPayload } from './SearchService';
 import { SearchResponseElement } from 'src/types/Search';
 
 const TIMEZONES_ENDPOINT = '/api/v1/i18n/timeZones';
@@ -35,7 +35,7 @@ export const getTimeZones = async (): Promise<TimeZonesResponse> => {
  * Return countries list from BE database
  */
 const getCountries = async (): Promise<Country[] | null> => {
-  const params: SearchRequestPayload = {
+  const params: RawSearchRequestPayload = {
     prefix: 'country',
     fields: ['code', 'name', 'subdivisions.code', 'subdivisions.name'],
     sortOrder: [{ field: 'name' }, { field: 'subdivisions.name' }],

--- a/src/services/NurseryBatchService.ts
+++ b/src/services/NurseryBatchService.ts
@@ -2,7 +2,7 @@ import { paths } from 'src/api/types/generated-schema';
 import HttpService, { Response } from './HttpService';
 import { Batch, CreateBatchRequestPayload } from 'src/types/Batch';
 import SearchService from './SearchService';
-import { SearchNodePayload, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
+import { SearchNodePayload, SearchRequestPayload, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
 import { getPromisesResponse } from './utils';
 import PhotoService from './PhotoService';
 
@@ -121,6 +121,7 @@ const getBatches = async (organizationId: number, batchIds: number[]): Promise<S
         children: {
           operation: 'field',
           field: 'id',
+          type: 'Exact',
           values: batchIds.map((id) => id.toString()),
         },
       },
@@ -147,6 +148,7 @@ const getBatchIdsForSpecies = async (
         children: {
           operation: 'field',
           field: 'species_id',
+          type: 'Exact',
           values: speciesIds.map((id) => id.toString()),
         },
       },
@@ -169,7 +171,7 @@ const getBatchesForSpeciesById = async (
   searchSortOrder?: SearchSortOrder,
   isExport?: boolean
 ): Promise<any> => {
-  const searchParams = {
+  const searchParams: SearchRequestPayload = {
     prefix: 'batches',
     search: {
       operation: 'and',

--- a/src/services/NurseryWithdrawalService.ts
+++ b/src/services/NurseryWithdrawalService.ts
@@ -2,8 +2,15 @@ import { paths } from 'src/api/types/generated-schema';
 import HttpService, { Response } from './HttpService';
 import { Batch, NurseryWithdrawal } from 'src/types/Batch';
 import { Delivery } from 'src/types/Tracking';
-import SearchService, { SearchRequestPayload } from './SearchService';
-import { FieldOptionsMap, SearchCriteria, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
+import SearchService from './SearchService';
+import {
+  FieldOptionsMap,
+  SearchCriteria,
+  SearchNodePayload,
+  SearchRequestPayload,
+  SearchResponseElement,
+  SearchSortOrder,
+} from 'src/types/Search';
 import strings from 'src/strings';
 import PhotoService from './PhotoService';
 
@@ -74,7 +81,7 @@ const uploadWithdrawalPhotos = async (
  */
 const listNurseryWithdrawals = async (
   organizationId: number,
-  searchCriteria: SearchCriteria,
+  searchCriteria: SearchNodePayload[],
   sortOrder?: SearchSortOrder
 ): Promise<SearchResponseElement[] | null> => {
   const searchParams: SearchRequestPayload = {

--- a/src/services/NurseryWithdrawalService.ts
+++ b/src/services/NurseryWithdrawalService.ts
@@ -5,7 +5,6 @@ import { Delivery } from 'src/types/Tracking';
 import SearchService from './SearchService';
 import {
   FieldOptionsMap,
-  SearchCriteria,
   SearchNodePayload,
   SearchRequestPayload,
   SearchResponseElement,

--- a/src/services/PlantingsService.ts
+++ b/src/services/PlantingsService.ts
@@ -1,5 +1,5 @@
-import { SearchCriteria, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
-import SearchService, { SearchRequestPayload } from 'src/services/SearchService';
+import { SearchCriteria, SearchRequestPayload, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
+import SearchService from 'src/services/SearchService';
 import HttpService, { Response } from './HttpService';
 import { UpdatePlantingSubzonePayload } from 'src/types/PlantingSite';
 

--- a/src/services/SeedBankService.ts
+++ b/src/services/SeedBankService.ts
@@ -1,8 +1,8 @@
 import { paths } from 'src/api/types/generated-schema';
 import strings from 'src/strings';
 import HttpService, { Response } from './HttpService';
-import SearchService, { SearchRequestPayload } from './SearchService';
-import { SearchCriteria, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
+import SearchService from './SearchService';
+import { SearchCriteria, SearchRequestPayload, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
 import { GetUploadStatusResponsePayload, UploadFileResponse } from 'src/types/File';
 
 /**
@@ -150,9 +150,10 @@ const getPendingAccessions = async (organizationId: number): Promise<SearchRespo
     search: SearchService.convertToSearchNodePayload(
       [
         {
-          field: 'state',
-          values: [strings.AWAITING_CHECK_IN],
           operation: 'field',
+          field: 'state',
+          type: 'Exact',
+          values: [strings.AWAITING_CHECK_IN],
         },
       ],
       organizationId

--- a/src/services/TrackingService.ts
+++ b/src/services/TrackingService.ts
@@ -28,16 +28,6 @@ type GetDeliveryResponsePayload =
 type PlantingSiteReportedPlantsPayload =
   paths[typeof REPORTED_PLANTS_ENDPOINT]['get']['responses'][200]['content']['application/json'];
 
-type SearchFieldType = {
-  operation: string;
-  children: {
-    operation: string;
-    field: string;
-    type: string;
-    values: string[];
-  }[];
-};
-
 /**
  * exported type
  */

--- a/src/services/test/NurseryWithdrawalService.test.ts
+++ b/src/services/test/NurseryWithdrawalService.test.ts
@@ -32,7 +32,7 @@ describe('Nursery withdrawals service', () => {
         ])
       );
 
-      expect(await NurseryWithdrawalService.listNurseryWithdrawals(1, {})).toEqual([
+      expect(await NurseryWithdrawalService.listNurseryWithdrawals(1, [])).toEqual([
         {
           id: '56',
           delivery_id: '24',
@@ -50,14 +50,14 @@ describe('Nursery withdrawals service', () => {
 
     it('should handle multiple items in the results list', async () => {
       search.mockImplementation(() => Promise.resolve(readData('nurseryWithdrawalsRaw.json')));
-      expect(await NurseryWithdrawalService.listNurseryWithdrawals(1, {})).toEqual(
+      expect(await NurseryWithdrawalService.listNurseryWithdrawals(1, [])).toEqual(
         readData('nurseryWithdrawalsProcessed.json')
       );
     });
 
     it('should return null if search returned null data due to an error', async () => {
       search.mockImplementation(() => Promise.resolve(null));
-      expect(await NurseryWithdrawalService.listNurseryWithdrawals(1, {})).toBe(null);
+      expect(await NurseryWithdrawalService.listNurseryWithdrawals(1, [])).toBe(null);
     });
   });
 

--- a/src/types/Search.ts
+++ b/src/types/Search.ts
@@ -6,8 +6,11 @@ export type NotNodePayload = components['schemas']['NotNodePayload'] & { operati
 export type OrNodePayload = components['schemas']['OrNodePayload'] & { operation: 'or' };
 export type SearchNodePayload = AndNodePayload | FieldNodePayload | NotNodePayload | OrNodePayload;
 export type FieldValuesPayload = { [key: string]: components['schemas']['FieldValuesPayload'] };
-export type SearchCriteria = Record<string, SearchNodePayload>;
+export type SearchCriteria = { [key: string]: SearchNodePayload };
 export type SearchSortOrder = components['schemas']['SearchSortOrderElement'];
 export type SearchResponseElement = components['schemas']['SearchResponsePayload']['results'][0];
 
 export type FieldOptionsMap = { [key: string]: { partial: boolean; values: (string | null)[] } };
+
+/** Search request payload that requires a search node to be specified. */
+export type SearchRequestPayload = components['schemas']['SearchRequestPayload'] & { search: SearchNodePayload };


### PR DESCRIPTION
To avoid a circular type reference, we replaced the definition of
`SearchNodePayload` in `generated-schema.ts` with "any".

Unfortunately, "any" effectively causes type checking to be disabled, so there
was some search-related code that used the wrong types and TypeScript couldn't
detect it.

- Update the OpenAPI code generator so it replaces `SearchNodePayload` with a
  real type, though one that still avoids the circular reference.
- Fix the incorrect types that become visible to the type checker once we've
  stopped using "any".
- Introduce a stricter version of `SearchRequestPayload` that requires a search
  query (it is optional in the API).

This shouldn't change any behavior.
