### PR TITLE
Refactor the accession summary grid, stub out project card

### DIFF
--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -366,19 +366,9 @@ export default function Accession2View(): JSX.Element {
     (accession?.state === 'Awaiting Check-In' && accession?.bagNumbers !== undefined ? 1 : 0) +
     (accession?.facilityId !== undefined ? 1 : 0) +
     (accession?.state === 'Drying' ? 1 : 0) +
-    3;
+    4;
 
-  const getOverviewGridSize = (row: number) => {
-    if (isMobile) {
-      return 12;
-    } else if (isTablet) {
-      if (overviewItemCount < 6 && row === 2) {
-        return 6;
-      }
-      return 4;
-    }
-    return 1;
-  };
+  const overviewGridSize = isMobile ? '100%' : isTablet ? '50%' : overviewItemCount <= 6 ? '33%' : '25%';
 
   const quantityEditable = userCanEdit && (accession?.state === 'Drying' || accession?.state === 'In Storage');
   const viabilityEditable = userCanEdit && accession?.state !== 'Used Up';
@@ -540,11 +530,11 @@ export default function Accession2View(): JSX.Element {
         container
         ref={contentRef}
         spacing={themeObj.spacing(3)}
-        columns={!isMobile && !isTablet ? overviewItemCount : 12}
         marginBottom={themeObj.spacing(3)}
+        alignItems={'stretch'}
       >
         {accession?.state && (
-          <Grid item xs={getOverviewGridSize(1)}>
+          <Grid item flexBasis={overviewGridSize} flexGrow={1}>
             <OverviewItemCard
               isEditable={!(isAwaitingCheckin || !userCanEdit)}
               handleEdit={() => setOpenEditStateModal(true)}
@@ -566,13 +556,9 @@ export default function Accession2View(): JSX.Element {
             />
           </Grid>
         )}
-        {isAwaitingCheckin && accession?.bagNumbers !== undefined && (
-          <Grid item xs={getOverviewGridSize(1)}>
-            <OverviewItemCard isEditable={false} title={strings.BAG_ID} contents={accession.bagNumbers.join(', ')} />
-          </Grid>
-        )}
+
         {accession?.facilityId !== undefined && (
-          <Grid item xs={getOverviewGridSize(1)}>
+          <Grid item flexBasis={overviewGridSize} flexGrow={1}>
             <OverviewItemCard
               isEditable={userCanEdit}
               handleEdit={() => setOpenEditLocationModal(true)}
@@ -586,8 +572,9 @@ export default function Accession2View(): JSX.Element {
             />
           </Grid>
         )}
+
         {accession?.state === 'Drying' && (
-          <Grid item xs={getOverviewGridSize(1)}>
+          <Grid item flexBasis={overviewGridSize} flexGrow={1}>
             <OverviewItemCard
               isEditable={userCanEdit}
               handleEdit={() => setOpenEndDryingReminderModal(true)}
@@ -601,7 +588,18 @@ export default function Accession2View(): JSX.Element {
             />
           </Grid>
         )}
-        <Grid item xs={getOverviewGridSize(1)}>
+
+        <Grid item flexBasis={overviewGridSize} flexGrow={1}>
+          <OverviewItemCard isEditable={false} title={strings.PROJECT} contents={'TODO projects dropdown'} />
+        </Grid>
+
+        {isAwaitingCheckin && accession?.bagNumbers !== undefined && (
+          <Grid item flexBasis={overviewGridSize} flexGrow={1}>
+            <OverviewItemCard isEditable={false} title={strings.BAG_ID} contents={accession.bagNumbers.join(', ')} />
+          </Grid>
+        )}
+
+        <Grid item flexBasis={overviewGridSize} flexGrow={1}>
           <OverviewItemCard
             isEditable={quantityEditable}
             handleEdit={() => setOpenQuantityModal(true)}
@@ -632,10 +630,12 @@ export default function Accession2View(): JSX.Element {
             }
           />
         </Grid>
-        <Grid item xs={getOverviewGridSize(2)}>
+
+        <Grid item flexBasis={overviewGridSize} flexGrow={1}>
           <OverviewItemCard isEditable={false} title={strings.AGE} contents={age} />
         </Grid>
-        <Grid item xs={getOverviewGridSize(2)}>
+
+        <Grid item flexBasis={overviewGridSize} flexGrow={1}>
           <OverviewItemCard
             isEditable={viabilityEditable}
             handleEdit={() => setOpenViabilityModal(true)}

--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -41,6 +41,7 @@ import { getUnitName, isUnitInPreferredSystem } from 'src/units';
 import ConvertedValue from 'src/components/ConvertedValue';
 import { useLocationTimeZone } from 'src/utils/useTimeZoneUtils';
 import OptionsMenu from 'src/components/common/OptionsMenu';
+import isEnabled from '../../../features';
 
 const useStyles = makeStyles((theme: Theme) => ({
   iconStyle: {
@@ -108,6 +109,7 @@ export default function Accession2View(): JSX.Element {
   const contentRef = useRef(null);
   const { activeLocale } = useLocalization();
   const locationTimeZone = useLocationTimeZone();
+  const featureFlagProjects = isEnabled('Projects');
 
   const seedBankTimeZone = useMemo(() => {
     const facility = accession?.facilityId
@@ -589,9 +591,11 @@ export default function Accession2View(): JSX.Element {
           </Grid>
         )}
 
-        <Grid item flexBasis={overviewGridSize} flexGrow={1}>
-          <OverviewItemCard isEditable={false} title={strings.PROJECT} contents={'TODO projects dropdown'} />
-        </Grid>
+        {featureFlagProjects && (
+          <Grid item flexBasis={overviewGridSize} flexGrow={1}>
+            <OverviewItemCard isEditable={false} title={strings.PROJECT} contents={'TODO projects dropdown'} />
+          </Grid>
+        )}
 
         {isAwaitingCheckin && accession?.bagNumbers !== undefined && (
           <Grid item flexBasis={overviewGridSize} flexGrow={1}>

--- a/src/components/accession2/view/Accession2View.tsx
+++ b/src/components/accession2/view/Accession2View.tsx
@@ -41,7 +41,7 @@ import { getUnitName, isUnitInPreferredSystem } from 'src/units';
 import ConvertedValue from 'src/components/ConvertedValue';
 import { useLocationTimeZone } from 'src/utils/useTimeZoneUtils';
 import OptionsMenu from 'src/components/common/OptionsMenu';
-import isEnabled from '../../../features';
+import isEnabled from 'src/features';
 
 const useStyles = makeStyles((theme: Theme) => ({
   iconStyle: {


### PR DESCRIPTION
- Stub out project card behind feature flag
- Refactor the grid so it works as expected with variable summary card counts

**6 items**
![2023-12-13 14.34.05.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/2948d77e-5eb3-454c-949b-30ad561e6f38.gif)

**7 items**
![2023-12-13 14.28.48.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/1c6a91ca-c813-46f0-a54c-be745134b850.gif)

