### PR TITLE
SW-4953: UI to assign cohorts to modules

### DIFF
--- a/src/redux/features/cohorts/cohortsAsyncThunks.ts
+++ b/src/redux/features/cohorts/cohortsAsyncThunks.ts
@@ -1,6 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
-import { setCohortAction, setCohortsAction } from 'src/redux/features/cohorts/cohortsSlice';
+import { setCohortAction, setCohortModulesAction, setCohortsAction } from 'src/redux/features/cohorts/cohortsSlice';
 import CohortService, {
   CreateCohortResponsePayload,
   DeleteCohortResponsePayload,
@@ -9,7 +9,7 @@ import CohortService, {
 } from 'src/services/CohortService';
 import { Response2 } from 'src/services/HttpService';
 import strings from 'src/strings';
-import { Cohort, CreateCohortRequestPayload, UpdateCohortRequestPayload } from 'src/types/Cohort';
+import { Cohort, CreateCohortRequestPayload, MockModule, UpdateCohortRequestPayload } from 'src/types/Cohort';
 
 export const requestCohorts = createAsyncThunk(
   'cohorts/list',
@@ -33,6 +33,19 @@ export const requestCohort = createAsyncThunk(
     if (response !== null && response.requestSucceeded && response.data !== undefined) {
       dispatch(setCohortAction({ error: response.error, cohorts: [response.data] }));
       return response.data;
+    }
+
+    return rejectWithValue(strings.GENERIC_ERROR);
+  }
+);
+
+export const requestCohortModules = createAsyncThunk(
+  'cohorts/modules',
+  async (request: { cohortId: number; }, { dispatch, rejectWithValue }) => {
+    const response: Response2<MockModule[]>  = await CohortService.listCohortModules(request.cohortId);
+
+    if (response !== null && response.requestSucceeded && response.data !== undefined) {
+      dispatch(setCohortModulesAction({ cohortId: request.cohortId, error: response.error, modules: response.data }));
     }
 
     return rejectWithValue(strings.GENERIC_ERROR);

--- a/src/redux/features/cohorts/cohortsAsyncThunks.ts
+++ b/src/redux/features/cohorts/cohortsAsyncThunks.ts
@@ -9,7 +9,7 @@ import CohortService, {
 } from 'src/services/CohortService';
 import { Response2 } from 'src/services/HttpService';
 import strings from 'src/strings';
-import { Cohort, CreateCohortRequestPayload, MockModule, UpdateCohortRequestPayload } from 'src/types/Cohort';
+import { Cohort, CreateCohortRequestPayload, MockCohortModule, UpdateCohortRequestPayload } from 'src/types/Cohort';
 
 export const requestCohorts = createAsyncThunk(
   'cohorts/list',
@@ -42,7 +42,7 @@ export const requestCohort = createAsyncThunk(
 export const requestCohortModules = createAsyncThunk(
   'cohorts/modules',
   async (request: { cohortId: number }, { dispatch, rejectWithValue }) => {
-    const response: Response2<MockModule[]> = await CohortService.listCohortModules(request.cohortId);
+    const response: Response2<MockCohortModule[]> = await CohortService.listCohortModules(request.cohortId);
 
     if (response !== null && response.requestSucceeded && response.data !== undefined) {
       dispatch(setCohortModulesAction({ cohortId: request.cohortId, error: response.error, modules: response.data }));

--- a/src/redux/features/cohorts/cohortsAsyncThunks.ts
+++ b/src/redux/features/cohorts/cohortsAsyncThunks.ts
@@ -41,8 +41,8 @@ export const requestCohort = createAsyncThunk(
 
 export const requestCohortModules = createAsyncThunk(
   'cohorts/modules',
-  async (request: { cohortId: number; }, { dispatch, rejectWithValue }) => {
-    const response: Response2<MockModule[]>  = await CohortService.listCohortModules(request.cohortId);
+  async (request: { cohortId: number }, { dispatch, rejectWithValue }) => {
+    const response: Response2<MockModule[]> = await CohortService.listCohortModules(request.cohortId);
 
     if (response !== null && response.requestSucceeded && response.data !== undefined) {
       dispatch(setCohortModulesAction({ cohortId: request.cohortId, error: response.error, modules: response.data }));

--- a/src/redux/features/cohorts/cohortsSelectors.ts
+++ b/src/redux/features/cohorts/cohortsSelectors.ts
@@ -9,3 +9,5 @@ export const selectCohort =
     state.cohorts?.cohorts?.find((cohort) => cohort.id === cohortId);
 
 export const selectCohortRequest = (state: RootState, requestId: string) => state.cohortsRequests[requestId];
+
+export const selectCohortModules = (state: RootState, cohortId: number) => state.cohortModules[cohortId];

--- a/src/redux/features/cohorts/cohortsSlice.ts
+++ b/src/redux/features/cohorts/cohortsSlice.ts
@@ -3,7 +3,7 @@ import { ActionReducerMapBuilder, PayloadAction, createSlice } from '@reduxjs/to
 import { StatusT, buildReducers } from 'src/redux/features/asyncUtils';
 import { requestCohortDelete, requestCohortUpdate } from 'src/redux/features/cohorts/cohortsAsyncThunks';
 import { UpdateCohortResponsePayload } from 'src/services/CohortService';
-import { Cohort, MockModule } from 'src/types/Cohort';
+import { Cohort, MockCohortModule } from 'src/types/Cohort';
 
 // Define a type for the slice state
 type Data = {
@@ -63,12 +63,12 @@ export const cohortsRequestsReducer = cohortsRequestsSlice.reducer;
 type CohortId = number;
 
 // Define a type for the slice state
-type CohortModulesState = Record<CohortId, MockModule[]>;
+type CohortModulesState = Record<CohortId, MockCohortModule[]>;
 
 type CohortModulesData = {
   cohortId: CohortId;
   error?: string;
-  modules?: MockModule[];
+  modules?: MockCohortModule[];
 };
 
 const initialCohortModulesState: CohortModulesState = {};

--- a/src/redux/features/cohorts/cohortsSlice.ts
+++ b/src/redux/features/cohorts/cohortsSlice.ts
@@ -3,7 +3,7 @@ import { ActionReducerMapBuilder, PayloadAction, createSlice } from '@reduxjs/to
 import { StatusT, buildReducers } from 'src/redux/features/asyncUtils';
 import { requestCohortDelete, requestCohortUpdate } from 'src/redux/features/cohorts/cohortsAsyncThunks';
 import { UpdateCohortResponsePayload } from 'src/services/CohortService';
-import { Cohort } from 'src/types/Cohort';
+import { Cohort, MockModule } from 'src/types/Cohort';
 
 // Define a type for the slice state
 type Data = {
@@ -55,3 +55,35 @@ export const cohortsRequestsSlice = createSlice({
 });
 
 export const cohortsRequestsReducer = cohortsRequestsSlice.reducer;
+
+/**
+ * Cohort modules list
+ */
+
+type CohortId = number;
+
+// Define a type for the slice state
+type CohortModulesState = Record<CohortId, MockModule[]>;
+
+type CohortModulesData = {
+  cohortId: CohortId;
+  error?: string;
+  modules?: MockModule[];
+};
+
+const initialCohortModulesState: CohortModulesState = {};
+
+export const cohortModulesSlice = createSlice({
+  name: 'cohortModulesSlice',
+  initialState: initialCohortModulesState,
+  reducers: {
+    setCohortModulesAction: (state, action: PayloadAction<CohortModulesData>) => {
+      if (action.payload.cohortId && action.payload.modules) {
+        state[action.payload.cohortId] = action.payload.modules;
+      }
+    }
+  },
+});
+
+export const { setCohortModulesAction } = cohortModulesSlice.actions;
+export const cohortModulesReducer = cohortModulesSlice.reducer;

--- a/src/redux/features/cohorts/cohortsSlice.ts
+++ b/src/redux/features/cohorts/cohortsSlice.ts
@@ -81,7 +81,7 @@ export const cohortModulesSlice = createSlice({
       if (action.payload.cohortId && action.payload.modules) {
         state[action.payload.cohortId] = action.payload.modules;
       }
-    }
+    },
   },
 });
 

--- a/src/redux/rootReducer.ts
+++ b/src/redux/rootReducer.ts
@@ -1,6 +1,6 @@
 import { Action, combineReducers } from '@reduxjs/toolkit';
 
-import { cohortsReducer, cohortsRequestsReducer } from 'src/redux/features/cohorts/cohortsSlice';
+import { cohortModulesReducer, cohortsReducer, cohortsRequestsReducer } from 'src/redux/features/cohorts/cohortsSlice';
 import {
   deliverablesEditReducer,
   deliverablesReducer,
@@ -52,6 +52,7 @@ export const reducers = {
   appVersion: appVersionReducer,
   batches: batchesReducer,
   batchesRequests: batchesRequestsReducer,
+  cohortModules: cohortModulesReducer,
   cohorts: cohortsReducer,
   cohortsRequests: cohortsRequestsReducer,
   deliverablesEdit: deliverablesEditReducer,

--- a/src/scenes/AcceleratorRouter/CohortView.tsx
+++ b/src/scenes/AcceleratorRouter/CohortView.tsx
@@ -71,7 +71,13 @@ const CohortView = () => {
             <TextField label={strings.PHASE} id='phase' type='text' value={cohort?.phase} display={true} />
           </Grid>
           <Grid item xs={12}>
-            <TextField label="Modules" id='phase' type='text' value={cohortModules?.map(module => module.name).join(', ')} display={true} />
+            <TextField
+              label='Modules'
+              id='phase'
+              type='text'
+              value={cohortModules?.map((module) => module.name).join(', ')}
+              display={true}
+            />
           </Grid>
         </Grid>
       </Card>

--- a/src/scenes/AcceleratorRouter/CohortView.tsx
+++ b/src/scenes/AcceleratorRouter/CohortView.tsx
@@ -63,7 +63,7 @@ const CohortView = () => {
   return (
     <Page crumbs={crumbs} title={cohort?.name || ''} rightComponent={rightComponent}>
       <Card flushMobile style={{ display: 'flex', flexDirection: 'column', flexGrow: 1, borderRadius: '24px' }}>
-        <Grid container>
+        <Grid container spacing={3}>
           <Grid item xs={4}>
             <TextField label={strings.NAME} id='name' type='text' value={cohort?.name} display={true} />
           </Grid>

--- a/src/scenes/AcceleratorRouter/CohortView.tsx
+++ b/src/scenes/AcceleratorRouter/CohortView.tsx
@@ -11,7 +11,7 @@ import TextField from 'src/components/common/Textfield/Textfield';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
 import { useLocalization, useUser } from 'src/providers';
-import { requestCohort } from 'src/redux/features/cohorts/cohortsAsyncThunks';
+import { requestCohort, requestCohortModules } from 'src/redux/features/cohorts/cohortsAsyncThunks';
 import { selectCohort } from 'src/redux/features/cohorts/cohortsSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
@@ -28,9 +28,11 @@ const CohortView = () => {
   const cohortId = Number(pathParams.cohortId);
 
   const cohort = useAppSelector(selectCohort(cohortId));
+  const cohortModules = useAppSelector((state) => state.cohortModules[cohortId]);
 
   useEffect(() => {
     void dispatch(requestCohort({ cohortId }));
+    void dispatch(requestCohortModules({ cohortId }));
   }, [cohortId, dispatch]);
 
   const goToEditCohort = useCallback(
@@ -67,6 +69,9 @@ const CohortView = () => {
           </Grid>
           <Grid item xs={8}>
             <TextField label={strings.PHASE} id='phase' type='text' value={cohort?.phase} display={true} />
+          </Grid>
+          <Grid item xs={12}>
+            <TextField label="Modules" id='phase' type='text' value={cohortModules?.map(module => module.name).join(', ')} display={true} />
           </Grid>
         </Grid>
       </Card>

--- a/src/services/CohortService.ts
+++ b/src/services/CohortService.ts
@@ -66,7 +66,6 @@ const deleteCohort = (cohortId: number) =>
     urlReplacements: { '{cohortId}': `${cohortId}` },
   });
 
-
 /**
  * List module(s) for a cohort
  */
@@ -84,15 +83,12 @@ type MockModule = {
 // TODO: remove mock data when BE is done
 let mockResponseData: MockModule[] = [];
 
-const listCohortModules = async (
-  cohortId: number,
-): Promise<Response2<MockModule[]>> =>
+const listCohortModules = async (cohortId: number): Promise<Response2<MockModule[]>> =>
   new Promise((resolve) => {
     setTimeout(() => {
-      resolve({ data: mockResponseData, requestSucceeded: true});
+      resolve({ data: mockResponseData, requestSucceeded: true });
     }, 300);
-  }
-  );
+  });
 
 /**
  * Exported functions
@@ -161,4 +157,3 @@ mockResponseData = [
     updatedAt: '2021-01-01T00:00:00Z',
   },
 ];
-

--- a/src/services/CohortService.ts
+++ b/src/services/CohortService.ts
@@ -66,15 +66,99 @@ const deleteCohort = (cohortId: number) =>
     urlReplacements: { '{cohortId}': `${cohortId}` },
   });
 
+
+/**
+ * List module(s) for a cohort
+ */
+type MockModule = {
+  id: number;
+  name: string;
+  description: string;
+  duration: number;
+  order: number;
+  status: 'draft' | 'published';
+  createdAt: string;
+  updatedAt: string;
+};
+
+// TODO: remove mock data when BE is done
+let mockResponseData: MockModule[] = [];
+
+const listCohortModules = async (
+  cohortId: number,
+): Promise<Response2<MockModule[]>> =>
+  new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({ data: mockResponseData, requestSucceeded: true});
+    }, 300);
+  }
+  );
+
 /**
  * Exported functions
  */
 const CohortService = {
-  listCohorts,
   createCohort,
-  getCohort,
-  updateCohort,
   deleteCohort,
+  getCohort,
+  listCohortModules,
+  listCohorts,
+  updateCohort,
 };
 
 export default CohortService;
+
+// TODO: remove mock data once BE is done
+mockResponseData = [
+  {
+    id: 1,
+    name: 'Module 1',
+    description: 'Module 1 description',
+    duration: 3,
+    order: 1,
+    status: 'published',
+    createdAt: '2021-01-01T00:00:00Z',
+    updatedAt: '2021-01-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    name: 'Module 2',
+    description: 'Module 2 description',
+    duration: 5,
+    order: 2,
+    status: 'published',
+    createdAt: '2021-01-01T00:00:00Z',
+    updatedAt: '2021-01-01T00:00:00Z',
+  },
+  {
+    id: 3,
+    name: 'Module 3',
+    description: 'Module 3 description',
+    duration: 7,
+    order: 3,
+    status: 'published',
+    createdAt: '2021-01-01T00:00:00Z',
+    updatedAt: '2021-01-01T00:00:00Z',
+  },
+  {
+    id: 4,
+    name: 'Module 4',
+    description: 'Module 4 description',
+    duration: 9,
+    order: 4,
+    status: 'published',
+    createdAt: '2021-01-01T00:00:00Z',
+    updatedAt: '2021-01-01T00:00:00Z',
+  },
+  {
+    id: 5,
+    name: 'Module 5',
+    description: 'Module 5 description',
+    duration: 11,
+    order: 5,
+    status: 'published',
+    createdAt: '2021-01-01T00:00:00Z',
+    updatedAt: '2021-01-01T00:00:00Z',
+  },
+];
+

--- a/src/services/CohortService.ts
+++ b/src/services/CohortService.ts
@@ -1,6 +1,6 @@
 import { paths } from 'src/api/types/generated-schema';
 import HttpService, { Response, Response2 } from 'src/services/HttpService';
-import { Cohort, CreateCohortRequestPayload, UpdateCohortRequestPayload } from 'src/types/Cohort';
+import { Cohort, CreateCohortRequestPayload, MockCohortModule, UpdateCohortRequestPayload } from 'src/types/Cohort';
 
 /**
  * Cohort related services
@@ -69,21 +69,10 @@ const deleteCohort = (cohortId: number) =>
 /**
  * List module(s) for a cohort
  */
-type MockModule = {
-  id: number;
-  name: string;
-  description: string;
-  duration: number;
-  order: number;
-  status: 'draft' | 'published';
-  createdAt: string;
-  updatedAt: string;
-};
-
 // TODO: remove mock data when BE is done
-let mockResponseData: MockModule[] = [];
+let mockResponseData: MockCohortModule[] = [];
 
-const listCohortModules = async (cohortId: number): Promise<Response2<MockModule[]>> =>
+const listCohortModules = async (cohortId: number): Promise<Response2<MockCohortModule[]>> =>
   new Promise((resolve) => {
     setTimeout(() => {
       resolve({ data: mockResponseData, requestSucceeded: true });

--- a/src/services/CohortService.ts
+++ b/src/services/CohortService.ts
@@ -96,7 +96,8 @@ export default CohortService;
 // TODO: remove mock data once BE is done
 mockResponseData = [
   {
-    id: 1,
+    cohortId: 1,
+    moduleId: 1,
     name: 'Module 1',
     description: 'Module 1 description',
     duration: 3,
@@ -106,7 +107,8 @@ mockResponseData = [
     updatedAt: '2021-01-01T00:00:00Z',
   },
   {
-    id: 2,
+    cohortId: 1,
+    moduleId: 2,
     name: 'Module 2',
     description: 'Module 2 description',
     duration: 5,
@@ -116,7 +118,8 @@ mockResponseData = [
     updatedAt: '2021-01-01T00:00:00Z',
   },
   {
-    id: 3,
+    cohortId: 1,
+    moduleId: 3,
     name: 'Module 3',
     description: 'Module 3 description',
     duration: 7,
@@ -126,7 +129,8 @@ mockResponseData = [
     updatedAt: '2021-01-01T00:00:00Z',
   },
   {
-    id: 4,
+    cohortId: 1,
+    moduleId: 4,
     name: 'Module 4',
     description: 'Module 4 description',
     duration: 9,
@@ -136,7 +140,8 @@ mockResponseData = [
     updatedAt: '2021-01-01T00:00:00Z',
   },
   {
-    id: 5,
+    cohortId: 1,
+    moduleId: 5,
     name: 'Module 5',
     description: 'Module 5 description',
     duration: 11,

--- a/src/types/Cohort.ts
+++ b/src/types/Cohort.ts
@@ -6,10 +6,11 @@ export type CreateCohortRequestPayload = components['schemas']['CreateCohortRequ
 export type UpdateCohortRequestPayload = components['schemas']['UpdateCohortRequestPayload'];
 
 export type MockCohortModule = {
+  cohortId: number;
   createdAt: string;
   description: string;
   duration: number;
-  id: number;
+  moduleId: number;
   name: string;
   order: number;
   status: 'draft' | 'published';

--- a/src/types/Cohort.ts
+++ b/src/types/Cohort.ts
@@ -4,3 +4,14 @@ export type Cohort = components['schemas']['CohortPayload'];
 
 export type CreateCohortRequestPayload = components['schemas']['CreateCohortRequestPayload'];
 export type UpdateCohortRequestPayload = components['schemas']['UpdateCohortRequestPayload'];
+
+export type MockModule = {
+  createdAt: string;
+  description: string;
+  duration: number;
+  id: number;
+  name: string;
+  order: number;
+  status: 'draft' | 'published';
+  updatedAt: string;
+};

--- a/src/types/Cohort.ts
+++ b/src/types/Cohort.ts
@@ -5,7 +5,7 @@ export type Cohort = components['schemas']['CohortPayload'];
 export type CreateCohortRequestPayload = components['schemas']['CreateCohortRequestPayload'];
 export type UpdateCohortRequestPayload = components['schemas']['UpdateCohortRequestPayload'];
 
-export type MockModule = {
+export type MockCohortModule = {
   createdAt: string;
   description: string;
   duration: number;


### PR DESCRIPTION
This PR includes changes to support showing related modules in the `CohortView`.

I'm not sure if there's an existing pattern for displaying a list of values as a form field, so I went the MVP route and just joined the text to create an inline list. I imagine we'd prefer to display this in a list at the very least and I'm happy to update, but I also imagine most of what's in this PR is incorrect/temporary and will be updated so wasn't sure if I should spend the time.

## Example

![localhost_3000_accelerator_cohorts_1](https://github.com/terraware/terraware-web/assets/1474361/55d00561-83a9-493d-b92e-fbb66331037a)
