### PR TITLE
SW-4944 Create ACL for global roles, plumb into the UserProvider

### DIFF
--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -14,7 +14,6 @@ import { useOrganization, useUser } from 'src/providers/hooks';
 import Link from 'src/components/common/Link';
 import AcceleratorBreadcrumbs from 'src/components/TopBar/AcceleratorBreadcrumbs';
 import { APP_PATHS } from 'src/constants';
-import { isAcceleratorAdmin } from 'src/types/User';
 
 const useStyles = makeStyles((theme: Theme) => ({
   logo: {
@@ -83,9 +82,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
         {organizations && organizations.length > 0 && (
           <>
             <div className={classes.separator} />
-            {isAcceleratorRoute && featureFlagAccelerator && user && isAcceleratorAdmin(user) && (
-              <AcceleratorBreadcrumbs />
-            )}
+            {isAcceleratorRoute && featureFlagAccelerator && user && <AcceleratorBreadcrumbs />}
             {!isAcceleratorRoute && <OrganizationsDropdown />}
           </>
         )}

--- a/src/providers/DataTypes.ts
+++ b/src/providers/DataTypes.ts
@@ -2,16 +2,18 @@ import React from 'react';
 import { User } from 'src/types/User';
 import { Organization } from 'src/types/Organization';
 import { TimeZoneDescription } from 'src/types/TimeZones';
+import { GlobalRolePermission } from 'src/utils/acl';
 
 export type PreferencesType = { [key: string]: unknown };
 
 export type ProvidedUserData = {
-  user?: User;
-  reloadUser: () => void;
   bootstrapped: boolean;
-  userPreferences: PreferencesType;
+  isAllowed: (permission: GlobalRolePermission) => boolean;
+  reloadUser: () => void;
   reloadUserPreferences: () => void;
   updateUserPreferences: (preferences: PreferencesType) => Promise<boolean>;
+  user?: User;
+  userPreferences: PreferencesType;
 };
 
 export type ProvidedOrganizationData = {

--- a/src/providers/UserProvider.tsx
+++ b/src/providers/UserProvider.tsx
@@ -6,6 +6,7 @@ import { PreferencesType, ProvidedUserData } from './DataTypes';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { updateGtmInstrumented } from 'src/redux/features/user/userAnalyticsSlice';
 import { selectUserAnalytics } from 'src/redux/features/user/userAnalyticsSelectors';
+import { GlobalRolePermission, isAllowed as isAllowedACL } from 'src/utils/acl';
 
 export type UserProviderProps = {
   children?: React.ReactNode;
@@ -43,7 +44,7 @@ export default function UserProvider({ children }: UserProviderProps): JSX.Eleme
       if (response.requestSucceeded) {
         setUser(response.user!);
         if (response.user && !userAnalyticsState?.gtmInstrumented && (window as any).INIT_GTAG) {
-          await dispatch(updateGtmInstrumented({ gtmInstrumented: true }));
+          dispatch(updateGtmInstrumented({ gtmInstrumented: true }));
 
           // Put the language in the "lang" attribute of the <html> tag before initializing Google
           // Analytics because the cookie consent UI code will look there to determine which
@@ -65,12 +66,24 @@ export default function UserProvider({ children }: UserProviderProps): JSX.Eleme
     populateUser();
   }, [setUser, userAnalyticsState?.gtmInstrumented, dispatch]);
 
+  const isAllowed = useCallback(
+    (permission: GlobalRolePermission, metadata?: unknown): boolean => {
+      if (!(userPreferences && user)) {
+        return false;
+      }
+
+      return isAllowedACL(user, permission, metadata);
+    },
+    [user, userPreferences]
+  );
+
   const [userData, setUserData] = useState<ProvidedUserData>({
     reloadUser,
     bootstrapped: false,
     userPreferences: {},
     reloadUserPreferences,
     updateUserPreferences,
+    isAllowed,
   });
 
   useEffect(() => {
@@ -90,8 +103,9 @@ export default function UserProvider({ children }: UserProviderProps): JSX.Eleme
       userPreferences: userPreferences ?? {},
       reloadUserPreferences,
       bootstrapped: Boolean(userPreferences && user),
+      isAllowed,
     }));
-  }, [user, userPreferences, reloadUserPreferences]);
+  }, [isAllowed, user, userPreferences, reloadUserPreferences]);
 
   return <UserContext.Provider value={userData}>{children}</UserContext.Provider>;
 }

