### PR TITLE
SW-4909: Add colored bar to top of Accelerator Console

### DIFF
--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -1,6 +1,8 @@
 import { AppBar, Theme, Toolbar } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import React from 'react';
+import { useRouteMatch } from 'react-router-dom';
+import { APP_PATHS } from 'src/constants';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -29,6 +31,7 @@ type TopBarProps = {
 
 export default function TopBar(props: TopBarProps): JSX.Element {
   const { isDesktop } = useDeviceInfo();
+  const isAcceleratorRoute = useRouteMatch(APP_PATHS.ACCELERATOR);
   const classes = useStyles({ isDesktop, fullWidth: props.fullWidth });
 
   return (
@@ -37,10 +40,11 @@ export default function TopBar(props: TopBarProps): JSX.Element {
         className={isDesktop ? undefined : classes.mobile}
         disableGutters={true}
         sx={{
+          borderTop: isAcceleratorRoute ? '8px solid #EF7047' : undefined,
           paddingBottom: '24px',
-          paddingTop: '24px',
           paddingLeft: '32px',
           paddingRight: '32px',
+          paddingTop: isAcceleratorRoute ? '16px' : '24px',
         }}
       >
         <div className={classes.flex}>{props.children}</div>


### PR DESCRIPTION
This PR includes changes to add a colored bar to the top of the Accelerator Console.

## Example

https://github.com/terraware/terraware-web/assets/1474361/24b58f23-5c5a-4e4d-a487-fd0d142baf5c

### BEFORE

![localhost_3000_projects_organizationId=1](https://github.com/terraware/terraware-web/assets/1474361/05d920ae-29ed-475f-88b5-503d428ed107)

### AFTER

![localhost_3000_projects_organizationId=1 (1)](https://github.com/terraware/terraware-web/assets/1474361/21e21061-3495-4ca4-a933-cd07973016c0)
