### PR TITLE
SW-4489 Add new project entity filtering, entity specific and project multi-select filters

### DIFF
--- a/src/components/NewProjectFlow/flow/ProjectEntitiesFiltersPopover.tsx
+++ b/src/components/NewProjectFlow/flow/ProjectEntitiesFiltersPopover.tsx
@@ -1,0 +1,251 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Popover, Theme, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import Icon from 'src/components/common/icon/Icon';
+import strings from 'src/strings';
+import { getAllNurseries } from 'src/utils/organization';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
+import { useOrganization } from 'src/providers/hooks';
+import FilterMultiSelect from 'src/components/common/FilterMultiSelect';
+import { useAppSelector } from 'src/redux/store';
+import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
+import { ACCESSION_2_STATES } from 'src/types/Accession';
+import { ProjectEntitiesFilters } from 'src/components/NewProjectFlow/flow/useProjectEntitySelection';
+import { FlowStates } from 'src/components/NewProjectFlow';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  dropdown: {
+    cursor: 'pointer',
+    border: `1px solid ${theme.palette.TwClrBrdrSecondary}`,
+    borderRadius: '4px',
+    width: '176px',
+    height: '40px',
+    padding: theme.spacing(1, 2, 1, 1),
+    marginTop: theme.spacing(0.5),
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+  dropdownIconRight: {
+    height: '24px',
+    width: '24px',
+  },
+  popoverContainer: {
+    '& .MuiPaper-root': {
+      borderRadius: '8px',
+      overflow: 'visible',
+      width: '480px',
+    },
+  },
+  mobileContainer: {
+    borderRadius: '8px',
+    overflow: 'visible',
+    position: 'fixed',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    maxHeight: '90%',
+    width: '90%',
+    zIndex: 1300,
+  },
+}));
+
+type ProjectEntitiesFiltersPopoverProps = {
+  flowState: FlowStates;
+  filters: ProjectEntitiesFilters;
+  setFilters: (value: ProjectEntitiesFilters) => void;
+};
+
+export default function ProjectEntitiesFiltersPopover(props: ProjectEntitiesFiltersPopoverProps): JSX.Element {
+  const { flowState, filters, setFilters } = props;
+
+  const { selectedOrganization } = useOrganization();
+  const { isMobile } = useDeviceInfo();
+  const classes = useStyles({ isMobile });
+
+  const projects = useAppSelector(selectProjects);
+  const nurseries = useMemo(() => getAllNurseries(selectedOrganization), [selectedOrganization]);
+
+  const [entitySpecificOptions, setEntitySpecificOptions] = useState<(number | string)[]>([]);
+  const [projectOptions, setProjectOptions] = useState<number[]>([]);
+  const [anchorEls, setAnchorEls] = useState<{ [key: string]: undefined | HTMLElement }>({});
+
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLElement>, filterKey: string) =>
+      setAnchorEls({ ...anchorEls, [filterKey]: event.currentTarget }),
+    [anchorEls]
+  );
+
+  const handleClose = useCallback(
+    (filterKey: string) => setAnchorEls({ ...anchorEls, [filterKey]: undefined }),
+    [anchorEls]
+  );
+
+  const handleConfirm = useCallback(
+    (filterKey: string, selected: (number | string)[]) => {
+      handleClose(filterKey);
+      setFilters({ [filterKey]: selected });
+    },
+    [handleClose, setFilters]
+  );
+
+  useEffect(() => setProjectOptions(projects?.map((project) => project.id) || []), [projects]);
+
+  useEffect(() => {
+    if (flowState === 'accessions') {
+      setEntitySpecificOptions(ACCESSION_2_STATES);
+    } else if (flowState === 'batches') {
+      setEntitySpecificOptions(nurseries.map((nursery) => nursery.id));
+    }
+  }, [selectedOrganization, flowState, nurseries]);
+
+  const EntitySpecificFilterMultiSelect = useMemo(() => {
+    let label = '';
+    let initialSelection: (number | string)[] = [];
+    let filterKey = '';
+    let renderOption = (value: number | string) => `${value}`;
+
+    if (flowState === 'accessions') {
+      label = strings.STATUS;
+      initialSelection = filters.statuses ?? [];
+      filterKey = 'statuses';
+    } else if (flowState === 'batches') {
+      label = strings.NURSERY;
+      initialSelection = filters.nurseryIds ?? [];
+      filterKey = 'nurseryIds';
+      renderOption = (nurseryId: number | string) => nurseries.find((nursery) => nursery.id === nurseryId)?.name || '';
+    }
+
+    const isOpen = Boolean(anchorEls[filterKey]);
+
+    return (
+      <div>
+        <div className={classes.dropdown} onClick={(event) => handleClick(event, filterKey)}>
+          <Typography>{label}</Typography>
+          <Icon name={isOpen ? 'chevronUp' : 'chevronDown'} className={classes.dropdownIconRight} />
+        </div>
+        {isMobile && isOpen ? (
+          <div className={classes.mobileContainer}>
+            <FilterMultiSelect
+              label={label}
+              initialSelection={initialSelection}
+              onCancel={() => handleClose(filterKey)}
+              onConfirm={(selected) => handleConfirm(filterKey, selected)}
+              options={entitySpecificOptions}
+              renderOption={renderOption}
+            />
+          </div>
+        ) : (
+          <Popover
+            id='pre-exposed-filter-popover'
+            open={isOpen}
+            onClose={handleClose}
+            anchorEl={anchorEls[filterKey]}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'left',
+            }}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'left',
+            }}
+            className={classes.popoverContainer}
+          >
+            <FilterMultiSelect
+              label={label}
+              initialSelection={initialSelection}
+              onCancel={() => handleClose(filterKey)}
+              onConfirm={(selected) => handleConfirm(filterKey, selected)}
+              options={entitySpecificOptions}
+              renderOption={renderOption}
+            />
+          </Popover>
+        )}
+      </div>
+    );
+  }, [
+    anchorEls,
+    classes,
+    entitySpecificOptions,
+    filters.nurseryIds,
+    filters.statuses,
+    flowState,
+    handleClick,
+    handleClose,
+    handleConfirm,
+    isMobile,
+    nurseries,
+  ]);
+
+  const ProjectFilterMultiSelect = useMemo(() => {
+    const label = strings.PROJECT;
+    const initialSelection = filters.projectIds ?? [];
+    const filterKey = 'projectIds';
+    const renderOption = (projectId: number) =>
+      (projects || []).find((project) => project.id === projectId)?.name || '';
+
+    const isOpen = Boolean(anchorEls[filterKey]);
+
+    return (
+      <div>
+        <div className={classes.dropdown} onClick={(event) => handleClick(event, filterKey)}>
+          <Typography>{label}</Typography>
+          <Icon name={isOpen ? 'chevronUp' : 'chevronDown'} className={classes.dropdownIconRight} />
+        </div>
+        {isMobile && isOpen ? (
+          <div className={classes.mobileContainer}>
+            <FilterMultiSelect
+              label={label}
+              initialSelection={initialSelection}
+              onCancel={() => handleClose(filterKey)}
+              onConfirm={(selected) => handleConfirm('projectIds', selected)}
+              options={projectOptions}
+              renderOption={renderOption}
+            />
+          </div>
+        ) : (
+          <Popover
+            id='pre-exposed-filter-popover'
+            open={isOpen}
+            onClose={() => handleClose(filterKey)}
+            anchorEl={anchorEls[filterKey]}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'left',
+            }}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'left',
+            }}
+            className={classes.popoverContainer}
+          >
+            <FilterMultiSelect
+              label={label}
+              initialSelection={initialSelection}
+              onCancel={() => handleClose(filterKey)}
+              onConfirm={(selected) => handleConfirm('projectIds', selected)}
+              options={projectOptions}
+              renderOption={renderOption}
+            />
+          </Popover>
+        )}
+      </div>
+    );
+  }, [
+    filters.projectIds,
+    anchorEls,
+    classes,
+    isMobile,
+    projectOptions,
+    projects,
+    handleClick,
+    handleClose,
+    handleConfirm,
+  ]);
+
+  return (
+    <>
+      {flowState !== 'plantingSites' && EntitySpecificFilterMultiSelect}
+      {ProjectFilterMultiSelect}
+    </>
+  );
+}

