### PR TITLE
SW-4868 Enable create/update of draft sites

### DIFF
--- a/src/scenes/PlantingSitesRouter/edit/PlantingSiteDraftEdit.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/PlantingSiteDraftEdit.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { BusySpinner } from '@terraware/web-components';
-import useDraftPlantingSite from 'src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSite';
+import useDraftPlantingSite from 'src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteGet';
 import PlantingSiteEditor from './editor/Editor';
 
 export default function PlantingSiteDraftEdit(): JSX.Element {

--- a/src/scenes/PlantingSitesRouter/edit/editor/Details.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Details.tsx
@@ -4,10 +4,11 @@ import { UpdatedPlantingSeason } from 'src/types/Tracking';
 import { DraftPlantingSite } from 'src/types/PlantingSite';
 import DetailsInputForm from 'src/scenes/PlantingSitesRouter/edit/DetailsInputForm';
 import StepTitleDescription from './StepTitleDescription';
+import { OnValidate } from './types';
 
 export type DetailsProps = {
   onChange: (id: string, value: unknown) => void;
-  onValidate?: (hasErrors: boolean) => void;
+  onValidate?: OnValidate;
   plantingSeasons?: UpdatedPlantingSeason[];
   setPlantingSeasons: (plantingSeasons: UpdatedPlantingSeason[]) => void;
   setPlantingSite: (setFn: (previousValue: DraftPlantingSite) => DraftPlantingSite) => void;
@@ -27,7 +28,7 @@ export default function Details({
       <StepTitleDescription description={[]} title={strings.DETAILS} />
       <DetailsInputForm<DraftPlantingSite>
         onChange={onChange}
-        onValidate={onValidate}
+        onValidate={onValidate?.apply}
         plantingSeasons={plantingSeasons}
         record={site}
         setPlantingSeasons={setPlantingSeasons}

--- a/src/scenes/PlantingSitesRouter/edit/editor/Editor.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Editor.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import _ from 'lodash';
 import { makeStyles } from '@mui/styles';
 import { useHistory } from 'react-router-dom';
 import { Box, Grid, Typography, useTheme } from '@mui/material';
@@ -73,16 +72,16 @@ export default function Editor(props: EditorProps): JSX.Element {
 
   // update local state when draft is created
   useEffect(() => {
-    if (createDraftStatus === 'success' && createdDraft) {
+    if (createdDraft) {
       setPlantingSite(createdDraft.draft);
       setCurrentStep(createdDraft.nextStep);
       onFinishCreate();
     }
-  }, [createDraftStatus, createdDraft, onFinishCreate, setPlantingSite]);
+  }, [createdDraft, onFinishCreate, setPlantingSite]);
 
   // update local state when draft is updated
   useEffect(() => {
-    if (updateDraftStatus === 'success' && updatedDraft) {
+    if (updatedDraft) {
       setPlantingSite(updatedDraft.draft);
       setCurrentStep(updatedDraft.nextStep);
       if (updatedDraft.optionalSteps) {
@@ -90,7 +89,7 @@ export default function Editor(props: EditorProps): JSX.Element {
       }
       onFinishUpdate();
     }
-  }, [updateDraftStatus, updatedDraft, onFinishUpdate, setPlantingSite]);
+  }, [updatedDraft, onFinishUpdate, setPlantingSite]);
 
   const isSimpleSite = useMemo<boolean>(() => siteType === 'simple', [siteType]);
 
@@ -213,9 +212,9 @@ export default function Editor(props: EditorProps): JSX.Element {
       ...plantingSite,
       // start over only resets the polygonal information
       // edits to name, description, planting seasons and project are preserved
-      boundary: _.cloneDeep(site.boundary),
-      exclusion: _.cloneDeep(site.exclusion),
-      plantingZones: _.cloneDeep(site.plantingZones),
+      boundary: undefined,
+      exclusion: undefined,
+      plantingZones: undefined,
       siteEditStep: nextStep,
     };
 

--- a/src/scenes/PlantingSitesRouter/edit/editor/Editor.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Editor.tsx
@@ -135,7 +135,11 @@ export default function Editor(props: EditorProps): JSX.Element {
   }, [activeLocale, isSimpleSite, completedOptionalSteps]);
 
   const goToPlantingSites = () => {
-    history.push(APP_PATHS.PLANTING_SITES);
+    if (plantingSite.id !== -1) {
+      history.push(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${plantingSite.id}`));
+    } else {
+      history.push(APP_PATHS.PLANTING_SITES);
+    }
   };
 
   const getCurrentStepIndex = (): number => {

--- a/src/scenes/PlantingSitesRouter/edit/editor/Exclusions.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Exclusions.tsx
@@ -13,34 +13,35 @@ import MapIcon from 'src/components/Map/MapIcon';
 import StepTitleDescription, { Description } from './StepTitleDescription';
 
 export type ExclusionsProps = {
-  onChange: (id: string, value: unknown) => void;
-  onValidate?: (hasErrors: boolean, isOptionalStepCompleted?: boolean) => void;
+  onValidate?: (hasErrors: boolean, data?: Partial<DraftPlantingSite>, isOptionalStepCompleted?: boolean) => void;
   site: DraftPlantingSite;
 };
 
-export default function Exclusions({ onChange, onValidate, site }: ExclusionsProps): JSX.Element {
-  const [exclusions, setExclusions, undo, redo] = useUndoRedoState<FeatureCollection | undefined>();
+const featureSiteExclusions = (site: DraftPlantingSite): FeatureCollection | undefined => {
+  if (site.exclusion) {
+    return {
+      type: 'FeatureCollection',
+      features: [toFeature(site.exclusion!, {}, 0)],
+    };
+  } else {
+    return undefined;
+  }
+};
+
+export default function Exclusions({ onValidate, site }: ExclusionsProps): JSX.Element {
+  const [exclusions, setExclusions, undo, redo] = useUndoRedoState<FeatureCollection | undefined>(
+    featureSiteExclusions(site)
+  );
   const getRenderAttributes = useRenderAttributes();
   const { activeLocale } = useLocalization();
 
   useEffect(() => {
-    if (site.exclusion) {
-      setExclusions({
-        type: 'FeatureCollection',
-        features: [toFeature(site.exclusion!, {}, 0)],
-      });
-    }
-  }, [setExclusions, site.exclusion]);
-
-  useEffect(() => {
     if (onValidate) {
-      const boundary = exclusions ? unionMultiPolygons(exclusions) : null;
-      if (boundary) {
-        onChange('exclusion', boundary);
-      }
-      onValidate(false, !!boundary);
+      const exclusion = exclusions ? unionMultiPolygons(exclusions) : null;
+      const data = exclusion ? { exclusion } : undefined;
+      onValidate(false, data, !!data);
     }
-  }, [onChange, onValidate, exclusions]);
+  }, [onValidate, exclusions]);
 
   const readOnlyBoundary = useMemo<RenderableReadOnlyBoundary[] | undefined>(() => {
     if (!site.boundary) {

--- a/src/scenes/PlantingSitesRouter/edit/editor/Exclusions.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Exclusions.tsx
@@ -11,9 +11,10 @@ import { toFeature, unionMultiPolygons } from 'src/components/Map/utils';
 import useRenderAttributes from 'src/components/Map/useRenderAttributes';
 import MapIcon from 'src/components/Map/MapIcon';
 import StepTitleDescription, { Description } from './StepTitleDescription';
+import { OnValidate } from './types';
 
 export type ExclusionsProps = {
-  onValidate?: (hasErrors: boolean, data?: Partial<DraftPlantingSite>, isOptionalStepCompleted?: boolean) => void;
+  onValidate?: OnValidate;
   site: DraftPlantingSite;
 };
 
@@ -39,7 +40,7 @@ export default function Exclusions({ onValidate, site }: ExclusionsProps): JSX.E
     if (onValidate) {
       const exclusion = exclusions ? unionMultiPolygons(exclusions) : null;
       const data = exclusion ? { exclusion } : undefined;
-      onValidate(false, data, !!data);
+      onValidate.apply(false, data, !!data);
     }
   }, [onValidate, exclusions]);
 

--- a/src/scenes/PlantingSitesRouter/edit/editor/Subzones.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Subzones.tsx
@@ -36,8 +36,7 @@ import {
 import useStyles from './useMapStyle';
 
 export type SubzonesProps = {
-  onChange: (id: string, value: unknown) => void;
-  onValidate?: (hasErrors: boolean, isOptionalStepCompleted?: boolean) => void;
+  onValidate?: (hasErrors: boolean, data?: Partial<DraftPlantingSite>, isOptionalStepCompleted?: boolean) => void;
   site: DraftPlantingSite;
 };
 
@@ -61,7 +60,7 @@ type Stack = {
   fixedBoundaries?: Record<number, FeatureCollection>;
 };
 
-export default function Subzones({ onChange, onValidate, site }: SubzonesProps): JSX.Element {
+export default function Subzones({ onValidate, site }: SubzonesProps): JSX.Element {
   const [selectedZone, setSelectedZone] = useState<number | undefined>(site.plantingZones?.[0]?.id);
 
   // map of zone id to subzones
@@ -132,9 +131,9 @@ export default function Subzones({ onChange, onValidate, site }: SubzonesProps):
       return { ...zone, plantingSubzones };
     });
     const numSubzones = plantingZones?.flatMap((zone) => zone.plantingSubzones)?.length ?? 0;
-    onChange('plantingZones', plantingZones);
-    onValidate(plantingZones === undefined, numSubzones > numZones);
-  }, [subzonesData?.errorAnnotations, onChange, onValidate, site, snackbar, subzones, zones]);
+    const data = plantingZones ? { plantingZones } : undefined;
+    onValidate(plantingZones === undefined, data, numSubzones > numZones);
+  }, [subzonesData?.errorAnnotations, onValidate, site, snackbar, subzones, zones]);
 
   const readOnlyBoundary = useMemo<RenderableReadOnlyBoundary[] | undefined>(() => {
     if (!zones) {

--- a/src/scenes/PlantingSitesRouter/edit/editor/Subzones.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Subzones.tsx
@@ -34,9 +34,10 @@ import {
   toZoneFeature,
 } from './utils';
 import useStyles from './useMapStyle';
+import { OnValidate } from './types';
 
 export type SubzonesProps = {
-  onValidate?: (hasErrors: boolean, data?: Partial<DraftPlantingSite>, isOptionalStepCompleted?: boolean) => void;
+  onValidate?: OnValidate;
   site: DraftPlantingSite;
 };
 
@@ -103,13 +104,12 @@ export default function Subzones({ onValidate, site }: SubzonesProps): JSX.Eleme
     const hasSubzoneSizeErrors = !!subzonesData?.errorAnnotations?.length;
     if (hasSubzoneSizeErrors) {
       snackbar.toastError(strings.SITE_SUBZONE_BOUNDARIES_TOO_SMALL);
-      onValidate(hasSubzoneSizeErrors);
+      onValidate.apply(true);
       return;
     }
 
     // subzones are children of zones, we need to repopuplate zones with new subzones information
     // and update `plantingZones` in the site
-    const numZones = site.plantingZones?.length ?? 0;
     const plantingZones: MinimalPlantingZone[] | undefined = site.plantingZones?.map((zone) => {
       const plantingSubzones: MinimalPlantingSubzone[] = (subzones?.[zone.id]?.features ?? [])
         .map((subzone) => {
@@ -130,9 +130,10 @@ export default function Subzones({ onValidate, site }: SubzonesProps): JSX.Eleme
         .filter((subzone) => !!subzone) as MinimalPlantingSubzone[];
       return { ...zone, plantingSubzones };
     });
+    const numZones = site.plantingZones?.length ?? 0;
     const numSubzones = plantingZones?.flatMap((zone) => zone.plantingSubzones)?.length ?? 0;
     const data = plantingZones ? { plantingZones } : undefined;
-    onValidate(plantingZones === undefined, data, numSubzones > numZones);
+    onValidate.apply(plantingZones === undefined, data, numSubzones > numZones);
   }, [subzonesData?.errorAnnotations, onValidate, site, snackbar, subzones, zones]);
 
   const readOnlyBoundary = useMemo<RenderableReadOnlyBoundary[] | undefined>(() => {

--- a/src/scenes/PlantingSitesRouter/edit/editor/types.ts
+++ b/src/scenes/PlantingSitesRouter/edit/editor/types.ts
@@ -1,0 +1,6 @@
+import { DraftPlantingSite } from 'src/types/PlantingSite';
+
+export type OnValidate = {
+  isSaveAndClose: boolean;
+  apply: (hasErrors: boolean, data?: Partial<DraftPlantingSite>, isOptionalCompleted?: boolean) => void;
+};

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
@@ -49,7 +49,6 @@ export default function useDraftPlantingSiteCreate(): Response {
 
   const createDraft = useCallback(
     (request: Data, redirectToDraft: boolean) => {
-      setCreatedDraft(undefined);
       const dispatched = dispatch(requestCreateDraft(request.draft));
       setRequestId(dispatched.requestId);
       setDraftRequest(request);
@@ -84,7 +83,10 @@ export default function useDraftPlantingSiteCreate(): Response {
       createDraft,
       createDraftStatus: draftResult?.status,
       createdDraft,
-      onFinishCreate: () => void setRequestId(''),
+      onFinishCreate: () => {
+        setCreatedDraft(undefined);
+        setRequestId('');
+      },
     }),
     [createDraft, createdDraft, draftResult?.status]
   );

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import _ from 'lodash';
+import strings from 'src/strings';
+import { APP_PATHS } from 'src/constants';
+import { DraftPlantingSite, SiteEditStep } from 'src/types/PlantingSite';
+import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import { Statuses } from 'src/redux/features/asyncUtils';
+import { selectDraftPlantingSiteCreate } from 'src/redux/features/draftPlantingSite/draftPlantingSiteSelectors';
+import { requestCreateDraft } from 'src/redux/features/draftPlantingSite/draftPlantingSiteThunks';
+import useSnackbar from 'src/utils/useSnackbar';
+
+/**
+ * Data type for request and response in hook functions.
+ * Also is a container to pass state data back to client.
+ * @param draft
+ *  The draft planting site to be created
+ * @param nextStep
+ *  Next step to use in the flow if create was successful.
+ */
+export type Data = {
+  draft: DraftPlantingSite;
+  nextStep: SiteEditStep;
+};
+
+export type Response = {
+  createDraft: (draft: Data, redirectToDraft: boolean) => void;
+  createDraftStatus?: Statuses;
+  createdDraft?: Data;
+  onFinishCreate: () => void;
+};
+
+/**
+ * Hook to isolate workflow logic to create a draft planting site.
+ * Returns create function, status on request and the created draft site.
+ * Optionally redirects to the created draft.
+ */
+export default function useDraftPlantingSiteCreate(): Response {
+  const dispatch = useAppDispatch();
+  const history = useHistory();
+  const snackbar = useSnackbar();
+
+  const [createdDraft, setCreatedDraft] = useState<Data | undefined>();
+  const [draftRequest, setDraftRequest] = useState<Data>();
+  const [redirect, setRedirect] = useState<boolean>(false);
+
+  const [requestId, setRequestId] = useState<string>('');
+  const draftResult = useAppSelector(selectDraftPlantingSiteCreate(requestId));
+
+  const createDraft = useCallback(
+    (request: Data, redirectToDraft: boolean) => {
+      setCreatedDraft(undefined);
+      const dispatched = dispatch(requestCreateDraft(request.draft));
+      setRequestId(dispatched.requestId);
+      setDraftRequest(request);
+      setRedirect(redirectToDraft);
+    },
+    [dispatch]
+  );
+
+  useEffect(() => {
+    if (draftResult?.status === 'error') {
+      snackbar.toastError(strings.GENERIC_ERROR);
+    }
+  }, [draftResult?.status, snackbar]);
+
+  useEffect(() => {
+    if (draftResult?.status === 'success' && draftResult?.data && draftRequest) {
+      const id = draftResult.data;
+      if (redirect) {
+        snackbar.toastSuccess(strings.PLANTING_SITE_SAVED);
+        history.push(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${id}`));
+      } else {
+        setCreatedDraft({
+          ...draftRequest,
+          draft: { ..._.cloneDeep(draftRequest.draft), id },
+        });
+      }
+    }
+  }, [draftRequest, draftResult?.data, draftResult?.status, history, redirect, snackbar]);
+
+  return useMemo<Response>(
+    () => ({
+      createDraft,
+      createDraftStatus: draftResult?.status,
+      createdDraft,
+      onFinishCreate: () => void setRequestId(''),
+    }),
+    [createDraft, createdDraft, draftResult?.status]
+  );
+}

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import _ from 'lodash';
 import strings from 'src/strings';
 import { APP_PATHS } from 'src/constants';
 import { DraftPlantingSite, SiteEditStep } from 'src/types/PlantingSite';
