### PR TITLE
Fix Deliverable page message layout issue

### DIFF
--- a/src/scenes/AcceleratorRouter/DeliverableView.tsx
+++ b/src/scenes/AcceleratorRouter/DeliverableView.tsx
@@ -42,7 +42,7 @@ const DeliverableView = (props: Props): JSX.Element => {
   return (
     <Page title={<TitleBar {...viewProps} />} rightComponent={props.callToAction} crumbs={crumbs}>
       {props.isBusy && <BusySpinner />}
-      <Box display='flex' flexDirection='column' sx={{ flexGrow: 1 }}>
+      <Box display='flex' flexDirection='column' flexGrow={1}>
         <RejectedDeliverableMessage {...viewProps} />
         <Card style={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
           <Metadata {...viewProps} />

--- a/src/scenes/AcceleratorRouter/DeliverableView.tsx
+++ b/src/scenes/AcceleratorRouter/DeliverableView.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { BusySpinner } from '@terraware/web-components';
+import { Box } from '@mui/material';
 import strings from 'src/strings';
 import { APP_PATHS } from 'src/constants';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
@@ -40,15 +41,15 @@ const DeliverableView = (props: Props): JSX.Element => {
 
   return (
     <Page title={<TitleBar {...viewProps} />} rightComponent={props.callToAction} crumbs={crumbs}>
-      <>
-        {props.isBusy && <BusySpinner />}
+      {props.isBusy && <BusySpinner />}
+      <Box display='flex' flexDirection='column' sx={{ flexGrow: 1 }}>
         <RejectedDeliverableMessage {...viewProps} />
         <Card style={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
           <Metadata {...viewProps} />
           <DocumentsUploader {...viewProps} />
           <DocumentsList {...viewProps} />
         </Card>
-      </>
+      </Box>
     </Page>
   );
 };

--- a/src/scenes/DeliverablesRouter/DeliverableView.tsx
+++ b/src/scenes/DeliverablesRouter/DeliverableView.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { Box } from '@mui/material';
 import { BusySpinner } from '@terraware/web-components';
 import strings from 'src/strings';
 import { APP_PATHS } from 'src/constants';
@@ -40,15 +41,15 @@ const DeliverableView = (props: Props): JSX.Element => {
 
   return (
     <Page title={<TitleBar {...props} />} crumbs={crumbs}>
-      <>
-        {props.isBusy && <BusySpinner />}
+      {props.isBusy && <BusySpinner />}
+      <Box display='flex' flexDirection='column' sx={{ flexGrow: 1 }}>
         <RejectedDeliverableMessage {...viewProps} />
         <Card style={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
           <Metadata {...viewProps} />
           <DocumentsUploader {...viewProps} />
           <DocumentsList {...viewProps} />
         </Card>
-      </>
+      </Box>
     </Page>
   );
 };

--- a/src/scenes/DeliverablesRouter/DeliverableView.tsx
+++ b/src/scenes/DeliverablesRouter/DeliverableView.tsx
@@ -42,7 +42,7 @@ const DeliverableView = (props: Props): JSX.Element => {
   return (
     <Page title={<TitleBar {...props} />} crumbs={crumbs}>
       {props.isBusy && <BusySpinner />}
-      <Box display='flex' flexDirection='column' sx={{ flexGrow: 1 }}>
+      <Box display='flex' flexDirection='column' flexGrow={1}>
         <RejectedDeliverableMessage {...viewProps} />
         <Card style={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
           <Metadata {...viewProps} />


### PR DESCRIPTION
This PR includes changes to fix a layout issue that resulted in the Deliverable Rejected page message showing beside the rest of the page content on browsers with higher/wider resolution.

## Example

### BEFORE

![localhost_3000_accelerator_deliverables_1](https://github.com/terraware/terraware-web/assets/1474361/edce1857-a9ff-403d-acfe-44261ffe2068)

### AFTER

![localhost_3000_accelerator_deliverables_1 (1)](https://github.com/terraware/terraware-web/assets/1474361/7ecedc62-7e90-44df-a1bd-205c26e13202)
