### PR TITLE
SW-4873 SW-4967 Hide 'needs translation' status for participants

### DIFF
--- a/src/components/DeliverableView/DeliverableStatusBadge.tsx
+++ b/src/components/DeliverableView/DeliverableStatusBadge.tsx
@@ -4,6 +4,7 @@ import { useTheme } from '@mui/material';
 import { Badge } from '@terraware/web-components';
 import { BadgeProps } from '@terraware/web-components/components/Badge';
 
+import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import { useLocalization } from 'src/providers/hooks';
 import strings from 'src/strings';
 import { DeliverableStatusType } from 'src/types/Deliverables';
@@ -16,6 +17,7 @@ const DeliverableStatusBadge = (props: DeliverableStatusBadgeProps): JSX.Element
   const { status } = props;
   const { activeLocale } = useLocalization();
   const theme = useTheme();
+  const { isAcceleratorRoute } = useAcceleratorConsole();
 
   const badgeProps = useMemo((): BadgeProps | undefined => {
     if (!activeLocale) {
@@ -35,14 +37,14 @@ const DeliverableStatusBadge = (props: DeliverableStatusBadgeProps): JSX.Element
           backgroundColor: theme.palette.TwClrBgWarningTertiary,
           borderColor: theme.palette.TwClrBrdrWarning,
           labelColor: theme.palette.TwClrTxtWarning,
-          label: strings.APPROVED,
+          label: strings.IN_REVIEW,
         };
       case 'Needs Translation':
         return {
           backgroundColor: theme.palette.TwClrBgInfoTertiary,
           borderColor: theme.palette.TwClrBrdrInfo,
           labelColor: theme.palette.TwClrTxtInfo,
-          label: strings.APPROVED,
+          label: isAcceleratorRoute ? strings.NEEDS_TRANSLATION : strings.IN_REVIEW,
         };
       case 'Not Needed':
         return {
@@ -68,17 +70,9 @@ const DeliverableStatusBadge = (props: DeliverableStatusBadgeProps): JSX.Element
       default:
         return undefined;
     }
-  }, [activeLocale, status, theme]);
+  }, [activeLocale, isAcceleratorRoute, status, theme]);
 
-  return (
-    <>
-      {activeLocale && badgeProps ? (
-        <div style={{ float: 'right', marginBottom: '0px', marginLeft: '16px' }}>
-          <Badge {...badgeProps} />
-        </div>
-      ) : undefined}
-    </>
-  );
+  return <>{badgeProps && <Badge {...badgeProps} />}</>;
 };
 
 export default DeliverableStatusBadge;

--- a/src/components/DeliverableView/Metadata.tsx
+++ b/src/components/DeliverableView/Metadata.tsx
@@ -24,14 +24,18 @@ const Metadata = (props: ViewProps): JSX.Element => {
         >
           <InternalComment deliverable={deliverable} />
 
-          {deliverable.status !== 'Rejected' && <DeliverableStatusBadge status={deliverable.status} />}
+          <div style={{ float: 'right', marginBottom: '0px', marginLeft: '16px' }}>
+            {deliverable.status !== 'Rejected' && <DeliverableStatusBadge status={deliverable.status} />}
+          </div>
         </Box>
       )}
 
       <Box marginBottom='16px'>
-        {deliverable.status !== 'Rejected' && !isAcceleratorRoute && (
-          <DeliverableStatusBadge status={deliverable.status} />
-        )}
+        <div style={{ float: 'right', marginBottom: '0px', marginLeft: '16px' }}>
+          {deliverable.status !== 'Rejected' && !isAcceleratorRoute && (
+            <DeliverableStatusBadge status={deliverable.status} />
+          )}
+        </div>
 
         <div dangerouslySetInnerHTML={{ __html: deliverable.descriptionHtml || '' }} />
       </Box>

--- a/src/components/DeliverableView/Metadata.tsx
+++ b/src/components/DeliverableView/Metadata.tsx
@@ -24,18 +24,20 @@ const Metadata = (props: ViewProps): JSX.Element => {
         >
           <InternalComment deliverable={deliverable} />
 
-          <div style={{ float: 'right', marginBottom: '0px', marginLeft: '16px' }}>
-            {deliverable.status !== 'Rejected' && <DeliverableStatusBadge status={deliverable.status} />}
-          </div>
+          {deliverable.status !== 'Rejected' && (
+            <div style={{ float: 'right', marginBottom: '0px', marginLeft: '16px' }}>
+              <DeliverableStatusBadge status={deliverable.status} />
+            </div>
+          )}
         </Box>
       )}
 
       <Box marginBottom='16px'>