@@ -72,7 +71,7 @@ export default function useDraftPlantingSiteCreate(): Response {
       } else {
         setCreatedDraft({
           ...draftRequest,
-          draft: { ..._.cloneDeep(draftRequest.draft), id },
+          draft: { ...draftRequest.draft, id },
         });
       }
     }

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteGet.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteGet.ts
@@ -18,7 +18,11 @@ export type Response = {
   site?: DraftPlantingSite;
 };
 
-export default function useDraftPlantingSite({ draftId }: Props): Response {
+/**
+ * Hook to fetch a draft planting site.
+ * Returns status on request and the fetched draft site.
+ */
+export default function useDraftPlantingSiteGet({ draftId }: Props): Response {
   const snackbar = useSnackbar();
   const history = useHistory();
   const dispatch = useAppDispatch();

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import _ from 'lodash';
 import strings from 'src/strings';
 import { APP_PATHS } from 'src/constants';
 import { DraftPlantingSite, SiteEditStep } from 'src/types/PlantingSite';
@@ -72,7 +71,7 @@ export default function useDraftPlantingSiteUpdate(): Response {
         snackbar.toastSuccess(strings.PLANTING_SITE_SAVED);
         history.push(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${draftRequest.draft.id}`));
       } else {
-        setUpdatedDraft({ ...draftRequest, draft: _.cloneDeep(draftRequest.draft) });
+        setUpdatedDraft(draftRequest);
       }
     }
   }, [draftRequest, draftResult?.status, history, redirect, snackbar]);

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
@@ -52,7 +52,6 @@ export default function useDraftPlantingSiteUpdate(): Response {
 
   const updateDraft = useCallback(
     (request: Data, redirectToDraft: boolean) => {
-      setUpdatedDraft(undefined);
       const dispatched = dispatch(requestUpdateDraft(request.draft));
       setRequestId(dispatched.requestId);
       setDraftRequest(request);
@@ -80,7 +79,10 @@ export default function useDraftPlantingSiteUpdate(): Response {
 
   return useMemo<Response>(
     () => ({
-      onFinishUpdate: () => void setRequestId(''),
+      onFinishUpdate: () => {
+        setUpdatedDraft(undefined);
+        setRequestId('');
+      },
       updateDraft,
       updateDraftStatus: draftResult?.status,
       updatedDraft,

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import _ from 'lodash';
+import strings from 'src/strings';
+import { APP_PATHS } from 'src/constants';
+import { DraftPlantingSite, SiteEditStep } from 'src/types/PlantingSite';
+import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import { Statuses } from 'src/redux/features/asyncUtils';
+import { selectDraftPlantingSiteEdit } from 'src/redux/features/draftPlantingSite/draftPlantingSiteSelectors';
+import { requestUpdateDraft } from 'src/redux/features/draftPlantingSite/draftPlantingSiteThunks';
+import useSnackbar from 'src/utils/useSnackbar';
+
+/**
+ * Data type for request and response in hook functions.
+ * Also is a container to pass state data back to client.
+ * @param draft
+ *  The draft planting site to be created
+ * @param nextStep
+ *  Next step to use in the flow if update was successful.
+ * @param optionalSteps
+ *  Dictionary of optional steps that were completed if update was successful.
+ */
+export type Data = {
+  draft: DraftPlantingSite;
+  nextStep: SiteEditStep;
+  optionalSteps?: Record<SiteEditStep, boolean>;
+};
+
+export type Response = {
+  onFinishUpdate: () => void;
+  updateDraft: (draft: Data, redirectToDraft: boolean) => void;
+  updateDraftStatus?: Statuses;
+  updatedDraft?: Data;
+};
+
+/**
+ * Hook to isoloate workflow logic to update a draft planting site.
+ * Returns update function, status on request and the updated draft site.
+ * Optionally redirects to draft after update.
+ */
+export default function useDraftPlantingSiteUpdate(): Response {
+  const dispatch = useAppDispatch();
+  const history = useHistory();
+  const snackbar = useSnackbar();
+
+  const [draftRequest, setDraftRequest] = useState<Data>();
+  const [updatedDraft, setUpdatedDraft] = useState<Data | undefined>();
+  const [redirect, setRedirect] = useState<boolean>(false);
+
+  const [requestId, setRequestId] = useState<string>('');
+  const draftResult = useAppSelector(selectDraftPlantingSiteEdit(requestId));
+
+  const updateDraft = useCallback(
+    (request: Data, redirectToDraft: boolean) => {
+      setUpdatedDraft(undefined);
+      const dispatched = dispatch(requestUpdateDraft(request.draft));
+      setRequestId(dispatched.requestId);
+      setDraftRequest(request);
+      setRedirect(redirectToDraft);
+    },
+    [dispatch]
+  );
+
+  useEffect(() => {
+    if (draftResult?.status === 'error') {
+      snackbar.toastError(strings.GENERIC_ERROR);
+    }
+  }, [draftResult?.status, snackbar]);
+
+  useEffect(() => {
+    if (draftResult?.status === 'success' && draftRequest) {
+      if (redirect) {
+        snackbar.toastSuccess(strings.PLANTING_SITE_SAVED);
+        history.push(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${draftRequest.draft.id}`));
+      } else {
+        setUpdatedDraft({ ...draftRequest, draft: _.cloneDeep(draftRequest.draft) });
+      }
+    }
+  }, [draftRequest, draftResult?.status, history, redirect, snackbar]);
+
+  return useMemo<Response>(
+    () => ({
+      onFinishUpdate: () => void setRequestId(''),
+      updateDraft,
+      updateDraftStatus: draftResult?.status,
+      updatedDraft,
+    }),
+    [updateDraft, updatedDraft, draftResult?.status]
+  );
+}

