### PR TITLE
SW-4839 Add onUnAssign prop to the ProjectAssignModal and implement allowUnselect to underlying ProjectsDropdown component so we can do something when a user unselects the project

### DIFF
--- a/src/components/ProjectAssignModal/index.tsx
+++ b/src/components/ProjectAssignModal/index.tsx
@@ -18,10 +18,11 @@ interface ProjectAssignModalProps<T extends ProjectAssignableEntity> {
   reloadEntity?: () => void;
   isModalOpen?: boolean;
   onClose: () => void;
+  onUnAssign?: () => void;
 }
 
 function ProjectAssignModal<T extends ProjectAssignableEntity>(props: ProjectAssignModalProps<T>) {
-  const { onClose, isModalOpen, assignPayloadCreator, reloadEntity } = props;
+  const { onClose, isModalOpen, assignPayloadCreator, reloadEntity, onUnAssign } = props;
 
   const dispatch = useAppDispatch();
   const snackbar = useSnackbar();
@@ -33,13 +34,17 @@ function ProjectAssignModal<T extends ProjectAssignableEntity>(props: ProjectAss
   const projectRequest = useAppSelector((state) => selectProjectRequest(state, requestId));
 
   const handleSave = useCallback(() => {
+    if (onUnAssign && entity.projectId === null) {
+      onUnAssign();
+    }
+
     if (entity.projectId && props.entity.projectId !== entity.projectId) {
       const request = dispatch(requestProjectAssign({ projectId: entity.projectId, entities: assignPayloadCreator() }));
       setRequestId(request.requestId);
     }
 
     onClose();
-  }, [entity.projectId, props.entity.projectId, onClose, dispatch, assignPayloadCreator]);
+  }, [entity.projectId, props.entity.projectId, onClose, dispatch, assignPayloadCreator, onUnAssign]);
 
   const handleUpdateProject = useCallback(
     (setFn: (previousEntity: T) => T) => {
@@ -80,7 +85,12 @@ function ProjectAssignModal<T extends ProjectAssignableEntity>(props: ProjectAss
       ]}
     >
       <Grid item xs={12} textAlign='left'>
-        <ProjectsDropdown availableProjects={availableProjects} record={entity} setRecord={handleUpdateProject} />
+        <ProjectsDropdown
+          availableProjects={availableProjects}
+          record={entity}
+          setRecord={handleUpdateProject}
+          allowUnselect
+        />
       </Grid>
     </DialogBox>
   );

--- a/src/components/ProjectAssignModal/index.tsx
+++ b/src/components/ProjectAssignModal/index.tsx
@@ -89,7 +89,7 @@ function ProjectAssignModal<T extends ProjectAssignableEntity>(props: ProjectAss
           availableProjects={availableProjects}
           record={entity}
           setRecord={handleUpdateProject}
-          allowUnselect
+          allowUnselect={!!onUnAssign}
         />
       </Grid>
     </DialogBox>

--- a/src/components/ProjectOverviewItemCard/index.tsx
+++ b/src/components/ProjectOverviewItemCard/index.tsx
@@ -16,6 +16,7 @@ interface OverviewItemCardProjectProps<T extends { id: number; projectId?: numbe
   entity: T;
   reloadData: () => void;
   projectAssignPayloadCreator: () => AssignProjectRequestPayload;
+  onUnAssign?: () => void;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -31,6 +32,7 @@ const ProjectOverviewItemCard = <T extends { id: number; projectId?: number }>({
   entity,
   reloadData,
   projectAssignPayloadCreator,
+  onUnAssign,
 }: OverviewItemCardProjectProps<T>) => {
   const { selectedOrganization } = useOrganization();
   const userCanEdit = !isContributor(selectedOrganization);
@@ -66,6 +68,7 @@ const ProjectOverviewItemCard = <T extends { id: number; projectId?: number }>({
             }}
             isModalOpen={isProjectAssignModalOpen}
             onClose={() => setIsProjectAssignModalOpen(false)}
+            onUnAssign={onUnAssign}
           />
         </>
       }


### PR DESCRIPTION
Since there is no "un assign from project" endpoint, optionally pass an `onUnAssign` handler into the ProjectAssignModal and plumb through the ProjectOverviewItemCard so implementers (in later PRs, accession view and batch view) can un-assign a project through the modal.