### PR TITLE
SW-4484 Enable Filter by SubLocation

### DIFF
--- a/src/components/InventoryV2/DownloadReportModal.tsx
+++ b/src/components/InventoryV2/DownloadReportModal.tsx
@@ -21,6 +21,7 @@ export default function DownloadReportModal(props: DownloadReportModalProps): JS
         reportData.organizationId,
         reportData.searchSortOrder,
         reportData.facilityIds,
+        reportData.subLocationIds,
         reportData.query,
         true
       );

--- a/src/components/InventoryV2/FilterUtils.ts
+++ b/src/components/InventoryV2/FilterUtils.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import { Organization } from 'src/types/Organization';
 import { getAllNurseries } from 'src/utils/organization';
 import { SearchNodePayload, SearchResponseElement } from 'src/types/Search';
-import { InventoryFiltersType } from './InventoryFiltersPopover';
+import { InventoryFiltersType } from 'src/components/InventoryV2/InventoryFilter';
 
 export const getNurseryName = (facilityId: number, organization: Organization) => {
   const found = getAllNurseries(organization).find((n) => n.id.toString() === facilityId.toString());

--- a/src/components/InventoryV2/InventoryListByBatch.tsx
+++ b/src/components/InventoryV2/InventoryListByBatch.tsx
@@ -8,7 +8,7 @@ import { BE_SORTED_FIELDS, SearchInventoryParams } from 'src/services/NurseryInv
 import { useOrganization } from 'src/providers';
 import useDebounce from 'src/utils/useDebounce';
 import useForm from 'src/utils/useForm';
-import { InventoryFiltersType } from 'src/components/Inventory/InventoryFiltersPopover';
+import { InventoryFiltersType } from 'src/components/InventoryV2/InventoryFilter';
 import { BatchInventoryResult, InventoryResultWithBatchNumber } from 'src/components/InventoryV2';
 import { makeStyles } from '@mui/styles';
 import strings from 'src/strings';
@@ -99,6 +99,7 @@ export default function InventoryListByBatch({ setReportData }: InventoryListByB
       organizationId: selectedOrganization.id,
       query: debouncedSearchTerm,
       facilityIds: filters.facilityIds,
+      subLocationIds: filters.subLocationsIds,
       searchSortOrder,
     });
 
@@ -106,6 +107,7 @@ export default function InventoryListByBatch({ setReportData }: InventoryListByB
       selectedOrganization.id,
       searchSortOrder,
       filters.facilityIds,
+      filters.subLocationsIds,
       debouncedSearchTerm
     );
 

--- a/src/components/InventoryV2/InventoryListByNursery.tsx
+++ b/src/components/InventoryV2/InventoryListByNursery.tsx
@@ -8,7 +8,7 @@ import NurseryInventoryService, { BE_SORTED_FIELDS, SearchInventoryParams } from
 import { useOrganization } from 'src/providers';
 import useDebounce from 'src/utils/useDebounce';
 import useForm from 'src/utils/useForm';
-import { InventoryFiltersType } from 'src/components/Inventory/InventoryFiltersPopover';
+import { InventoryFiltersType } from 'src/components/InventoryV2/InventoryFilter';
 import { FacilitySpeciesInventoryResult } from 'src/components/InventoryV2';
 import { makeStyles } from '@mui/styles';
 import strings from 'src/strings';
@@ -81,6 +81,7 @@ export default function InventoryListByNursery({ setReportData }: InventoryListB
       organizationId: selectedOrganization.id,
       query: debouncedSearchTerm,
       facilityIds: filters.facilityIds,
+      speciesIds: filters.speciesIds,
       searchSortOrder,
     });
 
@@ -88,6 +89,7 @@ export default function InventoryListByNursery({ setReportData }: InventoryListB
       organizationId: selectedOrganization.id,
       query: debouncedSearchTerm,
       facilityIds: filters.facilityIds,
+      speciesIds: filters.speciesIds,
       searchSortOrder,
     });
 

--- a/src/components/InventoryV2/InventoryTable.tsx
+++ b/src/components/InventoryV2/InventoryTable.tsx
@@ -5,7 +5,7 @@ import { TableColumnType } from '@terraware/web-components';
 import { Box, Grid } from '@mui/material';
 import { SearchResponseElement } from 'src/types/Search';
 import InventoryCellRenderer from './InventoryCellRenderer';
