### PR TITLE
SW-4767 Refactor nursery withdrawals table to use the search filters wrapper, implement noScroll option into the wrapper so we can let the implementation decide since this table needs it and others don't

### DIFF
--- a/src/components/common/SearchFiltersWrapper.tsx
+++ b/src/components/common/SearchFiltersWrapper.tsx
@@ -43,6 +43,7 @@ export type SearchFiltersProps = {
   filterOptions: FieldOptionsMap;
   filterColumns: FilterField[];
   optionsRenderer?: (filterName: string, values: FieldValuesPayload) => Option[] | undefined;
+  noScroll?: boolean;
 };
 
 export type SearchProps = SearchInputProps & {
@@ -207,7 +208,7 @@ export default function SearchFiltersWrapper({
                     filtersProps.setFilters(fs);
                   }}
                   onCancel={handleFilterClose}
-                  noScroll={true}
+                  noScroll={filtersProps.noScroll === undefined}
                   optionsRenderer={filtersProps.optionsRenderer}
                 />
               </Popover>

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
@@ -1,9 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { Grid, Popover, Theme } from '@mui/material';
-import TextField from '@terraware/web-components/components/Textfield/Textfield';
-import { makeStyles } from '@mui/styles';
-import { SortOrder, Tooltip } from '@terraware/web-components';
+import { Grid } from '@mui/material';
+import { SortOrder } from '@terraware/web-components';
 import strings from 'src/strings';
 import { APP_PATHS } from 'src/constants';
 import useQuery from 'src/utils/useQuery';
@@ -22,24 +20,11 @@ import WithdrawalLogRenderer from './WithdrawalLogRenderer';
 import useDebounce from 'src/utils/useDebounce';
 import { getRequestId, setRequestId } from 'src/utils/requestsId';
 import { useLocalization, useOrganization } from 'src/providers';
-import { Button, PillList } from '@terraware/web-components';
+import { PillList } from '@terraware/web-components';
 import Table from 'src/components/common/table';
 import { TableColumnType } from '@terraware/web-components/components/table/types';
-import FilterGroup, { FilterField } from 'src/components/common/FilterGroup';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  searchField: {
-    width: '300px',
-  },
-  popoverContainer: {
-    '& .MuiPaper-root': {
-      border: `1px solid ${theme.palette.TwClrBaseGray300}`,
-      borderRadius: '8px',
-      overflow: 'visible',
-      width: '480px',
-    },
-  },
-}));
+import { FilterField } from 'src/components/common/FilterGroup';
+import SearchFiltersWrapper, { SearchFiltersProps } from '../../components/common/SearchFiltersWrapper';
 
 const columns = (): TableColumnType[] => [
   { key: 'withdrawnDate', name: strings.DATE, type: 'string' },
@@ -58,21 +43,12 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   const query = useQuery();
   const history = useHistory();
   const location = useStateLocation();
-  const classes = useStyles();
   const [searchResults, setSearchResults] = useState<SearchResponseElement[] | null>();
   const [searchValue, setSearchValue] = useState('');
   const debouncedSearchTerm = useDebounce(searchValue, 250);
-  const [filters, setFilters] = useState<Record<string, any>>({});
+  const [filters, setFilters] = useState<Record<string, SearchNodePayload>>({});
   const subzoneParam = query.get('subzoneName');
   const siteParam = query.get('siteName');
-
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const handleFilterClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-  const handleFilterClose = () => {
-    setAnchorEl(null);
-  };
 
   const [searchSortOrder, setSearchSortOrder] = useState<SearchSortOrder>({
     field: 'withdrawnDate',
@@ -100,11 +76,22 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
 
   const [filterOptions, setFilterOptions] = useState<FieldOptionsMap>({});
 
+  const filtersProps: SearchFiltersProps = useMemo(
+    () => ({
+      filters,
+      setFilters,
+      filterColumns,
+      filterOptions,
+      noScroll: false,
+    }),
+    [filterColumns, filterOptions, filters]
+  );
+
   useEffect(() => {
     const getApiSearchResults = async () => {
       setFilterOptions(await NurseryWithdrawalService.getFilterOptions(selectedOrganization.id));
     };
-    getApiSearchResults();
+    void getApiSearchResults();
   }, [selectedOrganization]);
 
   const filterPillData = useMemo(
@@ -248,7 +235,7 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   }, [subzoneParam, query, history, location]);
 
   useEffect(() => {
-    onApplyFilters();
+    void onApplyFilters();
   }, [filters, onApplyFilters]);
 
   const onSortChange = (order: SortOrder, orderBy: string) => {
@@ -262,53 +249,9 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   return (
     <Grid container>
       <Grid item xs={12} sx={{ display: 'flex', marginBottom: '16px', alignItems: 'center' }}>
-        <TextField
-          placeholder={strings.SEARCH}
-          iconLeft='search'
-          label=''
-          id='search'
-          type='text'
-          className={classes.searchField}
-          iconRight='cancel'
-          value={searchValue}
-          onChange={(value) => setSearchValue(value as string)}
-        />
-        <Tooltip title={strings.FILTER}>
-          <Button
-            id='filterNurseryWithdrawal'
-            onClick={(event) => event && handleFilterClick(event)}
-            type='passive'
-            priority='ghost'
-            icon='filter'
-          />
-        </Tooltip>
-        <Popover
-          id='simple-popover'
-          open={Boolean(anchorEl)}
-          anchorEl={anchorEl}
-          onClose={handleFilterClose}
-          anchorOrigin={{
-            vertical: 'bottom',
-            horizontal: 'center',
-          }}
-          transformOrigin={{
-            vertical: 'top',
-            horizontal: 'center',
-          }}
-          className={classes.popoverContainer}
-        >
-          <FilterGroup
-            initialFilters={filters}
-            fields={filterColumns}
-            values={filterOptions || {}}
-            onConfirm={(fs) => {
-              handleFilterClose();
-              setFilters(fs);
-            }}
-            onCancel={handleFilterClose}
-          />
-        </Popover>
+        <SearchFiltersWrapper search={searchValue} onSearch={setSearchValue} filtersProps={filtersProps} />
       </Grid>
+
       <Grid xs={12} display='flex'>
         <PillList data={filterPillData} />
       </Grid>

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Grid } from '@mui/material';
 import { SortOrder } from '@terraware/web-components';
-import { PillList } from '@terraware/web-components';
 import { TableColumnType } from '@terraware/web-components/components/table/types';
 import strings from 'src/strings';
 import { APP_PATHS } from 'src/constants';
@@ -93,25 +92,6 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
     };
     void getApiSearchResults();
   }, [selectedOrganization]);
