### PR TITLE
SW-4760 Redo map click handling for popup info from multiple sources

### DIFF
--- a/src/components/PlantingSites/editor/Zones.tsx
+++ b/src/components/PlantingSites/editor/Zones.tsx
@@ -213,16 +213,10 @@ export default function Zones({ onChange, onValidate, site }: ZonesProps): JSX.E
   const popupRenderer = useMemo(
     (): MapPopupRenderer => ({
       className: `${classes.tooltip} ${classes.box}`,
-      cleanup: () => {
-        if (overridePopupInfo) {
-          setOverridePopupInfo(undefined);
-        }
-      },
       render: (properties: MapSourceProperties, onClose?: () => void): JSX.Element | null => {
         const { name, targetPlantingDensity } = properties;
 
         const close = () => {
-          setOverridePopupInfo(undefined);
           onClose?.();
         };
 
@@ -252,7 +246,7 @@ export default function Zones({ onChange, onValidate, site }: ZonesProps): JSX.E
         );
       },
     }),
-    [classes.box, classes.tooltip, overridePopupInfo]
+    [classes.box, classes.tooltip]
   );
 
   return (

--- a/src/types/Map.ts
+++ b/src/types/Map.ts
@@ -114,7 +114,6 @@ export type MapOptions = {
 export type MapPopupRenderer = {
   anchor?: mapboxgl.Anchor;
   className?: string;
-  cleanup?: () => void;
   render: (properties: MapSourceProperties, onClose?: () => void) => JSX.Element | null;
   style?: object;
 };


### PR DESCRIPTION
- cleaned this up better, leveraging one entry point to initialize popups, this removes race conditions and ambiguity
- disabled interactive layers while polygon draw is active, the interactive layers enable map clicks to return clicked-on geometries, which we don't want while polygon is being drawn
- removed a bunch of unnecessary code
- UX is cleaner now where user can click across geometries to see popup info
- see screen/video attached

![screencast 2024-01-18 20-25-30](https://github.com/terraware/terraware-web/assets/1865174/68a354ac-26bc-4835-bb71-5130b2336877)


