### PR TITLE
Use unique ids for tables, ids are used to generate user preference names

### DIFF
--- a/src/components/InventoryV2/InventoryTable.tsx
+++ b/src/components/InventoryV2/InventoryTable.tsx
@@ -76,7 +76,7 @@ export default function InventoryTable(props: InventoryTableProps): JSX.Element 
           <Grid container spacing={4} marginTop={0}>
             <Grid item xs={12}>
               <Table
-                id='inventory-table'
+                id='inventory-table-v2'
                 columns={columns}
                 rows={results}
                 orderBy='species_scientificName'

--- a/src/components/InventoryV2/view/InventorySeedlingsForNurseryTable.tsx
+++ b/src/components/InventoryV2/view/InventorySeedlingsForNurseryTable.tsx
@@ -381,7 +381,7 @@ export default function InventorySeedlingsForNurseryTable(props: InventorySeedli
 
           <Box marginTop={theme.spacing(2)}>
             <Table
-              id='batches-table'
+              id='inventory-seedlings-for-nursery-table'
               columns={columns}
               rows={filteredBatches}
               orderBy='batchNumber'

--- a/src/components/InventoryV2/view/InventorySeedlingsTable.tsx
+++ b/src/components/InventoryV2/view/InventorySeedlingsTable.tsx
@@ -412,7 +412,7 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
 
           <Box marginTop={theme.spacing(2)}>
             <Table
-              id='batches-table'
+              id='inventory-seedlings-table'
               columns={columns}
               rows={filteredBatches}
               orderBy='batchNumber'

--- a/src/components/Observations/zone/index.tsx
+++ b/src/components/Observations/zone/index.tsx
@@ -149,7 +149,7 @@ export default function ObservationPlantingZone(): JSX.Element {
               <Search search={search} onSearch={(value: string) => onSearch(value)} filtersProps={filtersProps} />
               <Box marginTop={2}>
                 <Table
-                  id='observation-details-table'
+                  id='observation-zone-table'
                   columns={columns}
                   rows={plantingZone?.plantingSubzones?.flatMap((subzone) => subzone.monitoringPlots) ?? []}
                   orderBy='plantingZoneName'


### PR DESCRIPTION
- We use the [table ids to generate user preference names](https://github.com/terraware/terraware-web/blob/main/src/components/common/table/index.tsx#L54), to store table column ordering iff user changes the column locations (drag n drop)
- This table id design decision seems to be backfiring a bit now, we don't have any checks in place to ensure unique table ids (sigh)
- For now, fix the table ids to be unique (maybe we can keep an eye out for such changes going forward)
- Open to other ways of ensuring unique ids (maybe leverage some typescript magic?)
- Note that changing the column definitions would require changing the table ids (since preserved columns would no longer match the definition)