### PR TITLE
SW-4858: FE - Remove side nav "Terraware button" and implement breadcrumbs at top of Accelerator global header

### DIFF
--- a/src/components/TopBar/AcceleratorBreadcrumbs.tsx
+++ b/src/components/TopBar/AcceleratorBreadcrumbs.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import Link from 'src/components/common/Link';
+import { APP_PATHS } from 'src/constants';
+import strings from 'src/strings';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  selected: {
+    backgroundColor: '#EF7047',
+    borderRadius: '16px',
+    color: theme.palette.TwClrBaseWhite,
+    fontFamily: 'Inter',
+    fontSize: '16px',
+    fontWeight: 500,
+    padding: '0.5em 0.8em',
+    userSelect: 'none',
+  },
+  separator: {
+    color: theme.palette.TwClrBaseGray300,
+    fontSize: '16px',
+    margin: '0 1em',
+    userSelect: 'none',
+  },
+}));
+
+export default function AcceleratorBreadcrumbs(): JSX.Element | null {
+  const classes = useStyles();
+
+  return (
+    <div>
+      <Link fontSize={16} to={APP_PATHS.HOME}>
+        Terraware
+      </Link>
+      <span className={classes.separator}>/</span>
+      <span className={classes.selected}>{strings.ACCELERATOR_CONSOLE}</span>
+    </div>
+  );
+}

--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useRouteMatch } from 'react-router-dom';
 import { IconButton, Theme, Grid } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { Svg } from '@terraware/web-components';
@@ -9,9 +9,11 @@ import OrganizationsDropdown from '../OrganizationsDropdown';
 import UserMenu from '../UserMenu';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import SmallDeviceUserMenu from '../SmallDeviceUserMenu';
-import { useOrganization } from 'src/providers/hooks';
+import { useOrganization, useUser } from 'src/providers/hooks';
 import Link from 'src/components/common/Link';
 import { APP_PATHS } from 'src/constants';
