### PR TITLE
SW-4950: Remove the 'Feedback' section that is part of the metadata

### DIFF
--- a/src/components/DeliverableView/Metadata.tsx
+++ b/src/components/DeliverableView/Metadata.tsx
@@ -13,18 +13,6 @@ const Metadata = (props: ViewProps): JSX.Element => {
 
   return (
     <Box display='flex' flexDirection='column'>
-      {deliverable.status === 'Rejected' && (
-        <Box
-          border={`1px solid ${theme.palette.TwClrBaseGray100}`}
-          borderRadius='8px'
-          marginBottom='16px'
-          padding='16px'
-        >
-          <DeliverableStatusBadge status={deliverable.status} />
-          <strong>{strings.FEEDBACK}</strong> {deliverable.feedback}
-        </Box>
-      )}
-
       {isAcceleratorRoute && (
         <Box
           border={`1px solid ${theme.palette.TwClrBaseGray100}`}

--- a/src/components/DeliverableView/Metadata.tsx
+++ b/src/components/DeliverableView/Metadata.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Box, useTheme } from '@mui/material';
-import strings from 'src/strings';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import DeliverableStatusBadge from 'src/components/DeliverableView/DeliverableStatusBadge';
 import { ViewProps } from './types';


### PR DESCRIPTION
This PR includes changes to remove the redundant feedback section of the Deliverable View.

## Example

### BEFORE

![localhost_3000_accelerator_deliverables_1 (2)](https://github.com/terraware/terraware-web/assets/1474361/326ef7ad-be38-4253-a626-f10a7a9b3a71)

### AFTER

![localhost_3000_accelerator_deliverables_1 (3)](https://github.com/terraware/terraware-web/assets/1474361/4c246e34-f4e1-4dbc-9dfd-41f390c5d22f)
