### PR TITLE
SW-4558 Add sublocation edit functionality to batch details view

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/styled-engine-sc": "^5.12.0",
     "@mui/styles": "^5.11.9",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^2.3.70-rc.0",
+    "@terraware/web-components": "^2.3.70",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/styled-engine-sc": "^5.12.0",
     "@mui/styles": "^5.11.9",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^2.3.68",
+    "@terraware/web-components": "^2.3.70-rc.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/src/components/InventoryV2/BatchSummary.tsx
+++ b/src/components/InventoryV2/BatchSummary.tsx
@@ -12,6 +12,7 @@ import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { requestSaveBatch } from 'src/redux/features/batches/batchesAsyncThunks';
 import { selectBatchesRequest } from 'src/redux/features/batches/batchesSelectors';
 import useSnackbar from 'src/utils/useSnackbar';
+import { BatchData } from 'src/services/NurseryBatchService';
 
 interface BatchSummaryProps {
   batch: Batch;
@@ -51,10 +52,15 @@ export default function BatchSummary(props: BatchSummaryProps): JSX.Element {
   }, [batch, dispatch, props.batch, showSubLocationEdit]);
 
   useEffect(() => {
-    if (batchesRequest?.status === 'error') {
+    if (batchesRequest?.status === 'success' && batchesRequest.data) {
+      const nextBatch = (batchesRequest.data as BatchData).batch;
+      if (nextBatch) {
+        setBatch(nextBatch);
+      }
+    } else if (batchesRequest?.status === 'error') {
       snackbar.toastError(strings.GENERIC_ERROR);
     }
-  }, [batchesRequest?.status, snackbar]);
+  }, [batchesRequest.data, batchesRequest?.status, snackbar]);
 
   return (
     <Grid container spacing={3} marginBottom={theme.spacing(4)}>

--- a/src/components/InventoryV2/BatchSummary.tsx
+++ b/src/components/InventoryV2/BatchSummary.tsx
@@ -21,7 +21,6 @@ export default function BatchSummary(props: BatchSummaryProps): JSX.Element {
   const [showSubLocationEdit, setShowSubLocationEdit] = useState<boolean>(false);
 
   const handleSubLocationEdit = useCallback(() => {
-    console.log('edit');
     setShowSubLocationEdit(!showSubLocationEdit);
   }, [showSubLocationEdit]);
 
@@ -47,7 +46,7 @@ export default function BatchSummary(props: BatchSummaryProps): JSX.Element {
                 minimal
               />
             ) : (
-              (selectedSubLocations || []).map((subLocation) => subLocation.name).join(',')
+              (selectedSubLocations || []).map((subLocation) => subLocation.name).join(', ')
             )
           }
           isEditable

--- a/src/components/InventoryV2/BatchSummary.tsx
+++ b/src/components/InventoryV2/BatchSummary.tsx
@@ -1,87 +1,25 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React from 'react';
 import { Grid, useTheme } from '@mui/material';
-import _ from 'lodash';
 import strings from 'src/strings';
 import { Batch } from 'src/types/Batch';
 import OverviewItemCard from 'src/components/common/OverviewItemCard';
 import Link from 'src/components/common/Link';
 import { APP_PATHS } from 'src/constants';
-import { useSubLocations } from 'src/components/InventoryV2/form/useSubLocations';
-import SubLocationsDropdown from 'src/components/InventoryV2/form/SubLocationsDropdown';
-import { useAppDispatch, useAppSelector } from 'src/redux/store';
-import { requestSaveBatch } from 'src/redux/features/batches/batchesAsyncThunks';
-import { selectBatchesRequest } from 'src/redux/features/batches/batchesSelectors';
-import useSnackbar from 'src/utils/useSnackbar';
-import { BatchData } from 'src/services/NurseryBatchService';
+import OverviewItemCardSubLocations from './view/OverviewItemCardSubLocations';
 
 interface BatchSummaryProps {
   batch: Batch;
 }
 
 export default function BatchSummary(props: BatchSummaryProps): JSX.Element {
-  const dispatch = useAppDispatch();
+  const { batch } = props;
+
   const theme = useTheme();
-  const snackbar = useSnackbar();
-
-  const [batch, setBatch] = useState<Batch>(props.batch);
-  const { availableSubLocations, selectedSubLocations } = useSubLocations(batch.facilityId, batch);
-
-  const [requestId, setRequestId] = useState('');
-  const batchesRequest = useAppSelector(selectBatchesRequest(requestId));
-
-  const [showSubLocationEdit, setShowSubLocationEdit] = useState<boolean>(false);
-
-  const handleUpdateSubLocations = useCallback(
-    (setFn: (previousBatch: Batch) => Batch) => {
-      const nextBatch = setFn(batch);
-      setBatch(nextBatch);
-    },
-    [batch]
-  );
-
-  const toggleSubLocationEdit = useCallback(() => {
-    const nextShowSubLocationEdit = !showSubLocationEdit;
-
-    // If we're "turning off" the edit mode, and the sub locations aren't the same, we need to update the batch
-    if (!nextShowSubLocationEdit && !_.isEqual(props.batch.subLocationIds, batch.subLocationIds)) {
-      const request = dispatch(requestSaveBatch({ batch }));
-      setRequestId(request.requestId);
-    }
-
-    setShowSubLocationEdit(nextShowSubLocationEdit);
-  }, [batch, dispatch, props.batch, showSubLocationEdit]);
-
-  useEffect(() => {
-    if (batchesRequest?.status === 'success' && batchesRequest.data) {
-      const nextBatch = (batchesRequest.data as BatchData).batch;
-      if (nextBatch) {
-        setBatch(nextBatch);
-      }
-    } else if (batchesRequest?.status === 'error') {
-      snackbar.toastError(strings.GENERIC_ERROR);
-    }
-  }, [batchesRequest, snackbar]);
 
   return (
     <Grid container spacing={3} marginBottom={theme.spacing(4)}>
       <Grid item xs={2}>
-        <OverviewItemCard
-          title={strings.SUB_LOCATION}
-          contents={
-            showSubLocationEdit ? (
-              <SubLocationsDropdown<Batch>
-                availableSubLocations={availableSubLocations}
-                record={batch}
-                setRecord={handleUpdateSubLocations}
-                minimal
-              />
-            ) : (
-              (selectedSubLocations || []).map((subLocation) => subLocation.name).join(', ')
-            )
-          }
-          isEditable
-          handleEdit={toggleSubLocationEdit}
-        />
+        <OverviewItemCardSubLocations batch={batch} />
       </Grid>
       <Grid item xs={2}>
         <OverviewItemCard isEditable={false} title={strings.GERMINATION_RATE} contents={batch.germinationRate || '%'} />

--- a/src/components/InventoryV2/BatchSummary.tsx
+++ b/src/components/InventoryV2/BatchSummary.tsx
@@ -60,7 +60,7 @@ export default function BatchSummary(props: BatchSummaryProps): JSX.Element {
     } else if (batchesRequest?.status === 'error') {
       snackbar.toastError(strings.GENERIC_ERROR);
     }
-  }, [batchesRequest.data, batchesRequest?.status, snackbar]);
+  }, [batchesRequest, snackbar]);
 
   return (
     <Grid container spacing={3} marginBottom={theme.spacing(4)}>

--- a/src/components/InventoryV2/BatchSummary.tsx
+++ b/src/components/InventoryV2/BatchSummary.tsx
@@ -1,44 +1,58 @@
+import React, { useCallback, useState } from 'react';
 import { Grid, useTheme } from '@mui/material';
 import strings from 'src/strings';
 import { Batch } from 'src/types/Batch';
-import OverviewItemCard from '../common/OverviewItemCard';
-import { SubLocationService } from 'src/services';
-import React, { useEffect, useState } from 'react';
+import OverviewItemCard from 'src/components/common/OverviewItemCard';
 import Link from 'src/components/common/Link';
 import { APP_PATHS } from 'src/constants';
+import { useSubLocations } from 'src/components/InventoryV2/form/useSubLocations';
+import SubLocationsDropdown from 'src/components/InventoryV2/form/SubLocationsDropdown';
 
 interface BatchSummaryProps {
   batch: Batch;
 }
 
 export default function BatchSummary(props: BatchSummaryProps): JSX.Element {
-  const { batch } = props;
   const theme = useTheme();
-  const [batchSubLocations, setBatchSubLocations] = useState<string[]>([]);
 
-  useEffect(() => {
-    const setLocations = async () => {
-      if (batch?.facilityId) {
-        const response = await SubLocationService.getSubLocations(Number(batch.facilityId));
-        if (response.requestSucceeded) {
-          const nurserySLs: string[] = [];
-          batch.subLocationIds.forEach((subLocId) => {
-            const found = response.subLocations.find((iSublocation) => iSublocation.id === subLocId);
-            if (found) {
-              nurserySLs.push(found.name);
-            }
-          });
-          setBatchSubLocations(nurserySLs);
-        }
-      }
-    };
-    setLocations();
-  }, [batch]);
+  const [batch, setBatch] = useState<Batch>(props.batch);
+  const { availableSubLocations, selectedSubLocations } = useSubLocations(batch.facilityId, batch);
+
+  const [showSubLocationEdit, setShowSubLocationEdit] = useState<boolean>(false);
+
+  const handleSubLocationEdit = useCallback(() => {
+    console.log('edit');
+    setShowSubLocationEdit(!showSubLocationEdit);
+  }, [showSubLocationEdit]);
+
+  const handleUpdateSubLocations = useCallback(
+    (setFn: (previousBatch: Batch) => Batch) => {
+      const nextBatch = setFn(batch);
+      setBatch(nextBatch);
+    },
+    [batch]
+  );
 
   return (
     <Grid container spacing={3} marginBottom={theme.spacing(4)}>
       <Grid item xs={2}>
-        <OverviewItemCard isEditable={false} title={strings.SUB_LOCATION} contents={batchSubLocations.join(',')} />
+        <OverviewItemCard
+          title={strings.SUB_LOCATION}
+          contents={
+            showSubLocationEdit ? (
+              <SubLocationsDropdown<Batch>
+                availableSubLocations={availableSubLocations}
+                record={batch}
+                setRecord={handleUpdateSubLocations}
+                minimal
+              />
+            ) : (
+              (selectedSubLocations || []).map((subLocation) => subLocation.name).join(',')
+            )
+          }
+          isEditable
+          handleEdit={handleSubLocationEdit}
+        />
       </Grid>
       <Grid item xs={2}>
         <OverviewItemCard isEditable={false} title={strings.GERMINATION_RATE} contents={batch.germinationRate || '%'} />

--- a/src/components/InventoryV2/form/SubLocationsDropdown.tsx
+++ b/src/components/InventoryV2/form/SubLocationsDropdown.tsx
@@ -1,15 +1,16 @@
-import { MultiSelect } from '@terraware/web-components';
-import strings from '../../../strings';
-import { SubLocation } from '../../../types/Facility';
 import React from 'react';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material';
+import { MultiSelect } from '@terraware/web-components';
+import strings from 'src/strings';
+import { SubLocation } from 'src/types/Facility';
 
 type SubLocationsDropdownProps<T extends { subLocationIds?: number[] } | undefined> = {
   availableSubLocations: SubLocation[] | undefined;
+  minimal?: boolean;
+  onBlur?: () => void;
   record: T;
   setRecord: (setFn: (previousValue: T) => T) => void;
-  minimal?: boolean;
 };
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -21,9 +22,10 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 function SubLocationsDropdown<T extends { subLocationIds?: number[] } | undefined>({
   availableSubLocations,
+  minimal,
+  onBlur,
   record,
   setRecord,
-  minimal,
 }: SubLocationsDropdownProps<T>) {
   const classes = useStyles();
 
@@ -48,6 +50,7 @@ function SubLocationsDropdown<T extends { subLocationIds?: number[] } | undefine
       valueRenderer={(val: string) => val}
       selectedOptions={record?.subLocationIds || []}
       placeHolder={strings.SELECT}
+      onBlur={onBlur}
     />
   );
 }

--- a/src/components/InventoryV2/form/SubLocationsDropdown.tsx
+++ b/src/components/InventoryV2/form/SubLocationsDropdown.tsx
@@ -2,22 +2,36 @@ import { MultiSelect } from '@terraware/web-components';
 import strings from '../../../strings';
 import { SubLocation } from '../../../types/Facility';
 import React from 'react';
+import { makeStyles } from '@mui/styles';
+import { Theme } from '@mui/material';
 
 type SubLocationsDropdownProps<T extends { subLocationIds?: number[] } | undefined> = {
   availableSubLocations: SubLocation[] | undefined;
   record: T;
   setRecord: (setFn: (previousValue: T) => T) => void;
+  minimal: boolean;
 };
+
+const useStyles = makeStyles((theme: Theme) => ({
+  multiSelectStyle: {
+    height: '100%',
+    width: '100%',
+  },
+}));
 
 function SubLocationsDropdown<T extends { subLocationIds?: number[] } | undefined>({
   availableSubLocations,
   record,
   setRecord,
+  minimal,
 }: SubLocationsDropdownProps<T>) {
+  const classes = useStyles();
+
   return (
     <MultiSelect<number, string>
+      className={classes.multiSelectStyle}
       fullWidth={true}
-      label={strings.SUB_LOCATIONS}
+      label={!minimal ? strings.SUB_LOCATIONS : undefined}
       onAdd={(subLocationId: number) => {
         setRecord((previousValue) => ({
           ...previousValue,

--- a/src/components/InventoryV2/form/SubLocationsDropdown.tsx
+++ b/src/components/InventoryV2/form/SubLocationsDropdown.tsx
@@ -9,7 +9,7 @@ type SubLocationsDropdownProps<T extends { subLocationIds?: number[] } | undefin
   availableSubLocations: SubLocation[] | undefined;
   record: T;
   setRecord: (setFn: (previousValue: T) => T) => void;
-  minimal: boolean;
+  minimal?: boolean;
 };
 
 const useStyles = makeStyles((theme: Theme) => ({

--- a/src/components/InventoryV2/form/SubLocationsDropdown.tsx
+++ b/src/components/InventoryV2/form/SubLocationsDropdown.tsx
@@ -8,7 +8,7 @@ import { SubLocation } from 'src/types/Facility';
 type SubLocationsDropdownProps<T extends { subLocationIds?: number[] } | undefined> = {
   availableSubLocations: SubLocation[] | undefined;
   minimal?: boolean;
-  onBlur?: () => void;
+  onBlur?: (nextRecord: T) => void;
   record: T;
   setRecord: (setFn: (previousValue: T) => T) => void;
 };
@@ -29,6 +29,12 @@ function SubLocationsDropdown<T extends { subLocationIds?: number[] } | undefine
 }: SubLocationsDropdownProps<T>) {
   const classes = useStyles();
 
+  const handleOnBlur = () => {
+    if (onBlur) {
+      onBlur(record);
+    }
+  };
+
   return (
     <MultiSelect<number, string>
       className={classes.multiSelectStyle}
@@ -41,16 +47,24 @@ function SubLocationsDropdown<T extends { subLocationIds?: number[] } | undefine
         }));
       }}
       onRemove={(subLocationId: number) => {
-        setRecord((previousValue) => ({
-          ...previousValue,
-          subLocationIds: previousValue?.subLocationIds?.filter((id: number) => id !== subLocationId) || [],
-        }));
+        setRecord((previousValue) => {
+          const nextRecord = {
+            ...previousValue,
+            subLocationIds: previousValue?.subLocationIds?.filter((id: number) => id !== subLocationId) || [],
+          };
+
+          if (onBlur) {
+            onBlur(nextRecord);
+          }
+
+          return nextRecord;
+        });
       }}
       options={new Map(availableSubLocations?.map((subLocation) => [subLocation.id, subLocation.name]))}
       valueRenderer={(val: string) => val}
       selectedOptions={record?.subLocationIds || []}
       placeHolder={strings.SELECT}
-      onBlur={onBlur}
+      onBlur={handleOnBlur}
     />
   );
 }

--- a/src/components/InventoryV2/view/OverviewItemCardSubLocations.tsx
+++ b/src/components/InventoryV2/view/OverviewItemCardSubLocations.tsx
@@ -1,0 +1,90 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import _ from 'lodash';
+import strings from 'src/strings';
+import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import { selectBatchesRequest } from 'src/redux/features/batches/batchesSelectors';
+import { requestSaveBatch } from 'src/redux/features/batches/batchesAsyncThunks';
+import { BatchData } from 'src/services/NurseryBatchService';
+import useSnackbar from 'src/utils/useSnackbar';
+import { Batch } from 'src/types/Batch';
+import OverviewItemCard from 'src/components/common/OverviewItemCard';
+import { useSubLocations } from 'src/components/InventoryV2/form/useSubLocations';
+import SubLocationsDropdown from 'src/components/InventoryV2/form/SubLocationsDropdown';
+
+interface OverviewItemCardSubLocationsProps {
+  batch: Batch;
+}
+
+const OverviewItemCardSubLocations = (props: OverviewItemCardSubLocationsProps) => {
+  const dispatch = useAppDispatch();
+  const snackbar = useSnackbar();
+
+  const [batch, setBatch] = useState<Batch>(props.batch);
+
+  const { availableSubLocations, selectedSubLocations } = useSubLocations(batch.facilityId, batch);
+
+  const [requestId, setRequestId] = useState('');
+  const batchesRequest = useAppSelector(selectBatchesRequest(requestId));
+
+  const [showSubLocationEdit, setShowSubLocationEdit] = useState<boolean>(false);
+
+  const handleUpdateSubLocations = useCallback(
+    (setFn: (previousBatch: Batch) => Batch) => {
+      const nextBatch = setFn(batch);
+      setBatch(nextBatch);
+    },
+    [batch]
+  );
+
+  const syncSubLocations = useCallback(() => {
+    if (!_.isEqual(props.batch.subLocationIds, batch.subLocationIds)) {
+      const request = dispatch(requestSaveBatch({ batch }));
+      setRequestId(request.requestId);
+    }
+  }, [batch, dispatch, props.batch.subLocationIds]);
+
+  const toggleSubLocationEdit = useCallback(() => {
+    const nextShowSubLocationEdit = !showSubLocationEdit;
+
+    // If we're "turning off" the edit mode, and the sub locations aren't the same, we need to update the batch
+    if (!nextShowSubLocationEdit) {
+      syncSubLocations();
+    }
+
+    setShowSubLocationEdit(nextShowSubLocationEdit);
+  }, [showSubLocationEdit, syncSubLocations]);
+
+  useEffect(() => {
+    if (batchesRequest?.status === 'success' && batchesRequest.data) {
+      const nextBatch = (batchesRequest.data as BatchData).batch;
+      if (nextBatch) {
+        setBatch(nextBatch);
+      }
+    } else if (batchesRequest?.status === 'error') {
+      snackbar.toastError(strings.GENERIC_ERROR);
+    }
+  }, [batchesRequest, snackbar]);
+
+  return (
+    <OverviewItemCard
+      title={strings.SUB_LOCATION}
+      contents={
+        showSubLocationEdit ? (
+          <SubLocationsDropdown<Batch>
+            availableSubLocations={availableSubLocations}
+            minimal
+            onBlur={syncSubLocations}
+            record={batch}
+            setRecord={handleUpdateSubLocations}
+          />
+        ) : (
+          (selectedSubLocations || []).map((subLocation) => subLocation.name).join(', ')
+        )
+      }
+      isEditable
+      handleEdit={toggleSubLocationEdit}
+    />
+  );
+};
+
+export default OverviewItemCardSubLocations;

--- a/src/components/InventoryV2/view/OverviewItemCardSubLocations.tsx
+++ b/src/components/InventoryV2/view/OverviewItemCardSubLocations.tsx
@@ -54,6 +54,11 @@ const OverviewItemCardSubLocations = (props: OverviewItemCardSubLocationsProps) 
     setShowSubLocationEdit(nextShowSubLocationEdit);
   }, [showSubLocationEdit, syncSubLocations]);
 
+  const handleOnBlur = useCallback(() => {
+    syncSubLocations();
+    setShowSubLocationEdit(false);
+  }, [syncSubLocations]);
+
   useEffect(() => {
     if (batchesRequest?.status === 'success' && batchesRequest.data) {
       const nextBatch = (batchesRequest.data as BatchData).batch;
@@ -75,7 +80,7 @@ const OverviewItemCardSubLocations = (props: OverviewItemCardSubLocationsProps) 
           <SubLocationsDropdown<Batch>
             availableSubLocations={availableSubLocations}
             minimal
-            onBlur={syncSubLocations}
+            onBlur={handleOnBlur}
             record={batch}
             setRecord={handleUpdateSubLocations}
           />

--- a/src/components/InventoryV2/view/OverviewItemCardSubLocations.tsx
+++ b/src/components/InventoryV2/view/OverviewItemCardSubLocations.tsx
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import strings from 'src/strings';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { selectBatchesRequest } from 'src/redux/features/batches/batchesSelectors';
-import { requestSaveBatch } from 'src/redux/features/batches/batchesAsyncThunks';
+import { requestFetchBatch, requestSaveBatch } from 'src/redux/features/batches/batchesAsyncThunks';
 import { BatchData } from 'src/services/NurseryBatchService';
 import useSnackbar from 'src/utils/useSnackbar';
 import { Batch } from 'src/types/Batch';
@@ -60,10 +60,12 @@ const OverviewItemCardSubLocations = (props: OverviewItemCardSubLocationsProps) 
       if (nextBatch) {
         setBatch(nextBatch);
       }
+      // Since we've updated the batch, we want to make sure any consumers are updated
+      dispatch(requestFetchBatch({ batchId: batch.id }));
     } else if (batchesRequest?.status === 'error') {
       snackbar.toastError(strings.GENERIC_ERROR);
     }
-  }, [batchesRequest, snackbar]);
+  }, [batch.id, batchesRequest, dispatch, snackbar]);
 
   return (
     <OverviewItemCard

--- a/src/components/InventoryV2/view/OverviewItemCardSubLocations.tsx
+++ b/src/components/InventoryV2/view/OverviewItemCardSubLocations.tsx
@@ -36,28 +36,34 @@ const OverviewItemCardSubLocations = (props: OverviewItemCardSubLocationsProps) 
     [batch]
   );
 
