### PR TITLE
Fix video modal description text style when the text is too long

### DIFF
--- a/src/components/Map/MapIcon.tsx
+++ b/src/components/Map/MapIcon.tsx
@@ -11,24 +11,30 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: '20px',
     height: '20px',
   },
+  centerAligned: {
+    position: 'relative',
+    top: '3px',
+  },
 }));
 
 export type MapIconType = 'polygon' | 'slice' | 'trash';
 
 export type MapIconProps = {
+  centerAligned?: boolean;
   icon: MapIconType;
 };
 
-export default function MapIcon({ icon }: MapIconProps): JSX.Element {
+export default function MapIcon({ centerAligned, icon }: MapIconProps): JSX.Element {
   const classes = useStyles();
+  const className = centerAligned ? classes.centerAligned : '';
 
   if (icon === 'polygon') {
-    return <button className={`mapbox-gl-draw_polygon mapbox-gl-draw_ctrl-draw-btn ${classes.icon}`} />;
+    return <button className={`mapbox-gl-draw_polygon mapbox-gl-draw_ctrl-draw-btn ${classes.icon} ${className}`} />;
   }
 
   if (icon === 'trash') {
-    return <button className={`mapbox-gl-draw_trash mapbox-gl-draw_ctrl-draw-btn ${classes.icon}`} />;
+    return <button className={`mapbox-gl-draw_trash mapbox-gl-draw_ctrl-draw-btn ${classes.icon} ${className}`} />;
   }
 
-  return <Icon className={classes.icon} name='iconSlice' />;
+  return <Icon className={`${classes.icon} ${className}`} name='iconSlice' />;
 }

--- a/src/components/common/VideoDialog.tsx
+++ b/src/components/common/VideoDialog.tsx
@@ -52,7 +52,7 @@ export default function VideoDialog(props: VideoDialogProps): JSX.Element {
   return (
     <DialogBox scrolled onClose={onClose} open={open} title={title} size={'large'} middleButtons={buttons()}>
       <Box display='flex' flexDirection='column'>
-        <Typography textAlign='center' margin={theme.spacing(0, 'auto', 2)} display='flex' alignItems='center'>
+        <Typography margin={theme.spacing(0, 'auto', 2)} display='inline-block'>
           {description}
         </Typography>
         <iframe

--- a/src/scenes/PlantingSitesRouter/edit/editor/Exclusions.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Exclusions.tsx
@@ -80,7 +80,7 @@ export default function Exclusions({ onChange, onValidate, site }: ExclusionsPro
     }
     return strings.formatString(
       strings.PLANTING_SITE_CREATE_EXCLUSIONS_INSTRUCTIONS_DESCRIPTION,
-      <MapIcon icon='polygon' />
+      <MapIcon centerAligned icon='polygon' />
     ) as JSX.Element[];
   }, [activeLocale]);
 

--- a/src/scenes/PlantingSitesRouter/edit/editor/SiteBoundary.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/SiteBoundary.tsx
@@ -154,7 +154,7 @@ export default function SiteBoundary({ isSimpleSite, onChange, onValidate, site 
     }
     return strings.formatString(
       strings.PLANTING_SITE_CREATE_INSTRUCTIONS_DESCRIPTION,
-      <MapIcon icon='polygon' />
+      <MapIcon centerAligned icon='polygon' />
     ) as JSX.Element[];
   }, [activeLocale]);
 

--- a/src/scenes/PlantingSitesRouter/edit/editor/Subzones.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Subzones.tsx
@@ -219,7 +219,7 @@ export default function Subzones({ onChange, onValidate, site }: SubzonesProps):
     }
     return strings.formatString(
       strings.ADDING_SUBZONE_BOUNDARIES_INSTRUCTIONS_DESCRIPTION,
-      <MapIcon icon='slice' />
+      <MapIcon centerAligned icon='slice' />
     ) as JSX.Element[];
   }, [activeLocale]);
 

--- a/src/scenes/PlantingSitesRouter/edit/editor/Zones.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Zones.tsx
@@ -182,7 +182,7 @@ export default function Zones({ onChange, onValidate, site }: ZonesProps): JSX.E
     }
     return strings.formatString(
       strings.ADDING_ZONE_BOUNDARIES_INSTRUCTIONS_DESCRIPTION,
-      <MapIcon icon='slice' />
+      <MapIcon centerAligned icon='slice' />
     ) as JSX.Element[];
   }, [activeLocale]);
 


### PR DESCRIPTION
- use an inline style
- add some top space for icon

#### before
<img width="334" alt="Terraware App 2024-02-09 13-06-37" src="https://github.com/terraware/terraware-web/assets/1865174/5debaa59-ba28-41ec-a910-2014332db099">

#### after
<img width="351" alt="Terraware App 2024-02-09 13-06-10" src="https://github.com/terraware/terraware-web/assets/1865174/2595b323-645d-41a3-8acb-e3525455608c">