### PR TITLE
SW-4461 Disable auto scroll when typing into species dropdown selector

### DIFF
--- a/src/components/common/SpeciesSelector/index.tsx
+++ b/src/components/common/SpeciesSelector/index.tsx
@@ -113,6 +113,7 @@ export default function SpeciesSelector<T extends AccessionPostRequestBody>(
           editable={true}
           errorText={validate && !record.speciesId ? strings.REQUIRED_FIELD : ''}
           tooltipTitle={tooltipTitle}
+          fixedMenu={true}
         />
       </Grid>
     </>


### PR DESCRIPTION
- the new inventory / new accession forms were auto scrolling down when user typed in the species input
- this scroll was seen in FF not Chrome
- looks like this is a known issue and we have an 'option' to disable the scroll
- enabled the option and observed no auto-scroll in FF