### PR TITLE
SW-4663 Strip tab query param from inventory links

### DIFF
--- a/src/components/InventoryV2/InventoryCellRenderer.tsx
+++ b/src/components/InventoryV2/InventoryCellRenderer.tsx
@@ -46,6 +46,7 @@ export default function InventoryCellRenderer(props: RendererProps<TableRowType>
   };
 
   const createLinkWithQuery = (path: string, iValue: React.ReactNode | unknown[]) => {
+    query.delete('tab');
     const queryString = query.toString();
 
     let to = path;


### PR DESCRIPTION
- tab query param has different semantics across inventory and batch detail views
- tab value for inventory is persisted/retrieved using user preference