### PR TITLE
SW-4486 Fix map zoom for sites with multiple polygons

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -267,11 +267,10 @@ export default function Map(props: MapProps): JSX.Element {
         if (!foundSource || !foundSource.data) {
           return;
         }
-        const feature = foundSource.data.features.find((featureData: any) => featureData.id === entity.id);
-        if (!feature) {
-          return;
-        }
-        coordinates.push(feature.geometry.coordinates);
+        const features = foundSource.data.features.filter((featureData: any) => featureData.id === entity.id);
+        features.forEach((feature: any) => {
+          coordinates.push(feature.geometry.coordinates);
+        });
       });
       if (coordinates.length > 0) {
         const bbox = MapService.getBoundingBox([coordinates]);


### PR DESCRIPTION
- the focus code was picking the first geometry to zoom into
- fix code to fetch all geometries that match the focus criteria