### PR TITLE
SW-4468 Remove planting season months from UI

### DIFF
--- a/src/components/PlantingSites/PlantingSiteCreate.tsx
+++ b/src/components/PlantingSites/PlantingSiteCreate.tsx
@@ -20,8 +20,6 @@ import { TimeZoneDescription } from 'src/types/TimeZones';
 import LocationTimeZoneSelector from '../LocationTimeZoneSelector';
 import { PlantingSiteId } from 'src/services/TrackingService';
 import Card from 'src/components/common/Card';
-import { getMonth } from 'src/utils/dateFormatter';
-import { useLocalization } from 'src/providers';
 import PlantingSiteMapEditor from 'src/components/Map/PlantingSiteMapEditor';
 import { makeStyles } from '@mui/styles';
 import { MultiPolygon } from 'geojson';
@@ -39,7 +37,6 @@ const useStyles = makeStyles(() => ({
 
 export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
-  const { activeLocale } = useLocalization();
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
   const classes = useStyles();
@@ -207,28 +204,6 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
                         tooltip={strings.TOOLTIP_TIME_ZONE_PLANTING_SITE}
                       />
                     </Grid>
-                    {selectedPlantingSite && (
-                      <>
-                        <Grid item xs={gridSize()} marginTop={isMobile ? 1 : 0}>
-                          <TextField
-                            label={strings.PLANTING_SEASON_START}
-                            id='planting-season-start'
-                            type='text'
-                            value={getMonth(selectedPlantingSite?.plantingSeasonStartMonth, activeLocale)}
-                            display={true}
-                          />
-                        </Grid>
-                        <Grid item xs={gridSize()}>
-                          <TextField
-                            label={strings.PLANTING_SEASON_END}
-                            id='planting-season-end'
-                            type='text'
-                            value={getMonth(selectedPlantingSite?.plantingSeasonEndMonth, activeLocale)}
-                            display={true}
-                          />
-                        </Grid>
-                      </>
-                    )}
                   </Grid>
                   <Grid container flexGrow={1}>
                     <Grid item xs={12} display='flex'>

--- a/src/components/PlantingSites/PlantingSiteView.tsx
+++ b/src/components/PlantingSites/PlantingSiteView.tsx
@@ -14,8 +14,6 @@ import BoundariesAndZones from 'src/components/PlantingSites/BoundariesAndZones'
 import BackToLink from 'src/components/common/BackToLink';
 import { useLocationTimeZone } from 'src/utils/useTimeZoneUtils';
 import Card from 'src/components/common/Card';
-import { getMonth } from 'src/utils/dateFormatter';
-import { useLocalization } from 'src/providers';
 import SimplePlantingSite from 'src/components/PlantingSites/SimplePlantingSite';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -29,7 +27,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export default function PlantingSiteView(): JSX.Element {
   const { isMobile } = useDeviceInfo();
-  const { activeLocale } = useLocalization();
   const classes = useStyles();
   const theme = useTheme();
   const { plantingSiteId } = useParams<{ plantingSiteId: string }>();
@@ -95,24 +92,6 @@ export default function PlantingSiteView(): JSX.Element {
               type='text'
               value={tz.longName}
               tooltipTitle={strings.TOOLTIP_TIME_ZONE_PLANTING_SITE}
-              display={true}
-            />
-          </Grid>
-          <Grid item xs={gridSize()} marginTop={isMobile ? 3 : 0}>
-            <TextField
-              label={strings.PLANTING_SEASON_START}
-              id='planting-season-start'
-              type='text'
-              value={getMonth(plantingSite?.plantingSeasonStartMonth, activeLocale)}
-              display={true}
-            />
-          </Grid>
-          <Grid item xs={gridSize()} marginTop={isMobile ? 3 : 0}>
-            <TextField
-              label={strings.PLANTING_SEASON_END}
-              id='planting-season-end'
-              type='text'
-              value={getMonth(plantingSite?.plantingSeasonEndMonth, activeLocale)}
               display={true}
             />
           </Grid>

--- a/src/utils/dateFormatter.ts
+++ b/src/utils/dateFormatter.ts
@@ -1,5 +1,3 @@
-import strings from 'src/strings';
-
 /**
  * Returns <Month> <Year> (eg. July 2023) from yyyy-mm-dd format
  */
@@ -20,44 +18,3 @@ export const getShortTime = (dateTime: string, locale: string | undefined | null
   new Intl.DateTimeFormat(locale || 'en-US', { timeStyle: 'short', timeZone: timeZone ?? 'UTC' })
     .format(new Date(dateTime))
     .toLowerCase();
-
-// return string version for a month from number, eg. 1 -> January
-export const getMonth = (month: number | undefined | null, locale: string | undefined | null): string => {
-  if (!month || !locale) {
-    return '';
-  }
-
-  // avoid generating the key like so
-  // return strings[`MONTH_${month.toString().padStart(2, '0')}`];
-  // which won't catch missing key issues
-
-  // use an exhaustive switch instead
-  switch (month) {
-    case 1:
-      return strings.MONTH_01;
-    case 2:
-      return strings.MONTH_02;
-    case 3:
-      return strings.MONTH_03;
-    case 4:
-      return strings.MONTH_04;
-    case 5:
-      return strings.MONTH_05;
-    case 6:
-      return strings.MONTH_06;
-    case 7:
-      return strings.MONTH_07;
-    case 8:
-      return strings.MONTH_08;
-    case 9:
-      return strings.MONTH_09;
-    case 10:
-      return strings.MONTH_10;
-    case 11:
-      return strings.MONTH_11;
-    case 12:
-      return strings.MONTH_12;
-    default:
-      return '';
-  }
-};


### PR DESCRIPTION
We're going to be replacing the admin-specified planting season start and end
months with a new user-editable planting season schedule. Since we won't be
bothering to set the start/end months given the new feature is coming up, stop
showing them in the UI.