--- a/src/components/NewProjectFlow/flow/Search.tsx
+++ b/src/components/NewProjectFlow/flow/Search.tsx
@@ -1,66 +1,78 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Grid, Box, useTheme } from '@mui/material';
 import { PillListItem, Textfield } from '@terraware/web-components';
 import { PillList } from '@terraware/web-components';
 import strings from 'src/strings';
 import { ProjectEntitiesFilters } from 'src/components/NewProjectFlow/flow/useProjectEntitySelection';
+import { FlowStates } from 'src/components/NewProjectFlow';
+import { useAppSelector } from 'src/redux/store';
+import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
+import { getAllNurseries } from 'src/utils/organization';
+import { useOrganization } from 'src/providers';
+import ProjectEntitiesFiltersPopover from 'src/components/NewProjectFlow/flow/ProjectEntitiesFiltersPopover';
 
 interface SearchProps {
+  flowState: FlowStates;
   searchValue: string;
   onSearch: (value: string) => void;
   filters: ProjectEntitiesFilters;
-  setFilters: React.Dispatch<React.SetStateAction<ProjectEntitiesFilters>>;
+  setFilters: (value: ProjectEntitiesFilters) => void;
 }
 
 type PillListItemWithEmptyValue = PillListItem<string> & { emptyValue: unknown };
 
 export default function Search(props: SearchProps): JSX.Element | null {
-  const { searchValue, onSearch, filters, setFilters } = props;
+  const { flowState, searchValue, onSearch, filters, setFilters } = props;
 
   const theme = useTheme();
+  const { selectedOrganization } = useOrganization();
+
+  const projects = useAppSelector(selectProjects);
+  const nurseries = useMemo(() => getAllNurseries(selectedOrganization), [selectedOrganization]);
 
   const [filterPillData, setFilterPillData] = useState<PillListItemWithEmptyValue[]>([]);
 
   useEffect(() => {
-    let data: PillListItemWithEmptyValue[] = [];
+    const data: PillListItemWithEmptyValue[] = [];
+
     if (filters.projectIds && filters.projectIds.length > 0) {
-      data = [
-        {
-          id: 'projectIds',
-          label: strings.PROJECT,
-          // TODO
-          value: filters.projectIds.join(','),
-          emptyValue: [],
-        },
-      ];
+      data.push({
+        id: 'projectIds',
+        label: strings.PROJECT,
+        // TODO
+        value: filters.projectIds
+          .map((projectId: number) => (projects || []).find((project) => project.id === projectId))
+          .map((project) => project?.name)
+          .join(','),
+        emptyValue: [],
+      });
     }
 
     if (filters.statuses && filters.statuses.length > 0) {
-      data = [
-        {
-          id: 'statuses',
-          label: strings.STATUS,
-          // TODO
-          value: filters.statuses.join(','),
-          emptyValue: [],
-        },
-      ];
+      data.push({
+        id: 'statuses',
+        label: strings.STATUS,
+        // TODO
+        value: filters.statuses.join(','),
+        emptyValue: [],
+      });
     }
 
     if (filters.nurseryIds && filters.nurseryIds.length > 0) {
-      data = [
-        {
-          id: 'nurseryIds',
-          label: strings.NURSERY,
-          // TODO
-          value: filters.nurseryIds.join(','),
-          emptyValue: [],
-        },
-      ];
+      data.push({
+        id: 'nurseryIds',
+        label: strings.NURSERY,
+        // TODO
+        value: filters.nurseryIds
+          .map((nurseryId: number) => nurseries.find((nursery) => nursery.id === nurseryId))
+          .map((nursery) => nursery?.name)
+          .join(','),
+        emptyValue: [],
+      });
     }
 
     setFilterPillData(data);
-  }, [filters.projectIds, filters.statuses, filters.nurseryIds]);
+  }, [filters, nurseries, projects]);
 
   const onRemovePillList = useCallback(
     (filterId: string) => {
@@ -86,6 +98,7 @@ export default function Search(props: SearchProps): JSX.Element | null {
             onClickRightIcon={() => onSearch('')}
           />
         </Box>
+        <ProjectEntitiesFiltersPopover flowState={flowState} filters={filters} setFilters={setFilters} />
       </Box>
       <Grid
         display='flex'

--- a/src/components/NewProjectFlow/flow/SelectBatches.tsx
+++ b/src/components/NewProjectFlow/flow/SelectBatches.tsx
@@ -104,7 +104,15 @@ export default function SelectBatches(props: SelectBatchesProps): JSX.Element | 
         });
       }
 
