### PR TITLE
Make it possible to use string values within the FilterMultiSelectContainer component tree

### DIFF
--- a/src/components/common/FilterMultiSelectContainer/index.tsx
+++ b/src/components/common/FilterMultiSelectContainer/index.tsx
@@ -52,11 +52,11 @@ type FilterMultiSelectContainerProps<T> = {
   notPresentFilterLabel?: string;
   notPresentFilterShown?: boolean;
   options: (string | number)[];
-  renderOption: (id: number) => string;
+  renderOption: (id: number | string) => string;
   setFilters: (f: T) => void;
 };
 
-export default function FilterMultiSelectContainer<T extends Record<string, (number | null)[]>>(
+export default function FilterMultiSelectContainer<T extends Record<string, (string | number | null)[]>>(
   props: FilterMultiSelectContainerProps<T>
 ): JSX.Element {
   const {
@@ -123,16 +123,16 @@ export default function FilterMultiSelectContainer<T extends Record<string, (num
 
   const renderFilterMultiSelect = () => {
     return (
-      <FilterMultiSelect
+      <FilterMultiSelect<string | number>
         filterKey={String(filterKey)}
         initialSelection={initialSelection}
         label={label}
         onCancel={handleClose}
-        onConfirm={(selectedIds: (number | null)[]) => {
+        onConfirm={(selectedValues: (string | number | null)[]) => {
           handleClose();
-          setFilters({ ...filters, [filterKey]: selectedIds });
+          setFilters({ ...filters, [filterKey]: selectedValues });
         }}
-        options={options.map((option) => Number(option))}
+        options={options}
         optionsVisible={optionsVisible}
         renderOption={renderOption}
         notPresentFilterLabel={notPresentFilterLabel}

--- a/src/scenes/InventoryRouter/InventoryFilter.tsx
+++ b/src/scenes/InventoryRouter/InventoryFilter.tsx
@@ -24,7 +24,7 @@ type InventoryFilterProps = {
   notPresentFilterLabel?: string;
   notPresentFilterShown?: boolean;
   options: number[];
-  renderOption: (id: number) => string;
+  renderOption: (id: string | number) => string;
   setFilters: (f: InventoryFiltersType) => void;
 };
 

--- a/src/scenes/InventoryRouter/Search.tsx
+++ b/src/scenes/InventoryRouter/Search.tsx
@@ -253,7 +253,7 @@ export default function Search<T extends { facilityInventories?: string }>(props
             label={strings.NURSERY}
             filterKey='facilityIds'
             options={nurseries.map((n: Facility) => n.id)}
-            renderOption={(id: number) => nurseries.find((n) => n.id === id)?.name ?? ''}
+            renderOption={(id: string | number) => nurseries.find((n) => n.id === id)?.name ?? ''}
           />
         )}
         {origin === 'Nursery' && (
@@ -265,7 +265,9 @@ export default function Search<T extends { facilityInventories?: string }>(props
             options={[...(availableSpecies || [])]
               .sort((a, b) => a.scientificName.localeCompare(b.scientificName, activeLocale || undefined))
               .map((n: Species) => n.id)}
-            renderOption={(id: number) => (availableSpecies || []).find((n) => n.id === id)?.scientificName ?? ''}
+            renderOption={(id: string | number) =>
+              (availableSpecies || []).find((n) => n.id === id)?.scientificName ?? ''
+            }
           />
         )}
 
@@ -277,7 +279,7 @@ export default function Search<T extends { facilityInventories?: string }>(props
               label={strings.NURSERY}
               filterKey='facilityIds'
               options={nurseries.map((n: Facility) => n.id)}
-              renderOption={(id: number) => nurseries.find((n) => n.id === id)?.name ?? ''}
+              renderOption={(id: string | number) => nurseries.find((n) => n.id === id)?.name ?? ''}
             />
             {filters.facilityIds && filters.facilityIds.length > 0 && (
               <InventoryFilters
@@ -287,7 +289,7 @@ export default function Search<T extends { facilityInventories?: string }>(props
                 label={strings.SUB_LOCATIONS}
                 filterKey='subLocationsIds'
                 options={subLocations?.map((sl: SubLocation) => sl.id) ?? []}
-                renderOption={(id: number) => subLocations?.find((sl) => sl.id === id)?.name ?? ''}
+                renderOption={(id: string | number) => subLocations?.find((sl) => sl.id === id)?.name ?? ''}
               />
             )}
           </>
@@ -300,7 +302,7 @@ export default function Search<T extends { facilityInventories?: string }>(props
             label={strings.PROJECT}
             filterKey='projectIds'
             options={(projects || []).map((n: Project) => n.id)}
-            renderOption={(id: number) => (id ? (projects || []).find((n) => n.id === id)?.name ?? '' : '')}
+            renderOption={(id: string | number) => (id ? (projects || []).find((n) => n.id === id)?.name ?? '' : '')}
             notPresentFilterShown
             notPresentFilterLabel={strings.NO_PROJECT}
           />

--- a/src/scenes/PlantingSitesRouter/view/PlantingSitesTable.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSitesTable.tsx
@@ -125,7 +125,7 @@ export default function PlantingSitesTable(props: PlantingSitesTableProps): JSX.
             label={strings.PROJECTS}
             filterKey='projectIds'
             options={projects?.map((project: Project) => project.id) ?? []}
-            renderOption={(id: number) => projects?.find((project) => project.id === id)?.name ?? ''}
+            renderOption={(id: string | number) => projects?.find((project) => project.id === id)?.name ?? ''}
           />
         )}
       </Box>


### PR DESCRIPTION
The multi select container was set up to only use numbers (for things that are filtered by ID), this allows it to use strings if desired.