### PR TITLE
SW-5026 Admin -> Console, move link to top bar

### DIFF
--- a/src/components/TopBar/AcceleratorBreadcrumbs.tsx
+++ b/src/components/TopBar/AcceleratorBreadcrumbs.tsx
@@ -1,13 +1,21 @@
 import React from 'react';
 
-import { Theme } from '@mui/material';
+import { Grid, Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
+import { Separator } from '@terraware/web-components';
 
 import Link from 'src/components/common/Link';
 import { APP_PATHS } from 'src/constants';
+import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import strings from 'src/strings';
 
 const useStyles = makeStyles((theme: Theme) => ({
+  link: {
+    height: '40px',
+    lineHeight: '40px',
+    marginLeft: theme.spacing(1),
+    marginRight: theme.spacing(1),
+  },
   selected: {
     backgroundColor: theme.palette.TwClrBgAccent,
     borderRadius: '16px',
@@ -28,14 +36,36 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export default function AcceleratorBreadcrumbs(): JSX.Element | null {
   const classes = useStyles();
+  const { isAcceleratorRoute, isAllowedViewConsole } = useAcceleratorConsole();
 
-  return (
-    <div>
-      <Link fontSize={16} to={APP_PATHS.HOME}>
-        Terraware
-      </Link>
-      <span className={classes.separator}>/</span>
-      <span className={classes.selected}>{strings.ACCELERATOR_CONSOLE}</span>
-    </div>
-  );
+  if (isAcceleratorRoute) {
+    return (
+      <div>
+        <Link fontSize={16} to={APP_PATHS.HOME}>
+          Terraware
+        </Link>
+        <span className={classes.separator}>/</span>
+        <span className={classes.selected}>{strings.ACCELERATOR_CONSOLE}</span>
+      </div>
+    );
+  }
+
+  if (!isAcceleratorRoute && isAllowedViewConsole) {
+    return (
+      <div>
+        <Grid container>
+          <Grid item>
+            <Link fontSize={16} to={APP_PATHS.ACCELERATOR} className={classes.link}>
+              {strings.ACCELERATOR_CONSOLE}
+            </Link>
+          </Grid>
+          <Grid item>
+            <Separator height={'40px'} />
+          </Grid>
+        </Grid>
+      </div>
+    );
+  }
+
+  return null;
 }

--- a/src/components/TopBar/AcceleratorBreadcrumbs.tsx
+++ b/src/components/TopBar/AcceleratorBreadcrumbs.tsx
@@ -7,6 +7,7 @@ import { Separator } from '@terraware/web-components';
 import Link from 'src/components/common/Link';
 import { APP_PATHS } from 'src/constants';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
+import { useLocalization } from 'src/providers';
 import strings from 'src/strings';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -37,6 +38,11 @@ const useStyles = makeStyles((theme: Theme) => ({
 export default function AcceleratorBreadcrumbs(): JSX.Element | null {
   const classes = useStyles();
   const { isAcceleratorRoute, isAllowedViewConsole } = useAcceleratorConsole();
+  const { activeLocale } = useLocalization();
+
+  if (!activeLocale) {
+    return null;
+  }
 
   if (isAcceleratorRoute) {
     return (

--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -85,7 +85,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
         {organizations && organizations.length > 0 && (
           <>
             <div className={classes.separator} />
-            {isAcceleratorRoute && featureFlagAccelerator && user && <AcceleratorBreadcrumbs />}
+            {featureFlagAccelerator && user && <AcceleratorBreadcrumbs />}
             {!isAcceleratorRoute && <OrganizationsDropdown />}
           </>
         )}

--- a/src/hooks/useAcceleratorConsole.ts
+++ b/src/hooks/useAcceleratorConsole.ts
@@ -2,12 +2,17 @@ import { useRouteMatch } from 'react-router-dom';
 
 import { APP_PATHS } from 'src/constants';
 import isEnabled from 'src/features';
+import { useUser } from 'src/providers';
+import { isAllowed } from 'src/utils/acl';
 
 const useAcceleratorConsole = () => {
   const featureFlagAccelerator = isEnabled('Accelerator');
   const isAcceleratorRoute = !!useRouteMatch(APP_PATHS.ACCELERATOR);
+  const { user } = useUser();
 
-  return { featureFlagAccelerator, isAcceleratorRoute };
+  const isAllowedViewConsole = user && isAllowed(user, 'VIEW_CONSOLE');
+
+  return { featureFlagAccelerator, isAcceleratorRoute, isAllowedViewConsole };
 };
 
 export default useAcceleratorConsole;

--- a/src/scenes/OrgRouter/NavBar.tsx
+++ b/src/scenes/OrgRouter/NavBar.tsx
@@ -34,7 +34,7 @@ export default function NavBar({
   const [showNurseryWithdrawals, setShowNurseryWithdrawals] = useState<boolean>(false);
   const [reports, setReports] = useState<Reports>([]);
   const [hasDeliverables, setHasDeliverables] = useState<boolean>(false);
-  const { isDesktop } = useDeviceInfo();
+  const { isDesktop, isMobile } = useDeviceInfo();
   const history = useHistory();
   const featureFlagAccelerator = isEnabled('Accelerator');
   const { user } = useUser();
@@ -175,6 +175,14 @@ export default function NavBar({
       setShowNavBar={setShowNavBar as React.Dispatch<React.SetStateAction<boolean>>}
       backgroundTransparent={backgroundTransparent}
     >
+      {isMobile && featureFlagAccelerator && user && (
+        <NavItem
+          label={strings.ACCELERATOR_CONSOLE}
+          icon='home'
+          onClick={() => closeAndNavigateTo(APP_PATHS.ACCELERATOR_OVERVIEW)}
+          id='console'
+        />
+      )}
       <NavItem
         label={strings.HOME}
         icon='home'

--- a/src/scenes/OrgRouter/NavBar.tsx
+++ b/src/scenes/OrgRouter/NavBar.tsx
@@ -175,14 +175,6 @@ export default function NavBar({
       setShowNavBar={setShowNavBar as React.Dispatch<React.SetStateAction<boolean>>}
       backgroundTransparent={backgroundTransparent}
     >
-      {featureFlagAccelerator && user && (
-        <NavItem
-          label={strings.ACCELERATOR_ADMIN}
-          icon='home'
-          onClick={() => closeAndNavigateTo(APP_PATHS.ACCELERATOR_OVERVIEW)}
-          id='home'
-        />
-      )}
       <NavItem
         label={strings.HOME}
         icon='home'
@@ -265,7 +257,7 @@ export default function NavBar({
       )}
       {hasDeliverables && (
         <>
-          <NavSection title={strings.PARTICIPANTS.toUpperCase()} />
+          <NavSection title={strings.ACCELERATOR.toUpperCase()} />
           <NavItem
             label={strings.DELIVERABLES}
             icon='iconSubmit'

--- a/src/scenes/OrgRouter/NavBar.tsx
+++ b/src/scenes/OrgRouter/NavBar.tsx
@@ -10,7 +10,8 @@ import NavSection from 'src/components/common/Navbar/NavSection';
 import Navbar from 'src/components/common/Navbar/Navbar';
 import { APP_PATHS } from 'src/constants';
 import isEnabled from 'src/features';
-import { useLocalization, useOrganization, useUser } from 'src/providers/hooks';
+import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
+import { useLocalization, useOrganization } from 'src/providers/hooks';
 import { NurseryWithdrawalService } from 'src/services';
 import DeliverablesService from 'src/services/DeliverablesService';
 import ReportService, { Reports } from 'src/services/ReportService';
@@ -37,7 +38,7 @@ export default function NavBar({
   const { isDesktop, isMobile } = useDeviceInfo();
   const history = useHistory();
   const featureFlagAccelerator = isEnabled('Accelerator');
-  const { user } = useUser();
+  const { isAllowedViewConsole } = useAcceleratorConsole();
   const { activeLocale } = useLocalization();
 
   const isAccessionDashboardRoute = useRouteMatch(APP_PATHS.SEEDS_DASHBOARD + '/');
@@ -175,7 +176,7 @@ export default function NavBar({
       setShowNavBar={setShowNavBar as React.Dispatch<React.SetStateAction<boolean>>}
       backgroundTransparent={backgroundTransparent}
     >
-      {isMobile && featureFlagAccelerator && user && (
+      {isMobile && featureFlagAccelerator && isAllowedViewConsole && (
         <NavItem
           label={strings.ACCELERATOR_CONSOLE}
           icon='home'

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -1,4 +1,5 @@
 key_name,en,comment
+ACCELERATOR,Accelerator,
 ACCELERATOR_ADMIN,Accelerator Admin,
 ACCELERATOR_CONSOLE,Accelerator Console,
 ACCEPT,Accept,

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -1,6 +1,5 @@
 key_name,en,comment
 ACCELERATOR,Accelerator,
-ACCELERATOR_ADMIN,Accelerator Admin,
 ACCELERATOR_CONSOLE,Accelerator Console,
 ACCEPT,Accept,
 ACCESSION,Accession,


### PR DESCRIPTION
- Move link to accelerator to top bar breadcrumbs
- Rename 'Participants' to 'Accelerator'
- Rename 'Accelerator Admin' to 'Accelerator Console'
- Remove 'accelerator admin' from strings
- Leaving 'Participants' in strings because we are using it later

![2024-03-13 12.13.29.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/c7c82e83-aa26-4fd0-b131-e3b146740c9b.gif)

