### PR TITLE
SW-4607 Allow withdrawals on batches that only have non-zero germinating quantity

### DIFF
--- a/src/components/Inventory/withdraw/BatchWithdrawFlow.tsx
+++ b/src/components/Inventory/withdraw/BatchWithdrawFlow.tsx
@@ -49,7 +49,9 @@ export default function BatchWithdrawFlow(props: BatchWithdrawFlowProps): JSX.El
       );
 
       if (searchResponse) {
-        const withdrawable = searchResponse.filter((batch: any) => +batch['totalQuantity(raw)'] > 0);
+        const withdrawable = searchResponse.filter(
+          (batch: any) => +batch['totalQuantity(raw)'] + +batch['germinatingQuantity(raw)'] > 0
+        );
         if (!withdrawable.length) {
           snackbar.toastError(strings.NO_BATCHES_TO_WITHDRAW_FROM); // temporary until we have a solution from design
         }

--- a/src/components/Inventory/withdraw/flow/SelectPurposeForm.tsx
+++ b/src/components/Inventory/withdraw/flow/SelectPurposeForm.tsx
@@ -378,15 +378,10 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
   const nurseriesOptions = useMemo(() => {
     const nurseries = batches
       .filter((batchData) => {
-        const batch = {
-          ...batchData,
-          readyQuantity: +batchData['readyQuantity(raw)'],
-          totalQuantity: +batchData['totalQuantity(raw)'],
-        };
         if (isOutplant) {
-          return +batch.readyQuantity > 0;
+          return +batchData['readyQuantity(raw)'] > 0;
         }
-        return +batch.totalQuantity > 0;
+        return +batchData['totalQuantity(raw)'] + +batchData['germinatingQuantity(raw)'] > 0;
       })
       .reduce((acc, batch) => {
         if (!acc[batch.facility_id.toString()]) {

--- a/src/components/InventoryV2/view/BatchesCellRenderer.tsx
+++ b/src/components/InventoryV2/view/BatchesCellRenderer.tsx
@@ -55,7 +55,7 @@ export default function BatchesCellRenderer(props: RendererProps<TableRowType>):
               size='small'
               priority='secondary'
               className={classes.text}
-              disabled={Number(row.totalQuantity) === 0}
+              disabled={Number(row.totalQuantity) + Number(row.germinatingQuantity) === 0}
             />
           }
         />


### PR DESCRIPTION
- previously we were gating off totalQuantity (which does not include germinating quantity, as per requirements)
- include germinating quantity in decision whether to allow withdrawals (this is a valid use-case)