-
-  const filterPillData = useMemo(
-    () =>
-      Object.keys(filters).map((key) => {
-        const removeFilter = (k: string) => {
-          const result = { ...filters };
-          delete result[k];
-          setFilters(result);
-        };
-
-        return {
-          id: key,
-          label: filterColumns.find((f) => key === f.name)?.label ?? '',
-          value: filters[key].values.join(', '),
-          onRemove: () => removeFilter(key),
-        };
-      }),
-    [filters, filterColumns]
-  );
 
   const onWithdrawalClicked = (withdrawal: any) => {
     history.push({
@@ -250,10 +230,6 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
     <Grid container>
       <Grid item xs={12} sx={{ display: 'flex', marginBottom: '16px', alignItems: 'center' }}>
         <SearchFiltersWrapper search={searchValue} onSearch={setSearchValue} filtersProps={filtersProps} />
-      </Grid>
-
-      <Grid xs={12} display='flex'>
-        <PillList data={filterPillData} />
       </Grid>
 
       <Grid item xs={12}>

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
@@ -2,8 +2,13 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Grid } from '@mui/material';
 import { SortOrder } from '@terraware/web-components';
+import { PillList } from '@terraware/web-components';
+import { TableColumnType } from '@terraware/web-components/components/table/types';
 import strings from 'src/strings';
 import { APP_PATHS } from 'src/constants';
+import { useLocalization, useOrganization } from 'src/providers';
+import useDebounce from 'src/utils/useDebounce';
+import { getRequestId, setRequestId } from 'src/utils/requestsId';
 import useQuery from 'src/utils/useQuery';
 import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
 import { NurseryWithdrawalService } from 'src/services';
@@ -16,15 +21,10 @@ import {
   SearchResponseElement,
   SearchSortOrder,
 } from 'src/types/Search';
-import WithdrawalLogRenderer from './WithdrawalLogRenderer';
-import useDebounce from 'src/utils/useDebounce';
-import { getRequestId, setRequestId } from 'src/utils/requestsId';
-import { useLocalization, useOrganization } from 'src/providers';
-import { PillList } from '@terraware/web-components';
 import Table from 'src/components/common/table';
-import { TableColumnType } from '@terraware/web-components/components/table/types';
 import { FilterField } from 'src/components/common/FilterGroup';
-import SearchFiltersWrapper, { SearchFiltersProps } from '../../components/common/SearchFiltersWrapper';
+import SearchFiltersWrapper, { SearchFiltersProps } from 'src/components/common/SearchFiltersWrapper';
+import WithdrawalLogRenderer from 'src/scenes/NurseryRouter/WithdrawalLogRenderer';
 
 const columns = (): TableColumnType[] => [
   { key: 'withdrawnDate', name: strings.DATE, type: 'string' },


### PR DESCRIPTION
SW-4767 Refactor nursery withdrawals table to use the search filters wrapper, implement noScroll option into the wrapper so we can let the implementation decide since this table needs it and others don't

Relative paths

Remove pill list since it is in the search filters wrapper