--- a/src/providers/contexts.ts
+++ b/src/providers/contexts.ts
@@ -1,6 +1,7 @@
 import { createContext } from 'react';
 import { Organization } from 'src/types/Organization';
 import { ProvidedLocalizationData, ProvidedOrganizationData, ProvidedUserData } from './DataTypes';
+import { GlobalRolePermission } from 'src/utils/acl';
 
 export const UserContext = createContext<ProvidedUserData>({
   reloadUser: () => {
@@ -14,6 +15,7 @@ export const UserContext = createContext<ProvidedUserData>({
   userPreferences: {},
   bootstrapped: false,
   updateUserPreferences: () => Promise.resolve(true),
+  isAllowed: (_: GlobalRolePermission, __?: unknown) => false,
 });
 
 export const defaultSelectedOrg: Organization = {

--- a/src/scenes/TerrawareRouter/NavBar.tsx
+++ b/src/scenes/TerrawareRouter/NavBar.tsx
@@ -4,7 +4,6 @@ import SubNavbar from '@terraware/web-components/components/Navbar/SubNavbar';
 import { APP_PATHS } from 'src/constants';
 import strings from 'src/strings';
 import { NurseryWithdrawalService } from 'src/services';
-import { isAcceleratorAdmin } from 'src/types/User';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import { useLocalization, useOrganization, useUser } from 'src/providers/hooks';
 import ReportService, { Reports } from 'src/services/ReportService';
@@ -174,7 +173,7 @@ export default function NavBar({
       setShowNavBar={setShowNavBar as React.Dispatch<React.SetStateAction<boolean>>}
       backgroundTransparent={backgroundTransparent}
     >
-      {featureFlagAccelerator && user && isAcceleratorAdmin(user) && (
+      {featureFlagAccelerator && user && (
         <NavItem
           label={strings.ACCELERATOR_ADMIN}
           icon='home'

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -3,6 +3,7 @@ import { components } from 'src/api/types/generated-schema';
 
 export type User = components['schemas']['UserProfilePayload'];
 export type UserGlobalRoles = User['globalRoles'];
+export type UserGlobalRole = User['globalRoles'][0];
 
 export type OrganizationUser = {
   firstName?: string;
@@ -12,8 +13,3 @@ export type OrganizationUser = {
   role: OrganizationRole;
   addedTime?: string;
 };
-
-const AcceleratorAdminRoles: UserGlobalRoles = ['Super-Admin', 'Accelerator Admin'];
-
-export const isAcceleratorAdmin = (user: User): boolean =>
-  user.globalRoles.some((globalRole: UserGlobalRoles[0]) => AcceleratorAdminRoles.includes(globalRole));

--- a/src/utils/acl.test.ts
+++ b/src/utils/acl.test.ts
@@ -1,0 +1,142 @@
+import { User } from 'src/types/User';
+import {
+  GLOBAL_ROLE_ACCELERATOR_ADMIN,
+  GLOBAL_ROLE_READ_ONLY,
+  GLOBAL_ROLE_SUPER_ADMIN,
+  GLOBAL_ROLE_TF_EXPERT,
+  isAllowed,
+} from './acl';
+
+describe('isAllowed', () => {
+  it('has the correct permissions for a user with the Super Admin global role', () => {
+    const user: User = {
+      id: 1,
+      emailNotificationsEnabled: false,
+      email: 'mock@email.com',
+      globalRoles: [GLOBAL_ROLE_SUPER_ADMIN],
+    };
+
+    // Allowed Permissions
+    expect(isAllowed(user, 'VIEW_CONSOLE')).toBeTruthy();
+    expect(isAllowed(user, 'READ_GLOBAL_ROLES')).toBeTruthy();
+    expect(isAllowed(user, 'CREATE_COHORTS')).toBeTruthy();
+    expect(isAllowed(user, 'READ_COHORTS')).toBeTruthy();
+    expect(isAllowed(user, 'UPDATE_COHORTS')).toBeTruthy();
+    expect(isAllowed(user, 'DELETE_COHORTS')).toBeTruthy();
+    expect(isAllowed(user, 'CREATE_PARTICIPANTS')).toBeTruthy();
+    expect(isAllowed(user, 'READ_PARTICIPANTS')).toBeTruthy();
+    expect(isAllowed(user, 'UPDATE_PARTICIPANTS')).toBeTruthy();
+    expect(isAllowed(user, 'DELETE_PARTICIPANTS')).toBeTruthy();
+    expect(isAllowed(user, 'ASSIGN_PARTICIPANT_TO_COHORT')).toBeTruthy();
+    expect(isAllowed(user, 'READ_PROJECT_ACCELERATOR_DATA')).toBeTruthy();
+    expect(isAllowed(user, 'UPDATE_PROJECT_ACCELERATOR_DATA')).toBeTruthy();
+    expect(isAllowed(user, 'ASSIGN_PROJECT_TO_PARTICIPANT')).toBeTruthy();
+
+    // Role to set must be passed for this rule
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER')).toBeFalsy();
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_SUPER_ADMIN })).toBeTruthy();
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_ACCELERATOR_ADMIN })).toBeTruthy();
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_TF_EXPERT })).toBeTruthy();
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_READ_ONLY })).toBeTruthy();
+  });
+
+  it('has the correct permissions for a user with the Accelerator Admin global role', () => {
+    const user: User = {
+      id: 1,
+      emailNotificationsEnabled: false,
+      email: 'mock@email.com',
+      globalRoles: [GLOBAL_ROLE_ACCELERATOR_ADMIN],
+    };
+
+    // Allowed Permissions
+    expect(isAllowed(user, 'VIEW_CONSOLE')).toBeTruthy();
+    expect(isAllowed(user, 'READ_GLOBAL_ROLES')).toBeTruthy();
+    expect(isAllowed(user, 'CREATE_COHORTS')).toBeTruthy();
+    expect(isAllowed(user, 'READ_COHORTS')).toBeTruthy();
+    expect(isAllowed(user, 'UPDATE_COHORTS')).toBeTruthy();
+    expect(isAllowed(user, 'DELETE_COHORTS')).toBeTruthy();
+    expect(isAllowed(user, 'CREATE_PARTICIPANTS')).toBeTruthy();
+    expect(isAllowed(user, 'READ_PARTICIPANTS')).toBeTruthy();
+    expect(isAllowed(user, 'UPDATE_PARTICIPANTS')).toBeTruthy();
+    expect(isAllowed(user, 'DELETE_PARTICIPANTS')).toBeTruthy();
+    expect(isAllowed(user, 'ASSIGN_PARTICIPANT_TO_COHORT')).toBeTruthy();
+    expect(isAllowed(user, 'READ_PROJECT_ACCELERATOR_DATA')).toBeTruthy();
+    expect(isAllowed(user, 'UPDATE_PROJECT_ACCELERATOR_DATA')).toBeTruthy();
+    expect(isAllowed(user, 'ASSIGN_PROJECT_TO_PARTICIPANT')).toBeTruthy();
+
+    // Role to set must be passed for this rule
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER')).toBeFalsy();
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_SUPER_ADMIN })).toBeFalsy();
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_ACCELERATOR_ADMIN })).toBeTruthy();
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_TF_EXPERT })).toBeTruthy();
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_READ_ONLY })).toBeTruthy();
+  });
+
+  it('has the correct permissions for a user with the TF Expert global role', () => {
+    const user: User = {
+      id: 1,
+      emailNotificationsEnabled: false,
+      email: 'mock@email.com',
+      globalRoles: [GLOBAL_ROLE_TF_EXPERT],
+    };
+
+    // Allowed permissions
+    expect(isAllowed(user, 'VIEW_CONSOLE')).toBeTruthy();
+    expect(isAllowed(user, 'READ_COHORTS')).toBeTruthy();
+    expect(isAllowed(user, 'READ_PARTICIPANTS')).toBeTruthy();
+    expect(isAllowed(user, 'UPDATE_PARTICIPANTS')).toBeTruthy();
+    expect(isAllowed(user, 'ASSIGN_PARTICIPANT_TO_COHORT')).toBeTruthy();
+    expect(isAllowed(user, 'READ_PROJECT_ACCELERATOR_DATA')).toBeTruthy();
+    expect(isAllowed(user, 'UPDATE_PROJECT_ACCELERATOR_DATA')).toBeTruthy();
+    expect(isAllowed(user, 'ASSIGN_PROJECT_TO_PARTICIPANT')).toBeTruthy();
+
+    // Not allowed permissions
+    expect(isAllowed(user, 'READ_GLOBAL_ROLES')).toBeFalsy();
+    expect(isAllowed(user, 'CREATE_COHORTS')).toBeFalsy();
+    expect(isAllowed(user, 'UPDATE_COHORTS')).toBeFalsy();
+    expect(isAllowed(user, 'DELETE_COHORTS')).toBeFalsy();
+    expect(isAllowed(user, 'CREATE_PARTICIPANTS')).toBeFalsy();
+    expect(isAllowed(user, 'DELETE_PARTICIPANTS')).toBeFalsy();
+
+    // Role to set must be passed for this rule
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER')).toBeFalsy();
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_SUPER_ADMIN })).toBeFalsy();
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_ACCELERATOR_ADMIN })).toBeFalsy();
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_TF_EXPERT })).toBeFalsy();
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_READ_ONLY })).toBeFalsy();
+  });
+
+  it('has the correct permissions for a user with the Ready Only global role', () => {
+    const user: User = {
+      id: 1,
+      emailNotificationsEnabled: false,
+      email: 'mock@email.com',
+      globalRoles: [GLOBAL_ROLE_READ_ONLY],
+    };
+
+    // Allowed permissions
+    expect(isAllowed(user, 'VIEW_CONSOLE')).toBeTruthy();
+    expect(isAllowed(user, 'READ_PROJECT_ACCELERATOR_DATA')).toBeTruthy();
+
+    // Not allowed permissions
+    expect(isAllowed(user, 'READ_GLOBAL_ROLES')).toBeFalsy();
+    expect(isAllowed(user, 'READ_COHORTS')).toBeFalsy();
+    expect(isAllowed(user, 'CREATE_COHORTS')).toBeFalsy();
+    expect(isAllowed(user, 'UPDATE_COHORTS')).toBeFalsy();
+    expect(isAllowed(user, 'DELETE_COHORTS')).toBeFalsy();
+    expect(isAllowed(user, 'CREATE_PARTICIPANTS')).toBeFalsy();
+    expect(isAllowed(user, 'READ_PARTICIPANTS')).toBeFalsy();
+    expect(isAllowed(user, 'UPDATE_PARTICIPANTS')).toBeFalsy();
+    expect(isAllowed(user, 'DELETE_PARTICIPANTS')).toBeFalsy();
+    expect(isAllowed(user, 'ASSIGN_PARTICIPANT_TO_COHORT')).toBeFalsy();
+    expect(isAllowed(user, 'UPDATE_PROJECT_ACCELERATOR_DATA')).toBeFalsy();
+    expect(isAllowed(user, 'ASSIGN_PROJECT_TO_PARTICIPANT')).toBeFalsy();
+
+    // Role to set must be passed for this rule
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER')).toBeFalsy();
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_SUPER_ADMIN })).toBeFalsy();
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_ACCELERATOR_ADMIN })).toBeFalsy();
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_TF_EXPERT })).toBeFalsy();
+    expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_READ_ONLY })).toBeFalsy();
+  });
+});

