### PR TITLE
SW-4434 Link Location->Nursery->SubLocation->BatchCount to inventory batch view with filters set

### DIFF
--- a/src/components/Nursery/NurserySubLocations.tsx
+++ b/src/components/Nursery/NurserySubLocations.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { APP_PATHS } from 'src/constants';
 import { PartialSubLocation } from 'src/types/Facility';
 import SubLocations from 'src/components/common/SubLocations';
 import isEnabled from 'src/features';
@@ -12,8 +13,12 @@ export default function NurserySubLocations({ nurseryId, onEdit }: NurserySubLoc
   const nurseryV2 = isEnabled('Nursery Updates');
 
   const renderLink = useCallback((facilityId: number, locationName: string) => {
-    // TODO: See SW-4434
-    return '';
+    return [
+      `${APP_PATHS.INVENTORY}/?`,
+      `subLocationName=${encodeURIComponent(locationName)}`,
+      `facilityId=${facilityId}`,
+      `tab=batches_by_batch`,
+    ].join('&');
   }, []);
 
   if (!nurseryV2) {


### PR DESCRIPTION
- Added link from location view to inventory/batch view
- The batch view will have the facilityId and subLocationName in the URL as query params, we need to apply those filters and clear them from url (similar to seedbank location link)
- Updated PRs with info on filter, added a note in https://terraformation.atlassian.net/browse/SW-4384 to check SW-4434 for filter info

<img width="496" alt="Screen Shot 2023-11-08 at 4 15 26 PM 2023-11-08 16-15-51" src="https://github.com/terraware/terraware-web/assets/1865174/8eca6f3e-c7a1-4bf4-9ea4-f10a70a1605e">

<img width="464" alt="Terraware App 2023-11-08 16-14-20" src="https://github.com/terraware/terraware-web/assets/1865174/b4094f20-7b10-4f74-b357-75c048e7dc60">