-      return NurseryBatchService.getAllBatches(organizationId, searchSortOrder, facilityIds, query, false, fields);
+      return NurseryBatchService.getAllBatches(
+        organizationId,
+        searchSortOrder,
+        facilityIds,
+        undefined,
+        query,
+        false,
+        fields
+      );
     },
     []
   );

--- a/src/components/NewProjectFlow/flow/SelectBatches.tsx
+++ b/src/components/NewProjectFlow/flow/SelectBatches.tsx
@@ -11,7 +11,10 @@ import { SearchResponseBatches } from 'src/services/NurseryBatchService';
 import { FieldNodePayload, SearchNodePayload, SearchSortOrder } from 'src/types/Search';
 import { FlowStates } from 'src/components/NewProjectFlow';
 import Search from 'src/components/NewProjectFlow/flow/Search';
-import { useProjectEntitySelection } from 'src/components/NewProjectFlow/flow/useProjectEntitySelection';
+import {
+  ProjectEntitiesFilters,
+  useProjectEntitySelection,
+} from 'src/components/NewProjectFlow/flow/useProjectEntitySelection';
 
 type SelectBatchesProps = {
   project: CreateProjectRequest;
@@ -76,10 +79,32 @@ export default function SelectBatches(props: SelectBatchesProps): JSX.Element | 
   const { isMobile } = useDeviceInfo();
 
   const getSearchResults = useCallback(
-    (organizationId: number, searchFields: SearchNodePayload[], searchSortOrder?: SearchSortOrder) => {
-      const facilityIds = undefined;
-      const query = searchFields[0]?.values[0] || '';
-      return NurseryBatchService.getAllBatches(organizationId, searchSortOrder, facilityIds, query);
+    (
+      organizationId: number,
+      searchFields: SearchNodePayload[],
+      searchSortOrder?: SearchSortOrder,
+      searchFilters?: ProjectEntitiesFilters
+    ) => {
+      let facilityIds;
+      const query = undefined;
+      const fields = [...searchFields];
+
+      const nurseryIds = searchFilters?.nurseryIds || [];
+      if (nurseryIds.length > 0) {
+        facilityIds = nurseryIds;
+      }
+
+      const projectIds = searchFilters?.projectIds || [];
+      if (projectIds.length > 0) {
+        fields.push({
+          field: 'project_id',
+          operation: 'field',
+          type: 'Exact',
+          values: projectIds.map((projectId: number) => `${projectId}`),
+        });
+      }
+
+      return NurseryBatchService.getAllBatches(organizationId, searchSortOrder, facilityIds, query, false, fields);
     },
     []
   );
@@ -176,6 +201,7 @@ export default function SelectBatches(props: SelectBatchesProps): JSX.Element | 
                 }}
               >
                 <Search
