### PR TITLE
SW-4661 Disable accession dropdown on inventory add form

### DIFF
--- a/src/components/InventoryV2/form/AccessionsDropdown.tsx
+++ b/src/components/InventoryV2/form/AccessionsDropdown.tsx
@@ -37,6 +37,8 @@ function AccessionsDropdown<T extends { accessionId?: number; speciesId?: number
           accessionId: Number(accessionId),
         }))
       }
+      tooltipTitle={strings.TOOLTIP_INVENTORY_ADD_ACCESSION_ID}
+      disabled={(availableAccessions && availableAccessions.length === 0) || (record && record.speciesId === undefined)}
       fullWidth
     />
   );

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -1369,6 +1369,7 @@ TOOLTIP_COUNTRY_MY_ACCOUNT,Your country affects how we display numbers and other
 TOOLTIP_DASHBOARD_TOTAL_ACTIVE_ACCESSIONS,"This number represents all accessions with the statuses Awaiting Check In, Awaiting Processing, Processing, Drying, and In Storage.",
 TOOLTIP_ECOSYSTEM_TYPE,"Relatively large units of land or water containing a distinct assemblage of natural communities sharing a large majority of species, dynamics, and environmental conditions.",
 TOOLTIP_GERMINATING_QUANTITY,Germinating indicates that seedlings have not yet emerged from seeds. Germinating quantity does not count toward the total quantity.,
+TOOLTIP_INVENTORY_ADD_ACCESSION_ID,"The ID of the accession used to create this batch.  Unavailable for species that don't have any accessions."
 TOOLTIP_NOT_READY_QUANTITY,What determines a plant as “not ready” is up to your team and is often species specific. For example: size of plant or amount of time acclimated.,
 TOOLTIP_READY_QUANTITY,What determines a plant as “ready” is up to your team and is often species specific. For example: size of plant or amount of time acclimated.,
 TOOLTIP_SCIENTIFIC_NAME,The binomial Latin name (genus + species) currently accepted in the botanical literature.,


### PR DESCRIPTION
If there is no species selected, or no accessions for the species we disable the dropdown.  Also added a tooltip.