### PR TITLE
Create searchAndSort function which acts as a local Search API replacement that can use the same interfaces

### DIFF
--- a/src/services/DeliverablesService.ts
+++ b/src/services/DeliverablesService.ts
@@ -7,6 +7,7 @@ import {
 } from 'src/types/Deliverables';
 import HttpService, { Response, Params } from 'src/services/HttpService';
 import { paths } from 'src/api/types/generated-schema';
+import { SearchOrderConfig, searchAndSort } from 'src/utils/searchAndSort';
 
 /**
  * Accelerator "deliverable" related services
@@ -63,15 +64,25 @@ const list = async (
   search?: SearchNodePayload,
   searchSortOrder?: SearchSortOrder
   // TODO sort, search, etc...
-): Promise<(DeliverablesData & Response) | null> =>
-  httpDeliverables.get<ListDeliverablesResponsePayload, DeliverablesData>(
+): Promise<(DeliverablesData & Response) | null> => {
+  let searchOrderConfig: SearchOrderConfig;
+  if (searchSortOrder) {
+    searchOrderConfig = {
+      locale,
+      sortOrder: searchSortOrder,
+      numberFields: ['id', 'numDocuments', 'organizationId', 'participantId'],
+    };
+  }
+
+  return httpDeliverables.get<ListDeliverablesResponsePayload, DeliverablesData>(
     {
       params: request as Params,
     },
     (data) => ({
-      deliverables: (data?.deliverables || []).sort((a, b) => a.name.localeCompare(b.name, locale || undefined)),
+      deliverables: searchAndSort(data?.deliverables || [], search, searchOrderConfig),
     })
   );
+};
 
 const DeliverablesService = {
   get,

--- a/src/types/Search.ts
+++ b/src/types/Search.ts
@@ -16,3 +16,8 @@ export type FieldOptionsMap = { [key: string]: { partial: boolean; values: (stri
 /** Search request payload that requires a search node to be specified. */
 export type SearchRequestPayload = components['schemas']['SearchRequestPayload'] & { search: SearchNodePayload };
 export type OptionalSearchRequestPayload = components['schemas']['SearchRequestPayload'];
+
+export const isFieldNodePayload = (node: SearchNodePayload): node is FieldNodePayload => node.operation === 'field';
+export const isNotNodePayload = (node: SearchNodePayload): node is NotNodePayload => node.operation === 'not';
+export const isAndNodePayload = (node: SearchNodePayload): node is AndNodePayload => node.operation === 'and';
+export const isOrNodePayload = (node: SearchNodePayload): node is OrNodePayload => node.operation === 'or';

--- a/src/utils/searchAndSort.test.ts
+++ b/src/utils/searchAndSort.test.ts
@@ -11,37 +11,7 @@ type MockResult = {
   status?: string;
 };
 
