### PR TITLE
SW-4742 Do not show empty batches screen when filters are applied

### DIFF
--- a/src/components/InventoryV2/InventoryListByBatch.tsx
+++ b/src/components/InventoryV2/InventoryListByBatch.tsx
@@ -161,7 +161,7 @@ export default function InventoryListByBatch({ setReportData }: InventoryListByB
     updatedResult = updatedResult?.filter((result) => showEmptyBatches || !isBatchEmpty(result));
 
     if (updatedResult) {
-      if (!debouncedSearchTerm && !filters.facilityIds?.length) {
+      if (!debouncedSearchTerm && !filters.facilityIds?.length && !filters.projectIds?.length) {
         setShowResults(updatedResult.length > 0);
       }
       if (getRequestId('searchInventory') === requestId) {

--- a/src/components/InventoryV2/InventoryListByNursery.tsx
+++ b/src/components/InventoryV2/InventoryListByNursery.tsx
@@ -105,7 +105,7 @@ export default function InventoryListByNursery({ setReportData }: InventoryListB
     });
 
     if (updatedResult) {
-      if (!debouncedSearchTerm && !filters.facilityIds?.length) {
+      if (!debouncedSearchTerm && !filters.facilityIds?.length && !filters.speciesIds?.length) {
         setShowResults(updatedResult.length > 0);
       }
       if (getRequestId('searchInventory') === requestId) {
@@ -115,7 +115,7 @@ export default function InventoryListByNursery({ setReportData }: InventoryListB
   }, [filters, debouncedSearchTerm, selectedOrganization, searchSortOrder, setReportData]);
 
   useEffect(() => {
-    onApplyFilters();
+    void onApplyFilters();
   }, [filters, onApplyFilters]);
 
   return (


### PR DESCRIPTION
SW-4742 Do not show empty batches screen when filters are applied

Add same fix for nursery inventory