### PR TITLE
SW-4961 Global roles redux and service layer

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -48,6 +48,14 @@ export interface paths {
      */
     put: operations["updateSubmission"];
   };
+  "/api/v1/accelerator/globalRoles/users": {
+    /** Gets the list of users that have global roles. */
+    get: operations["listGlobalRoles"];
+  };
+  "/api/v1/accelerator/globalRoles/users/{userId}": {
+    /** Apply the supplied global roles to the user. */
+    post: operations["updateGlobalRoles"];
+  };
   "/api/v1/automations": {
     /** Gets a list of automations for a device or facility. */
     get: operations["listAutomations"];
@@ -2368,6 +2376,10 @@ export interface components {
       status: components["schemas"]["SuccessOrError"];
       withdrawals: components["schemas"]["GetWithdrawalPayload"][];
     };
+    GlobalRoleUsersListResponsePayload: {
+      status: components["schemas"]["SuccessOrError"];
+      users: components["schemas"]["UserWithGlobalRolesPayload"][];
+    };
     GoalProgressPayloadV1: {
       /** @enum {string} */
       goal: "NoPoverty" | "ZeroHunger" | "GoodHealth" | "QualityEducation" | "GenderEquality" | "CleanWater" | "AffordableEnergy" | "DecentWork" | "Industry" | "ReducedInequalities" | "SustainableCities" | "ResponsibleConsumption" | "ClimateAction" | "LifeBelowWater" | "LifeOnLand" | "Peace" | "Partnerships";
@@ -3489,6 +3501,9 @@ export interface components {
      * @enum {string}
      */
     SuccessOrError: "ok" | "error";
+    SuccessResponsePayload: {
+      status: components["schemas"]["SuccessOrError"];
+    };
     SummarizeAccessionSearchRequestPayload: {
       search?: components["schemas"]["AndNodePayload"] | components["schemas"]["FieldNodePayload"] | components["schemas"]["NotNodePayload"] | components["schemas"]["OrNodePayload"];
     };
@@ -3779,6 +3794,9 @@ export interface components {
        */
       timeZone?: string;
     };
+    UpdateGlobalRolesRequestPayload: {
+      globalRoles: string[];
+    };
     UpdateNotificationRequestPayload: {
       read: boolean;
     };
@@ -4014,6 +4032,14 @@ export interface components {
        * @example America/New_York
        */
       timeZone?: string;
+    };
+    UserWithGlobalRolesPayload: {
+      email: string;
+      firstName?: string;
+      globalRoles: ("Super-Admin" | "Accelerator Admin" | "TF Expert" | "Read Only")[];
+      /** Format: int64 */
+      id: number;
+      lastName?: string;
     };
     VersionsEntryPayload: {
       appName: string;
@@ -4282,6 +4308,44 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["SimpleSuccessResponsePayload"];
+        };
+      };
+    };
+  };
+  /** Gets the list of users that have global roles. */
+  listGlobalRoles: {
+    responses: {
+      /** @description The requested operation succeeded. */
+      200: {
+        content: {
+          "application/json": components["schemas"]["GlobalRoleUsersListResponsePayload"];
+        };
+      };
+    };
+  };
+  /** Apply the supplied global roles to the user. */
+  updateGlobalRoles: {
+    parameters: {
+      path: {
+        userId: number;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UpdateGlobalRolesRequestPayload"];
+      };
+    };
+    responses: {
+      /** @description The requested operation succeeded. */
+      200: {
+        content: {
+          "application/json": components["schemas"]["SuccessResponsePayload"];
+        };
+      };
+      /** @description The requested resource was not found. */
+      404: {
+        content: {
+          "application/json": components["schemas"]["SimpleErrorResponsePayload"];
         };
       };
     };

--- a/src/redux/features/globalRoles/globalRolesAsyncThunks.ts
+++ b/src/redux/features/globalRoles/globalRolesAsyncThunks.ts
@@ -1,0 +1,42 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+import GlobalRolesService from 'src/services/GlobalRolesService';
+import { Response } from 'src/services/HttpService';
+import strings from 'src/strings';
+import { GlobalRole, UserWithGlobalRoles } from 'src/types/GlobalRoles';
+import { SearchNodePayload, SearchSortOrder } from 'src/types/Search';
+
+export const requestListGlobalRolesUsers = createAsyncThunk(
+  'globalRoles/list',
+  async (
+    request: {
+      locale: string | null;
+      search?: SearchNodePayload;
+      searchSortOrder?: SearchSortOrder;
+    },
+    { rejectWithValue }
+  ) => {
+    const { locale, search, searchSortOrder } = request;
+
+    const response = await GlobalRolesService.list(locale, search, searchSortOrder);
+    if (response) {
+      return response;
+    }
+
+    return rejectWithValue(strings.GENERIC_ERROR);
+  }
+);
+
+export const requestUpdateGlobalRolesUser = createAsyncThunk(
+  'globalRoles/update-for-user',
+  async (request: { user: UserWithGlobalRoles; globalRole: GlobalRole }, { rejectWithValue }) => {
+    const { user, globalRole } = request;
+
+    const response: Response = await GlobalRolesService.update(user, globalRole);
+    if (response && response.requestSucceeded) {
+      return user.id;
+    }
+
+    return rejectWithValue(strings.GENERIC_ERROR);
+  }
+);

--- a/src/redux/features/globalRoles/globalRolesSelectors.ts
+++ b/src/redux/features/globalRoles/globalRolesSelectors.ts
@@ -1,0 +1,7 @@
+import { RootState } from 'src/redux/rootReducer';
+
+export const selectGlobalRolesUsersSearchRequest = (requestId: string) => (state: RootState) =>
+  state.globalRolesUsersList[requestId];
+
+export const selectGlobalRolesUserUpdateRequest = (requestId: string) => (state: RootState) =>
+  state.globalRolesUserUpdate[requestId];

--- a/src/redux/features/globalRoles/globalRolesSlice.ts
+++ b/src/redux/features/globalRoles/globalRolesSlice.ts
@@ -1,0 +1,38 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import { StatusT, buildReducers } from 'src/redux/features/asyncUtils';
+import { requestListGlobalRolesUsers, requestUpdateGlobalRolesUser } from './globalRolesAsyncThunks';
+import { GlobalRolesUsersData } from 'src/types/GlobalRoles';
+
+/**
+ * Users with global roles list
+ */
+const initialStateGlobalRolesUsersList: { [key: string]: StatusT<GlobalRolesUsersData> } = {};
+
+export const globalRolesUsersListSlice = createSlice({
+  name: 'globalRolesUsersListSlice',
+  initialState: initialStateGlobalRolesUsersList,
+  reducers: {},
+  extraReducers: (builder) => {
+    buildReducers(requestListGlobalRolesUsers)(builder);
+  },
+});
+
+export const globalRolesUsersListReducer = globalRolesUsersListSlice.reducer;
+
+/**
+ * Simple OK/response for requests updating a user's global roles, keeps
+ * state of user id that was edited.
+ */
+const initialStateGlobalRolesUserUpdate: { [key: number | string]: StatusT<number> } = {};
+
+export const globalRolesUserUpdateSlice = createSlice({
+  name: 'globalRolesUserUpdateSlice',
+  initialState: initialStateGlobalRolesUserUpdate,
+  reducers: {},
+  extraReducers: (builder) => {
+    buildReducers(requestUpdateGlobalRolesUser)(builder);
+  },
+});
+
+export const globalRolesUserUpdateReducer = globalRolesUserUpdateSlice.reducer;

--- a/src/redux/features/globalRoles/globalRolesSlice.ts
+++ b/src/redux/features/globalRoles/globalRolesSlice.ts
@@ -1,8 +1,9 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 import { StatusT, buildReducers } from 'src/redux/features/asyncUtils';
-import { requestListGlobalRolesUsers, requestUpdateGlobalRolesUser } from './globalRolesAsyncThunks';
 import { GlobalRolesUsersData } from 'src/types/GlobalRoles';
+
+import { requestListGlobalRolesUsers, requestUpdateGlobalRolesUser } from './globalRolesAsyncThunks';
 
 /**
  * Users with global roles list

--- a/src/redux/rootReducer.ts
+++ b/src/redux/rootReducer.ts
@@ -12,6 +12,10 @@ import {
   draftPlantingSiteGetReducer,
   draftPlantingSiteSearchReducer,
 } from 'src/redux/features/draftPlantingSite/draftPlantingSiteSlice';
+import {
+  globalRolesUserUpdateReducer,
+  globalRolesUsersListReducer,
+} from 'src/redux/features/globalRoles/globalRolesSlice';
 import { projectsReducer, projectsRequestsReducer } from 'src/redux/features/projects/projectsSlice';
 import { reportsSettingsReducer } from 'src/redux/features/reportsSettings/reportsSettingsSlice';
 import { speciesProjectsReducer } from 'src/redux/features/species/speciesProjectsSlice';
@@ -61,6 +65,8 @@ export const reducers = {
   draftPlantingSiteEdit: draftPlantingSiteEditReducer,
   draftPlantingSiteGet: draftPlantingSiteGetReducer,
   draftPlantingSiteSearch: draftPlantingSiteSearchReducer,
+  globalRolesUsersList: globalRolesUsersListReducer,
+  globalRolesUserUpdate: globalRolesUserUpdateReducer,
   message: messageReducer,
   monitoringPlots: monitoringPlotsReducer,
   observations: observationsReducer,

--- a/src/scenes/AcceleratorRouter/PeopleView.tsx
+++ b/src/scenes/AcceleratorRouter/PeopleView.tsx
@@ -36,6 +36,7 @@ const PeopleView = () => {
     setRequestId(request.requestId);
   }, [activeLocale, dispatch]);
 
+  // tslint:disable:no-console
   console.log('globalRoleUsers', globalRoleUsers);
 
   return <AcceleratorMain />;

--- a/src/scenes/AcceleratorRouter/PeopleView.tsx
+++ b/src/scenes/AcceleratorRouter/PeopleView.tsx
@@ -1,8 +1,43 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
+import { useLocalization } from 'src/providers';
+import { requestListGlobalRolesUsers } from 'src/redux/features/globalRoles/globalRolesAsyncThunks';
+import { selectGlobalRolesUsersSearchRequest } from 'src/redux/features/globalRoles/globalRolesSelectors';
+import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import AcceleratorMain from 'src/scenes/AcceleratorRouter/AcceleratorMain';
+import strings from 'src/strings';
+import { UserWithGlobalRoles } from 'src/types/GlobalRoles';
+import useSnackbar from 'src/utils/useSnackbar';
 
 const PeopleView = () => {
+  const dispatch = useAppDispatch();
+  const snackbar = useSnackbar();
+  const { activeLocale } = useLocalization();
+
+  const [globalRoleUsers, setGlobalRoleUsers] = useState<UserWithGlobalRoles[]>();
+  const [requestId, setRequestId] = useState('');
+
+  const listRequest = useAppSelector(selectGlobalRolesUsersSearchRequest(requestId));
+
+  useEffect(() => {
+    if (!listRequest) {
+      return;
+    }
+
+    if (listRequest.status === 'success') {
+      setGlobalRoleUsers(listRequest.data?.users);
+    } else if (listRequest.status === 'error') {
+      snackbar.toastError(strings.GENERIC_ERROR);
+    }
+  }, [listRequest, snackbar]);
+
+  useEffect(() => {
+    const request = dispatch(requestListGlobalRolesUsers({ locale: activeLocale }));
+    setRequestId(request.requestId);
+  }, [activeLocale, dispatch]);
+
+  console.log('globalRoleUsers', globalRoleUsers);
+
   return <AcceleratorMain />;
 };
 

--- a/src/services/GlobalRolesService.ts
+++ b/src/services/GlobalRolesService.ts
@@ -1,0 +1,67 @@
+import { paths } from 'src/api/types/generated-schema';
+import HttpService, { Params, Response } from 'src/services/HttpService';
+import { GlobalRole, GlobalRolesUsersData, UserWithGlobalRoles } from 'src/types/GlobalRoles';
+import { SearchNodePayload, SearchSortOrder } from 'src/types/Search';
+import { SearchOrderConfig, searchAndSort } from 'src/utils/searchAndSort';
+
+/**
+ * Accelerator "globalRole" related services
+ */
+
+const ENDPOINT_GLOBAL_ROLES_USERS = '/api/v1/accelerator/globalRoles/users';
+const ENDPOINT_GLOBAL_ROLES_USER = '/api/v1/accelerator/globalRoles/users/{userId}';
+
+export type GlobalRoleUsersListResponsePayload =
+  paths[typeof ENDPOINT_GLOBAL_ROLES_USERS]['get']['responses'][200]['content']['application/json'];
+
+export type UpdateGlobalRolesRequestPayload =
+  paths[typeof ENDPOINT_GLOBAL_ROLES_USER]['post']['requestBody']['content']['application/json'];
+export type UpdateGlobalRolesResponsePayload =
+  paths[typeof ENDPOINT_GLOBAL_ROLES_USER]['post']['responses'][200]['content']['application/json'];
+
+const httpGlobalRolesUsers = HttpService.root(ENDPOINT_GLOBAL_ROLES_USERS);
+const httpGlobalRolesUser = HttpService.root(ENDPOINT_GLOBAL_ROLES_USER);
+
+const update = async (user: UserWithGlobalRoles, globalRole: GlobalRole): Promise<Response> => {
+  const payload: UpdateGlobalRolesRequestPayload = {
+    globalRoles: [...user.globalRoles, globalRole],
+  };
+
+  return httpGlobalRolesUser.post2<UpdateGlobalRolesResponsePayload>({
+    urlReplacements: {
+      '{userId}': `${user.id}`,
+    },
+    entity: payload,
+  });
+};
+
+const list = async (
+  locale: string | null,
+  search?: SearchNodePayload,
+  searchSortOrder?: SearchSortOrder
+): Promise<(GlobalRolesUsersData & Response) | null> => {
+  let searchOrderConfig: SearchOrderConfig;
+  if (searchSortOrder) {
+    searchOrderConfig = {
+      locale,
+      sortOrder: searchSortOrder,
+      numberFields: ['id'],
+    };
+  }
+
+  return httpGlobalRolesUsers.get<GlobalRoleUsersListResponsePayload, GlobalRolesUsersData>(
+    {
+      params: {} as Params,
+    },
+    (data) => ({
+      users: searchAndSort(data?.users || [], search, searchOrderConfig),
+    })
+  );
+};
+
+const GlobalRolesService = {
+  list,
+  update,
+};
+
+export default GlobalRolesService;

--- a/src/types/GlobalRoles.ts
+++ b/src/types/GlobalRoles.ts
@@ -1,0 +1,10 @@
+import { components } from 'src/api/types/generated-schema';
+
+export type UserWithGlobalRoles = components['schemas']['UserWithGlobalRolesPayload'];
+
+export type GlobalRole = UserWithGlobalRoles['globalRoles'][0];
+export const GlobalRoles: GlobalRole[] = ['Super-Admin', 'Accelerator Admin', 'TF Expert', 'Read Only'];
+
+export type GlobalRolesUsersData = {
+  users: UserWithGlobalRoles[];
+};


### PR DESCRIPTION
- Add new types from global roles API from BE
- Add redux for the global roles users search and user update
- Stub out the request dispatch / select within the accelerator `PeopleView`