### PR TITLE
SW-4881 Search and filtering within internal deliverables table

### DIFF
--- a/src/components/common/SearchFiltersWrapperV2/FeaturedFilters.tsx
+++ b/src/components/common/SearchFiltersWrapperV2/FeaturedFilters.tsx
@@ -14,7 +14,7 @@ interface FeaturedFiltersProps {
 type MultiSelectFilters = Record<string, (string | number | null)[]>;
 
 const defaultSearchNodeCreator = (field: string, values: (number | string | null)[]) => ({
-  field: 'status',
+  field,
   operation: 'field',
   type: 'Exact',
   values: values.map((value: number | string | null): string | null => (value === null ? value : `${value}`)),

--- a/src/redux/features/deliverables/deliverablesAsyncThunks.ts
+++ b/src/redux/features/deliverables/deliverablesAsyncThunks.ts
@@ -1,6 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import strings from 'src/strings';
-import { SearchCriteria, SearchSortOrder } from 'src/types/Search';
+import { SearchNodePayload, SearchSortOrder } from 'src/types/Search';
 import { Response } from 'src/services/HttpService';
 import DeliverablesService from 'src/services/DeliverablesService';
 import { DeliverableData, SearchResponseDeliverable, UpdateStatusRequest } from 'src/types/Deliverables';
@@ -8,14 +8,14 @@ import { DeliverableData, SearchResponseDeliverable, UpdateStatusRequest } from 
 export const requestDeliverablesSearch = createAsyncThunk(
   'deliverables/search',
   async (
-    request: { organizationId: number; searchCriteria?: SearchCriteria; sortOrder?: SearchSortOrder },
+    request: { organizationId: number; search?: SearchNodePayload; searchSortOrder?: SearchSortOrder },
     { rejectWithValue }
   ) => {
-    const { organizationId, searchCriteria, sortOrder } = request;
+    const { organizationId, search, searchSortOrder } = request;
 
     const response: SearchResponseDeliverable[] | null = await (organizationId === -1
-      ? DeliverablesService.searchDeliverablesForAdmin(organizationId, searchCriteria, sortOrder)
-      : DeliverablesService.searchDeliverablesForParticipant(organizationId, searchCriteria, sortOrder));
+      ? DeliverablesService.searchDeliverablesForAdmin(organizationId, search, searchSortOrder)
+      : DeliverablesService.searchDeliverablesForParticipant(organizationId, search, searchSortOrder));
 
     if (response) {
       return response;

--- a/src/services/DeliverablesService.ts
+++ b/src/services/DeliverablesService.ts
@@ -1,4 +1,11 @@
-import { SearchCriteria, SearchRequestPayload, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
+import {
+  OptionalSearchRequestPayload,
+  SearchCriteria,
+  SearchNodePayload,
+  SearchRequestPayload,
+  SearchResponseElement,
+  SearchSortOrder,
+} from 'src/types/Search';
 import {
   Deliverable,
   DeliverableTypeType,
@@ -67,16 +74,14 @@ let mockResponseData: SearchResponseElement[] = [];
 const searchDeliverables = async (
   fields: string[],
   organizationId: number,
-  searchCriteria?: SearchCriteria,
+  search?: SearchNodePayload,
   sortOrder?: SearchSortOrder
 ): Promise<SearchResponseElement[] | null> => {
-  const params: SearchRequestPayload = {
+  const params: OptionalSearchRequestPayload = {
     // TODO confirm prefix when BE is done
     prefix: 'deliverables',
     fields,
-    // TODO this might need to be updated, this function injects a search criteria for `facility_organization_id`
-    // which may not be applicable
-    search: SearchService.convertToSearchNodePayload(searchCriteria ?? {}, organizationId),
+    search,
     // TODO implement pagination when BE is done
     count: 1000,
   };
@@ -104,10 +109,10 @@ const transformAdminDeliverableElement = (element: SearchResponseElement): Searc
 
 const searchDeliverablesForAdmin = async (
   organizationId: number,
-  searchCriteria?: SearchCriteria,
+  search?: SearchNodePayload,
   sortOrder?: SearchSortOrder
 ): Promise<SearchResponseDeliverableAdmin[] | null> => {
-  const result = await searchDeliverables(SEARCH_FIELDS_DELIVERABLES_ADMIN, organizationId, searchCriteria, sortOrder);
+  const result = await searchDeliverables(SEARCH_FIELDS_DELIVERABLES_ADMIN, organizationId, search, sortOrder);
   if (!result) {
     return result;
   }
@@ -117,15 +122,10 @@ const searchDeliverablesForAdmin = async (
 
 const searchDeliverablesForParticipant = async (
   organizationId: number,
-  searchCriteria?: SearchCriteria,
+  search?: SearchNodePayload,
   sortOrder?: SearchSortOrder
 ): Promise<SearchResponseDeliverableParticipant[] | null> => {
-  const result = await searchDeliverables(
-    SEARCH_FIELDS_DELIVERABLES_PARTICIPANT,
-    organizationId,
-    searchCriteria,
-    sortOrder
-  );
+  const result = await searchDeliverables(SEARCH_FIELDS_DELIVERABLES_PARTICIPANT, organizationId, search, sortOrder);
   if (!result) {
     return result;
   }

--- a/src/services/DeliverablesService.ts
+++ b/src/services/DeliverablesService.ts
@@ -1,8 +1,6 @@
 import {
   OptionalSearchRequestPayload,
-  SearchCriteria,
   SearchNodePayload,
-  SearchRequestPayload,
   SearchResponseElement,
   SearchSortOrder,
 } from 'src/types/Search';
@@ -16,7 +14,6 @@ import {
   SearchResponseDeliverableAdmin,
   UpdateStatusRequest,
 } from 'src/types/Deliverables';
-import SearchService from 'src/services/SearchService';
 import { Response } from 'src/services/HttpService';
 
 /**

--- a/src/types/Search.ts
+++ b/src/types/Search.ts
@@ -15,3 +15,4 @@ export type FieldOptionsMap = { [key: string]: { partial: boolean; values: (stri
 
 /** Search request payload that requires a search node to be specified. */
 export type SearchRequestPayload = components['schemas']['SearchRequestPayload'] & { search: SearchNodePayload };
+export type OptionalSearchRequestPayload = components['schemas']['SearchRequestPayload'];


### PR DESCRIPTION
Pass the following through into the `requestDeliverablesSearch` call from the internal deliverables table:
- Fuzzy search
- Table featured filters
- Participant dropdown filter

This just shows the `SearchNodePayload` being created

![2024-02-26 11.22.42.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/550dacc7-3f14-475e-8074-bfe20ba19f89.gif)