+import strings from 'src/strings';
+import { isAcceleratorAdmin } from 'src/types/User';
 
 const useStyles = makeStyles((theme: Theme) => ({
   logo: {
@@ -19,6 +21,22 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   backgroundLogo: {
     background: 'url(/assets/logo.svg) no-repeat center/37px',
+  },
+  breadcrumbSelected: {
+    backgroundColor: '#EF7047',
+    borderRadius: '16px',
+    color: theme.palette.TwClrBaseWhite,
+    fontFamily: 'Inter',
+    fontSize: '16px',
+    fontWeight: 500,
+    padding: '0.5em 0.8em',
+    userSelect: 'none',
+  },
+  breadcrumbSeparator: {
+    color: theme.palette.TwClrBaseGray300,
+    fontSize: '16px',
+    margin: '0 1em',
+    userSelect: 'none',
   },
   separator: {
     width: '1px',
@@ -61,6 +79,8 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
   const { selectedOrganization, organizations, reloadOrganizations } = useOrganization();
   const { setShowNavBar } = props;
   const { isDesktop } = useDeviceInfo();
+  const { user } = useUser();
+  const isAcceleratorRoute = useRouteMatch(APP_PATHS.ACCELERATOR);
 
   const onHandleLogout = () => {
     window.location.href = `/sso/logout`;
@@ -74,13 +94,24 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
             <Svg.Logo className={classes.logo} />
           </Link>
         </div>
+
         {organizations && organizations.length > 0 && (
           <>
             <div className={classes.separator} />
+            {isAcceleratorRoute && user && isAcceleratorAdmin(user) && (
+              <div>
+                <Link fontSize={16} to={APP_PATHS.HOME}>
+                  Terraware
+                </Link>
+                <span className={classes.breadcrumbSeparator}>/</span>
+                <span className={classes.breadcrumbSelected}>{strings.ACCELERATOR_CONSOLE}</span>
+              </div>
+            )}
             <OrganizationsDropdown />
           </>
         )}
       </div>
+
       <div className={classes.right}>
         <NotificationsDropdown
           organizationId={selectedOrganization.id !== -1 ? selectedOrganization.id : undefined}

--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -11,8 +11,8 @@ import useDeviceInfo from 'src/utils/useDeviceInfo';
 import SmallDeviceUserMenu from '../SmallDeviceUserMenu';
 import { useOrganization, useUser } from 'src/providers/hooks';
 import Link from 'src/components/common/Link';
+import AcceleratorBreadcrumbs from 'src/components/TopBar/AcceleratorBreadcrumbs';
 import { APP_PATHS } from 'src/constants';
-import strings from 'src/strings';
 import { isAcceleratorAdmin } from 'src/types/User';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -21,22 +21,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   backgroundLogo: {
     background: 'url(/assets/logo.svg) no-repeat center/37px',
-  },
-  breadcrumbSelected: {
-    backgroundColor: '#EF7047',
-    borderRadius: '16px',
-    color: theme.palette.TwClrBaseWhite,
-    fontFamily: 'Inter',
-    fontSize: '16px',
-    fontWeight: 500,
-    padding: '0.5em 0.8em',
-    userSelect: 'none',
-  },
-  breadcrumbSeparator: {
-    color: theme.palette.TwClrBaseGray300,
-    fontSize: '16px',
-    margin: '0 1em',
-    userSelect: 'none',
   },
   separator: {
     width: '1px',
@@ -98,15 +82,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
         {organizations && organizations.length > 0 && (
           <>
             <div className={classes.separator} />
-            {isAcceleratorRoute && user && isAcceleratorAdmin(user) && (
-              <div>
-                <Link fontSize={16} to={APP_PATHS.HOME}>
-                  Terraware
-                </Link>
-                <span className={classes.breadcrumbSeparator}>/</span>
-                <span className={classes.breadcrumbSelected}>{strings.ACCELERATOR_CONSOLE}</span>
-              </div>
-            )}
+            {isAcceleratorRoute && user && isAcceleratorAdmin(user) && <AcceleratorBreadcrumbs />}
             <OrganizationsDropdown />
           </>
         )}

--- a/src/scenes/AcceleratorRouter/NavBar.tsx
+++ b/src/scenes/AcceleratorRouter/NavBar.tsx
@@ -44,14 +44,18 @@ export default function NavBar({ backgroundTransparent, setShowNavBar }: NavBarP
       backgroundTransparent={backgroundTransparent}
       setShowNavBar={setShowNavBar as React.Dispatch<React.SetStateAction<boolean>>}
     >
-      <NavItem
-        icon='home'
-        id='home'
-        label={strings.BACK_TO_TERRAWARE}
-        onClick={() => closeAndNavigateTo(APP_PATHS.HOME)}
-      />
+      {!isDesktop && (
+        <>
+          <NavItem
+            icon='home'
+            id='home'
+            label={strings.BACK_TO_TERRAWARE}
+            onClick={() => closeAndNavigateTo(APP_PATHS.HOME)}
+          />
 
-      <NavSection />
+          <NavSection />
+        </>
+      )}
 
       <NavItem
         id='overview'


### PR DESCRIPTION
This PR includes changes to add breadcrumbs in the `TopBar` component for the Accelerator Admin Console.

Note: There isn't room to show the breadcrumbs on mobile so I opted to leave the "Back to Terraware" link for mobile devices as a quick fix. Happy to adjust this if desired.

## Screenshots

![localhost_3000_accelerator_overview_organizationId=1](https://github.com/terraware/terraware-web/assets/1474361/eb8e6bdc-dbed-4be4-921e-d718d5da0b63)

<img src="https://github.com/terraware/terraware-web/assets/1474361/5700d526-6e18-4299-8d64-3495c850327b" width="50%" alt="" />

<img src="https://github.com/terraware/terraware-web/assets/1474361/be549f89-924a-4e9b-a111-e32821fe597e" width="50%" alt="" />
