### PR TITLE
SW-4790 Validate subzone minimum size contraints

### DIFF
--- a/src/components/Map/EditableMapDrawV2.tsx
+++ b/src/components/Map/EditableMapDrawV2.tsx
@@ -27,7 +27,6 @@ export type MapEditorMode =
 
 type MapEditorProps = ConstructorParameters<typeof MapboxDraw>[0] & {
   boundary?: FeatureCollection;
-  clearOnEdit?: boolean;
   onBoundaryChanged?: (boundary?: FeatureCollection) => void;
   setMode?: (mode: MapEditorMode) => void;
 };
@@ -72,8 +71,6 @@ function featureHasCoordinates(feature: Feature | undefined): boolean {
  * @param boundary
  *  Initial boundary. If this is specified, the editor will start out in EditingBoundary mode;
  *  otherwise it will start out in CreatingBoundary mode.
- * @param clearOnEdit
- *  Whether to clear the boundary in the editor after onChange callbacks are notified
  * @param onBoundaryChanged
  *  Called when the user adds, edits, or deletes the boundary. The boundary is always a
  *  MultiPolygon containing a single polygon.
@@ -81,13 +78,7 @@ function featureHasCoordinates(feature: Feature | undefined): boolean {
  * @param otherProps
  *  Additional properties to pass to the MapboxDraw control.
  */
-export default function EditableMapDraw({
-  boundary,
-  clearOnEdit,
-  onBoundaryChanged,
-  setMode,
-  ...otherProps
-}: MapEditorProps) {
+export default function EditableMapDraw({ boundary, onBoundaryChanged, setMode, ...otherProps }: MapEditorProps) {
   const [mapRef, setMapRef] = useState<MapRef>();
   const [drawMode, setDrawMode] = useState<DrawMode>();
   const [selection, setSelection] = useState<Feature>();
@@ -140,11 +131,8 @@ export default function EditableMapDraw({
 
       const updatedFeatures = fetchUpdatedFeatures(features);
       onBoundaryChanged(updatedFeatures);
-      if (clearOnEdit) {
-        draw.deleteAll();
-      }
     },
-    [clearOnEdit, draw, fetchUpdatedFeatures, onBoundaryChanged]
+    [fetchUpdatedFeatures, onBoundaryChanged]
   );
 
   const onCreate = useCallback(

--- a/src/components/Map/EditableMapV2.tsx
+++ b/src/components/Map/EditableMapV2.tsx
@@ -57,10 +57,10 @@ export type FeatureSelectorOnClick = (features: LayerFeature[]) => LayerFeature 
 
 export type EditableMapProps = {
   activeContext?: MapEntityOptions;
-  clearOnEdit?: boolean;
   editableBoundary?: FeatureCollection;
   errorAnnotations?: Feature[];
   featureSelectorOnClick?: FeatureSelectorOnClick;
+  isSliceTool?: boolean;
   onEditableBoundaryChanged: (boundary?: FeatureCollection, isUndoRedo?: boolean) => void;
   onRedo?: () => void;
   onUndo?: () => void;
@@ -73,10 +73,10 @@ export type EditableMapProps = {
 
 export default function EditableMap({
   activeContext,
-  clearOnEdit,
   editableBoundary,
   errorAnnotations,
   featureSelectorOnClick,
+  isSliceTool,
   onEditableBoundaryChanged,
   onRedo,
   onUndo,
@@ -277,7 +277,7 @@ export default function EditableMap({
 
   return (
     <Box
-      className={clearOnEdit ? classes.sliceTool : ''}
+      className={isSliceTool ? classes.sliceTool : ''}
       ref={containerRef}
       display='flex'
       flexDirection='column'
@@ -318,7 +318,6 @@ export default function EditableMap({
             <FullscreenControl position='top-left' />
             <MapViewStyleControl mapViewStyle={mapViewStyle} onChangeMapViewStyle={onChangeMapViewStyle} />
             <EditableMapDraw
-              clearOnEdit={clearOnEdit}
               boundary={editableBoundary}
               onBoundaryChanged={onEditableBoundaryChanged}
               setMode={setEditMode}

--- a/src/components/Map/useRenderAttributes.ts
+++ b/src/components/Map/useRenderAttributes.ts
@@ -33,6 +33,7 @@ export default function useRenderAttributes(): (type: RenderableObject) => MapSo
           hoverFillColor: getRgbaFromHex(theme.palette.TwClrBaseLightGreen300 as string, 0.4),
           lineColor: theme.palette.TwClrBaseLightGreen300 as string,
           lineWidth: 4,
+          selectFillColor: getRgbaFromHex(theme.palette.TwClrBaseLightGreen300 as string, 0.1),
           selectLineColor: getRgbaFromHex(theme.palette.TwClrBaseLightGreen300 as string, 0.6),
           selectLineWidth: 8,
         };
@@ -52,8 +53,9 @@ export default function useRenderAttributes(): (type: RenderableObject) => MapSo
           hoverFillColor: getRgbaFromHex(theme.palette.TwClrBaseBlue300 as string, 0.4),
           lineColor: theme.palette.TwClrBaseBlue300 as string,
           lineWidth: 2,
+          selectFillColor: getRgbaFromHex(theme.palette.TwClrBaseBlue300 as string, 0.5),
           selectLineColor: getRgbaFromHex(theme.palette.TwClrBaseBlue300 as string, 0.6),
-          selectLineWidth: 8,
+          selectLineWidth: 6,
         };
       } else if (objectType === 'permanentPlot') {
         return {

--- a/src/scenes/PlantingSitesRouter/editor/Zones.tsx
+++ b/src/scenes/PlantingSitesRouter/editor/Zones.tsx
@@ -302,6 +302,7 @@ export default function Zones({ onChange, onValidate, site }: ZonesProps): JSX.E
         editableBoundary={zonesData?.editableBoundary}
         errorAnnotations={zonesData?.errorAnnotations}
         featureSelectorOnClick={featureSelectorOnClick}
+        isSliceTool
         onEditableBoundaryChanged={onEditableBoundaryChanged}
         onRedo={redo}
         onUndo={undo}
@@ -389,7 +390,7 @@ const TooltipContents = ({
       <Box display='flex' flexDirection='column' padding={theme.spacing(2)}>
         <Typography>{strings.PLANTING_SITE_ZONE_NAME_HELP}</Typography>
         <Textfield
-          autoFocus={true}
+          autoFocus
           className={classes.textInput}
           label={strings.NAME}
           id='zone-name'

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -1256,6 +1256,8 @@ SITE_SUBZONE_BOUNDARIES_DESCRIPTION_0,"Each Zone is divided into one or more Sub
 SITE_SUBZONE_BOUNDARIES_DESCRIPTION_1,Use the slice {0} tool to create subzone polygons within the zones. (Watch a [tutorial].),
 SITE_SUBZONE_BOUNDARIES_SELECT_A_ZONE,Select the zone to create subzones.,
 SITE_SUBZONE_BOUNDARIES_SELECTED_ZONE,Zone {0} is currently selected to create subzones.,
+SITE_SUBZONE_BOUNDARIES_TOO_SMALL,One or more subzones have a boundary smaller than 25m x 25m,
+SITE_SUBZONE_BOUNDARY_TOO_SMALL,Subzone boundary smaller than 25m x 25m,
 SITE_WITH_NAME_EXISTS,Site with this name already exists.,
 SITE_ZONE_BOUNDARIES,Zone Boundaries,
 SITE_ZONE_BOUNDARIES_DESCRIPTION_0,"A Zone is a stratum of a Planting Site where planting and growing conditions are similar. Each planting site must have at least one zone and usually no more than five. An example of a Zone might be the slope of an east facing hill, where sunlight and soil conditions are similar.",


### PR DESCRIPTION
- visually mark where invalid subzones would be created (without creating them), same flow/utility as in zone validation
- remove the clearOnEdit temporary solution now that zones/subzones have control over this data which flows top down to the draw control
- add option to set the slice tool icon (previously piggy-backed onto clearOnEdit)
- refactor DetailsInputForm to continually validate after first error on save, this was removed during a bugfix last week because it was not separated out into a separate useEffect

<img width="765" alt="Terraware App 2024-02-02 14-52-03" src="https://github.com/terraware/terraware-web/assets/1865174/70d371e8-88b9-4ba2-b1d3-a396e054ee31">
