### PR TITLE
Rename the AcceleratorCohort* views to Cohort*

### DIFF
--- a/src/scenes/AcceleratorRouter/CohortEditView.tsx
+++ b/src/scenes/AcceleratorRouter/CohortEditView.tsx
@@ -11,7 +11,7 @@ import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import AcceleratorMain from 'src/scenes/AcceleratorRouter/AcceleratorMain';
 import CohortForm from 'src/scenes/AcceleratorRouter/CohortForm';
 
-export default function AcceleratorCohortEditView(): JSX.Element {
+export default function CohortEditView(): JSX.Element {
   const dispatch = useAppDispatch();
   const history = useHistory();
   const theme = useTheme();

--- a/src/scenes/AcceleratorRouter/CohortNewView.tsx
+++ b/src/scenes/AcceleratorRouter/CohortNewView.tsx
@@ -10,7 +10,7 @@ import { CreateCohortRequestPayload } from 'src/types/Cohort';
 import useForm from 'src/utils/useForm';
 import useSnackbar from 'src/utils/useSnackbar';
 
-export default function AcceleratorCohortNewView(): JSX.Element {
+export default function CohortNewView(): JSX.Element {
   const history = useHistory();
   const theme = useTheme();
   const [isBusy, setIsBusy] = useState<boolean>(false);

--- a/src/scenes/AcceleratorRouter/CohortNewView.tsx
+++ b/src/scenes/AcceleratorRouter/CohortNewView.tsx
@@ -25,6 +25,13 @@ export default function CohortNewView(): JSX.Element {
     history.push({ pathname: APP_PATHS.ACCELERATOR_COHORTS });
   }, [history]);
 
+  const goToCohortView = useCallback(
+    (cohortId: number) => {
+      history.push({ pathname: APP_PATHS.ACCELERATOR_COHORTS_VIEW.replace(':cohortId', `${cohortId}`) });
+    },
+    [history]
+  );
+
   const createNewCohort = useCallback(
     async (cohort: CreateCohortRequestPayload) => {
       // first create the cohort
@@ -48,9 +55,9 @@ export default function CohortNewView(): JSX.Element {
       snackbar.toastSuccess(strings.formatString(strings.COHORT_ADDED, cohort.name) as string);
 
       // navigate to cohorts list
-      goToCohortsList();
+      goToCohortView(cohortId);
     },
-    [setIsBusy, snackbar, goToCohortsList]
+    [setIsBusy, snackbar, goToCohortView]
   );
 
   const onCohortSaved = useCallback(

--- a/src/scenes/AcceleratorRouter/index.tsx
+++ b/src/scenes/AcceleratorRouter/index.tsx
@@ -9,8 +9,8 @@ import useStateLocation from 'src/utils/useStateLocation';
 import { getRgbaFromHex } from 'src/utils/color';
 import CohortListView from 'src/scenes/AcceleratorRouter/CohortListView';
 import CohortView from 'src/scenes/AcceleratorRouter/CohortView';
-import AcceleratorCohortEditView from 'src/scenes/AcceleratorRouter/AcceleratorCohortEditView';
-import AcceleratorCohortNewView from 'src/scenes/AcceleratorRouter/AcceleratorCohortNewView';
+import CohortEditView from 'src/scenes/AcceleratorRouter/CohortEditView';
+import CohortNewView from 'src/scenes/AcceleratorRouter/CohortNewView';
 import AcceleratorDeliverableViewWrapper from 'src/scenes/AcceleratorRouter/AcceleratorDeliverableViewWrapper';
 import AcceleratorDeliverablesList from 'src/scenes/AcceleratorRouter/AcceleratorDeliverablesList';
 import AcceleratorModuleContentView from 'src/scenes/AcceleratorRouter/AcceleratorModuleContentView';
@@ -78,13 +78,13 @@ const AcceleratorRouter = ({ showNavBar, setShowNavBar }: AcceleratorRouterProps
               <AcceleratorOverviewView />
             </Route>
             <Route path={APP_PATHS.ACCELERATOR_COHORTS_EDIT}>
-              <AcceleratorCohortEditView />
+              <CohortEditView />
             </Route>
             <Route exact path={APP_PATHS.ACCELERATOR_COHORTS}>
               <CohortListView />
             </Route>
             <Route path={APP_PATHS.ACCELERATOR_COHORTS_NEW}>
-              <AcceleratorCohortNewView />
+              <CohortNewView />
             </Route>
             <Route path={APP_PATHS.ACCELERATOR_COHORTS_VIEW}>
               <CohortView />


### PR DESCRIPTION
No need to disambiguate since these views will only exist within the AcceleratorRouter. No functional changes here.