### PR TITLE
SW-4456 Make nursery filter clickable in v2 inventory list

### DIFF
--- a/src/components/InventoryV2/InventoryTable.tsx
+++ b/src/components/InventoryV2/InventoryTable.tsx
@@ -94,7 +94,7 @@ export default function InventoryTable(props: InventoryTableProps): JSX.Element 
       </Box>
       <Grid item xs={12}>
         <div>
-          <Grid container spacing={4}>
+          <Grid container spacing={4} marginTop={0}>
             <Grid item xs={12}>
               <Table
                 id='inventory-table'


### PR DESCRIPTION
- the table container had a negatve margin, eating into the nursery filter space (a subsequent padding essentially made that whitespace)
- fixes are to either update z-index on filter or add positive margin to container so it does not overlap the filter space
- here i added a positive margin (downside is there's some space above the table)

<img width="818" alt="Terraware App 2023-11-15 09-18-41" src="https://github.com/terraware/terraware-web/assets/1865174/72a35507-3738-4c59-b449-843e03ff119b">
