### PR TITLE
SW-4959 Handle race condition in accessions search when page is loaded with filters in the url

### DIFF
--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -36,6 +36,7 @@ import { SearchCriteria, SearchNodePayload, SearchResponseElementWithId, SearchS
 import { useSessionFilters } from 'src/utils/filterHooks/useSessionFilters';
 import { getAllSeedBanks } from 'src/utils/organization';
 import { isAdmin } from 'src/utils/organization';
+import { getRequestId, setRequestId } from 'src/utils/requestsId';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import useQuery from 'src/utils/useQuery';
 import useSnackbar, { SNACKBAR_PAGE_CLOSE_KEY } from 'src/utils/useSnackbar';
@@ -423,86 +424,80 @@ export default function Database(props: DatabaseProps): JSX.Element {
     void populatePendingAccessions();
   }, [selectedOrganization.id]);
 
-  const initAccessions = useCallback(
-    (activeRequests: boolean) => {
-      const getFieldsFromSearchColumns = () => {
-        let columnsNamesToSearch: string[];
-        if (searchColumns.includes('active')) {
-          columnsNamesToSearch = [...searchColumns, 'id'];
-        } else {
-          columnsNamesToSearch = [...searchColumns, 'active', 'id'];
-        }
+  const initAccessions = useCallback(() => {
+    const getFieldsFromSearchColumns = () => {
+      let columnsNamesToSearch: string[];
+      if (searchColumns.includes('active')) {
+        columnsNamesToSearch = [...searchColumns, 'id'];
+      } else {
+        columnsNamesToSearch = [...searchColumns, 'active', 'id'];
+      }
 
-        return columnsNamesToSearch;
+      return columnsNamesToSearch;
+    };
+
+    if (selectedOrganization) {
+      const populateSearchResults = async () => {
+        const requestId = setRequestId('accessions_search');
+        const apiResponse: SearchResponseElementWithId[] | null = await SeedBankService.searchAccessions({
+          organizationId: selectedOrganization.id,
+          fields: getFieldsFromSearchColumns(),
+          sortOrder: searchSortOrder,
+          searchCriteria,
+        });
+
+        if (requestId === getRequestId('accessions_search')) {
+          setSearchResults(apiResponse);
+        }
       };
 
-      if (selectedOrganization) {
-        const populateSearchResults = async () => {
-          const apiResponse: SearchResponseElementWithId[] | null = await SeedBankService.searchAccessions({
-            organizationId: selectedOrganization.id,
-            fields: getFieldsFromSearchColumns(),
-            sortOrder: searchSortOrder,
-            searchCriteria,
-          });
+      const populateAvailableFieldOptions = async () => {
+        const requestId = setRequestId('accessions_search_available_values');
+        const singleAndMultiChoiceFields = filterSelectFields(searchColumns);
+        const data = await SeedBankService.searchFieldValues(
+          singleAndMultiChoiceFields,
+          searchCriteria,
+          selectedOrganization.id
+        );
 
-          if (activeRequests) {
-            setSearchResults(apiResponse);
-          }
-        };
+        if (requestId === getRequestId('accessions_search_available_values')) {
+          setAvailableFieldOptions(data);
+        }
+      };
 
-        const populateAvailableFieldOptions = async () => {
-          const singleAndMultiChoiceFields = filterSelectFields(searchColumns);
-          const data = await SeedBankService.searchFieldValues(
-            singleAndMultiChoiceFields,
-            searchCriteria,
-            selectedOrganization.id
-          );
+      const populateFieldOptions = async () => {
+        const requestId = setRequestId('accessions_search_all_values');
+        // Since the seed bank service doesn't return values for project IDs, we need to merge the values in
+        const singleAndMultiChoiceFields = filterSelectFields(
+          searchColumns.filter((column) => column !== 'project_name')
+        );
 
-          if (activeRequests) {
-            setAvailableFieldOptions(data);
-          }
-        };
+        const allValues =
+          (await SeedBankService.searchFieldValues(singleAndMultiChoiceFields, {}, selectedOrganization.id)) || {};
 
-        const populateFieldOptions = async () => {
-          // Since the seed bank service doesn't return values for project IDs, we need to merge the values in
-          const singleAndMultiChoiceFields = filterSelectFields(
-            searchColumns.filter((column) => column !== 'project_name')
-          );
-
-          const allValues =
-            (await SeedBankService.searchFieldValues(singleAndMultiChoiceFields, {}, selectedOrganization.id)) || {};
-
-          if (featureFlagProjects) {
-            allValues.project_name = {
-              partial: false,
-              values: (projects || []).map((project: Project) => project.name),
-            };
-          }
-
-          if (activeRequests) {
-            setFieldOptions(allValues);
-          }
-        };
-
-        if (searchCriteria) {
-          void populateSearchResults();
+        if (featureFlagProjects) {
+          allValues.project_name = {
+            partial: false,
+            values: (projects || []).map((project: Project) => project.name),
+          };
         }
 
-        void populateAvailableFieldOptions();
-        void populateFieldOptions();
+        if (requestId === getRequestId('accessions_search_all_values')) {
+          setFieldOptions(allValues);
+        }
+      };
+
+      if (searchCriteria) {
+        void populateSearchResults();
       }
-    },
-    [featureFlagProjects, projects, searchColumns, searchCriteria, searchSortOrder, selectedOrganization]
-  );
+
+      void populateAvailableFieldOptions();
+      void populateFieldOptions();
+    }
+  }, [featureFlagProjects, projects, searchColumns, searchCriteria, searchSortOrder, selectedOrganization]);
 
   useEffect(() => {
-    let activeRequests = true;
-
-    void initAccessions(activeRequests);
-
-    return () => {
-      activeRequests = false;
-    };
+    void initAccessions();
   }, [initAccessions]);
 
   useEffect(() => {
@@ -687,7 +682,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
   }, [searchResults]);
 
   const reloadAccessions = useCallback(() => {
-    void initAccessions(true);
+    void initAccessions();
   }, [initAccessions]);
 
   return (

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -437,8 +437,9 @@ export default function Database(props: DatabaseProps): JSX.Element {
     };
 
     if (selectedOrganization) {
+      const requestId = setRequestId('accessions_search');
+
       const populateSearchResults = async () => {
-        const requestId = setRequestId('accessions_search');
         const apiResponse: SearchResponseElementWithId[] | null = await SeedBankService.searchAccessions({
           organizationId: selectedOrganization.id,
           fields: getFieldsFromSearchColumns(),
@@ -452,7 +453,6 @@ export default function Database(props: DatabaseProps): JSX.Element {
       };
 
       const populateAvailableFieldOptions = async () => {
-        const requestId = setRequestId('accessions_search_available_values');
         const singleAndMultiChoiceFields = filterSelectFields(searchColumns);
         const data = await SeedBankService.searchFieldValues(
           singleAndMultiChoiceFields,
@@ -460,13 +460,12 @@ export default function Database(props: DatabaseProps): JSX.Element {
           selectedOrganization.id
         );
 
-        if (requestId === getRequestId('accessions_search_available_values')) {
+        if (requestId === getRequestId('accessions_search')) {
           setAvailableFieldOptions(data);
         }
       };
 
       const populateFieldOptions = async () => {
-        const requestId = setRequestId('accessions_search_all_values');
         // Since the seed bank service doesn't return values for project IDs, we need to merge the values in
         const singleAndMultiChoiceFields = filterSelectFields(
           searchColumns.filter((column) => column !== 'project_name')
@@ -482,7 +481,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
           };
         }
 
-        if (requestId === getRequestId('accessions_search_all_values')) {
+        if (requestId === getRequestId('accessions_search')) {
           setFieldOptions(allValues);
         }
       };

--- a/src/utils/requestsId.tsx
+++ b/src/utils/requestsId.tsx
@@ -4,8 +4,9 @@ export type RequestIds = {
 
 export const requestIds: RequestIds = {};
 
-export const setRequestId = (key: string, id: string) => {
+export const setRequestId = (key: string, id?: string): string => {
   requestIds[key] = id || Math.random().toString();
+  return getRequestId(key);
 };
 
 export const getRequestId = (key: string): string => requestIds[key] || '';


### PR DESCRIPTION
- when we first load the page and it already has filters in the url (such as when visiting from the dashboard links), there are 
a bunch of requests in-flight in succession and existing mechanism to handle races is faulty
- applying another mechanism which we use across the board, not the most elegant but it works