+                  flowState={flowState}
                   searchValue={temporalSearchValue || ''}
                   onSearch={(val) => setTemporalSearchValue(val)}
                   filters={filters}

--- a/src/components/NewProjectFlow/flow/SelectPlantingSites.tsx
+++ b/src/components/NewProjectFlow/flow/SelectPlantingSites.tsx
@@ -10,7 +10,10 @@ import { PlantingSiteSearchResult } from 'src/types/Tracking';
 import { TrackingService } from 'src/services';
 import { FieldNodePayload, SearchNodePayload, SearchSortOrder } from 'src/types/Search';
 import { FlowStates } from 'src/components/NewProjectFlow';
-import { useProjectEntitySelection } from 'src/components/NewProjectFlow/flow/useProjectEntitySelection';
+import {
+  ProjectEntitiesFilters,
+  useProjectEntitySelection,
+} from 'src/components/NewProjectFlow/flow/useProjectEntitySelection';
 import Search from 'src/components/NewProjectFlow/flow/Search';
 
 type SelectPlantingSitesProps = {
@@ -63,8 +66,25 @@ export default function SelectPlantingSites(props: SelectPlantingSitesProps): JS
   const { isMobile } = useDeviceInfo();
 
   const getSearchResults = useCallback(
-    (organizationId: number, searchFields: SearchNodePayload[], searchSortOrder?: SearchSortOrder) => {
-      return TrackingService.searchPlantingSites(organizationId, searchFields[0], searchSortOrder);
+    (
+      organizationId: number,
+      searchFields: SearchNodePayload[],
+      searchSortOrder?: SearchSortOrder,
+      searchFilters?: ProjectEntitiesFilters
+    ) => {
+      const fields = [...searchFields];
+      const projectIds = searchFilters?.projectIds || [];
+
+      if (projectIds.length > 0) {
+        fields.push({
+          field: 'project_id',
+          operation: 'field',
+          type: 'Exact',
+          values: projectIds.map((projectId: number) => `${projectId}`),
+        });
+      }
+
+      return TrackingService.searchPlantingSites(organizationId, fields, searchSortOrder);
     },
     []
   );
@@ -162,6 +182,7 @@ export default function SelectPlantingSites(props: SelectPlantingSitesProps): JS
                 }}
               >
                 <Search