--- a/src/scenes/PlantingSitesRouter/hooks/usePlantingSiteCreate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/usePlantingSiteCreate.ts
@@ -1,0 +1,45 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { APP_PATHS } from 'src/constants';
+import { DraftPlantingSite } from 'src/types/PlantingSite';
+import { Statuses } from 'src/redux/features/asyncUtils';
+
+export type Response = {
+  createPlantingSite: (draft: DraftPlantingSite) => void;
+  createPlantingSiteStatus?: Statuses;
+};
+
+/**
+ * Hook to create a planting site from a draft.
+ * Deletes draft if create is successful.
+ * Redirects user to created planting site.
+ * Returns create function and status on request.
+ */
+export default function usePlantingSiteCreate(): Response {
+  const history = useHistory();
+  const [status, setStatus] = useState<Statuses>();
+
+  const createPlantingSite = useCallback(
+    (request: DraftPlantingSite) => {
+      // TODO update with dispatch when ready
+      if (request) {
+        setStatus('pending');
+        // timeout is temporarily to mock an in-flight network request
+        setTimeout(() => {
+          history.push(APP_PATHS.PLANTING_SITES);
+        }, 100);
+      }
+    },
+    [history]
+  );
+
+  // TODO: add dispatch/selector/error-handling for create when BE API is ready
+
+  return useMemo<Response>(
+    () => ({
+      createPlantingSite,
+      createPlantingSiteStatus: status,
+    }),
+    [createPlantingSite, status]
+  );
+}

