### PR TITLE
SW-4448 Species selector dropdown uses BE search endpoint for querying

### DIFF
--- a/src/components/Inventory/InventoryCreate.tsx
+++ b/src/components/Inventory/InventoryCreate.tsx
@@ -10,7 +10,7 @@ import PageForm from 'src/components/common/PageForm';
 import getDateDisplayValue, { getTodaysDateFormatted } from '@terraware/web-components/utils/date';
 import useSnackbar from 'src/utils/useSnackbar';
 import DatePicker from 'src/components/common/DatePicker';
-import { Species2Dropdown } from '../accession2/properties';
+import SpeciesSelector from 'src/components/common/SpeciesSelector';
 import { CreateBatchRequestPayload } from 'src/types/Batch';
 import NurseryBatchService from 'src/services/NurseryBatchService';
 import NurseryDropdown from './NurseryDropdown';
@@ -172,7 +172,7 @@ export default function CreateInventory(): JSX.Element {
           <Box marginTop={theme.spacing(3)}>
             <Grid container padding={0}>
               <Grid item xs={12} sx={marginTop}>
-                <Species2Dropdown record={record} setRecord={setRecord} validate={validateFields} />
+                <SpeciesSelector record={record} setRecord={setRecord} validate={validateFields} />
               </Grid>
               <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>
                 <NurseryDropdown

--- a/src/components/accession2/create/Accession2Create.tsx
+++ b/src/components/accession2/create/Accession2Create.tsx
@@ -13,8 +13,8 @@ import {
   CollectedReceivedDate2,
   Collectors2,
   SeedBank2Selector,
-  Species2Dropdown,
 } from '../properties';
+import SpeciesSelector from 'src/components/common/SpeciesSelector';
 import Textfield from 'src/components/common/Textfield/Textfield';
 import PageForm from 'src/components/common/PageForm';
 import { accessionCreateStates } from 'src/types/Accession';
@@ -153,7 +153,7 @@ export default function CreateAccession(): JSX.Element {
               </Typography>
             </Grid>
             <Grid item xs={12} sx={marginTop}>
-              <Species2Dropdown record={record} setRecord={setRecord} validate={validateFields} />
+              <SpeciesSelector record={record} setRecord={setRecord} validate={validateFields} />
             </Grid>
             <CollectedReceivedDate2
               onChange={onChange}

--- a/src/components/accession2/edit/Accession2EditModal.tsx
+++ b/src/components/accession2/edit/Accession2EditModal.tsx
@@ -10,9 +10,9 @@ import {
   Accession2GPS,
   CollectedReceivedDate2,
   Collectors2,
-  Species2Dropdown,
   Accession2PlantSiteDetails,
 } from '../properties';
+import SpeciesSelector from 'src/components/common/SpeciesSelector';
 import useSnackbar from 'src/utils/useSnackbar';
 import { useLocationTimeZone } from 'src/utils/useTimeZoneUtils';
 import { getSeedBank } from 'src/utils/organization';
@@ -105,7 +105,7 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
             tooltipTitle={strings.TOOLTIP_ACCESSIONS_ID}
           />
         </Grid>
-        <Species2Dropdown
+        <SpeciesSelector
           speciesId={record.speciesId}
           record={record}
           disabled={record.hasDeliveries}

--- a/src/components/accession2/properties/index.tsx
+++ b/src/components/accession2/properties/index.tsx
@@ -5,7 +5,6 @@ import CollectedReceivedDate2 from './CollectedReceivedDate2';
 import CollectionSource from './CollectionSource';
 import Collectors2 from './Collectors2';
 import SeedBank2Selector from './SeedBank2Selector';
-import Species2Dropdown from './Species2Dropdown';
 import FacilitySelector from 'src/components/accession2/properties/FacilitySelector';
 import SubLocationSelector from 'src/components/accession2/properties/SubLocationSelector';
 
@@ -17,7 +16,6 @@ export {
   CollectionSource,
   Collectors2,
   SeedBank2Selector,
-  Species2Dropdown,
   FacilitySelector,
   SubLocationSelector,
 };

--- a/src/types/Species.ts
+++ b/src/types/Species.ts
@@ -194,3 +194,5 @@ export enum SpeciesRequestError {
 }
 
 export type SpeciesDetails = components['schemas']['SpeciesLookupDetailsResponsePayload'];
+
+export type SuggestedSpecies = Partial<Species> & { scientificName: string };

--- a/src/utils/text.tsx
+++ b/src/utils/text.tsx
@@ -1,19 +1,5 @@
 import { isWhitespaces } from '@terraware/web-components/utils';
 
-/**
- * Removes accents and other diacritics from letters. This is typically used for things like
- * typeaheads where we want a value of "ábc" to match user input of "abc".
- */
-export function removeDiacritics(s: string): string {
-  // First, decompose characters into combining forms: "á" gets turned into a two-character sequence
-  // of "a" followed by a combining character that modifies the previous character to add an accent
-  // mark.
-  const normalized = s.normalize('NFD');
-
-  // Now remove all the combining characters, resulting in a string without diacritics.
-  return normalized.replace(/\p{Mn}/gu, '');
-}
-
 export const numWords = (testString: string): number => {
   return testString.trim().split(/\s+/).length;
 };


### PR DESCRIPTION
- previous was doing a client-side in-memory search based on client input
- now pass the client input to the BE, similar to species table, for a consistent search fuzzy match response
- request fewer properties for faster query response feedback
- moved Species2Dropdown to src/components/common and renamed it as SpeciesSelector
- updated callees
- added a function in SpeciesService to suggest species for the dropdown
- removed the 'removeDiacritics' utils since it is no longer used, can add it back if it helps 