-import { InventoryFiltersType } from './InventoryFiltersPopover';
+import { InventoryFiltersType } from 'src/components/InventoryV2/InventoryFilter';
 import { APP_PATHS } from 'src/constants';
 import Search from './Search';
 import Table from 'src/components/common/table';

--- a/src/components/InventoryV2/view/InventorySeedlingsTable.tsx
+++ b/src/components/InventoryV2/view/InventorySeedlingsTable.tsx
@@ -18,7 +18,7 @@ import { SortOrder } from 'src/components/common/table/sort';
 import OptionsMenu from 'src/components/common/OptionsMenu';
 import FilterGroup, { FilterField } from 'src/components/common/FilterGroup';
 import { convertFilterGroupToMap, isBatchEmpty } from 'src/components/InventoryV2/FilterUtils';
-import { InventoryFiltersType } from 'src/components/InventoryV2/InventoryFiltersPopover';
+import { InventoryFiltersType } from 'src/components/InventoryV2/InventoryFilter';
 import Search from 'src/components/InventoryV2/Search';
 import BatchesCellRenderer from './BatchesCellRenderer';
 import BatchDetailsModal from './BatchDetailsModal';

--- a/src/services/NurseryBatchService.ts
+++ b/src/services/NurseryBatchService.ts
@@ -217,6 +217,7 @@ const getAllBatches = async (
   organizationId: number,
   searchSortOrder?: SearchSortOrder,
   facilityIds?: number[],
+  subLocationIds?: number[],
   query?: string,
   isCsvExport?: boolean
 ): Promise<SearchResponseElement[] | null> => {
@@ -248,6 +249,15 @@ const getAllBatches = async (
       field: 'facility_id',
       type: 'Exact',
       values: facilityIds.map((id) => id.toString()),
+    } as SearchNodePayload);
+  }
+
+  if (subLocationIds && subLocationIds.length > 0) {
+    params.search.children.push({
+      operation: 'field',
+      field: 'subLocations.subLocation_id',
+      type: 'Exact',
+      values: subLocationIds.map((id) => id.toString()),
     } as SearchNodePayload);
   }
 

--- a/src/services/NurseryInventoryService.ts
+++ b/src/services/NurseryInventoryService.ts
@@ -7,6 +7,7 @@ import {
   AndNodePayload,
   FieldNodePayload,
   OrNodePayload,
+  SearchNodePayload,
   SearchRequestPayload,
   SearchResponseElement,
   SearchSortOrder,
@@ -71,6 +72,8 @@ export type SearchInventoryParams = {
   searchSortOrder?: SearchSortOrder;
   query?: string;
   facilityIds?: number[];
+  subLocationIds?: number[];
+  speciesIds?: number[];
   isCsvExport?: boolean;
 };
 
@@ -241,6 +244,7 @@ const searchInventoryByNursery = async ({
   organizationId,
   searchSortOrder,
   facilityIds,
+  speciesIds,
   query,
   isCsvExport,
 }: SearchInventoryParams): Promise<SearchResponseElement[] | null> => {
@@ -249,6 +253,7 @@ const searchInventoryByNursery = async ({
     fields: [
       'facility_id',
       'facility_name',
+      'facilityInventories.species_id',
       'facilityInventories.species_scientificName',
       'germinatingQuantity',
       'notReadyQuantity',
@@ -301,8 +306,16 @@ const searchInventoryByNursery = async ({
     params.search.children.push({
       operation: 'field',
       field: 'facility_id',
-      values: facilityIds,
-    });
+      values: facilityIds.map((f) => f.toString()),
+    } as SearchNodePayload);
+  }
+
+  if (speciesIds?.length) {
+    params.search.children.push({
+      operation: 'field',
+      field: 'facilityInventories.species_id',
+      values: speciesIds.map((s) => s.toString()),
+    } as SearchNodePayload);
   }
 
   return isCsvExport ? await SearchService.searchCsv(params) : await SearchService.search(params);


### PR DESCRIPTION
- Refactor InventoryFilter to be generic, pushing logic for the filter options into the Search component.
- Add SubLocation filter to Batch view
- Enable filtering by sublocation and by species, where appropriate
- Some [type-foolery](https://github.com/terraware/terraware-web/pull/1838/files#diff-2eae7c37411b0359763e941d4410e20f8198e0b617f3b6bf952c399bfab3068cR49-R52) to help prevent bugs
- Handle filter pill addition and deletion