### PR TITLE
SW-4616 Remove extra margin during scroll in batch details view

### DIFF
--- a/src/components/InventoryV2/InventoryBatch.tsx
+++ b/src/components/InventoryV2/InventoryBatch.tsx
@@ -201,7 +201,7 @@ export default function InventoryBatch({ origin, species }: InventoryBatchProps)
         {batch && (
           <Grid item xs={12} sx={{ display: 'flex', flexDirection: 'column' }}>
             <BatchSummary batch={batch} />
-            <Box ref={contentRef} display='flex' flexDirection='column' flexGrow={1} className={classes.tabs}>
+            <Box display='flex' flexDirection='column' flexGrow={1} className={classes.tabs}>
               <Tabs
                 activeTab={activeTab}
                 onTabChange={onTabChange}


### PR DESCRIPTION
- contentRef was being set on the tabs container, most likely a mistake since the contentRef was also being set correctly on the content container of tabs and info cards correctly
- removed the extra contentRef (which adds a marginTop 200px during scroll up which triggers a static page header)