### PR TITLE
SW-4904 Render HTML directly in the deliverable Metadata component

### DIFF
--- a/src/components/DeliverableView/Metadata.tsx
+++ b/src/components/DeliverableView/Metadata.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Box, useTheme } from '@mui/material';
 import { ViewProps } from './types';
 import DeliverableStatusBadge from 'src/components/DeliverableView/DeliverableStatusBadge';
@@ -37,7 +38,8 @@ const Metadata = (props: ViewProps): JSX.Element => {
         {deliverable.status !== 'Rejected' && !isAcceleratorConsole && (
           <DeliverableStatusBadge status={deliverable.status} />
         )}
-        Description coming soon!
+
+        <div dangerouslySetInnerHTML={{ __html: deliverable.deliverableContent }} />
       </Box>
     </Box>
   );

--- a/src/services/DeliverablesService.ts
+++ b/src/services/DeliverablesService.ts
@@ -27,17 +27,20 @@ const SEARCH_FIELDS_DELIVERABLES_PARTICIPANT = [...SEARCH_FIELDS_DELIVERABLES_AD
 const mockDeliverable: Deliverable = {
   category: 'Legal',
   // TODO need to figure out if we are going to allow raw HTML or just have regular text
-  deliverableContent:
-    'The Company Formation Document is to confirm the entity is properly formed and registered in the country.\n' +
-    '\n' +
-    'Depending on your jurisdiction, this document may be called a Certificate of Incorporation or a Business Registration Certificate, for example.\n' +
-    '\n' +
-    'Submit:\n' +
-    'A document issued by the relevant authority in your jurisdiction that contains the following information:\n' +
-    'Company Name\n' +
-    'Legal Form / Structure – (e.g. corporation, limited liability company, etc.)\n' +
-    'Date of Formation/Incorporation\n' +
-    'Company Number (if applicable)',
+  deliverableContent: `
+    <div>
+     	<p>The Company Formation Document is to confirm the entity is properly formed and registered in the country.</p>
+     	<p>Depending on your jurisdiction, this document may be called a Certificate of Incorporation or a Business Registration Certificate, for example.</p>
+     	<p><b>Submit:</b></p>
+     	<p>A document issued by the relevant authority in your jurisdiction that contains the following information:</p>
+   	  <ol>
+    		<li>Company Name</li>
+    		<li>Legal Form / Structure – (e.g. corporation, limited liability company, etc.)</li>
+    		<li>Date of Formation/Incorporation</li>
+    		<li>Company Number (if applicable)</li>
+		  </ol>
+    </div>
+  `,
   documents: [
     {
       name: 'Upload 1',


### PR DESCRIPTION
- Update mock with HTML, render HTML directly in the deliverable Metadata component
- I am using `dangerouslySetInnerHTML` here which is generally frowned upon because it potentially creates XSS vectors, but this HTML is not from user input and can be considered sanitized. This may change in the future if we enable deliverable management in the admin UI, at which point we may want to implement a library like `dompurify` or guarantee that the input is sanitized in the BE, or both.

![SCR-20240228-kfka.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/30a75f0f-31e8-4ed0-9077-64b24f318c33.png)

