### PR TITLE
Update types for deliverable document upload API and update the service call

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -33,13 +33,13 @@ export interface paths {
     /** Gets the details of a single deliverable and its submission documents, if any. */
     get: operations["getDeliverable"];
   };
+  "/api/v1/accelerator/deliverables/{deliverableId}/documents": {
+    /** Uploads a new document to satisfy a deliverable. */
+    post: operations["uploadDeliverableDocument"];
+  };
   "/api/v1/accelerator/deliverables/{deliverableId}/documents/{documentId}": {
     /** Gets a single submission document from a deliverable. */
     get: operations["getDeliverableDocument"];
-  };
-  "/api/v1/accelerator/deliverables/{deliverableId}/documents/{projectId}": {
-    /** Uploads a new document to satisfy a deliverable. */
-    post: operations["uploadDeliverableDocument"];
   };
   "/api/v1/accelerator/deliverables/{deliverableId}/submissions/{projectId}": {
     /**
@@ -4265,7 +4265,6 @@ export interface operations {
     parameters: {
       path: {
         deliverableId: number;
-        projectId: number;
       };
     };
     requestBody?: {
@@ -4274,6 +4273,7 @@ export interface operations {
           description: string;
           /** Format: binary */
           file: string;
+          projectId: string;
         };
       };
     };

--- a/src/services/DeliverablesService.ts
+++ b/src/services/DeliverablesService.ts
@@ -19,7 +19,7 @@ import { getPromisesResponse } from './utils';
 const ENDPOINT_DELIVERABLES = '/api/v1/accelerator/deliverables';
 const ENDPOINT_DELIVERABLE = '/api/v1/accelerator/deliverables/{deliverableId}';
 const ENDPOINT_DELIVERABLE_SUBMISSION = '/api/v1/accelerator/deliverables/{deliverableId}/submissions/{projectId}';
-const ENDPOINT_DELIVERABLE_DOCUMENT_UPLOAD = '/api/v1/accelerator/deliverables/{deliverableId}/documents/{projectId}';
+const ENDPOINT_DELIVERABLE_DOCUMENT_UPLOAD = '/api/v1/accelerator/deliverables/{deliverableId}/documents';
 
 export type ListDeliverablesRequestParams = paths[typeof ENDPOINT_DELIVERABLES]['get']['parameters']['query'];
 export type GetDeliverableResponsePayload =
@@ -94,16 +94,10 @@ const list = async (
  */
 const upload = async (deliverableId: number, documents: UploadDeliverableDocumentRequest[]): Promise<boolean> => {
   const headers = { 'content-type': 'multipart/form-data' };
-  const promises = documents.map((document) => {
-    const { description, file, projectId } = document;
-    const urlReplacements = {
-      '{deliverableId}': `${deliverableId}`,
-      '{projectId}': `${projectId}`,
-    };
-    const entity = { description, file };
-
-    return httpDocumentUpload.post({ urlReplacements, entity, headers });
-  });
+  const urlReplacements = {
+    '{deliverableId}': `${deliverableId}`,
+  };
+  const promises = documents.map((entity) => httpDocumentUpload.post({ urlReplacements, entity, headers }));
 
   const results = await getPromisesResponse<Response>(promises);
   return results.every((result) => result !== null && result.requestSucceeded === true);


### PR DESCRIPTION
- projectId is back in the payload, removed from path