### PR TITLE
Fix deliverable refresh on update

### DIFF
--- a/src/components/DeliverableView/useFetchDeliverable.ts
+++ b/src/components/DeliverableView/useFetchDeliverable.ts
@@ -5,7 +5,10 @@ import { APP_PATHS } from 'src/constants';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import { Statuses } from 'src/redux/features/asyncUtils';
 import { requestGetDeliverable } from 'src/redux/features/deliverables/deliverablesAsyncThunks';
-import { selectDeliverableFetchRequest } from 'src/redux/features/deliverables/deliverablesSelectors';
+import {
+  selectDeliverableData,
+  selectDeliverableFetchRequest,
+} from 'src/redux/features/deliverables/deliverablesSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 import { Deliverable } from 'src/types/Deliverables';
@@ -35,6 +38,7 @@ export default function useFetchDeliverable({ deliverableId, projectId }: Props)
   const [deliverable, setDeliverable] = useState<Deliverable>();
 
   const deliverableResult = useAppSelector(selectDeliverableFetchRequest(requestId));
+  const deliverableData = useAppSelector(selectDeliverableData(deliverableId, projectId));
 
   const goToDeliverables = useCallback(() => {
     history.push(isAcceleratorRoute ? APP_PATHS.ACCELERATOR_DELIVERABLES : APP_PATHS.DELIVERABLES);
@@ -57,6 +61,12 @@ export default function useFetchDeliverable({ deliverableId, projectId }: Props)
       setDeliverable(deliverableResult.data);
     }
   }, [deliverableResult?.status, deliverableResult?.data, goToDeliverables, snackbar]);
+
+  useEffect(() => {
+    if (deliverableData) {
+      setDeliverable(deliverableData);
+    }
+  }, [deliverableData]);
 
   return useMemo<Response>(
     () => ({

--- a/src/redux/features/deliverables/deliverablesSelectors.ts
+++ b/src/redux/features/deliverables/deliverablesSelectors.ts
@@ -1,9 +1,14 @@
 import { RootState } from 'src/redux/rootReducer';
 
+import { makeDeliverableProjectIdKey } from './deliverablesSlice';
+
 export const selectDeliverablesSearchRequest = (requestId: string) => (state: RootState) =>
   state.deliverablesSearch[requestId];
 
 export const selectDeliverableFetchRequest = (requestId: string) => (state: RootState) => state.deliverables[requestId];
+
+export const selectDeliverableData = (deliverableId: number, projectId: number) => (state: RootState) =>
+  state.deliverables[makeDeliverableProjectIdKey(deliverableId, projectId)]?.data;
 
 export const selectDeliverablesEditRequest = (requestId: string) => (state: RootState) =>
   state.deliverablesEdit[requestId];

--- a/src/redux/features/deliverables/deliverablesSlice.ts
+++ b/src/redux/features/deliverables/deliverablesSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-import { StatusT, buildReducers } from 'src/redux/features/asyncUtils';
+import { StatusT, buildReducers, setStatus } from 'src/redux/features/asyncUtils';
 import {
   requestGetDeliverable,
   requestListDeliverables,
@@ -27,15 +27,33 @@ export const deliverablesSearchReducer = deliverablesListSlice.reducer;
 
 /**
  * Individual Deliverable
+ * Can be accessed by a request ID or by a deliverable/project ID string
  */
 const initialStateDeliverables: { [key: number | string]: StatusT<Deliverable> } = {};
+export const makeDeliverableProjectIdKey = (deliverableId: number, projectId: number) =>
+  `d${deliverableId}-p${projectId}`;
 
 export const deliverablesSlice = createSlice({
   name: 'deliverablesSlice',
   initialState: initialStateDeliverables,
   reducers: {},
   extraReducers: (builder) => {
-    buildReducers(requestGetDeliverable)(builder);
+    builder
+      .addCase(requestGetDeliverable.pending, setStatus('pending'))
+      .addCase(requestGetDeliverable.fulfilled, (state, action) => {
+        setStatus('success')(state, action);
+
+        // Additionally store the deliverable at a predictable location so consumers unaware of
+        // the request ID can refresh their data if the deliverable is updated
+        const { deliverableId, projectId } = action.meta.arg;
+        if (action.payload) {
+          state[makeDeliverableProjectIdKey(deliverableId, projectId)] = {
+            status: 'success',
+            data: action.payload,
+          };
+        }
+      })
+      .addCase(requestGetDeliverable.rejected, setStatus('error'));
   },
 });
 


### PR DESCRIPTION
The deliverable refresh was broken when I had to modify the fetch to use deliverableId and projectId because the flow was changed to using the asyncThunk requestId for retrieving out of state. This additionally stores the deliverable at a predictable location so consumers unaware of the request ID can be updated when the deliverable is updated in state.


![2024-03-12 10.28.01.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/e601ac27-8f7b-4821-9531-58659257ef62.gif)
