### PR TITLE
Rename types to be more descriptive

### DIFF
--- a/src/scenes/PlantingSitesRouter/edit/DetailsInputForm.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/DetailsInputForm.tsx
@@ -3,7 +3,7 @@ import { Grid } from '@mui/material';
 import strings from 'src/strings';
 import { useDeviceInfo } from '@terraware/web-components/utils';
 import TextField from '@terraware/web-components/components/Textfield/Textfield';
-import { SiteDetails, UpdatedPlantingSeason } from 'src/types/Tracking';
+import { MinimalPlantingSite, UpdatedPlantingSeason } from 'src/types/Tracking';
 import isEnabled from 'src/features';
 import { TimeZoneDescription } from 'src/types/TimeZones';
 import { useLocalization, useOrganization } from 'src/providers';
@@ -15,7 +15,7 @@ import ProjectsDropdown from 'src/components/ProjectsDropdown';
 import LocationTimeZoneSelector from 'src/components/LocationTimeZoneSelector';
 import PlantingSeasonsEdit from './PlantingSeasonsEdit';
 
-export type DetailsInputFormProps<T extends SiteDetails> = {
+export type DetailsInputFormProps<T extends MinimalPlantingSite> = {
   onChange: (id: string, value: unknown) => void;
   onValidate?: (hasErrors: boolean) => void;
   plantingSeasons?: UpdatedPlantingSeason[];
@@ -24,7 +24,7 @@ export type DetailsInputFormProps<T extends SiteDetails> = {
   setRecord: (setFn: (previousValue: T) => T) => void;
 };
 
-export default function DetailsInputForm<T extends SiteDetails>({
+export default function DetailsInputForm<T extends MinimalPlantingSite>({
   onChange,
   onValidate,
   plantingSeasons,

--- a/src/scenes/PlantingSitesRouter/view/BoundariesAndZones.tsx
+++ b/src/scenes/PlantingSitesRouter/view/BoundariesAndZones.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from '@mui/styles';
 import { Box, Typography, useTheme } from '@mui/material';
 import getDateDisplayValue from '@terraware/web-components/utils/date';
 import strings from 'src/strings';
-import { PlantingZone, SiteDetails } from 'src/types/Tracking';
+import { PlantingZone, MinimalPlantingSite } from 'src/types/Tracking';
 import { MapEntityId, MapSourceProperties } from 'src/types/Map';
 import { ZoneAggregation } from 'src/types/Observations';
 import { useAppSelector } from 'src/redux/store';
@@ -33,7 +33,7 @@ export const useMapTooltipStyles = makeStyles(() => ({
 }));
 
 type BoundariesAndZonesProps = {
-  plantingSite: SiteDetails;
+  plantingSite: MinimalPlantingSite;
   setView?: (view: View) => void;
   view?: View;
 };
@@ -80,7 +80,7 @@ export default function BoundariesAndZones({ plantingSite, setView, view }: Boun
 }
 
 type PlantingSiteMapViewProps = {
-  plantingSite: SiteDetails;
+  plantingSite: MinimalPlantingSite;
   data: ZoneAggregation[];
   search: string;
 };
@@ -160,7 +160,7 @@ function PlantingSiteMapView({ plantingSite, data, search }: PlantingSiteMapView
 }
 
 const contextRenderer =
-  (site: SiteDetails, data: ZoneAggregation[], timeZone: string) =>
+  (site: MinimalPlantingSite, data: ZoneAggregation[], timeZone: string) =>
   (entity: MapSourceProperties): JSX.Element => {
     let properties: TooltipProperty[] = [];
     let title: string | undefined;

--- a/src/scenes/PlantingSitesRouter/view/GenericSiteView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/GenericSiteView.tsx
@@ -9,7 +9,7 @@ import TextField from '@terraware/web-components/components/Textfield/Textfield'
 import strings from 'src/strings';
 import { APP_PATHS } from 'src/constants';
 import isEnabled from 'src/features';
-import { PlantingSeason, SiteDetails } from 'src/types/Tracking';
+import { PlantingSeason, MinimalPlantingSite } from 'src/types/Tracking';
 import { useProjects } from 'src/hooks/useProjects';
 import PageSnackbar from 'src/components/PageSnackbar';
 import BoundariesAndZones from './BoundariesAndZones';
@@ -30,14 +30,14 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-export type GenericSiteViewProps<T extends SiteDetails> = {
+export type GenericSiteViewProps<T extends MinimalPlantingSite> = {
   editDisabled?: boolean;
   editUrl: string;
   onDelete: () => void;
   plantingSite: T;
 };
 
-export default function GenericSiteView<T extends SiteDetails>({
+export default function GenericSiteView<T extends MinimalPlantingSite>({
   editDisabled,
   editUrl,
   onDelete,

--- a/src/scenes/PlantingSitesRouter/view/PlantingSiteDetailsTable.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSiteDetailsTable.tsx
@@ -4,7 +4,7 @@ import { TableColumnType } from '@terraware/web-components';
 import getDateDisplayValue from '@terraware/web-components/utils/date';
 import strings from 'src/strings';
 import { SubzoneAggregation, ZoneAggregation } from 'src/types/Observations';
-import { SiteDetails } from 'src/types/Tracking';
+import { MinimalPlantingSite } from 'src/types/Tracking';
 import { APP_PATHS } from 'src/constants';
 import CellRenderer, { TableRowType } from 'src/components/common/table/TableCellRenderer';
 import { RendererProps } from 'src/components/common/table/types';
@@ -18,7 +18,7 @@ import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 
 type PlantingSiteDetailsTableProps = {
   data: ZoneAggregation[];
-  plantingSite: SiteDetails;
+  plantingSite: MinimalPlantingSite;
 };
 
 const useStyles = makeStyles(() => ({

--- a/src/scenes/PlantingSitesRouter/view/SimplePlantingSite.tsx
+++ b/src/scenes/PlantingSitesRouter/view/SimplePlantingSite.tsx
@@ -1,10 +1,10 @@
 import { Box, Typography, useTheme } from '@mui/material';
 import strings from 'src/strings';
-import { SiteDetails } from 'src/types/Tracking';
+import { MinimalPlantingSite } from 'src/types/Tracking';
 import SimplePlantingSiteMap from 'src/scenes/PlantsDashboardRouter/components/SimplePlantingSiteMap';
 
 type SimplePlantingSiteProps = {
-  plantingSite: SiteDetails;
+  plantingSite: MinimalPlantingSite;
 };
 
 export default function SimplePlantingSite({ plantingSite }: SimplePlantingSiteProps): JSX.Element {

--- a/src/services/MapService.ts
+++ b/src/services/MapService.ts
@@ -1,5 +1,5 @@
 import { paths } from 'src/api/types/generated-schema';
-import { MultiPolygon, PlantingSite, SiteDetails } from 'src/types/Tracking';
+import { MultiPolygon, PlantingSite, MinimalPlantingSite } from 'src/types/Tracking';
 import { MapBoundingBox, MapData, MapEntity, MapGeometry, MapSourceBaseData } from 'src/types/Map';
 import HttpService, { Response } from './HttpService';
 import {
@@ -141,7 +141,7 @@ const getPolygons = (boundary?: MultiPolygon): MapGeometry => {
 /**
  * Transform planting site geometry data into UI model
  */
-const extractPlantingSite = (site: SiteDetails): MapSourceBaseData => {
+const extractPlantingSite = (site: MinimalPlantingSite): MapSourceBaseData => {
   const { id, name, description, boundary } = site;
 
   return {
@@ -159,7 +159,7 @@ const extractPlantingSite = (site: SiteDetails): MapSourceBaseData => {
 /**
  * Transform zones geometry data into UI model
  */
-const extractPlantingZones = (site: SiteDetails): MapSourceBaseData => {
+const extractPlantingZones = (site: MinimalPlantingSite): MapSourceBaseData => {
   const zonesData =
     site.plantingZones?.map((zone) => {
       const { id, name, boundary } = zone;
@@ -179,7 +179,7 @@ const extractPlantingZones = (site: SiteDetails): MapSourceBaseData => {
 /**
  * Transform subzones geometry data into UI model
  */
-const extractSubzones = (site: SiteDetails): MapSourceBaseData => {
+const extractSubzones = (site: MinimalPlantingSite): MapSourceBaseData => {
   const allPlantingSubzonesData =
     site.plantingZones?.flatMap((zone) => {
       const { plantingSubzones } = zone;

--- a/src/types/Observations.ts
+++ b/src/types/Observations.ts
@@ -1,5 +1,5 @@
 import { components } from 'src/api/types/generated-schema';
-import { MultiPolygon, PlantingZone, PlantingSubzone, SiteDetails } from './Tracking';
+import { MultiPolygon, PlantingZone, PlantingSubzone, MinimalPlantingSite } from './Tracking';
 import strings from 'src/strings';
 
 // basic information on a single observation (excluding observation results)
@@ -129,6 +129,6 @@ export type ZoneAggregation = Omit<PlantingZone, 'plantingSubzones'> & {
   plantingSubzones: SubzoneAggregation[];
 };
 
-export type PlantingSiteAggregation = Omit<SiteDetails, 'plantingZones'> & {
+export type PlantingSiteAggregation = Omit<MinimalPlantingSite, 'plantingZones'> & {
   plantingZones: ZoneAggregation[];
 };

--- a/src/types/PlantingSite.ts
+++ b/src/types/PlantingSite.ts
@@ -1,5 +1,5 @@
 import { components } from 'src/api/types/generated-schema';
-import { MultiPolygon, PlantingSite, SiteDetails } from './Tracking';
+import { MultiPolygon, PlantingSite, MinimalPlantingSite } from './Tracking';
 
 export type Population = {
   species_scientificName: string;
@@ -57,7 +57,7 @@ export type GetDraftPlantingSiteResponsePayload = components['schemas']['GetDraf
 /**
  * Client side draft planting site with first class properties.
  */
-export type DraftPlantingSite = SiteDetails & {
+export type DraftPlantingSite = MinimalPlantingSite & {
   createdBy: number; // user that created this draft
   exclusion?: MultiPolygon;
   siteEditStep: SiteEditStep;

--- a/src/types/Tracking.ts
+++ b/src/types/Tracking.ts
@@ -41,20 +41,22 @@ export type Location = {
   timeZone?: string;
 };
 
-export type SitePlantingZone = Omit<PlantingZone, 'areaHa' | 'plantingSubzones'> & {
-  plantingSubzones: Omit<PlantingSubzone, 'areaHa'>[];
+export type MinimalPlantingSubzone = Omit<PlantingSubzone, 'areaHa'>;
+
+export type MinimalPlantingZone = Omit<PlantingZone, 'areaHa' | 'plantingSubzones'> & {
+  plantingSubzones: MinimalPlantingSubzone[];
 };
 
 /**
- * A minium planting site representation for basic details view/edit purposes.
+ * A minimal planting site representing basic details for view/edit purposes.
  */
-export type SiteDetails = Location & {
+export type MinimalPlantingSite = Location & {
   boundary?: MultiPolygon;
   description?: string;
   id: number;
   name: string;
   organizationId: number;
   plantingSeasons: PlantingSeason[];
-  plantingZones?: SitePlantingZone[];
+  plantingZones?: MinimalPlantingZone[];
   projectId?: number;
 };

--- a/src/utils/draftPlantingSiteUtils.test.ts
+++ b/src/utils/draftPlantingSiteUtils.test.ts
@@ -1,4 +1,4 @@
-import { MultiPolygon, PlantingSeason, SitePlantingZone } from 'src/types/Tracking';
+import { MultiPolygon, PlantingSeason, MinimalPlantingZone } from 'src/types/Tracking';
 import { DraftPlantingSite, DraftPlantingSitePayload } from 'src/types/PlantingSite';
 import { fromDraft, toDraft } from './draftPlantingSiteUtils';
 
@@ -124,7 +124,7 @@ const subzone22: MultiPolygon = {
 
 const plantingSeasons: PlantingSeason[] = [{ id: 1, startDate: '2024-01-01', endDate: '2024-02-01' }];
 
-const plantingZones: SitePlantingZone[] = [
+const plantingZones: MinimalPlantingZone[] = [
   {
     boundary: zone1,
     id: 1,

--- a/src/utils/draftPlantingSiteUtils.ts
+++ b/src/utils/draftPlantingSiteUtils.ts
@@ -1,4 +1,4 @@
-import { MultiPolygon, PlantingSeason, SitePlantingZone } from 'src/types/Tracking';
+import { MultiPolygon, PlantingSeason, MinimalPlantingZone } from 'src/types/Tracking';
 import { DraftPlantingSite, DraftPlantingSitePayload, SiteEditStep, SiteType } from 'src/types/PlantingSite';
 
 /**
@@ -71,7 +71,7 @@ export const toDraft = (payload: DraftPlantingSitePayload): DraftPlantingSite =>
   const boundary: MultiPolygon | undefined = data.boundary as MultiPolygon | undefined;
   const exclusion: MultiPolygon | undefined = data.exclusion as MultiPolygon | undefined;
   const plantingSeasons: PlantingSeason[] = data.plantingSeasons as PlantingSeason[];
-  const plantingZones: SitePlantingZone[] | undefined = data.plantingZones as SitePlantingZone[] | undefined;
+  const plantingZones: MinimalPlantingZone[] | undefined = data.plantingZones as MinimalPlantingZone[] | undefined;
   const siteEditStep: SiteEditStep = data.siteEditStep as SiteEditStep;
   const siteType: SiteType = data.siteType as SiteType;
 


### PR DESCRIPTION
- renamed SiteDetails to MinimalPlantingSite (capturing common properties between PlantingSite and DraftPlantingSite)
- similarly renamed zone/subzone properties
- no functional changes