### PR TITLE
SW-4717 Use viability test substrate values when creating a viability test

### DIFF
--- a/src/types/Accession.ts
+++ b/src/types/Accession.ts
@@ -115,6 +115,18 @@ export const batchSubstrateLocalizedToEnum = (substrate: string): Batch['substra
   }
 };
 
+export function accessionNurserySubstrates(): { label: string; value: ViabilityTest['substrate'] | null }[] {
+  return [
+    { label: strings.MEDIA_MIX, value: 'Media Mix' },
+    { label: strings.SOIL, value: 'Soil' },
+    { label: strings.SAND, value: 'Sand' },
+    { label: strings.MOSS, value: 'Moss' },
+    { label: strings.PERLITE_VERMICULITE, value: 'Perlite/Vermiculite' },
+    { label: strings.OTHER, value: 'Other' },
+    { label: strings.NONE, value: 'None' },
+  ];
+}
+
 export function nurserySubstrates(): { label: string; value: Batch['substrate'] | null }[] {
   return [
     { label: strings.MEDIA_MIX, value: 'MediaMix' },

--- a/src/utils/viabilityTest.tsx
+++ b/src/utils/viabilityTest.tsx
@@ -1,5 +1,5 @@
 import strings from 'src/strings';
-import { labSubstrates, nurserySubstrates } from 'src/types/Accession';
+import { labSubstrates, accessionNurserySubstrates } from 'src/types/Accession';
 
 export const getFullTestType = (testType: 'Lab' | 'Nursery' | 'Cut') => {
   if (testType === 'Lab') {
@@ -15,7 +15,7 @@ export const getSubstratesAccordingToType = (type?: string) => {
   if (type === 'Lab') {
     return labSubstrates();
   } else if (type === 'Nursery') {
-    return nurserySubstrates();
+    return accessionNurserySubstrates();
   } else {
     return [];
   }


### PR DESCRIPTION
- previously `nurserySubstrates` function returned those applicable to viablity tests
- this was replaced with batch substrates as part of the nursery effort
- restoring old code but as a new function so we have separation between viability test and batch substrate values