### PR TITLE
SW-4849 Use new draft planting site types in site editor

### DIFF
--- a/src/scenes/PlantingSitesRouter/edit/PlantingSiteDraftCreate.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/PlantingSiteDraftCreate.tsx
@@ -1,30 +1,26 @@
 import { useMemo } from 'react';
 import useQuery from 'src/utils/useQuery';
-import { PlantingSite } from 'src/types/Tracking';
-import { SiteType } from 'src/types/PlantingSite';
+import { DraftPlantingSite, SiteType } from 'src/types/PlantingSite';
 import { useOrganization } from 'src/providers';
 import PlantingSiteEditor from './editor/Editor';
 
-type PlantingSiteDraftCreateProps = {
-  reloadPlantingSites: () => void;
-};
-
-export default function PlantingSiteDraftCreate(props: PlantingSiteDraftCreateProps): JSX.Element {
-  const { reloadPlantingSites } = props;
+export default function PlantingSiteDraftCreate(): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const query = useQuery();
+  const siteType = useMemo<SiteType>(() => (query.has('detailed') ? 'detailed' : 'simple'), [query]);
 
-  const site = useMemo<PlantingSite>(
+  const site = useMemo<DraftPlantingSite>(
     () => ({
-      id: 0,
+      createdBy: -1,
+      id: -1,
       name: '',
       organizationId: selectedOrganization.id,
       plantingSeasons: [],
+      siteEditStep: 'details',
+      siteType,
     }),
-    [selectedOrganization.id]
+    [selectedOrganization.id, siteType]
   );
 
-  const siteType = useMemo<SiteType>(() => (query.has('detailed') ? 'detailed' : 'simple'), [query]);
-
-  return <PlantingSiteEditor reloadPlantingSites={reloadPlantingSites} site={site} siteType={siteType} />;
+  return <PlantingSiteEditor site={site} />;
 }

--- a/src/scenes/PlantingSitesRouter/edit/PlantingSiteDraftEdit.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/PlantingSiteDraftEdit.tsx
@@ -1,46 +1,15 @@
-import { useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { BusySpinner } from '@terraware/web-components';
-import { SiteType } from 'src/types/PlantingSite';
-import { useLocalization } from 'src/providers';
-import { useAppDispatch, useAppSelector } from 'src/redux/store';
-import { selectPlantingSite } from 'src/redux/features/tracking/trackingSelectors';
-import { requestPlantingSite } from 'src/redux/features/tracking/trackingThunks';
+import useDraftPlantingSite from 'src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSite';
 import PlantingSiteEditor from './editor/Editor';
 
-type PlantingSiteDraftEditProps = {
-  reloadPlantingSites: () => void;
-};
-
-export default function PlantingSiteDraftEdit(props: PlantingSiteDraftEditProps): JSX.Element {
-  const { reloadPlantingSites } = props;
-  const { activeLocale } = useLocalization();
-  const dispatch = useAppDispatch();
+export default function PlantingSiteDraftEdit(): JSX.Element {
   const { plantingSiteId } = useParams<{ plantingSiteId: string }>();
-  const plantingSite = useAppSelector((state) => selectPlantingSite(state, Number(plantingSiteId)));
+  const result = useDraftPlantingSite({ draftId: Number(plantingSiteId) });
 
-  useEffect(() => {
-    const siteId = Number(plantingSiteId);
-    if (!isNaN(siteId)) {
-      // TODO fetch draft planting site once BE has API
-      dispatch(requestPlantingSite(siteId, activeLocale));
-    }
-  }, [activeLocale, dispatch, plantingSiteId]);
-
-  const siteType = useMemo<SiteType>(() => {
-    // TODO: get planting site type when BE model has support
-    if (plantingSite) {
-      return 'simple';
-    } else {
-      return 'simple';
-    }
-  }, [plantingSite]);
-
-  // TODO: handle error state?
-
-  if (!plantingSite) {
-    return <BusySpinner withSkrim={true} />;
+  if (result.site !== undefined) {
+    return <PlantingSiteEditor site={result.site} />;
   }
 
-  return <PlantingSiteEditor reloadPlantingSites={reloadPlantingSites} site={plantingSite} siteType={siteType} />;
+  return <BusySpinner withSkrim={true} />;
 }

--- a/src/scenes/PlantingSitesRouter/edit/editor/Details.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Details.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@mui/material';
 import strings from 'src/strings';
-import { PlantingSite, UpdatedPlantingSeason } from 'src/types/Tracking';
+import { UpdatedPlantingSeason } from 'src/types/Tracking';
+import { DraftPlantingSite } from 'src/types/PlantingSite';
 import DetailsInputForm from 'src/scenes/PlantingSitesRouter/edit/DetailsInputForm';
 import StepTitleDescription from './StepTitleDescription';
 
@@ -9,8 +10,8 @@ export type DetailsProps = {
   onValidate?: (hasErrors: boolean) => void;
   plantingSeasons?: UpdatedPlantingSeason[];
   setPlantingSeasons: (plantingSeasons: UpdatedPlantingSeason[]) => void;
-  setPlantingSite: (setFn: (previousValue: PlantingSite) => PlantingSite) => void;
-  site: PlantingSite;
+  setPlantingSite: (setFn: (previousValue: DraftPlantingSite) => DraftPlantingSite) => void;
+  site: DraftPlantingSite;
 };
 
 export default function Details({
@@ -24,7 +25,7 @@ export default function Details({
   return (
     <Box display='flex' flexDirection='column'>
       <StepTitleDescription description={[]} title={strings.DETAILS} />
-      <DetailsInputForm<PlantingSite>
+      <DetailsInputForm<DraftPlantingSite>
         onChange={onChange}
         onValidate={onValidate}
         plantingSeasons={plantingSeasons}

--- a/src/scenes/PlantingSitesRouter/edit/editor/Editor.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Editor.tsx
@@ -5,8 +5,9 @@ import { useHistory } from 'react-router-dom';
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button, Message } from '@terraware/web-components';
 import strings from 'src/strings';
-import { PlantingSite, UpdatedPlantingSeason } from 'src/types/Tracking';
-import { SiteEditStep, SiteType } from 'src/types/PlantingSite';
+import { UpdatedPlantingSeason } from 'src/types/Tracking';
+import { DraftPlantingSite } from 'src/types/PlantingSite';
+import { SiteEditStep } from 'src/types/PlantingSite';
 import { APP_PATHS } from 'src/constants';
 import { useLocalization } from 'src/providers';
 import { useDocLinks } from 'src/docLinks';
@@ -27,9 +28,7 @@ import Subzones from './Subzones';
 import StartOverConfirmation from './StartOverConfirmation';
 
 export type EditorProps = {
-  reloadPlantingSites: () => void;
-  site: PlantingSite;
-  siteType: SiteType;
+  site: DraftPlantingSite;
 };
 
 const useStyles = makeStyles(() => ({
@@ -41,7 +40,8 @@ const useStyles = makeStyles(() => ({
 }));
 
 export default function Editor(props: EditorProps): JSX.Element {
-  const { reloadPlantingSites, site, siteType } = props;
+  const { site } = props;
+  const { siteEditStep, siteType } = site;
   const { activeLocale } = useLocalization();
   const contentRef = useRef(null);
   const history = useHistory();
@@ -56,7 +56,7 @@ export default function Editor(props: EditorProps): JSX.Element {
     ((hasErrors: boolean, isOptionalCompleted?: boolean) => void) | undefined
   >();
   const [showStartOver, setShowStartOver] = useState<boolean>(false);
-  const [currentStep, setCurrentStep] = useState<SiteEditStep>('details');
+  const [currentStep, setCurrentStep] = useState<SiteEditStep>(siteEditStep);
   const [completedOptionalSteps, setCompletedOptionalSteps] = useState<Record<SiteEditStep, boolean>>(
     {} as Record<SiteEditStep, boolean>
   );
@@ -129,7 +129,7 @@ export default function Editor(props: EditorProps): JSX.Element {
     goToPlantingSites();
   };
 
-  const saveSite = async (): Promise<PlantingSite | undefined> => {
+  const saveSite = async (): Promise<DraftPlantingSite | undefined> => {
     // TODO save site and update site state
     // return undefined if error and toast error
     return plantingSite;
@@ -149,8 +149,7 @@ export default function Editor(props: EditorProps): JSX.Element {
           return;
         }
         if (closeEditor) {
-          snackbar.toastSuccess(strings.SAVED);
-          reloadPlantingSites();
+          snackbar.toastSuccess(strings.PLANTING_SITE_SAVED);
           // TODO go to saved site
           goToPlantingSites();
         } else {
@@ -169,7 +168,7 @@ export default function Editor(props: EditorProps): JSX.Element {
 
   const onStartOver = () => {
     setCurrentStep('site_boundary');
-    setPlantingSite((current: PlantingSite) => ({
+    setPlantingSite((current: DraftPlantingSite) => ({
       ...current,
       // start over only resets the polygonal information
       // edits to name, description, planting seasons and project are preserved

--- a/src/scenes/PlantingSitesRouter/edit/editor/Exclusions.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Exclusions.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from 'react';
 import { Box } from '@mui/material';
 import { FeatureCollection } from 'geojson';
 import strings from 'src/strings';
-import { PlantingSite } from 'src/types/Tracking';
+import { DraftPlantingSite } from 'src/types/PlantingSite';
 import useUndoRedoState from 'src/hooks/useUndoRedoState';
 import { RenderableReadOnlyBoundary } from 'src/types/Map';
 import { useLocalization } from 'src/providers';
@@ -15,7 +15,7 @@ import StepTitleDescription, { Description } from './StepTitleDescription';
 export type ExclusionsProps = {
   onChange: (id: string, value: unknown) => void;
   onValidate?: (hasErrors: boolean, isOptionalStepCompleted?: boolean) => void;
-  site: PlantingSite;
+  site: DraftPlantingSite;
 };
 
 export default function Exclusions({ onChange, onValidate, site }: ExclusionsProps): JSX.Element {

--- a/src/scenes/PlantingSitesRouter/edit/editor/SiteBoundary.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/SiteBoundary.tsx
@@ -6,7 +6,8 @@ import bboxPolygon from '@turf/bbox-polygon';
 import centroid from '@turf/centroid';
 import _ from 'lodash';
 import strings from 'src/strings';
-import { PlantingSite, PlantingZone } from 'src/types/Tracking';
+import { MinimalPlantingZone } from 'src/types/Tracking';
+import { DraftPlantingSite } from 'src/types/PlantingSite';
 import useSnackbar from 'src/utils/useSnackbar';
 import useUndoRedoState from 'src/hooks/useUndoRedoState';
 import { useLocalization } from 'src/providers';
@@ -21,7 +22,7 @@ export type SiteBoundaryProps = {
   isSimpleSite: boolean;
   onChange: (id: string, value: unknown) => void;
   onValidate?: (hasErrors: boolean) => void;
-  site: PlantingSite;
+  site: DraftPlantingSite;
 };
 
 const featureSiteBoundary = (id: number, boundary?: MultiPolygon): FeatureCollection | undefined =>
@@ -102,9 +103,9 @@ export default function SiteBoundary({ isSimpleSite, onChange, onValidate, site 
         return;
       } else {
         onChange('boundary', boundary);
-        if (site.id !== -1) {
-          // create one zone per disjoint polygon in the site boundary
-          const zones: PlantingZone[] = boundary.coordinates.flatMap((coordinates: Position[][], index: number) => {
+        // create one zone per disjoint polygon in the site boundary
+        const zones: MinimalPlantingZone[] = boundary.coordinates.flatMap(
+          (coordinates: Position[][], index: number) => {
             const zoneBoundary: MultiPolygon = { type: 'MultiPolygon', coordinates: [coordinates] };
             return defaultZonePayload({
               boundary: zoneBoundary,
@@ -112,9 +113,9 @@ export default function SiteBoundary({ isSimpleSite, onChange, onValidate, site 
               name: isSimpleSite ? `${strings.ZONE}${index || ''}` : '',
               targetPlantingDensity: 1500,
             });
-          });
-          onChange('plantingZones', zones);
-        }
+          }
+        );
+        onChange('plantingZones', zones);
         onValidate(false);
       }
     }

--- a/src/scenes/PlantingSitesRouter/edit/editor/Subzones.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Subzones.tsx
@@ -3,7 +3,8 @@ import { Box, Typography, useTheme } from '@mui/material';
 import { Feature, FeatureCollection } from 'geojson';
 import { Textfield } from '@terraware/web-components';
 import strings from 'src/strings';
-import { PlantingSite, PlantingSubzone, PlantingZone } from 'src/types/Tracking';
+import { MinimalPlantingSubzone, MinimalPlantingZone } from 'src/types/Tracking';
+import { DraftPlantingSite } from 'src/types/PlantingSite';
 import useUndoRedoState from 'src/hooks/useUndoRedoState';
 import {
   GeometryFeature,
@@ -37,10 +38,10 @@ import useStyles from './useMapStyle';
 export type SubzonesProps = {
   onChange: (id: string, value: unknown) => void;
   onValidate?: (hasErrors: boolean, isOptionalStepCompleted?: boolean) => void;
-  site: PlantingSite;
+  site: DraftPlantingSite;
 };
 
-const featureSiteSubzones = (site: PlantingSite): Record<number, FeatureCollection> =>
+const featureSiteSubzones = (site: DraftPlantingSite): Record<number, FeatureCollection> =>
   (site.plantingZones ?? []).reduce(
     (subzonesMap, zone) => {
       subzonesMap[zone.id] = {
@@ -110,14 +111,13 @@ export default function Subzones({ onChange, onValidate, site }: SubzonesProps):
     // subzones are children of zones, we need to repopuplate zones with new subzones information
     // and update `plantingZones` in the site
     const numZones = site.plantingZones?.length ?? 0;
-    const plantingZones: PlantingZone[] | undefined = site.plantingZones?.map((zone) => {
-      const plantingSubzones: PlantingSubzone[] = (subzones?.[zone.id]?.features ?? [])
+    const plantingZones: MinimalPlantingZone[] | undefined = site.plantingZones?.map((zone) => {
+      const plantingSubzones: MinimalPlantingSubzone[] = (subzones?.[zone.id]?.features ?? [])
         .map((subzone) => {
           const { geometry, properties } = subzone;
           const multiPolygon = toMultiPolygon(geometry);
           if (multiPolygon && properties) {
             return {
-              areaHa: 0, // TODO update with api requirements when ready, we shouldn't be calculating this on the client
               boundary: multiPolygon,
               fullName: properties.name!,
               id: properties.id!,
@@ -128,7 +128,7 @@ export default function Subzones({ onChange, onValidate, site }: SubzonesProps):
             return undefined;
           }
         })
-        .filter((subzone) => !!subzone) as PlantingSubzone[];
+        .filter((subzone) => !!subzone) as MinimalPlantingSubzone[];
       return { ...zone, plantingSubzones };
     });
     const numSubzones = plantingZones?.flatMap((zone) => zone.plantingSubzones)?.length ?? 0;

--- a/src/scenes/PlantingSitesRouter/edit/editor/Zones.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Zones.tsx
@@ -3,7 +3,7 @@ import { Box, Typography, useTheme } from '@mui/material';
 import { Feature, FeatureCollection } from 'geojson';
 import { Textfield } from '@terraware/web-components';
 import strings from 'src/strings';
-import { PlantingSite } from 'src/types/Tracking';
+import { DraftPlantingSite } from 'src/types/PlantingSite';
 import {
   GeometryFeature,
   MapPopupRenderer,
@@ -34,10 +34,10 @@ import useStyles from './useMapStyle';
 export type ZonesProps = {
   onChange: (id: string, value: unknown) => void;
   onValidate?: (hasErrors: boolean, isOptionalStepCompleted?: boolean) => void;
-  site: PlantingSite;
+  site: DraftPlantingSite;
 };
 
-const featureSiteZones = (site: PlantingSite): FeatureCollection | undefined => {
+const featureSiteZones = (site: DraftPlantingSite): FeatureCollection | undefined => {
   if (site.plantingZones) {
     const features = site.plantingZones.map(plantingZoneToFeature);
     return { type: 'FeatureCollection', features };

--- a/src/scenes/PlantingSitesRouter/edit/editor/utils.ts
+++ b/src/scenes/PlantingSitesRouter/edit/editor/utils.ts
@@ -2,26 +2,24 @@ import { Feature, FeatureCollection, MultiPolygon, Polygon } from 'geojson';
 import area from '@turf/area';
 import bbox from '@turf/bbox';
 import bboxPolygon from '@turf/bbox-polygon';
-import { PlantingSubzone, PlantingZone } from 'src/types/Tracking';
+import { MinimalPlantingSubzone, MinimalPlantingZone } from 'src/types/Tracking';
 import { GeometryFeature } from 'src/types/Map';
 import { cutPolygons, toFeature } from 'src/components/Map/utils';
 
 const SQ_M_TO_HECTARES = 1 / 10000;
 
-export type DefaultZonePayload = Omit<PlantingZone, 'plantingSubzones' | 'areaHa'>;
+export type DefaultZonePayload = Omit<MinimalPlantingZone, 'plantingSubzones'>;
 
-export const defaultZonePayload = (payload: DefaultZonePayload): PlantingZone => {
+export const defaultZonePayload = (payload: DefaultZonePayload): MinimalPlantingZone => {
   const { boundary, id, name, targetPlantingDensity } = payload;
   const subzoneName = 'A';
 
   return {
-    areaHa: 0,
     boundary,
     id,
     name,
     plantingSubzones: [
       {
-        areaHa: 0,
         boundary,
         fullName: subzoneName,
         id,
@@ -78,7 +76,7 @@ export const toZoneFeature = (feature: Feature, idGenerator: () => number) =>
  * Utility to generate a feature from planting zone data.
  * This is from BE planting zone data to a zone feature.
  */
-export const plantingZoneToFeature = (zone: PlantingZone): Feature => {
+export const plantingZoneToFeature = (zone: MinimalPlantingZone): Feature => {
   const { boundary, id, name, targetPlantingDensity } = zone;
   return toFeature(boundary, { id, name, targetPlantingDensity }, id);
 };
@@ -87,7 +85,7 @@ export const plantingZoneToFeature = (zone: PlantingZone): Feature => {
  * Utility to generate a feature from planting subzone data.
  * This is from BE planting subzone data to a subzone feature.
  */
-export const plantingSubzoneToFeature = (subzone: PlantingSubzone): Feature => {
+export const plantingSubzoneToFeature = (subzone: MinimalPlantingSubzone): Feature => {
   const { boundary, id, name } = subzone;
   return toFeature(boundary, { id, name }, id);
 };

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSite.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSite.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { useHistory } from 'react-router-dom';
+import strings from 'src/strings';
+import { APP_PATHS } from 'src/constants';
+import { DraftPlantingSite } from 'src/types/PlantingSite';
+import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import { Statuses } from 'src/redux/features/asyncUtils';
+import { selectDraftPlantingSiteGet } from 'src/redux/features/draftPlantingSite/draftPlantingSiteSelectors';
+import { requestGetDraft } from 'src/redux/features/draftPlantingSite/draftPlantingSiteThunks';
+import useSnackbar from 'src/utils/useSnackbar';
+
+export type Props = {
+  draftId: number;
+};
+
+export type Response = {
+  status: Statuses;
+  site?: DraftPlantingSite;
+};
+
+export default function useDraftPlantingSite({ draftId }: Props): Response {
+  const snackbar = useSnackbar();
+  const history = useHistory();
+  const dispatch = useAppDispatch();
+  const draftResult = useAppSelector(selectDraftPlantingSiteGet(draftId));
+
+  const goToPlantingSites = useCallback(() => {
+    history.push(APP_PATHS.PLANTING_SITES);
+  }, [history]);
+
+  useEffect(() => {
+    if (!isNaN(draftId)) {
+      dispatch(requestGetDraft(draftId));
+    } else {
+      goToPlantingSites();
+    }
+  }, [dispatch, draftId, goToPlantingSites]);
+
+  useEffect(() => {
+    if (draftResult?.status === 'error') {
+      snackbar.toastError(strings.GENERIC_ERROR);
+      goToPlantingSites();
+    }
+  }, [draftResult?.status, goToPlantingSites, snackbar]);
+
+  return useMemo<Response>(
+    () => ({
+      status: draftResult?.status ?? 'pending',
+      site: draftResult?.data,
+    }),
+    [draftResult]
+  );
+}

--- a/src/scenes/PlantingSitesRouter/index.tsx
+++ b/src/scenes/PlantingSitesRouter/index.tsx
@@ -39,7 +39,7 @@ export default function PlantingSites({ reloadTracking }: PlantingSitesProps): J
       </Route>
       {userDrawnDetailedSites && (
         <Route path={APP_PATHS.PLANTING_SITES_DRAFT_VIEW}>
-          <PlantingSitesDraftRouter reloadTracking={reloadTracking} />
+          <PlantingSitesDraftRouter />
         </Route>
       )}
       <Route path={APP_PATHS.PLANTING_SITES_VIEW}>
@@ -101,14 +101,14 @@ export function PlantingSitesRouter({ reloadTracking }: PlantingSitesProps): JSX
   );
 }
 
-export function PlantingSitesDraftRouter({ reloadTracking }: PlantingSitesProps): JSX.Element {
+export function PlantingSitesDraftRouter(): JSX.Element {
   return (
     <Switch>
       <Route path={APP_PATHS.PLANTING_SITES_DRAFT_NEW}>
-        <PlantingSiteDraftCreate reloadPlantingSites={reloadTracking} />
+        <PlantingSiteDraftCreate />
       </Route>
       <Route path={APP_PATHS.PLANTING_SITES_DRAFT_EDIT}>
-        <PlantingSiteDraftEdit reloadPlantingSites={reloadTracking} />
+        <PlantingSiteDraftEdit />
       </Route>
       <Route path={APP_PATHS.PLANTING_SITES_DRAFT_VIEW}>
         <PlantingSiteDraftView />

--- a/src/scenes/PlantingSitesRouter/view/PlantingSiteDraftView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSiteDraftView.tsx
@@ -1,3 +1,26 @@
+import { useParams } from 'react-router-dom';
+import { BusySpinner } from '@terraware/web-components';
+import { DraftPlantingSite } from 'src/types/PlantingSite';
+import { APP_PATHS } from 'src/constants';
+import { useUser } from 'src/providers';
+import useDraftPlantingSite from 'src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSite';
+import GenericSiteView from './GenericSiteView';
+
 export default function PlantingSiteDraftView(): JSX.Element {
-  return <div>WIP</div>;
+  const { user } = useUser();
+  const { plantingSiteId } = useParams<{ plantingSiteId: string }>();
+  const result = useDraftPlantingSite({ draftId: Number(plantingSiteId) });
+
+  if (result.site !== undefined) {
+    return (
+      <GenericSiteView<DraftPlantingSite>
+        editDisabled={!user || result.site.createdBy !== user.id}
+        editUrl={APP_PATHS.PLANTING_SITES_DRAFT_EDIT}
+        onDelete={() => window.alert('WIP')}
+        plantingSite={result.site}
+      />
+    );
+  }
+
+  return <BusySpinner withSkrim={true} />;
 }

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -925,6 +925,7 @@ PLANTING_SITE_CREATE_INSTRUCTIONS_DESCRIPTION,Use the drawing {0} tool to draw t
 PLANTING_SITE_CREATE_INSTRUCTIONS_TITLE,Drawing Site Boundaries,
 PLANTING_SITE_DELETED,Planting site deleted!,
 PLANTING_SITE_MAP_VIEW_PROMPT,"In order to access map view, please select a single planting site.",
+PLANTING_SITE_SAVED,Planting Site Saved,
 PLANTING_SITE_TYPE,Planting Site Type,
 PLANTING_SITE_TYPE_DETAILED,Detailed,
 PLANTING_SITE_TYPE_SIMPLE,Simple,


### PR DESCRIPTION
- updated code to use new types
- cleaned up properties that weren't needed
- added a hook to fetch draft site by id (for the edit and view components)
- this is still unfinished work, need to be able to create/save a draft, in a follow up PR