-const results: MockResult[] = [
-  {
-    category: 'Legal Eligibility',
-    id: 1,
-    name: 'Incorporation Documents',
-    numberField: 2,
-    numberFieldAsString: '7',
-    projectName: 'Omega Project',
-    status: 'Rejected',
-  },
-  {
-    category: 'Financial Viability',
-    id: 9,
-    name: 'Budget',
-    numberField: 0,
-    numberFieldAsString: '2',
-    projectName: 'Omega Project',
-    status: 'Not Submitted',
-  },
-  {
-    category: 'GIS',
-    id: 3,
-    name: 'A Document',
-    numberField: 3,
-    numberFieldAsString: '1',
-    projectName: 'Another Project',
-    status: 'Submitted',
-  },
-];
-
-xdescribe('splitTrigrams', () => {
+describe('splitTrigrams', () => {
   it('should split a string into trigrams in the same way postgres does', () => {
     const catTrigrams = [' c', ' ca', 'cat', 'at '];
     expect(splitTrigrams('cat')).toEqual(catTrigrams);
@@ -53,6 +23,36 @@ xdescribe('splitTrigrams', () => {
 
 describe('searchAndSort', () => {
   it('should return the results in the same order if no search or sort are provided', () => {
+    const results: MockResult[] = [
+      {
+        category: 'Legal Eligibility',
+        id: 1,
+        name: 'Incorporation Documents',
+        numberField: 2,
+        numberFieldAsString: '7',
+        projectName: 'Omega Project',
+        status: 'Rejected',
+      },
+      {
+        category: 'Financial Viability',
+        id: 9,
+        name: 'Budget',
+        numberField: 0,
+        numberFieldAsString: '2',
+        projectName: 'Omega Project',
+        status: 'Not Submitted',
+      },
+      {
+        category: 'GIS',
+        id: 3,
+        name: 'A Document',
+        numberField: 3,
+        numberFieldAsString: '1',
+        projectName: 'Another Project',
+        status: 'Submitted',
+      },
+    ];
+
     expect(searchAndSort(results)).toEqual(results);
   });
 

--- a/src/utils/searchAndSort.test.ts
+++ b/src/utils/searchAndSort.test.ts
@@ -1,0 +1,530 @@
+import { SearchNodePayload } from 'src/types/Search';
+import { SearchOrderConfig, searchAndSort, splitTrigrams } from 'src/utils/searchAndSort';
+
+type MockResult = {
+  category?: string;
+  id?: number;
+  name?: string;
+  numberField?: number;
+  numberFieldAsString?: string;
+  projectName?: string;
+  status?: string;
+};
+
+const results: MockResult[] = [
+  {
+    category: 'Legal Eligibility',
+    id: 1,
+    name: 'Incorporation Documents',
+    numberField: 2,
+    numberFieldAsString: '7',
+    projectName: 'Omega Project',
+    status: 'Rejected',
+  },
+  {
+    category: 'Financial Viability',
+    id: 9,
+    name: 'Budget',
+    numberField: 0,
+    numberFieldAsString: '2',
+    projectName: 'Omega Project',
+    status: 'Not Submitted',
+  },
+  {
+    category: 'GIS',
+    id: 3,
+    name: 'A Document',
+    numberField: 3,
+    numberFieldAsString: '1',
+    projectName: 'Another Project',
+    status: 'Submitted',
+  },
+];
+
+xdescribe('splitTrigrams', () => {
+  it('should split a string into trigrams in the same way postgres does', () => {
+    const catTrigrams = [' c', ' ca', 'cat', 'at '];
+    expect(splitTrigrams('cat')).toEqual(catTrigrams);
+
+    const fooBarTrigrams = [' f', ' fo', 'foo', 'oo ', ' b', ' ba', 'bar', 'ar '];
+    expect(splitTrigrams('foo|bar')).toEqual(fooBarTrigrams);
+  });
+});
+
+describe('searchAndSort', () => {
+  it('should return the results in the same order if no search or sort are provided', () => {
+    expect(searchAndSort(results)).toEqual(results);
+  });
+
+  it('should filter the results as expected - or with fuzzy search filter', () => {
+    const results: MockResult[] = [
+      {
+        name: 'Incorporation Documents',
+        projectName: 'Project 1',
+      },
+      {
+        name: 'Budget',
+        projectName: 'Corpotrees',
+      },
+      {
+        name: 'A Document',
+        projectName: 'Project 1',
+      },
+    ];
+
+    const searchValue = 'corpot';
+
+    const search: SearchNodePayload = {
+      operation: 'or',
+      children: [
+        {
+          operation: 'field',
+          field: 'name',
+          type: 'Fuzzy',
+          values: [searchValue],
+        },
+        {
+          operation: 'field',
+          field: 'projectName',
+          type: 'Fuzzy',
+          values: [searchValue],
+        },
+      ],
+    };
+
+    const filteredResults: MockResult[] = [
+      {
+        name: 'Incorporation Documents',
+        projectName: 'Project 1',
+      },
+      {
+        name: 'Budget',
+        projectName: 'Corpotrees',
+      },
+    ];
+
+    expect(searchAndSort(results, search)).toEqual(filteredResults);
+  });
+
+  it('should filter the results as expected - or with exact search filter', () => {
+    const results: MockResult[] = [
+      {
+        name: 'Incorporation Documents',
+        projectName: 'Project 1',
+      },
+      {
+        name: 'Budget',
+        projectName: 'Corpotrees',
+      },
+      {
+        name: 'A Document',
+        projectName: 'Project 1',
+      },
+    ];
+
+    const searchValue = 'corpot';
+
+    const search: SearchNodePayload = {
+      operation: 'or',
+      children: [
+        {
+          operation: 'field',
+          field: 'name',
+          type: 'Exact',
+          values: [searchValue],
+        },
+        {
+          operation: 'field',
+          field: 'projectName',
+          type: 'Exact',
+          values: [searchValue],
+        },
+      ],
+    };
+
+    const filteredResults: MockResult[] = [
+      {
+        name: 'Budget',
+        projectName: 'Corpotrees',
+      },
+    ];
+
+    expect(searchAndSort(results, search)).toEqual(filteredResults);
+  });
+
+  it('should filter the results as expected - not filter - string', () => {
+    const results: MockResult[] = [
+      {
+        name: 'Incorporation Documents',
+        status: 'Rejected',
+      },
+      {
+        name: 'Budget',
+        projectName: 'Submitted',
+      },
+      {
+        name: 'A Document',
+        projectName: 'Submitted',
+      },
+    ];
+
+    const search: SearchNodePayload = {
+      operation: 'not',
+      child: {
+        operation: 'field',
+        field: 'status',
+        type: 'Exact',
+        values: ['Rejected'],
+      },
+    };
+
+    const filteredResults: MockResult[] = [
+      {
+        name: 'Budget',
+        projectName: 'Submitted',
+      },
+      {
+        name: 'A Document',
+        projectName: 'Submitted',
+      },
+    ];
+
+    expect(searchAndSort(results, search)).toEqual(filteredResults);
+  });
+
+  it('should filter the results as expected - not filter - number', () => {
+    const results: MockResult[] = [
+      {
+        name: 'Incorporation Documents',
+        id: 1,
+      },
+      {
+        name: 'Budget',
+        id: 2,
+      },
+      {
+        name: 'A Document',
+        id: 3,
+      },
+    ];
+
+    const search: SearchNodePayload = {
+      operation: 'not',
+      child: {
+        operation: 'field',
+        field: 'id',
+        type: 'Exact',
+        values: ['1'],
+      },
+    };
+
+    const filteredResults: MockResult[] = [
+      {
+        name: 'Budget',
+        id: 2,
+      },
+      {
+        name: 'A Document',
+        id: 3,
+      },
+    ];
+
+    expect(searchAndSort(results, search)).toEqual(filteredResults);
+  });
+
+  it('should filter the results as expected - and filter with multiselect', () => {
+    const results: MockResult[] = [
+      {
+        name: 'Incorporation Documents',
+        status: 'Rejected',
+        category: 'GIS',
+      },
+      {
+        name: 'Budget',
+        status: 'Submitted',
+        category: 'GIS',
+      },
+      {
+        name: 'A Document',
+        status: 'Submitted',
+        category: 'Legal',
+      },
+    ];
+
+    const search: SearchNodePayload = {
+      operation: 'and',
+      children: [
+        {
+          operation: 'field',
+          field: 'status',
+          type: 'Exact',
+          values: ['Submitted'],
+        },
+        {
+          operation: 'field',
+          field: 'category',
+          type: 'Exact',
+          values: ['GIS', 'Legal'],
+        },
+      ],
+    };
+
+    const filteredResults: MockResult[] = [
+      {
+        name: 'Budget',
+        status: 'Submitted',
+        category: 'GIS',
+      },
+      {
+        name: 'A Document',
+        status: 'Submitted',
+        category: 'Legal',
+      },
+    ];
+
+    expect(searchAndSort(results, search)).toEqual(filteredResults);
+  });
+
+  it('should filter the results as expected - complex filter with sorting', () => {
+    const results: MockResult[] = [
+      {
+        name: 'Incorporation Documents',
+        status: 'Rejected',
+        category: 'GIS',
+        projectName: 'Project 1',
+      },
+      {
+        name: 'Budget',
+        status: 'Submitted',
+        category: 'GIS',
+        projectName: 'Corpotrees',
+      },
+      {
+        name: 'A Document',
+        status: 'Submitted',
+        category: 'Legal',
+        projectName: 'Corpotrees',
+      },
+    ];
+
+    const searchValue = 'corpot';
+    const statusMultiSelect = ['Submitted'];
+    const categoryMultiSelect = ['GIS', 'Legal'];
+    const searchOrderConfig: SearchOrderConfig = {
+      locale: 'en',
+      sortOrder: {
+        field: 'name',
+        direction: 'Ascending',
+      },
+      numberFields: ['id', 'numberField', 'numberFieldAsString'],
+    };
+
+    const search: SearchNodePayload = {
+      operation: 'and',
+      children: [
+        {
+          operation: 'or',
+          children: [
+            {
+              operation: 'field',
+              field: 'name',
+              type: 'Fuzzy',
+              values: [searchValue],
+            },
+            {
+              operation: 'field',
+              field: 'projectName',
+              type: 'Fuzzy',
+              values: [searchValue],
+            },
+          ],
+        },
+        {
+          operation: 'field',
+          field: 'status',
+          type: 'Exact',
+          values: statusMultiSelect,
+        },
+        {
+          operation: 'field',
+          field: 'category',
+          type: 'Exact',
+          values: categoryMultiSelect,
+        },
+      ],
+    };
+
+    const filteredResults: MockResult[] = [
+      {
+        name: 'A Document',
+        status: 'Submitted',
+        category: 'Legal',
+        projectName: 'Corpotrees',
+      },
+      {
+        name: 'Budget',
+        status: 'Submitted',
+        category: 'GIS',
+        projectName: 'Corpotrees',
+      },
+    ];
+
+    expect(searchAndSort(results, search, searchOrderConfig)).toEqual(filteredResults);
+  });
+
+  it('should sort the results as expected for a string field', () => {
+    const searchOrderConfig: SearchOrderConfig = {
+      locale: 'en',
+      sortOrder: {
+        field: 'name',
+        direction: 'Ascending',
+      },
+      numberFields: ['id', 'numberField', 'numberFieldAsString'],
+    };
+
+    const results: MockResult[] = [
+      {
+        name: 'Incorporation Documents',
+      },
+      {
+        name: 'Budget',
+      },
+      {
+        name: 'A Document',
+      },
+    ];
+
+    const sortedResultsAscending: MockResult[] = [
+      {
+        name: 'A Document',
+      },
+      {
+        name: 'Budget',
+      },
+      {
+        name: 'Incorporation Documents',
+      },
+    ];
+
+    expect(searchAndSort(results, undefined, searchOrderConfig)).toEqual(sortedResultsAscending);
+
+    searchOrderConfig.sortOrder.direction = 'Descending';
+    const sortedResultsDescending: MockResult[] = [
+      {
+        name: 'Incorporation Documents',
+      },
+      {
+        name: 'Budget',
+      },
+      {
+        name: 'A Document',
+      },
+    ];
+
+    expect(searchAndSort(results, undefined, searchOrderConfig)).toEqual(sortedResultsDescending);
+  });
+
+  it('should sort the results as expected for a number field', () => {
+    const searchOrderConfig: SearchOrderConfig = {
+      locale: 'en',
+      sortOrder: {
+        field: 'numberField',
+        direction: 'Ascending',
+      },
+      numberFields: ['numberField', 'numberFieldAsString'],
+    };
+
+    const results: MockResult[] = [
+      {
+        numberField: 7,
+      },
+      {
+        numberField: 1,
+      },
+      {
+        numberField: 3,
+      },
+    ];
+
+    const sortedResultsAscending: MockResult[] = [
+      {
+        numberField: 1,
+      },
+      {
+        numberField: 3,
+      },
+      {
+        numberField: 7,
+      },
+    ];
+
+    expect(searchAndSort(results, undefined, searchOrderConfig)).toEqual(sortedResultsAscending);
+
+    searchOrderConfig.sortOrder.direction = 'Descending';
+    const sortedResultsDescending: MockResult[] = [
+      {
+        numberField: 7,
+      },
+      {
+        numberField: 3,
+      },
+      {
+        numberField: 1,
+      },
+    ];
+
+    expect(searchAndSort(results, undefined, searchOrderConfig)).toEqual(sortedResultsDescending);
+  });
+
+  it('should sort the results as expected for a number field that is a string in the result', () => {
+    const searchOrderConfig: SearchOrderConfig = {
+      locale: 'en',
+      sortOrder: {
+        field: 'numberFieldAsString',
+        direction: 'Ascending',
+      },
+      numberFields: ['numberField', 'numberFieldAsString'],
+    };
+
+    const results: MockResult[] = [
+      {
+        numberFieldAsString: '7',
+      },
+      {
+        numberFieldAsString: '1',
+      },
+      {
+        numberFieldAsString: '3',
+      },
+    ];
+
+    const sortedResultsAscending: MockResult[] = [
+      {
+        numberFieldAsString: '1',
+      },
+      {
+        numberFieldAsString: '3',
+      },
+      {
+        numberFieldAsString: '7',
+      },
+    ];
+
+    expect(searchAndSort(results, undefined, searchOrderConfig)).toEqual(sortedResultsAscending);
+
+    searchOrderConfig.sortOrder.direction = 'Descending';
+    const sortedResultsDescending: MockResult[] = [
+      {
+        numberFieldAsString: '7',
+      },
+      {
+        numberFieldAsString: '3',
+      },
+      {
+        numberFieldAsString: '1',
+      },
+    ];
+
+    expect(searchAndSort(results, undefined, searchOrderConfig)).toEqual(sortedResultsDescending);
+  });
+});

--- a/src/utils/searchAndSort.ts
+++ b/src/utils/searchAndSort.ts
@@ -21,7 +21,7 @@ export const splitTrigrams = (value: string): string[] => {
   const _value = value.replace(/[^0-9a-z]/gi, ' ').replace(/\s+/, ' ');
 
   // Split into words, pad each word with spaces
-  const words = _value.split(' ').map((value) => ` ${value} `);
+  const words = _value.split(' ').map((word) => ` ${word} `);
 
   for (const word of words) {
     position = 3;

--- a/src/utils/searchAndSort.ts
+++ b/src/utils/searchAndSort.ts
@@ -72,7 +72,16 @@ const searchConditionMet = <T extends Record<string, unknown>>(result: T, condit
   return false;
 };
 
-const sortResults = <T extends Record<string, unknown>>(
+// Try to get the `*(raw)` field if it exists, otherwise fall back to the regular field
+const getRawField = <T extends Record<string, unknown>>(result: T, field: string): unknown | undefined => {
+  const rawField = result[`${field}(raw)`];
+  if (rawField !== undefined) {
+    return rawField;
+  }
+  return result[field];
+};
+
+export const sortResults = <T extends Record<string, unknown>>(
   results: T[],
   locale: string | null,
   sortOrder: SearchSortOrder,
@@ -84,7 +93,7 @@ const sortResults = <T extends Record<string, unknown>>(
   const isNumberField = (numberFields || []).includes(field);
 
   if (isNumberField) {
-    results = results.sort((a, b) => Number(a[field]) - Number(b[field]));
+    results = results.sort((a, b) => Number(getRawField(a, field)) - Number(getRawField(b, field)));
   } else {
     results = results.sort((a, b) =>
       // TODO this might cause issues if the field is undefined on the result

--- a/src/utils/searchAndSort.ts
+++ b/src/utils/searchAndSort.ts
@@ -1,0 +1,122 @@
+import {
+  SearchNodePayload,
+  SearchSortOrder,
+  isAndNodePayload,
+  isFieldNodePayload,
+  isNotNodePayload,
+  isOrNodePayload,
+} from 'src/types/Search';
+
+export type SearchOrderConfig = {
+  locale: string | null;
+  sortOrder: SearchSortOrder;
+  numberFields?: string[];
+};
+
+export const splitTrigrams = (value: string): string[] => {
+  const trigrams = [];
+  let position;
+
+  // Remove non-alphanumeric characters
+  const _value = value.replace(/[^0-9a-z]/gi, ' ').replace(/\s+/, ' ');
+
+  // Split into words, pad each word with spaces
+  const words = _value.split(' ').map((value) => ` ${value} `);
+
+  for (const word of words) {
+    position = 3;
+    // For some reason the postgres implementation also includes the first 2 characters of each word
+    trigrams.push(word.substring(0, 2));
+
+    // Split the words into trigrams
+    for (let i = 0; i < word.length; i += 1) {
+      if (position <= word.length) {
+        trigrams.push(word.substring(i, position).toLowerCase());
+        position += 1;
+      }
+    }
+  }
+
+  return trigrams;
+};
+
+const searchConditionMet = <T extends Record<string, unknown>>(result: T, condition: SearchNodePayload): boolean => {
+  // `as SearchNodePayload` casts below are because the SearchNodePayload in the generated types only has `operation`
+  // The the union type from our types has the correct properties
+  if (isNotNodePayload(condition)) {
+    return !searchConditionMet(result, condition.child as SearchNodePayload);
+  } else if (isAndNodePayload(condition)) {
+    return (condition.children as SearchNodePayload[]).every((_condition) => searchConditionMet(result, _condition));
+  } else if (isOrNodePayload(condition)) {
+    return (condition.children as SearchNodePayload[]).some((_condition) => searchConditionMet(result, _condition));
+  } else if (isFieldNodePayload(condition)) {
+    // Only 'Exact' and 'Fuzzy' condition types are supported
+    // `null` values (XYZ field contains no value) are also not supported
+    const resultValue = `${result[condition.field]}`.toLowerCase();
+    const searchValues = condition.values
+      .filter((value: string | null): value is string => value !== null)
+      .map((value) => value.toLowerCase());
+
+    if (condition.type === 'Exact') {
+      return searchValues.some((value) => resultValue.includes(value));
+    } else if (condition.type === 'Fuzzy') {
+      return searchValues.some((value) => {
+        // Split the search value into trigrams and see if the result field contains any trigram
+        const trigrams = splitTrigrams(value);
+        return trigrams.some((trigram: string) => resultValue.includes(trigram));
+      });
+    }
+  }
+
+  // This is not possible unless new node types are introduced
+  return false;
+};
+
+/**
+ * In-memory search (filter) and sort on a result list using the Search API search and sortOrder interfaces
+ * The search currently only supports `Exact` and 'Fuzzy' type searches, 'Range' and 'ExactOrFuzzy' are not supported
+ * If the result type contains number fields, those must be supplied in the `sortOrderConfig` if you wish to sort on them
+ * @param results         The list of results you want to search and sort
+ * @param search          (optional) The SearchNodePayload which contains filter conditions to apply to the results
+ * @param sortOrderConfig (optional) The sort order configuration contains:
+ *    - a `locale`, used for sorting strings,
+ *    - the `sortOrder` which defines the field and order
+ *    - (optional) a list of `numberFields`, used to sort applicable fields numerically
+ *      - fields not supplied will be sorted as strings
+ *      - can be used to cast a string to a number, useful for SearchElementResponse numbers which come back as strings
+ */
+export const searchAndSort = <T extends Record<string, unknown>>(
+  results: T[],
+  search?: SearchNodePayload,
+  sortOrderConfig?: SearchOrderConfig
+): T[] => {
+  let _results = [...results];
+
+  if (search) {
+    _results = _results.filter((result: T) => searchConditionMet(result, search));
+  }
+
+  if (sortOrderConfig) {
+    const field = sortOrderConfig.sortOrder.field;
+    const locale = sortOrderConfig.locale || undefined;
+    // Defaults to ascending if not provided
+    const isDescending = sortOrderConfig.sortOrder.direction === 'Descending';
+    const isNumberField = (sortOrderConfig.numberFields || []).includes(field);
+
+    if (isNumberField) {
+      _results = _results.sort((a, b) =>
+        isDescending ? Number(b[field]) - Number(a[field]) : Number(a[field]) - Number(b[field])
+      );
+    } else {
+      _results = _results.sort((a, b) =>
+        // TODO this might cause issues if the field is undefined on the result
+        `${a[field]}`.localeCompare(`${b[field]}`, locale || undefined)
+      );
+      if (isDescending) {
+        _results.reverse();
+      }
+    }
+  }
+
+  return _results;
+};


### PR DESCRIPTION
I did my best replicating the Search API functionality locally without sacrificing the payloads that are normally sent. This means that we don't need to change the way that the `SearchFiltersWrapper` works, even if we aren't actually using the Search API. 

I don't think this is a bulletproof implementation, and things like `Range` and `ExactOrFuzzy` aren't implemented (although the latter sounds like it would be trivial). Hopefully the test coverage is adequate to cover the most common use cases. 