### PR TITLE
SW-4709 Add side nav button between base terraware and accelerator admin area

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,12 +6,13 @@ import { useRouteMatch } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { makeStyles } from '@mui/styles';
 import { APP_PATHS } from 'src/constants';
+import { isAcceleratorAdmin } from 'src/types/User';
 import useStateLocation from 'src/utils/useStateLocation';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import { isAdmin } from 'src/utils/organization';
 import { getRgbaFromHex } from 'src/utils/color';
 import { store } from 'src/redux/store';
-import { useLocalization, useOrganization } from 'src/providers';
+import { useLocalization, useOrganization, useUser } from 'src/providers';
 import { useAppVersion } from 'src/hooks/useAppVersion';
 import ToastSnackbar from 'src/components/ToastSnackbar';
 import TopBar from 'src/components/TopBar/TopBar';
@@ -76,6 +77,7 @@ function AppContent() {
   const location = useStateLocation();
   const { organizations, selectedOrganization } = useOrganization();
   const history = useHistory();
+  const { user } = useUser();
   const isAcceleratorRoute = useRouteMatch(APP_PATHS.ACCELERATOR);
 
   const [showNavBar, setShowNavBar] = useState(true);
@@ -108,7 +110,7 @@ function AppContent() {
       <div className={classes.container}>
         {organizations.length === 0 ? (
           <NoOrgRouter />
-        ) : isAcceleratorRoute && isAdmin(selectedOrganization) ? (
+        ) : isAcceleratorRoute && user && isAcceleratorAdmin(user) && isAdmin(selectedOrganization) ? (
           <AcceleratorRouter showNavBar={showNavBar} setShowNavBar={setShowNavBar} />
         ) : (
           <TerrawareRouter showNavBar={showNavBar} setShowNavBar={setShowNavBar} />

--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -3726,6 +3726,7 @@ export interface components {
       /** @description If true, the user wants to receive all the notifications for their organizations via email. This does not apply to certain kinds of notifications such as "You've been added to a new organization." */
       emailNotificationsEnabled: boolean;
       firstName?: string;
+      globalRoles: ("Super-Admin" | "Accelerator Admin")[];
       /**
        * Format: int64
        * @description User's unique ID. This should not be shown to the user, but is a required input to some API endpoints.

--- a/src/scenes/AcceleratorRouter/AcceleratorAdminView/index.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorAdminView/index.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { Container } from '@mui/material';
+import { Container, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import PageHeader from 'src/components/seeds/PageHeader';
 import TfMain from 'src/components/common/TfMain';
+import strings from 'src/strings';
+import { useUser } from 'src/providers';
 
 const useStyles = makeStyles(() => ({
   mainContainer: {
@@ -11,13 +13,14 @@ const useStyles = makeStyles(() => ({
 }));
 
 const AcceleratorAdminView = () => {
+  const { user } = useUser();
   const classes = useStyles();
 
   return (
     <TfMain>
-      <PageHeader subtitle={'Welcome to the accelerator admin dashboard'} page={'Accelerator Admin'} />
+      <PageHeader title={strings.ACCELERATOR_CONSOLE} />
       <Container maxWidth={false} className={classes.mainContainer}>
-        asdlfkjasldf
+        <Typography variant={'h4'}>Welcome{user ? `, ${user.firstName}` : ''}!</Typography>
       </Container>
     </TfMain>
   );

--- a/src/scenes/AcceleratorRouter/NavBar.tsx
+++ b/src/scenes/AcceleratorRouter/NavBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useHistory, useRouteMatch } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { APP_PATHS } from 'src/constants';
 import strings from 'src/strings';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
@@ -15,8 +15,6 @@ type NavBarProps = {
 export default function NavBar({ setShowNavBar, backgroundTransparent }: NavBarProps): JSX.Element | null {
   const { isDesktop } = useDeviceInfo();
   const history = useHistory();
-
-  const isAcceleratorAdminRoute = useRouteMatch(APP_PATHS.ACCELERATOR_ADMIN);
 
   const navigate = (url: string) => {
     history.push(url);
@@ -41,12 +39,9 @@ export default function NavBar({ setShowNavBar, backgroundTransparent }: NavBarP
       backgroundTransparent={backgroundTransparent}
     >
       <NavItem
-        label={strings.ADMIN}
+        label={strings.BACK_TO_TERRAWARE}
         icon='home'
-        selected={!!isAcceleratorAdminRoute}
-        onClick={() => {
-          closeAndNavigateTo(APP_PATHS.HOME);
-        }}
+        onClick={() => closeAndNavigateTo(APP_PATHS.HOME)}
         id='home'
       />
 
@@ -54,9 +49,7 @@ export default function NavBar({ setShowNavBar, backgroundTransparent }: NavBarP
         <NavItem
           label={strings.CONTACT_US}
           icon='mail'
-          onClick={() => {
-            closeAndNavigateTo(APP_PATHS.CONTACT_US);
-          }}
+          onClick={() => closeAndNavigateTo(APP_PATHS.CONTACT_US)}
           id='contactus'
         />
 

--- a/src/scenes/InventoryRouter/BatchHistory.tsx
+++ b/src/scenes/InventoryRouter/BatchHistory.tsx
@@ -13,7 +13,7 @@ import {
   BatchHistoryPayload,
   getBatchHistoryTypesEnum,
 } from 'src/types/Batch';
-import { User } from 'src/types/User';
+import { OrganizationUser } from 'src/types/User';
 import { useOrganization } from 'src/providers';
 import { getUserDisplayName } from 'src/utils/user';
 import { FieldOptionsMap, FieldValuesPayload } from 'src/types/Search';
@@ -57,7 +57,7 @@ export default function BatchHistory({ batchId, nurseryName }: BatchHistoryProps
   const [filters, setFilters] = useState<Record<string, any>>({});
   const [filterOptions, setFilterOptions] = useState<FieldOptionsMap>({});
   const [results, setResults] = useState<BatchHistoryItemForTable[] | null>();
-  const [users, setUsers] = useState<Record<number, User> | undefined>({});
+  const [users, setUsers] = useState<Record<number, OrganizationUser> | undefined>({});
   const { selectedOrganization } = useOrganization();
   const [selectedEvent, setSelectedEvent] = useState<any>();
   const [openEventDetailsModal, setOpenEventDetailsModal] = useState<boolean>(false);
@@ -122,7 +122,7 @@ export default function BatchHistory({ batchId, nurseryName }: BatchHistoryProps
     const fetchUsers = async () => {
       const response = await OrganizationUserService.getOrganizationUsers(selectedOrganization.id);
       if (response.requestSucceeded) {
-        const usersById: Record<number, User> = {};
+        const usersById: Record<number, OrganizationUser> = {};
         for (const user of response.users ?? []) {
           usersById[user.id] = user;
         }

--- a/src/scenes/TerrawareRouter/NavBar.tsx
+++ b/src/scenes/TerrawareRouter/NavBar.tsx
@@ -4,8 +4,9 @@ import SubNavbar from '@terraware/web-components/components/Navbar/SubNavbar';
 import { APP_PATHS } from 'src/constants';
 import strings from 'src/strings';
 import { NurseryWithdrawalService } from 'src/services';
+import { isAcceleratorAdmin } from 'src/types/User';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
-import { useOrganization } from 'src/providers/hooks';
+import { useOrganization, useUser } from 'src/providers/hooks';
 import ReportService, { Reports } from 'src/services/ReportService';
 import { isAdmin } from 'src/utils/organization';
 import isEnabled from 'src/features';
@@ -33,6 +34,7 @@ export default function NavBar({
   const { isDesktop } = useDeviceInfo();
   const history = useHistory();
   const featureFlagProjects = isEnabled('Projects');
+  const { user } = useUser();
 
   const isAccessionDashboardRoute = useRouteMatch(APP_PATHS.SEEDS_DASHBOARD + '/');
   const isAccessionsRoute = useRouteMatch(APP_PATHS.ACCESSIONS + '/');
@@ -133,6 +135,15 @@ export default function NavBar({
       setShowNavBar={setShowNavBar as React.Dispatch<React.SetStateAction<boolean>>}
       backgroundTransparent={backgroundTransparent}
     >
+      {user && isAcceleratorAdmin(user) && (
+        <NavItem
+          label={strings.ACCELERATOR_ADMIN}
+          icon='home'
+          onClick={() => closeAndNavigateTo(APP_PATHS.ACCELERATOR_ADMIN)}
+          id='home'
+        />
+      )}
+
       <NavItem
         label={strings.HOME}
         icon='home'

--- a/src/services/NurseryBatchService.ts
+++ b/src/services/NurseryBatchService.ts
@@ -11,7 +11,7 @@ import {
 } from 'src/types/Search';
 import { getPromisesResponse } from './utils';
 import PhotoService from './PhotoService';
-import { User } from 'src/types/User';
+import { OrganizationUser } from 'src/types/User';
 import { getUserDisplayName } from 'src/utils/user';
 
 /**
@@ -555,7 +555,7 @@ const getBatchHistory = async (
   batchId: number,
   search?: string,
   filter?: Record<string, any>,
-  users?: Record<number, User>
+  users?: Record<number, OrganizationUser>
 ): Promise<Response & BatchHistoryData> => {
   const response: Response & BatchHistoryData = await httpBatchHistory.get<
     GetBatchHistoryResponsePayload,

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -50,14 +50,15 @@ const getUser = async (): Promise<UserResponse> => {
   const response: UserResponse = await httpCurrentUser.get<UserServerResponse, UserData>({}, (data) => ({
     user: data?.user
       ? {
-          id: data.user.id,
-          email: data.user.email,
-          firstName: data.user.firstName,
-          lastName: data.user.lastName,
-          emailNotificationsEnabled: data.user.emailNotificationsEnabled,
-          timeZone: data.user.timeZone,
-          locale: data.user.locale,
           countryCode: data.user.countryCode,
+          email: data.user.email,
+          emailNotificationsEnabled: data.user.emailNotificationsEnabled,
+          firstName: data.user.firstName,
+          globalRoles: data.user.globalRoles,
+          id: data.user.id,
+          lastName: data.user.lastName,
+          locale: data.user.locale,
+          timeZone: data.user.timeZone,
         }
       : undefined,
   }));

--- a/src/services/test/CachedUserService.test.ts
+++ b/src/services/test/CachedUserService.test.ts
@@ -10,10 +10,12 @@ const USER = {
 };
 
 const UPDATED_USER = {
-  id: 1,
-  firstName: 'Constanza',
-  lastName: 'Uanini',
   email: 'constanza@terraformation.com',
+  emailNotificationsEnabled: false,
+  firstName: 'Constanza',
+  globalRoles: [],
+  id: 1,
+  lastName: 'Uanini',
 };
 
 const PREFERENCES = {

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -1,4 +1,6 @@
 key_name,en,comment
+ACCELERATOR_ADMIN,Accelerator Admin,
+ACCELERATOR_CONSOLE,Accelerator Console,
 ACCEPT,Accept,
 ACCESSION,Accession,
 ACCESSION_BY_STATUS,Accession by Status,

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,15 +1,8 @@
 import { OrganizationRole } from './Organization';
+import { components } from 'src/api/types/generated-schema';
 
-export type User = {
-  id: number;
-  firstName?: string;
-  lastName?: string;
-  email?: string;
-  emailNotificationsEnabled?: boolean;
-  timeZone?: string;
-  locale?: string;
-  countryCode?: string;
-};
+export type User = components['schemas']['UserProfilePayload'];
+export type UserGlobalRoles = User['globalRoles'];
 
 export type OrganizationUser = {
   firstName?: string;
@@ -19,3 +12,8 @@ export type OrganizationUser = {
   role: OrganizationRole;
   addedTime?: string;
 };
+
+const AcceleratorAdminRoles: UserGlobalRoles = ['Super-Admin', 'Accelerator Admin'];
+
+export const isAcceleratorAdmin = (user: User): boolean =>
+  user.globalRoles.some((globalRole: UserGlobalRoles[0]) => AcceleratorAdminRoles.includes(globalRole));

--- a/src/utils/renderUser.tsx
+++ b/src/utils/renderUser.tsx
@@ -1,6 +1,6 @@
-import { User } from 'src/types/User';
+import { OrganizationUser, User } from 'src/types/User';
 
-export const renderUser = (userSel: User, accUser: User, contributor: boolean): string => {
+export const renderUser = (userSel: User | OrganizationUser, accUser: User, contributor: boolean): string => {
   const firstName = contributor ? accUser.firstName : userSel?.firstName;
   const lastName = contributor ? accUser.lastName : userSel?.lastName;
   const email = contributor ? accUser.email : userSel?.email;

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,6 +1,6 @@
-import { User } from 'src/types/User';
+import { OrganizationUser, User } from 'src/types/User';
 
-export const getUserDisplayName = (user?: User): string => {
+export const getUserDisplayName = (user?: User | OrganizationUser): string => {
   if (user?.firstName && user?.lastName) {
     return `${user.firstName} ${user.lastName}`;
   }


### PR DESCRIPTION
- Read globalRoles from 'GET /me' API call to determine if the current user is an "accelerator admin"
- Only allow users who are accelerator admins to see the new admin area
- Add side nav button in base Terraware to the accelerator admin area
- Add side nav button in accelerator admin area back to base Terraware

![2024-01-23 14.54.32.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/d6101704-006f-4d23-97e5-2dd58e7f7fc6.gif)

