### PR TITLE
Change the 'update status' flow into 'update deliverable'

### DIFF
--- a/src/redux/features/deliverables/deliverablesAsyncThunks.ts
+++ b/src/redux/features/deliverables/deliverablesAsyncThunks.ts
@@ -3,7 +3,7 @@ import strings from 'src/strings';
 import { SearchNodePayload, SearchSortOrder } from 'src/types/Search';
 import { Response } from 'src/services/HttpService';
 import DeliverablesService from 'src/services/DeliverablesService';
-import { DeliverableData, SearchResponseDeliverable, UpdateStatusRequest } from 'src/types/Deliverables';
+import { DeliverableData, SearchResponseDeliverable, UpdateRequest } from 'src/types/Deliverables';
 
 export const requestDeliverablesSearch = createAsyncThunk(
   'deliverables/search',
@@ -37,10 +37,10 @@ export const requestDeliverableFetch = createAsyncThunk(
   }
 );
 
-export const requestUpdateDeliverableStatus = createAsyncThunk(
-  'deliverables/update-status',
-  async (request: UpdateStatusRequest, { rejectWithValue }) => {
-    const response: Response = await DeliverablesService.updateStatus(request);
+export const requestDeliverableUpdate = createAsyncThunk(
+  'deliverables/update',
+  async (request: UpdateRequest, { rejectWithValue }) => {
+    const response: Response = await DeliverablesService.update(request);
     if (response && response.requestSucceeded) {
       return request.id;
     }

--- a/src/redux/features/deliverables/deliverablesSlice.ts
+++ b/src/redux/features/deliverables/deliverablesSlice.ts
@@ -4,7 +4,7 @@ import { buildReducers, StatusT } from 'src/redux/features/asyncUtils';
 import {
   requestDeliverableFetch,
   requestDeliverablesSearch,
-  requestUpdateDeliverableStatus,
+  requestDeliverableUpdate,
 } from 'src/redux/features/deliverables/deliverablesAsyncThunks';
 
 /**
@@ -50,7 +50,7 @@ export const deliverablesEditSlice = createSlice({
   initialState: initialStateEditDeliverable,
   reducers: {},
   extraReducers: (builder) => {
-    buildReducers(requestUpdateDeliverableStatus)(builder);
+    buildReducers(requestDeliverableUpdate)(builder);
   },
 });
 

--- a/src/scenes/AcceleratorRouter/DeliverableViewWrapper.tsx
+++ b/src/scenes/AcceleratorRouter/DeliverableViewWrapper.tsx
@@ -7,14 +7,14 @@ import { DeliverableStatusType } from 'src/types/Deliverables';
 import Page from 'src/components/Page';
 import OptionsMenu from 'src/components/common/OptionsMenu';
 import useFetchDeliverable from 'src/components/DeliverableView/useFetchDeliverable';
-import useEditStatusDeliverable from './useEditStatusDeliverable';
+import useUpdateDeliverable from './useUpdateDeliverable';
 import DeliverableView from './DeliverableView';
 import RejectDialog from './RejectDialog';
 
 const DeliverableViewWrapper = () => {
   const [showRejectDialog, setShowRejectDialog] = useState<boolean>(false);
   const { deliverableId } = useParams<{ deliverableId: string }>();
-  const { status: requestStatus, update } = useEditStatusDeliverable();
+  const { status: requestStatus, update } = useUpdateDeliverable();
   const theme = useTheme();
 
   const { deliverable } = useFetchDeliverable({

--- a/src/scenes/AcceleratorRouter/useUpdateDeliverable.ts
+++ b/src/scenes/AcceleratorRouter/useUpdateDeliverable.ts
@@ -1,35 +1,36 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import strings from 'src/strings';
-import { UpdateStatusRequest } from 'src/types/Deliverables';
+import { UpdateRequest } from 'src/types/Deliverables';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { Statuses } from 'src/redux/features/asyncUtils';
 import { selectDeliverablesEditRequest } from 'src/redux/features/deliverables/deliverablesSelectors';
 import {
   requestDeliverableFetch,
-  requestUpdateDeliverableStatus,
+  requestDeliverableUpdate,
 } from 'src/redux/features/deliverables/deliverablesAsyncThunks';
 import useSnackbar from 'src/utils/useSnackbar';
 
 export type Response = {
+  internalComment?: string;
   status?: Statuses;
-  update: (request: UpdateStatusRequest) => void;
+  update: (request: UpdateRequest) => void;
 };
 
 /**
- * Hook to update a deliverable status.
+ * Hook to update a deliverable, which updates the underlying deliverable submission (used for internalComments and status currently).
  * Returns status on request and function to update status.
  */
-export default function useEditStatusDeliverable(): Response {
-  const [lastRequest, setLastRequest] = useState<UpdateStatusRequest | undefined>();
+export default function useUpdateDeliverable(): Response {
+  const [lastRequest, setLastRequest] = useState<UpdateRequest | undefined>();
   const [requestId, setRequestId] = useState<string>('');
   const snackbar = useSnackbar();
   const dispatch = useAppDispatch();
   const result = useAppSelector(selectDeliverablesEditRequest(requestId));
 
   const update = useCallback(
-    (request: UpdateStatusRequest) => {
+    (request: UpdateRequest) => {
       setLastRequest(undefined);
-      const dispatched = dispatch(requestUpdateDeliverableStatus(request));
+      const dispatched = dispatch(requestDeliverableUpdate(request));
       setRequestId(dispatched.requestId);
       setLastRequest(request);
     },
@@ -40,6 +41,7 @@ export default function useEditStatusDeliverable(): Response {
     if (!lastRequest) {
       return;
     }
+
     if (result?.status === 'error') {
       snackbar.toastError(strings.GENERIC_ERROR);
     } else if (result?.status === 'success') {

--- a/src/services/DeliverablesService.ts
+++ b/src/services/DeliverablesService.ts
@@ -12,7 +12,7 @@ import {
   DeliverableData,
   SearchResponseDeliverableParticipant,
   SearchResponseDeliverableAdmin,
-  UpdateStatusRequest,
+  UpdateRequest,
 } from 'src/types/Deliverables';
 import { Response } from 'src/services/HttpService';
 
@@ -68,6 +68,7 @@ const mockDeliverable: Deliverable = {
     },
   ],
   id: 1,
+  internalComment: 'This is a great looking submission',
   name: 'Company Formation Document',
   projectId: 1,
   projectName: 'Treemendo.us',
@@ -83,9 +84,13 @@ const getDeliverable = async (deliverableId: number): Promise<Response & Deliver
   };
 };
 
-const updateStatus = async ({ reason, status }: UpdateStatusRequest): Promise<Response> => {
-  mockDeliverable.status = status;
+const update = async ({ internalComment, reason, status }: UpdateRequest): Promise<Response> => {
+  if (status) {
+    mockDeliverable.status = status;
+  }
+
   mockDeliverable.reason = reason;
+  mockDeliverable.internalComment = internalComment;
   return { requestSucceeded: true };
 };
 
@@ -160,7 +165,7 @@ const DeliverablesService = {
   getDeliverable,
   searchDeliverablesForAdmin,
   searchDeliverablesForParticipant,
-  updateStatus,
+  update,
 };
 
 export default DeliverablesService;

--- a/src/types/Deliverables.ts
+++ b/src/types/Deliverables.ts
@@ -37,6 +37,7 @@ export type Deliverable = {
   deliverableContent: string;
   documents: DeliverableDocument[];
   id: number;
+  internalComment?: string;
   name: string;
   projectId: number;
   projectName: string;
@@ -63,10 +64,11 @@ export type SearchResponseDeliverableParticipant = SearchResponseDeliverableAdmi
   description: string;
 };
 
-export type UpdateStatusRequest = {
+export type UpdateRequest = {
   id: number;
+  internalComment?: string;
   reason?: string;
-  status: DeliverableStatusType;
+  status?: DeliverableStatusType;
 };
 
 export type SearchResponseDeliverable = SearchResponseDeliverableAdmin | SearchResponseDeliverableParticipant;


### PR DESCRIPTION
- Since `status` and `internalComment` will be modified through the same API, rename everything to be field agnostic.
- Add `internalComment` to mock deliverable and update it when the update request goes through