-  const syncSubLocations = useCallback(() => {
-    if (!_.isEqual(props.batch.subLocationIds, batch.subLocationIds)) {
-      const request = dispatch(requestSaveBatch({ batch }));
-      setRequestId(request.requestId);
-    }
-  }, [batch, dispatch, props.batch.subLocationIds]);
+  const syncSubLocations = useCallback(
+    (_batch: Batch) => {
+      if (!_.isEqual(props.batch.subLocationIds, _batch.subLocationIds)) {
+        const request = dispatch(requestSaveBatch({ batch: _batch }));
+        setRequestId(request.requestId);
+      }
+    },
+    [dispatch, props.batch.subLocationIds]
+  );
 
   const toggleSubLocationEdit = useCallback(() => {
     const nextShowSubLocationEdit = !showSubLocationEdit;
 
     // If we're "turning off" the edit mode, and the sub locations aren't the same, we need to update the batch
     if (!nextShowSubLocationEdit) {
-      syncSubLocations();
+      syncSubLocations(batch);
     }
 
     setShowSubLocationEdit(nextShowSubLocationEdit);
-  }, [showSubLocationEdit, syncSubLocations]);
+  }, [batch, showSubLocationEdit, syncSubLocations]);
 
-  const handleOnBlur = useCallback(() => {
-    syncSubLocations();
-    setShowSubLocationEdit(false);
-  }, [syncSubLocations]);
+  const handleOnBlur = useCallback(
+    (_batch: Batch) => {
+      syncSubLocations(_batch);
+      setShowSubLocationEdit(false);
+    },
+    [syncSubLocations]
+  );
 
   useEffect(() => {
     if (batchesRequest?.status === 'success' && batchesRequest.data) {

--- a/src/redux/features/asyncUtils.ts
+++ b/src/redux/features/asyncUtils.ts
@@ -14,7 +14,7 @@ export const buildReducers =
       .addCase(asyncThunk.fulfilled, setStatus<T>('success'))
       .addCase(asyncThunk.rejected, setStatus<T>('error'));
 
-const setStatus =
+export const setStatus =
   <T>(status: Statuses) =>
   (state: any, action: any) => {
     const requestId = action.meta.requestId;

--- a/src/redux/features/batches/batchesAsyncThunks.ts
+++ b/src/redux/features/batches/batchesAsyncThunks.ts
@@ -11,7 +11,7 @@ export type SavableBatch = (CreateBatchRequestPayload | UpdateBatchRequestPayloa
 
 export const requestSaveBatch = createAsyncThunk(
   'batches/save',
-  async (request: { batch: SavableBatch; timezone: string }, { rejectWithValue }) => {
+  async (request: { batch: SavableBatch; timezone?: string }, { rejectWithValue }) => {
     const { batch, timezone } = request;
 
     let response: (Response & BatchData) | (Response & BatchId) | undefined;

--- a/src/redux/features/batches/batchesAsyncThunks.ts
+++ b/src/redux/features/batches/batchesAsyncThunks.ts
@@ -69,3 +69,17 @@ export const requestSaveBatch = createAsyncThunk(
     return rejectWithValue(strings.GENERIC_ERROR);
   }
 );
+
+export const requestFetchBatch = createAsyncThunk(
+  'batches/fetch-one',
+  async (request: { batchId: number | string }, { rejectWithValue }) => {
+    const { batchId } = request;
+
+    const response = await NurseryBatchService.getBatch(Number(`${batchId}`));
+    if (response && response.requestSucceeded) {
+      return response.batch;
+    }
+
+    return rejectWithValue(strings.GENERIC_ERROR);
+  }
+);

--- a/src/redux/features/batches/batchesSelectors.ts
+++ b/src/redux/features/batches/batchesSelectors.ts
@@ -1,3 +1,5 @@
 import { RootState } from 'src/redux/rootReducer';
 
 export const selectBatchesRequest = (requestId: string) => (state: RootState) => state.batchesRequests[requestId];
+
+export const selectBatch = (batchId: number | string) => (state: RootState) => state.batches[batchId];

--- a/src/redux/rootReducer.ts
+++ b/src/redux/rootReducer.ts
@@ -26,11 +26,12 @@ import { messageReducer } from './features/message/messageSlice';
 import { userAnalyticsReducer } from './features/user/userAnalyticsSlice';
 import { projectsReducer, projectsRequestsReducer } from 'src/redux/features/projects/projectsSlice';
 import { subLocationsReducer } from './features/subLocations/subLocationsSlice';
-import { batchesRequestsReducer } from './features/batches/batchesSlice';
+import { batchesReducer, batchesRequestsReducer } from './features/batches/batchesSlice';
 
 // assembly of app reducers
 export const reducers = {
   appVersion: appVersionReducer,
+  batches: batchesReducer,
   batchesRequests: batchesRequestsReducer,
   message: messageReducer,
   monitoringPlots: monitoringPlotsReducer,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4602,10 +4602,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^2.3.70-rc.0":
-  version "2.3.70-rc.0"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.3.70-rc.0.tgz#3f16465ddc6cf900ba270b4484d59a53e2f857a3"
-  integrity sha512-T7BIS4PmVnAPrDjUxB0Md2yvSo6qOgjkqRkGUhfKv39iHZgWjGAXxFjCXjz4sAlDrjWTHt0boAiXC0IxkXxiJg==
+"@terraware/web-components@^2.3.70":
+  version "2.3.70"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.3.70.tgz#7899fd9857bc889abdeba0ccab5ae5145b6cf850"
+  integrity sha512-uDebDNzmBlYaHgrLJoKTdaEbTsPeAMXfZvZjIVAtZvADKBVd/69/p2/AUqM+CluoXNtIX1U+mwAKA9ZraokiPA==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.16.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4602,10 +4602,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^2.3.68":
-  version "2.3.68"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.3.68.tgz#bd3d024ffe0e84fa3c493d274dbf95ff1f34b726"
-  integrity sha512-qEC2UoT1w0V1Zb1NAqz+h+gkNalwMk4CMw2xNivitc0QZlBxZ/QOY+AfbQsvnd0fP52hKECV/4FXChhy4GlQeA==
+"@terraware/web-components@^2.3.70-rc.0":
+  version "2.3.70-rc.0"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.3.70-rc.0.tgz#3f16465ddc6cf900ba270b4484d59a53e2f857a3"
+  integrity sha512-T7BIS4PmVnAPrDjUxB0Md2yvSo6qOgjkqRkGUhfKv39iHZgWjGAXxFjCXjz4sAlDrjWTHt0boAiXC0IxkXxiJg==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.16.1"


### PR DESCRIPTION
- Move SubLocationsDropdown functionality within summary to its own component, save sub locations against the batch when the multi select is blurred - https://github.com/terraware/terraware-web/pull/1898/commits/7c3c04c7f99287e423709f0a728016cc52995785
- [Implement batches state with fetch batch so we can update consumers of batches within state](https://github.com/terraware/terraware-web/pull/1898/commits/7b1ec6c98d0d0f214aacf29898034ab8d3a2b8f2)
- [Use redux for batch within the InventoryBatch view](https://github.com/terraware/terraware-web/pull/1898/commits/94af90eaadc4e5a4b73c66f865558beff7023135)


Depends on https://github.com/terraware/web-components/pull/447


![2023-12-18 10.03.26.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/b39ef453-da2f-4978-ae94-590cc4286c13.gif)

