### PR TITLE
SW-4642 / SW-4586 Allow withdrawal of germinating quantities in inventory views + add tooltips

### DIFF
--- a/src/components/InventoryV2/view/InventorySeedlingsTableForNursery.tsx
+++ b/src/components/InventoryV2/view/InventorySeedlingsTableForNursery.tsx
@@ -76,9 +76,7 @@ export default function InventorySeedlingsTableForNursery(props: InventorySeedli
     [facilityId]
   );
 
-  const isSelectionBulkWithdrawable = useCallback((selectedRows: SearchResponseElement[]) => {
-    return selectedRows.some((row) => Number(row['totalQuantity(raw)']) > 0);
-  }, []);
+  const isSelectionBulkWithdrawable = useCallback(() => true, []);
 
   return (
     <InventorySeedlingsTable

--- a/src/components/InventoryV2/view/InventorySeedlingsTableForSpecies.tsx
+++ b/src/components/InventoryV2/view/InventorySeedlingsTableForSpecies.tsx
@@ -96,18 +96,18 @@ export default function InventorySeedlingsTableForSpecies(props: InventorySeedli
   );
 
   const areAllFromSameNursery = (selectedRows: SearchResponseElement[]) => {
+    if (!selectedRows.length) {
+      return false;
+    }
     const initialNurseryId = selectedRows[0].facilityId;
     const otherNursery = selectedRows.some((row) => `${row.facilityId}` !== `${initialNurseryId}`);
     return !otherNursery;
   };
 
-  const selectionHasWithdrawableQuantities = (selectedRows: SearchResponseElement[]) => {
-    return selectedRows.some((row) => Number(row['totalQuantity(raw)']) > 0);
-  };
-
-  const isSelectionBulkWithdrawable = useCallback((selectedRows: SearchResponseElement[]) => {
-    return areAllFromSameNursery(selectedRows) && selectionHasWithdrawableQuantities(selectedRows);
-  }, []);
+  const isSelectionBulkWithdrawable = useCallback(
+    (selectedRows: SearchResponseElement[]) => areAllFromSameNursery(selectedRows),
+    []
+  );
 
   return (
     <InventorySeedlingsTable

--- a/src/services/NurseryInventoryService.ts
+++ b/src/services/NurseryInventoryService.ts
@@ -32,7 +32,12 @@ export const BE_SORTED_FIELDS = [
   'totalQuantity',
 ];
 
-export const INVENTORY_FIELDS = [...BE_SORTED_FIELDS, 'species_commonName', 'totalQuantity(raw)'];
+export const INVENTORY_FIELDS = [
+  ...BE_SORTED_FIELDS,
+  'germinatingQuantity(raw)',
+  'species_commonName',
+  'totalQuantity(raw)',
+];
 
 export const FACILITY_SPECIFIC_FIELDS = [
   'species_id',

--- a/src/services/NurseryInventoryService.ts
+++ b/src/services/NurseryInventoryService.ts
@@ -258,6 +258,7 @@ const searchInventoryByNursery = async ({
       'facilityInventories.species_scientificName',
       'facilityInventories.batches.id',
       'germinatingQuantity',
+      'germinatingQuantity(raw)',
       'notReadyQuantity',
       'readyQuantity',
       'totalQuantity',

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -714,6 +714,7 @@ NO_SPECIES_CONTRIBUTOR_MSG,"There are no species in your species list yet. Only 
 NO_SPECIES_DESCRIPTION,"It looks like you haven’t added any species yet. Having a master species list helps streamline your organization’s seed and plant data entry. You can either add species manually and individually, or import data from a CSV.",
 NO_SUB_LOCATIONS,Edit this seed bank to add sub-locations.,
 NO_SUB_LOCATIONS_NURSERY,Edit this nursery to add sub-locations.,
+NO_WITHDRAWABLE_QUANTITIES_FOUND,No withdrawable quantities found,
 NONE,None,
 NOT_CONNECTED,Not Connected,
 NOT_READY,Not Ready,


### PR DESCRIPTION
- also check germinating quantities before disabling withdraw button
- also add tooltips to seedlings table views when button is disabled
- enable bulk withdrawal in seedlings table views even with single selection for consistency (Chudo feedback)

<img width="2150" alt="Screen Shot 2023-12-27 at 4 40 51 PM" src="https://github.com/terraware/terraware-web/assets/1865174/7a780a92-f4a2-47d5-b15e-955ffbf7a14b">

<img width="2156" alt="Screen Shot 2023-12-27 at 4 41 14 PM" src="https://github.com/terraware/terraware-web/assets/1865174/14ba447c-9a46-49e0-9404-9542ff00d823">

<img width="2159" alt="Screen Shot 2023-12-27 at 4 41 35 PM" src="https://github.com/terraware/terraware-web/assets/1865174/f8b9d07d-dd50-4fe7-ac9d-475660fb5715">