+                  flowState={flowState}
                   searchValue={temporalSearchValue || ''}
                   onSearch={(val) => setTemporalSearchValue(val)}
                   filters={filters}

--- a/src/components/NewProjectFlow/flow/useProjectEntitySelection.ts
+++ b/src/components/NewProjectFlow/flow/useProjectEntitySelection.ts
@@ -15,7 +15,8 @@ interface UseProjectEntitySelectionProps<T extends SearchResponseElement> {
   getSearchResults: (
     organizationId: number,
     searchFields: FieldNodePayload[],
-    searchSortOrder?: SearchSortOrder
+    searchSortOrder?: SearchSortOrder,
+    filters?: ProjectEntitiesFilters
   ) => Promise<T[] | null>;
   getSearchFields: (debouncedSearchTerm: string) => FieldNodePayload[];
 }
@@ -43,6 +44,7 @@ export const useProjectEntitySelection = <T extends SearchResponseElement>({
   const [temporalSearchValue, setTemporalSearchValue] = useState<string | null>(null);
   const [searchSortOrder, setSearchSortOrder] = useState<SearchSortOrder>();
   const [filters, setFilters] = useForm<ProjectEntitiesFilters>({});
+  const [isSearchDirty, setIsSearchDirty] = useForm<boolean>(false);
 
   const debouncedSearchTerm = useDebounce(temporalSearchValue, 250);
 
@@ -51,7 +53,8 @@ export const useProjectEntitySelection = <T extends SearchResponseElement>({
       const searchResponse = await getSearchResults(
         selectedOrganization.id,
         getSearchFields(debouncedSearchTerm || ''),
-        searchSortOrder
+        searchSortOrder,
+        filters
       );
 
       if (searchResponse) {
@@ -62,7 +65,7 @@ export const useProjectEntitySelection = <T extends SearchResponseElement>({
         }
       }
 
-      if (!searchResponse && !temporalSearchValue) {
+      if (!isSearchDirty && !searchResponse) {
         setHasEntities(false);
         return;
       }
@@ -77,17 +80,29 @@ export const useProjectEntitySelection = <T extends SearchResponseElement>({
     selectedOrganization.id,
     searchSortOrder,
     temporalSearchValue,
+    filters,
+    isSearchDirty,
   ]);
 
   useEffect(() => {
-    if (currentFlowState === thisFlowState && temporalSearchValue === null && entities.length === 0) {
+    if (currentFlowState === thisFlowState && !isSearchDirty && entities.length === 0) {
       onNext();
     }
-  }, [entities, currentFlowState, thisFlowState, temporalSearchValue, onNext]);
+  }, [entities, currentFlowState, thisFlowState, temporalSearchValue, onNext, isSearchDirty]);
 
   useEffect(() => {
     setProjectEntities(selectedRows);
   }, [setProjectEntities, selectedRows]);
+
+  const _setTemporalSearchValue = (value: string) => {
+    setIsSearchDirty(true);
+    setTemporalSearchValue(value);
+  };
+
+  const _setFilters = (value: ProjectEntitiesFilters) => {
+    setIsSearchDirty(true);
+    setFilters({ ...filters, ...value });
+  };
 
   return {
     entities,
@@ -96,9 +111,9 @@ export const useProjectEntitySelection = <T extends SearchResponseElement>({
     showAssignmentWarning,
     setShowAssignmentWarning,
     temporalSearchValue,
-    setTemporalSearchValue,
+    setTemporalSearchValue: _setTemporalSearchValue,
     filters,
-    setFilters,
+    setFilters: _setFilters,
     setSearchSortOrder,
   };
 };

--- a/src/components/NewProjectFlow/flow/useProjectEntitySelection.ts
+++ b/src/components/NewProjectFlow/flow/useProjectEntitySelection.ts
@@ -79,7 +79,6 @@ export const useProjectEntitySelection = <T extends SearchResponseElement>({
     setHasEntities,
     selectedOrganization.id,
     searchSortOrder,
-    temporalSearchValue,
     filters,
     isSearchDirty,
   ]);

--- a/src/services/NurseryBatchService.ts
+++ b/src/services/NurseryBatchService.ts
@@ -234,7 +234,8 @@ const getAllBatches = async (
   facilityIds?: number[],
   subLocationIds?: number[],
   query?: string,
-  isCsvExport?: boolean
+  isCsvExport?: boolean,
+  searchFields?: SearchNodePayload[]
 ): Promise<SearchResponseBatches[] | null> => {
   const params: SearchRequestPayload = {
     prefix: 'batches',
@@ -274,6 +275,12 @@ const getAllBatches = async (
       type: 'Exact',
       values: subLocationIds.map((id) => id.toString()),
     } as SearchNodePayload);
+  }
+
+  if (searchFields) {
+    for (const field of searchFields) {
+      params.search.children.push(field);
+    }
   }
 
   if (query) {

--- a/src/services/TrackingService.ts
+++ b/src/services/TrackingService.ts
@@ -5,6 +5,7 @@ import { PlantingSiteZone, Population } from 'src/types/PlantingSite';
 import SearchService from './SearchService';
 import { SearchNodePayload, SearchRequestPayload, SearchSortOrder } from 'src/types/Search';
 import { MonitoringPlotSearchResult, PlantingSiteSearchResult } from 'src/types/Tracking';
+import { isArray } from '../types/utils';
 
 /**
  * Tracking related services
@@ -247,7 +248,7 @@ const getReportedPlants = async (plantingSiteId: number): Promise<SiteReportedPl
  */
 async function searchPlantingSites(
   organizationId: number,
-  searchField?: SearchNodePayload,
+  searchField?: SearchNodePayload | SearchNodePayload[],
   sortOrder?: SearchSortOrder
 ): Promise<PlantingSiteSearchResult[] | null> {
   const defaultSortOrder = {
@@ -283,7 +284,13 @@ async function searchPlantingSites(
   };
 
   if (searchField) {
-    params.search.children.push(searchField);
+    if (isArray(searchField)) {
+      for (const field of searchField) {
+        params.search.children.push(field);
+      }
+    } else {
+      params.search.children.push(searchField);
+    }
   }
 
   return (await SearchService.search(params)) as PlantingSiteSearchResult[];


### PR DESCRIPTION
- Create [ProjectEntitiesFiltersPopover](https://github.com/terraware/terraware-web/pull/1843/files#diff-eaa422306fd83884e1cbcc92bdf2ff8c4f71638dfc51096fd84ed984c81abbc9R58) which houses the entity specific filters, added to the `NewProjectFlow/flow/Search` component.
- Select Accessions has filters for statuses and projects
![2023-12-05 08 38 21](https://github.com/terraware/terraware-web/assets/9541815/1fcf2717-9084-4345-beef-4f06be4e4fcb)

- Select Batches has filters for nurseries and projects
![2023-12-05 08 44 17](https://github.com/terraware/terraware-web/assets/9541815/3e8d9dff-2b9f-4300-8f7d-2a71e1c4b760)

- Select Planting Sites has filters for projects
![2023-12-05 08 44 54](https://github.com/terraware/terraware-web/assets/9541815/91e23f48-fc0f-4d54-90a4-248d5fc4c8a8)