-        <div style={{ float: 'right', marginBottom: '0px', marginLeft: '16px' }}>
-          {deliverable.status !== 'Rejected' && !isAcceleratorRoute && (
+        {deliverable.status !== 'Rejected' && !isAcceleratorRoute && (
+          <div style={{ float: 'right', marginBottom: '0px', marginLeft: '16px' }}>
             <DeliverableStatusBadge status={deliverable.status} />
-          )}
-        </div>
+          </div>
+        )}
 
         <div dangerouslySetInnerHTML={{ __html: deliverable.descriptionHtml || '' }} />
       </Box>

--- a/src/components/DeliverablesTable/DeliverableCellRenderer.tsx
+++ b/src/components/DeliverablesTable/DeliverableCellRenderer.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 
 import { makeStyles } from '@mui/styles';
-import { Badge } from '@terraware/web-components';
 
+import DeliverableStatusBadge from 'src/components/DeliverableView/DeliverableStatusBadge';
 import Link from 'src/components/common/Link';
 import CellRenderer, { TableRowType } from 'src/components/common/table/TableCellRenderer';
 import { RendererProps } from 'src/components/common/table/types';
 import { APP_PATHS } from 'src/constants';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import { useLocalization } from 'src/providers';
-import { DeliverableStatusType, statusLabel } from 'src/types/Deliverables';
+import { DeliverableStatusType } from 'src/types/Deliverables';
 
 const useStyles = makeStyles(() => ({
   text: {
@@ -49,7 +49,7 @@ export default function DeliverableCellRenderer(props: RendererProps<TableRowTyp
       <CellRenderer
         index={index}
         column={column}
-        value={activeLocale ? <Badge label={statusLabel(value as DeliverableStatusType)} /> : ''}
+        value={activeLocale ? <DeliverableStatusBadge status={value as DeliverableStatusType} /> : ''}
         row={row}
       />
     );

--- a/src/redux/features/deliverables/deliverablesAsyncThunks.ts
+++ b/src/redux/features/deliverables/deliverablesAsyncThunks.ts
@@ -3,8 +3,14 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import DeliverablesService, { ListDeliverablesRequestParams } from 'src/services/DeliverablesService';
 import { Response } from 'src/services/HttpService';
 import strings from 'src/strings';
-import { Deliverable, DeliverableData, UploadDeliverableDocumentRequest } from 'src/types/Deliverables';
+import {
+  Deliverable,
+  DeliverableData,
+  ListDeliverablesElement,
+  UploadDeliverableDocumentRequest,
+} from 'src/types/Deliverables';
 import { SearchNodePayload, SearchSortOrder } from 'src/types/Search';
+import { SearchAndSortFn } from 'src/utils/searchAndSort';
 
 export const requestListDeliverables = createAsyncThunk(
   'deliverables/list',
@@ -14,12 +20,13 @@ export const requestListDeliverables = createAsyncThunk(
       listRequest?: ListDeliverablesRequestParams;
       search?: SearchNodePayload;
       searchSortOrder?: SearchSortOrder;
+      searchAndSort?: SearchAndSortFn<ListDeliverablesElement>;
     },
     { rejectWithValue }
   ) => {
-    const { listRequest, locale, search, searchSortOrder } = request;
+    const { listRequest, locale, search, searchSortOrder, searchAndSort } = request;
 
-    const response = await DeliverablesService.list(locale, listRequest, search, searchSortOrder);
+    const response = await DeliverablesService.list(locale, listRequest, search, searchSortOrder, searchAndSort);
     if (response) {
       return response;
     }

--- a/src/scenes/DeliverablesRouter/DeliverablesList.tsx
+++ b/src/scenes/DeliverablesRouter/DeliverablesList.tsx
@@ -23,11 +23,6 @@ const columns = (activeLocale: string | null): TableColumnType[] =>
           type: 'string',
         },
         {
-          key: 'description',
-          name: strings.DESCRIPTION,
-          type: 'string',
-        },
-        {
           key: 'type',
           name: strings.TYPE,
           type: 'string',

--- a/src/services/DeliverablesService.ts
+++ b/src/services/DeliverablesService.ts
@@ -4,11 +4,12 @@ import {
   Deliverable,
   DeliverableData,
   DeliverablesData,
+  ListDeliverablesElement,
   ListDeliverablesResponsePayload,
   UploadDeliverableDocumentRequest,
 } from 'src/types/Deliverables';
 import { SearchNodePayload, SearchSortOrder } from 'src/types/Search';
-import { SearchOrderConfig, searchAndSort } from 'src/utils/searchAndSort';
+import { SearchAndSortFn, SearchOrderConfig, searchAndSort as genericSearchAndSort } from 'src/utils/searchAndSort';
 
 import { getPromisesResponse } from './utils';
 
@@ -67,8 +68,8 @@ const list = async (
   locale: string | null,
   request?: ListDeliverablesRequestParams,
   search?: SearchNodePayload,
-  searchSortOrder?: SearchSortOrder
-  // TODO sort, search, etc...
+  searchSortOrder?: SearchSortOrder,
+  searchAndSort?: SearchAndSortFn<ListDeliverablesElement>
 ): Promise<(DeliverablesData & Response) | null> => {
   let searchOrderConfig: SearchOrderConfig;
   if (searchSortOrder) {
@@ -84,7 +85,9 @@ const list = async (
       params: request as Params,
     },
     (data) => ({
-      deliverables: searchAndSort(data?.deliverables || [], search, searchOrderConfig),
+      deliverables: searchAndSort
+        ? searchAndSort(data?.deliverables || [], search, searchOrderConfig)
+        : genericSearchAndSort(data?.deliverables || [], search, searchOrderConfig),
     })
   );
 };

--- a/src/utils/searchAndSort.ts
+++ b/src/utils/searchAndSort.ts
@@ -180,7 +180,7 @@ export const modifySearchNode = (
     } else if (operation === 'REPLACE') {
       return {
         ...search,
-        values: values,
+        values,
       };
     }
   } else if (search.child) {

--- a/src/utils/searchAndSort.ts
+++ b/src/utils/searchAndSort.ts
@@ -106,6 +106,11 @@ export const sortResults = <T extends Record<string, unknown>>(
   return results;
 };
 
+export type SearchAndSortFn<T extends Record<string, unknown>> = (
+  results: T[],
+  search?: SearchNodePayload,
+  sortOrderConfig?: SearchOrderConfig
+) => T[];
 /**
  * In-memory search (filter) and sort on a result list using the Search API search and sortOrder interfaces
  * The search currently only supports `Exact` and 'Fuzzy' type searches, 'Range' and 'ExactOrFuzzy' are not supported
@@ -136,4 +141,60 @@ export const searchAndSort = <T extends Record<string, unknown>>(
   }
 
   return _results;
+};
+
+export type SearchNodeModifyConfig = {
+  field: string;
+  operation: 'APPEND' | 'REPLACE';
+  values: string[];
+  condition?: (values: string[]) => boolean;
+};
+
+/*
+ * Modifies a search node tree according to a provided configuration. This allows us to do some fancy things like
+ * filter for a specific thing that is not visible to the user, or modify searches where needed to provide extra
+ * search functionality without adding too much complication too the consumer. Can be extended in the future to
+ * change things like the search node's `operation`, `type`, or even add new children. For now just deals with
+ * `values`.
+ */
+export const modifySearchNode = (
+  modifyConfig: SearchNodeModifyConfig,
+  search?: SearchNodePayload
+): SearchNodePayload | undefined => {
+  if (!search) {
+    return search;
+  }
+
+  const { field, operation, values, condition } = modifyConfig;
+
+  if (search.field === field) {
+    if (condition && !condition(search.values)) {
+      return search;
+    }
+
+    if (operation === 'APPEND') {
+      return {
+        ...search,
+        values: [...search.values, ...values],
+      };
+    } else if (operation === 'REPLACE') {
+      return {
+        ...search,
+        values: values,
+      };
+    }
+  } else if (search.child) {
+    const modifiedChild = modifySearchNode(modifyConfig, search.child);
+    return {
+      ...search,
+      child: modifiedChild || search.child,
+    };
+  } else if (search.children) {
+    return {
+      ...search,
+      children: search.children.map((child: SearchNodePayload) => modifySearchNode(modifyConfig, child)),
+    };
+  }
+
+  return search;
 };


### PR DESCRIPTION
- Implement `filterModifiers` and `searchAndSort` in the `DeliverablesTable` so the consumer can add additional instructions to change the filtering and search. This allows us to modify the "participant view" of the table in a clean way without changing anything about how the "accelerator view" interacts with the table.
- Add `modifySearchNode` function that will modify a specific node within a search node tree according to instructions, allowing us to easily change things about a search out at the consumer level without putting conditional logic lower in the service layer.
- Participant view for deliverables does not show "needs translation" status (it shows as "in review), and any deliverables with that status will show up when the "in review" status filter is applied.
- Accelerator view is untouched

Showing the badge text changes:
![2024-03-05 10.20.42.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/0e068d7d-4235-44e1-be91-38bec7884327.gif)


Showing the filtering changes:
![2024-03-05 11.43.37.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/655bb084-7f12-44dd-8194-d0faa156daab.gif)

