### PR TITLE
SW-4645 Set PageHeaderWrapper width to 100% to fix inconsistency between Firefox and Chrome

### DIFF
--- a/src/components/common/PageHeaderWrapper.tsx
+++ b/src/components/common/PageHeaderWrapper.tsx
@@ -112,7 +112,7 @@ export default function PageHeaderWrapper({ children, nextElement, nextElementIn
     top: debouncedSticky ? (debouncedScrollDown ? `${TOP_BAR_HEIGHT - height}px` : `${TOP_BAR_HEIGHT}px`) : undefined,
     visibility: debouncedSticky && debouncedScrollDown ? 'hidden' : 'visible',
     animation: anim,
-    width: '-webkit-fill-available',
+    width: '100%',
     zIndex: debouncedSticky ? 100 : undefined,
   };
 


### PR DESCRIPTION
![SCR-20231229-kpak-2.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/b8b17541-12b1-434e-9fae-c752246754f4.png)

