### PR TITLE
SW-4652 Only export visible inventory-by-nursery fields

### DIFF
--- a/src/services/NurseryInventoryService.ts
+++ b/src/services/NurseryInventoryService.ts
@@ -254,21 +254,26 @@ const searchInventoryByNursery = async ({
   query,
   isCsvExport,
 }: SearchInventoryParams): Promise<SearchResponseElement[] | null> => {
+  const exportedFields = [
+    'facility_name',
+    'facilityInventories.species_scientificName',
+    'germinatingQuantity',
+    'notReadyQuantity',
+    'readyQuantity',
+    'totalQuantity',
+  ];
+  const nonExportedFields = [
+    'facility_id',
+    'facilityInventories.species_id',
+    'facilityInventories.batches.id',
+    'germinatingQuantity(raw)',
+    'totalQuantity(raw)',
+  ];
+  const fields = isCsvExport ? exportedFields : exportedFields.concat(nonExportedFields);
+
   const params: SearchRequestPayload = {
     prefix: 'facilities.facilityInventoryTotals',
-    fields: [
-      'facility_id',
-      'facility_name',
-      'facilityInventories.species_id',
-      'facilityInventories.species_scientificName',
-      'facilityInventories.batches.id',
-      'germinatingQuantity',
-      'germinatingQuantity(raw)',
-      'notReadyQuantity',
-      'readyQuantity',
-      'totalQuantity',
-      'totalQuantity(raw)',
-    ],
+    fields,
     sortOrder: searchSortOrder ? [searchSortOrder] : undefined,
     search: {
       operation: 'and',


### PR DESCRIPTION
CSV export of the "by nursery" inventory view was requesting the same set of
fields that are used to populate the UI, including IDs and raw numeric values.
The IDs weren't useful to users, and the raw numeric values were causing the
export to fail because CSVs need to be localized and thus can't include
non-localized fields.

Update the request construction code to only include the user-visible fields
when exporting the view to a CSV.