### PR TITLE
SW-4943 Add some spacing so that dropdown active state outline does get cutoff

### DIFF
--- a/src/scenes/AcceleratorRouter/DeliverablesList.tsx
+++ b/src/scenes/AcceleratorRouter/DeliverablesList.tsx
@@ -74,7 +74,7 @@ const DeliverablesList = () => {
     () =>
       activeLocale ? (
         <>
-          <Grid container>
+          <Grid container sx={{ marginTop: theme.spacing(0.5) }}>
             <Grid item>
               <Separator height={'40px'} />
             </Grid>

--- a/src/scenes/DeliverablesRouter/DeliverablesList.tsx
+++ b/src/scenes/DeliverablesRouter/DeliverablesList.tsx
@@ -80,7 +80,7 @@ const DeliverablesList = (): JSX.Element => {
     () =>
       activeLocale ? (
         <>
-          <Grid container>
+          <Grid container sx={{ marginTop: theme.spacing(0.5) }}>
             <Grid item>
               <Separator height={'40px'} />
             </Grid>


### PR DESCRIPTION
Before: 
<img width="592" alt="Screenshot 2024-02-28 at 8 08 11 PM" src="https://github.com/terraware/terraware-web/assets/104874529/c447090e-0553-47c6-a35f-1525a7474a97">
After:
<img width="555" alt="Screenshot 2024-02-28 at 8 08 20 PM" src="https://github.com/terraware/terraware-web/assets/104874529/d4d50ba3-16da-4c36-8964-b2f1b2dc73e5">