--- a/src/scenes/PlantingSitesRouter/view/PlantingSiteDraftView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSiteDraftView.tsx
@@ -3,7 +3,8 @@ import { BusySpinner } from '@terraware/web-components';
 import { DraftPlantingSite } from 'src/types/PlantingSite';
 import { APP_PATHS } from 'src/constants';
 import { useUser } from 'src/providers';
-import useDraftPlantingSite from 'src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSite';
+import useDraftPlantingSite from 'src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteGet';
+import TfMain from 'src/components/common/TfMain';
 import GenericSiteView from './GenericSiteView';
 
 export default function PlantingSiteDraftView(): JSX.Element {
@@ -13,12 +14,14 @@ export default function PlantingSiteDraftView(): JSX.Element {
 
   if (result.site !== undefined) {
     return (
-      <GenericSiteView<DraftPlantingSite>
-        editDisabled={!user || result.site.createdBy !== user.id}
-        editUrl={APP_PATHS.PLANTING_SITES_DRAFT_EDIT}
-        onDelete={() => window.alert('WIP')}
-        plantingSite={result.site}
-      />
+      <TfMain>
+        <GenericSiteView<DraftPlantingSite>
+          editDisabled={!user || result.site.createdBy !== user.id}
+          editUrl={APP_PATHS.PLANTING_SITES_DRAFT_EDIT}
+          onDelete={() => window.alert('WIP')}
+          plantingSite={result.site}
+        />
+      </TfMain>
     );
   }
 

--- a/src/services/DraftPlantingSiteService.ts
+++ b/src/services/DraftPlantingSiteService.ts
@@ -7,8 +7,8 @@ import {
 } from 'src/types/PlantingSite';
 import { fromDraft, toDraft } from 'src/utils/draftPlantingSiteUtils';
 
-const DRAFT_PLANTING_SITES_ENDPOINT = '/api/v1/draftSites';
-const DRAFT_PLANTING_SITE_ENDPOINT = '/api/v1/draftSites/{id}';
+const DRAFT_PLANTING_SITES_ENDPOINT = '/api/v1/tracking/draftSites';
+const DRAFT_PLANTING_SITE_ENDPOINT = '/api/v1/tracking/draftSites/{id}';
 
 const httpDrafts = HttpService.root(DRAFT_PLANTING_SITES_ENDPOINT);
 const httpDraft = HttpService.root(DRAFT_PLANTING_SITE_ENDPOINT);


### PR DESCRIPTION
- extracted out and isolated create, update logic into hooks
- leverage these hooks in the editor
- created a placeholder hook for create planting site (follow up after BE has support)
- refactored existing code a bit to remove onChange property usage
- see attached video

![screencast 2024-02-14 17-11-32](https://github.com/terraware/terraware-web/assets/1865174/c60e2328-551d-4a0e-82fa-ab14c3bdcb95)
