### PR TITLE
SW-4579 Exclude Used Up Accessions from Add Inventory Form

### DIFF
--- a/src/components/InventoryV2/form/BatchDetailsForm.tsx
+++ b/src/components/InventoryV2/form/BatchDetailsForm.tsx
@@ -86,7 +86,7 @@ export default function BatchDetailsForm(props: BatchDetailsModalProps): JSX.Ele
   const speciesId = origin === 'Species' ? originId : record?.speciesId;
 
   const { availableSubLocations, selectedSubLocations } = useSubLocations(facilityId, record);
-  const { availableAccessions, selectedAccession } = useAccessions(record);
+  const { availableAccessions, selectedAccession } = useAccessions(record, true);
   const { availableSpecies, selectedSpecies } = useSpecies(record);
   const { availableNurseries, selectedNursery } = useNurseries(record);
   const { availableProjects, selectedProject } = useProjects(record);


### PR DESCRIPTION
- Add an optional `excludeUsedUp` parameter to `useAccessions`
- Add search criteria to service call to filter out used up accessions