### PR TITLE
SW-4938: Rename reason to feedback

### DIFF
--- a/src/components/DeliverableView/Metadata.tsx
+++ b/src/components/DeliverableView/Metadata.tsx
@@ -21,7 +21,7 @@ const Metadata = (props: ViewProps): JSX.Element => {
           padding='16px'
         >
           <DeliverableStatusBadge status={deliverable.status} />
-          <strong>{strings.REASON}</strong> {deliverable.reason}
+          <strong>{strings.FEEDBACK}</strong> {deliverable.reason}
         </Box>
       )}
 

--- a/src/scenes/AcceleratorRouter/DeliverableViewWrapper.tsx
+++ b/src/scenes/AcceleratorRouter/DeliverableViewWrapper.tsx
@@ -32,9 +32,9 @@ const DeliverableViewWrapper = () => {
   );
 
   const rejectDeliverable = useCallback(
-    (reason: string) => {
+    (feedback: string) => {
       if (deliverable?.id !== undefined) {
-        update({ id: deliverable.id, status: 'Rejected', reason });
+        update({ id: deliverable.id, status: 'Rejected', reason: feedback });
       }
       setShowRejectDialog(false);
     },

--- a/src/scenes/AcceleratorRouter/RejectDialog.tsx
+++ b/src/scenes/AcceleratorRouter/RejectDialog.tsx
@@ -5,18 +5,18 @@ import strings from 'src/strings';
 
 export type RejectDialogProps = {
   onClose: () => void;
-  onSubmit: (reason: string) => void;
+  onSubmit: (feedback: string) => void;
 };
 
 export default function RejectDialog({ onClose, onSubmit }: RejectDialogProps): JSX.Element {
-  const [reason, setReason] = useState<string>('');
+  const [feedback, setFeedback] = useState<string>('');
   const [validate, setValidate] = useState<boolean>(false);
   const theme = useTheme();
 
   const reject = () => {
     setValidate(true);
-    if (reason) {
-      onSubmit(reason);
+    if (feedback) {
+      onSubmit(feedback);
     }
   };
 
@@ -51,12 +51,12 @@ export default function RejectDialog({ onClose, onSubmit }: RejectDialogProps): 
       <Box textAlign='left'>
         <Textfield
           autoFocus
-          errorText={validate && !reason.trim() ? strings.REQUIRED_FIELD : ''}
-          label={strings.REASON}
-          id='reason'
-          onChange={(value) => setReason(value as string)}
+          errorText={validate && !feedback.trim() ? strings.REQUIRED_FIELD : ''}
+          label={strings.FEEDBACK}
+          id='feedback'
+          onChange={(value) => setFeedback(value as string)}
           type='textarea'
-          value={reason}
+          value={feedback}
         />
       </Box>
     </DialogBox>

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -430,6 +430,7 @@ FACILITY_OPERATION_START_DATE_INVALID,Must be on or after build start and build 
 FACILITY_OPERATION_START_DATE_REQUIRED,Operation Start Date *,
 FAMILY,Family,
 FEATURE_AVAILABLE_ON_DESKTOP,This feature is only available from the desktop application.,
+FEEDBACK,Feedback,
 FERN,Fern,
 FIELD_NOTES,Field Notes,
 FIELD_NOTES_PLACEHOLDER,"Important notes about seeds, fruits, or plants",


### PR DESCRIPTION
This PR includes changes to rename "reason" to "feedback".

**NOTE:** Current changes include updating all instances of "reason" in the UI to "feedback" and all related code. There are a couple of potential changes I could also see making but wanted to confirm first:

- Rename “Reject Reason” to “Reject Feedback”?
- Change `Deliverable.reason` to `Deliverable.feedback` in the type for `Deliverable` and related mocks? (I’m not sure if the type for `Deliverable` is already defined in the BE API, and if so, if we want to update or leave as-is.)