--- a/src/utils/acl.ts
+++ b/src/utils/acl.ts
@@ -1,0 +1,119 @@
+import { User, UserGlobalRole, UserGlobalRoles } from 'src/types/User';
+import { isArrayOfT } from 'src/types/utils';
+
+// Acceptable permission are:
+// - view (page)
+// - create (entity)
+// - read (entity)
+// - update (entity)
+// - delete (entity)
+// - assign (entity->entity)
+//
+// Assign is (under the hood) an update, but we want to call it out specifically because there are some
+// roles that can assign to an entity but technically can't update it (assign global role is a good example)
+
+type PermissionConsole = 'VIEW_CONSOLE';
+type PermissionGlobalRole = 'READ_GLOBAL_ROLES' | 'ASSIGN_GLOBAL_ROLE_TO_USER';
+type PermissionCohort = 'CREATE_COHORTS' | 'READ_COHORTS' | 'UPDATE_COHORTS' | 'DELETE_COHORTS';
+type PermissionParticipant =
+  | 'CREATE_PARTICIPANTS'
+  | 'READ_PARTICIPANTS'
+  | 'UPDATE_PARTICIPANTS'
+  | 'DELETE_PARTICIPANTS'
+  | 'ASSIGN_PARTICIPANT_TO_COHORT';
+// This name might change, the entity doesn't exist yet. May end up adding extra properties to
+// the "project"" entity or creating a new "project accelerator data" entity
+type PermissionProjectAcceleratorData =
+  | 'READ_PROJECT_ACCELERATOR_DATA'
+  | 'UPDATE_PROJECT_ACCELERATOR_DATA'
+  | 'ASSIGN_PROJECT_TO_PARTICIPANT';
+
+export type GlobalRolePermission =
+  | PermissionConsole
+  | PermissionGlobalRole
+  | PermissionCohort
+  | PermissionParticipant
+  | PermissionProjectAcceleratorData;
+
+type PermissionCheckFn<T = any> = (user: User, permission: GlobalRolePermission, metadata: T) => boolean;
+
+const GLOBAL_ROLE_SUPER_ADMIN: UserGlobalRole = 'Super-Admin';
+const GLOBAL_ROLE_ACCELERATOR_ADMIN: UserGlobalRole = 'Accelerator Admin';
+const GLOBAL_ROLE_TF_EXPERT_ADMIN: UserGlobalRole = 'TF Expert';
+const GLOBAL_ROLE_READ_ONLY_ADMIN: UserGlobalRole = 'Read Only';
+const isUserGlobalRole = (input: unknown): input is UserGlobalRole =>
+  [
+    GLOBAL_ROLE_SUPER_ADMIN,
+    GLOBAL_ROLE_ACCELERATOR_ADMIN,
+    GLOBAL_ROLE_TF_EXPERT_ADMIN,
+    GLOBAL_ROLE_READ_ONLY_ADMIN,
+  ].includes(input as UserGlobalRole);
+
+const SuperAdminPlus: UserGlobalRoles = [GLOBAL_ROLE_SUPER_ADMIN];
+const AcceleratorAdminPlus: UserGlobalRoles = [...SuperAdminPlus, GLOBAL_ROLE_ACCELERATOR_ADMIN];
+const TFExpertPlus: UserGlobalRoles = [...AcceleratorAdminPlus, GLOBAL_ROLE_TF_EXPERT_ADMIN];
+const ReadOnlyPlus: UserGlobalRoles = [...TFExpertPlus, GLOBAL_ROLE_READ_ONLY_ADMIN];
+
+const isSuperAdmin = (user: User): boolean => user.globalRoles.includes(GLOBAL_ROLE_SUPER_ADMIN);
+const isAcceleratorAdmin = (user: User): boolean => user.globalRoles.includes(GLOBAL_ROLE_ACCELERATOR_ADMIN);
+
+// This one is a bit more complicated because the permission is dependent on the role
+type AssignGlobalRoleToUserMetadata = { roleToSet: UserGlobalRole };
+const isAllowedAssignGlobalRoleToUser: PermissionCheckFn<AssignGlobalRoleToUserMetadata> = (
+  user: User,
+  _: GlobalRolePermission,
+  metadata: AssignGlobalRoleToUserMetadata
+): boolean => {
+  if (isSuperAdmin(user)) {
+    return true;
+  } else if (isAcceleratorAdmin(user)) {
+    // Accelerator admin can only assign accelerator admin, tf expert, and read only
+    if (
+      (
+        [GLOBAL_ROLE_ACCELERATOR_ADMIN, GLOBAL_ROLE_TF_EXPERT_ADMIN, GLOBAL_ROLE_READ_ONLY_ADMIN] as UserGlobalRole[]
+      ).includes(metadata.roleToSet)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+// List of permissions and roles that have those permissions
+const ACL: Record<GlobalRolePermission, UserGlobalRoles | PermissionCheckFn> = {
+  VIEW_CONSOLE: ReadOnlyPlus,
+  READ_GLOBAL_ROLES: SuperAdminPlus,
+  ASSIGN_GLOBAL_ROLE_TO_USER: isAllowedAssignGlobalRoleToUser,
+  CREATE_COHORTS: AcceleratorAdminPlus,
+  READ_COHORTS: TFExpertPlus,
+  UPDATE_COHORTS: AcceleratorAdminPlus,
+  DELETE_COHORTS: AcceleratorAdminPlus,
+  CREATE_PARTICIPANTS: AcceleratorAdminPlus,
+  READ_PARTICIPANTS: TFExpertPlus,
+  UPDATE_PARTICIPANTS: TFExpertPlus,
+  DELETE_PARTICIPANTS: AcceleratorAdminPlus,
+  ASSIGN_PARTICIPANT_TO_COHORT: TFExpertPlus,
+  READ_PROJECT_ACCELERATOR_DATA: ReadOnlyPlus,
+  UPDATE_PROJECT_ACCELERATOR_DATA: TFExpertPlus,
+  ASSIGN_PROJECT_TO_PARTICIPANT: TFExpertPlus,
+};
+
+export const isAllowed: PermissionCheckFn = (
+  user: User,
+  permission: GlobalRolePermission,
+  metadata: unknown
+): boolean => {
+  const acl = ACL[permission];
+  if (!acl) {
+    return false;
+  }
+
+  // If it is an array of roles, validate the user has at least one of the allowed roles
+  if (isArrayOfT<UserGlobalRole>(acl, isUserGlobalRole)) {
+    return acl.some((role: UserGlobalRole) => user.globalRoles.includes(role));
+  } else {
+    // Otherwise the acl is a function, useful when there are more complicated rules
+    return acl(user, permission, metadata);
+  }
+};


### PR DESCRIPTION
- Create mechanism for easily adding and checking ACL as it pertains to a user's global roles
- Gate the accelerator console using this ACL checker
- Remove check for organizations for accelerator so user doesn't get redirected (https://terraformation.atlassian.net/browse/SW-4948)

TODO
[x] tests for the ACL mechanism
[ ] https://github.com/terraware/terraware-web/pull/2251/files#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R115
[ ] https://github.com/terraware/terraware-web/pull/2251/files#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R83