### PR TITLE
SW-4513 Fix outplant withdrawal error selecting a planting zone

### DIFF
--- a/src/components/SubzoneSelector/index.tsx
+++ b/src/components/SubzoneSelector/index.tsx
@@ -104,7 +104,7 @@ export default function SubzoneSelector(props: SubzoneSelectorProps): JSX.Elemen
     if (!selectedZone?.plantingSubzones) {
       return [];
     }
-    return selectedZone.plantingSubzones
+    return [...selectedZone.plantingSubzones]
       .sort((a, b) => a.fullName.localeCompare(b.fullName, undefined, { numeric: true }))
       .map((subzone) => subzoneToDropdownItem(subzone));
   }, [selectedZone]);


### PR DESCRIPTION
- planting zone/subzones are fetched from the redux store in the parent
- this data is read-only
- Subzone selector was sorting the planting subzones, sort is an in-place sort that returns a reference to the array, throwing an error (cannot modify read-only data due to in-place sort)
- See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
- for now make a copy of the array prior to sorting
- checked the codebase for other such occurrences but in all cases there's a filter call prior to sort, which ends up returning a different mutable array