### PR TITLE
SW-4826 Viability test fixes

### DIFF
--- a/src/scenes/AccessionsRouter/viabilityTesting/NewViabilityTestModal.tsx
+++ b/src/scenes/AccessionsRouter/viabilityTesting/NewViabilityTestModal.tsx
@@ -277,7 +277,6 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
 
   const hasErrors = () => {
     if (record) {
-      const seedTestedError = record.testType !== 'Cut' ? !validateSeedsTested(record.seedsTested) : false;
       const seedTestedError =
         record.testType !== 'Cut' && record?.id === -1 ? !validateSeedsTested(record.seedsTested) : false;
       const seedsGerminatedError = !validateSeedsGerminated();

--- a/src/scenes/AccessionsRouter/viabilityTesting/NewViabilityTestModal.tsx
+++ b/src/scenes/AccessionsRouter/viabilityTesting/NewViabilityTestModal.tsx
@@ -278,6 +278,8 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
   const hasErrors = () => {
     if (record) {
       const seedTestedError = record.testType !== 'Cut' ? !validateSeedsTested(record.seedsTested) : false;
+      const seedTestedError =
+        record.testType !== 'Cut' && record?.id === -1 ? !validateSeedsTested(record.seedsTested) : false;
       const seedsGerminatedError = !validateSeedsGerminated();
       const startDateError = !validateStartDate();
       const recordingDateError = !validateRecordingDate();
@@ -585,7 +587,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
                     aria-label={strings.DATE}
                     value={record?.startDate}
                     onChange={(value) => onChangeDate('startDate', value)}
-                    disabled={readOnly}
+                    disabled={readOnly || record?.id !== -1}
                     errorText={viabilityFieldsErrors.startDate}
                     defaultTimeZone={tz.id}
                   />
@@ -607,7 +609,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
                       onChange={(value) => onChangeSeedsTested('seedsTested', value)}
                       id='seedsTested'
                       value={record?.seedsTested}
-                      disabled={readOnly}
+                      disabled={readOnly || record?.id !== -1}
                       errorText={viabilityFieldsErrors.seedsTested}
                     />
                   )}


### PR DESCRIPTION
We were running the validation of the number of seeds tested even when editing an existing viability test which was triggering false failures.  Do not validate number of seeds in viability test after the test has been created. 

Do not allow for editing number of seeds in viability test after the test has been created.  We don't allow editing previously withdrawn quantities elsewhere in the product.