### PR TITLE
Enhance useArgAsKey functionality for composite keys

### DIFF
--- a/src/redux/features/asyncUtils.ts
+++ b/src/redux/features/asyncUtils.ts
@@ -7,17 +7,32 @@ export type StatusT<T> = { status: Statuses; data?: T };
 export type Status = StatusT<unknown>; // when data is not relevant in the response
 
 export const buildReducers =
-  <T>(asyncThunk: AsyncThunk<any, any, any>, useArgAsKey?: boolean) =>
+  <T>(asyncThunk: AsyncThunk<any, any, any>, useArgAsKey?: boolean, compositeKeyFn?: (args: unknown) => string) =>
   (builder: CaseReducers<any, any> | ActionReducerMapBuilder<any>) =>
     (builder as any)
-      .addCase(asyncThunk.pending, setStatus<T>('pending', useArgAsKey))
-      .addCase(asyncThunk.fulfilled, setStatus<T>('success', useArgAsKey))
-      .addCase(asyncThunk.rejected, setStatus<T>('error', useArgAsKey));
+      .addCase(asyncThunk.pending, setStatus<T>('pending', useArgAsKey, compositeKeyFn))
+      .addCase(asyncThunk.fulfilled, setStatus<T>('success', useArgAsKey, compositeKeyFn))
+      .addCase(asyncThunk.rejected, setStatus<T>('error', useArgAsKey, compositeKeyFn));
 
 export const setStatus =
-  <T>(status: Statuses, useArgAsKey?: boolean) =>
+  <T>(status: Statuses, useArgAsKey?: boolean, compositeKeyFn?: (arg: unknown) => string) =>
   (state: any, action: any) => {
-    const key = useArgAsKey ? action.meta.arg : action.meta.requestId;
     const data: T = action.payload as T;
+
+    state[action.meta.requestId] = { status, data };
+
+    if (!useArgAsKey) {
+      return;
+    }
+
+    let key = action.meta.arg;
+
+    if (compositeKeyFn) {
+      const compositeKey = compositeKeyFn(action.meta.arg);
+      if (compositeKey !== '') {
+        key = compositeKey;
+      }
+    }
+
     state[key] = { status, data };
   };

--- a/src/redux/features/deliverables/deliverablesSelectors.ts
+++ b/src/redux/features/deliverables/deliverablesSelectors.ts
@@ -1,6 +1,6 @@
 import { RootState } from 'src/redux/rootReducer';
 
-import { makeDeliverableProjectIdKey } from './deliverablesSlice';
+import { deliverableCompositeKeyFn } from './deliverablesSlice';
 
 export const selectDeliverablesSearchRequest = (requestId: string) => (state: RootState) =>
   state.deliverablesSearch[requestId];
@@ -8,7 +8,7 @@ export const selectDeliverablesSearchRequest = (requestId: string) => (state: Ro
 export const selectDeliverableFetchRequest = (requestId: string) => (state: RootState) => state.deliverables[requestId];
 
 export const selectDeliverableData = (deliverableId: number, projectId: number) => (state: RootState) =>
-  state.deliverables[makeDeliverableProjectIdKey(deliverableId, projectId)]?.data;
+  state.deliverables[deliverableCompositeKeyFn({ deliverableId, projectId })]?.data;
 
 export const selectDeliverablesEditRequest = (requestId: string) => (state: RootState) =>
   state.deliverablesEdit[requestId];

--- a/src/redux/features/deliverables/deliverablesSlice.ts
+++ b/src/redux/features/deliverables/deliverablesSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-import { StatusT, buildReducers } from 'src/redux/features/asyncUtils';
+import { StatusT, buildReducers, setStatus } from 'src/redux/features/asyncUtils';
 import {
   requestGetDeliverable,
   requestListDeliverables,

--- a/src/redux/features/deliverables/deliverablesSlice.ts
+++ b/src/redux/features/deliverables/deliverablesSlice.ts
@@ -30,30 +30,23 @@ export const deliverablesSearchReducer = deliverablesListSlice.reducer;
  * Can be accessed by a request ID or by a deliverable/project ID string
  */
 const initialStateDeliverables: { [key: number | string]: StatusT<Deliverable> } = {};
-export const makeDeliverableProjectIdKey = (deliverableId: number, projectId: number) =>
-  `d${deliverableId}-p${projectId}`;
+
+type DeliverableProjectIdArg = { deliverableId: number; projectId: number };
+export const deliverableCompositeKeyFn = (arg: unknown): string => {
+  const castArg = arg as DeliverableProjectIdArg;
+  if (!(castArg.deliverableId && castArg.projectId)) {
+    return '';
+  }
+
+  return `d${castArg.deliverableId}-p${castArg.projectId}`;
+};
 
 export const deliverablesSlice = createSlice({
   name: 'deliverablesSlice',
   initialState: initialStateDeliverables,
   reducers: {},
   extraReducers: (builder) => {
-    builder
-      .addCase(requestGetDeliverable.pending, setStatus('pending'))
-      .addCase(requestGetDeliverable.fulfilled, (state, action) => {
-        setStatus('success')(state, action);
-
-        // Additionally store the deliverable at a predictable location so consumers unaware of
-        // the request ID can refresh their data if the deliverable is updated
-        const { deliverableId, projectId } = action.meta.arg;
-        if (action.payload) {
-          state[makeDeliverableProjectIdKey(deliverableId, projectId)] = {
-            status: 'success',
-            data: action.payload,
-          };
-        }
-      })
-      .addCase(requestGetDeliverable.rejected, setStatus('error'));
+    buildReducers(requestGetDeliverable, true, deliverableCompositeKeyFn)(builder);
   },
 });
 

--- a/src/redux/features/deliverables/deliverablesSlice.ts
+++ b/src/redux/features/deliverables/deliverablesSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-import { StatusT, buildReducers, setStatus } from 'src/redux/features/asyncUtils';
+import { StatusT, buildReducers } from 'src/redux/features/asyncUtils';
 import {
   requestGetDeliverable,
   requestListDeliverables,


### PR DESCRIPTION
- Allow passing in of a composite key creator to the `buildReducers` function, which allows a slice creator to additionally store a thunk's result in state at a composite key. This allows for the `useArgAsKey` feature to work with multiple arg properties.
- Implement into the `deliverablesSlice`, storing the result at both `requestId` and `d$deliverableId-p$projectId` in state.