### PR TITLE
SW-4848 Add support to delete a draft planting site

### DIFF
--- a/src/scenes/PlantingSitesRouter/edit/DeleteDraftPlantingSiteModal.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/DeleteDraftPlantingSiteModal.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { Typography } from '@mui/material';
+import { BusySpinner, Button, DialogBox } from '@terraware/web-components';
+import strings from 'src/strings';
+import { APP_PATHS } from 'src/constants';
+import { DraftPlantingSite } from 'src/types/PlantingSite';
+import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import { selectDraftPlantingSiteEdit } from 'src/redux/features/draftPlantingSite/draftPlantingSiteSelectors';
+import { requestDeleteDraft } from 'src/redux/features/draftPlantingSite/draftPlantingSiteThunks';
+import useSnackbar from 'src/utils/useSnackbar';
+
+export type Props = {
+  plantingSite: DraftPlantingSite;
+  onClose: () => void;
+};
+
+export default function DeleteDraftPlantingSiteModal(props: Props): JSX.Element {
+  const { onClose, plantingSite } = props;
+  const history = useHistory();
+  const snackbar = useSnackbar();
+  const dispatch = useAppDispatch();
+  const [requestId, setRequestId] = useState<string>('');
+  const result = useAppSelector(selectDraftPlantingSiteEdit(requestId));
+
+  const deleteHandler = () => {
+    const request = dispatch(requestDeleteDraft(plantingSite.id));
+    setRequestId(request.requestId);
+  };
+
+  useEffect(() => {
+    if (result?.status === 'success') {
+      snackbar.toastSuccess(strings.PLANTING_SITE_DELETED);
+      history.push(APP_PATHS.PLANTING_SITES);
+    } else if (result?.status === 'error') {
+      snackbar.toastError();
+    }
+  }, [history, result?.status, snackbar]);
+
+  return (
+    <>
+      {result?.status === 'pending' && <BusySpinner withSkrim={true} />}
+      <DialogBox
+        onClose={onClose}
+        open={true}
+        title={strings.DELETE_PLANTING_SITE}
+        size='medium'
+        middleButtons={[
+          <Button
+            id='cancelDeletePlantingSite'
+            label={strings.CANCEL}
+            type='passive'
+            onClick={onClose}
+            priority='secondary'
+            key='button-1'
+          />,
+          <Button
+            id='saveDeletePlantingSite'
+            onClick={deleteHandler}
+            type='destructive'
+            label={strings.DELETE}
+            key='button-2'
+          />,
+        ]}
+        message={strings.formatString(strings.DELETE_PLANTING_SITE_MESSAGE, plantingSite.name)}
+        skrim={true}
+      >
+        <Typography sx={{ paddingTop: 3 }}>{strings.ARE_YOU_SURE}</Typography>
+      </DialogBox>
+    </>
+  );
+}

--- a/src/scenes/PlantingSitesRouter/view/PlantingSiteDraftView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSiteDraftView.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { BusySpinner } from '@terraware/web-components';
 import { DraftPlantingSite } from 'src/types/PlantingSite';
@@ -6,20 +7,25 @@ import { useUser } from 'src/providers';
 import { searchDraftPlantingSiteZones } from 'src/redux/features/draftPlantingSite/draftPlantingSiteSelectors';
 import useDraftPlantingSite from 'src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteGet';
 import TfMain from 'src/components/common/TfMain';
+import DeleteDraftPlantingSiteModal from 'src/scenes/PlantingSitesRouter/edit/DeleteDraftPlantingSiteModal';
 import GenericSiteView from './GenericSiteView';
 
 export default function PlantingSiteDraftView(): JSX.Element {
   const { user } = useUser();
   const { plantingSiteId } = useParams<{ plantingSiteId: string }>();
   const result = useDraftPlantingSite({ draftId: Number(plantingSiteId) });
+  const [deleteModalOpen, setDeleteModalOpen] = useState<boolean>(false);
 
   if (result.site !== undefined) {
     return (
       <TfMain>
+        {deleteModalOpen && (
+          <DeleteDraftPlantingSiteModal plantingSite={result.site} onClose={() => setDeleteModalOpen(false)} />
+        )}
         <GenericSiteView<DraftPlantingSite>
           editDisabled={!user || result.site.createdBy !== user.id}
           editUrl={APP_PATHS.PLANTING_SITES_DRAFT_EDIT}
-          onDelete={() => window.alert('WIP')}
+          onDelete={() => setDeleteModalOpen(true)}
           plantingSite={result.site}
           selector={searchDraftPlantingSiteZones}
           zoneViewUrl={APP_PATHS.PLANTING_SITES_DRAFT_ZONE_VIEW}


### PR DESCRIPTION
- used the delete modal for normal planting site as a template
- hooked up the dispatch/select functions to delete and listen for results
- added modal hooks in the draft view component
- works as expected

![screencast 2024-02-15 11-44-53](https://github.com/terraware/terraware-web/assets/1865174/ae29b899-f98b-420b-b61e-a1b84f0817c6)
