### PR TITLE
SW-2359 Remove extra space in accession change modal

### DIFF
--- a/src/scenes/AccessionsRouter/edit/EditState.tsx
+++ b/src/scenes/AccessionsRouter/edit/EditState.tsx
@@ -47,27 +47,27 @@ export default function EditState(props: EditStateProps): JSX.Element {
           />
         </Grid>
       </Grid>
-      <Box
-        sx={{
-          background: stateChanged ? '#FDE7C3' : 'initial',
-          borderRadius: '14px',
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          padding: theme.spacing(2, 1),
-          marginTop: theme.spacing(4),
-          height: '74px',
-        }}
-      >
-        {stateChanged && (
+      {stateChanged && (
+        <Box
+          sx={{
+            background: '#FDE7C3',
+            borderRadius: '14px',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            padding: theme.spacing(2, 1),
+            marginTop: theme.spacing(2),
+            height: '74px',
+          }}
+        >
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
             <Icon name='warning' className={classes.messageIcon} size='large' />
             <Typography sx={{ color: theme.palette.TwClrTxt, fontSize: '14px', paddingLeft: 0.5 }}>
               {strings.UPDATE_STATUS_WARNING}
             </Typography>
           </Box>
-        )}
-      </Box>
+        </Box>
+      )}
     </>
   );
 }


### PR DESCRIPTION
Previously there would be a large blank space saved in this modal in case the user updated the status.

<img width="324" alt="Screenshot 2024-03-13 at 1 11 28 PM" src="https://github.com/terraware/terraware-web/assets/104874529/400fd589-f76e-4f81-8863-5c478bf2160d">
<img width="323" alt="Screenshot 2024-03-13 at 1 11 36 PM" src="https://github.com/terraware/terraware-web/assets/104874529/428f03d6-9fb7-4a19-aa3b-10d2bbca8289">
<img width="485" alt="Screenshot 2024-03-13 at 1 11 55 PM" src="https://github.com/terraware/terraware-web/assets/104874529/d22e0060-40d4-4611-a0b9-f145e8e3dff3">
<img width="490" alt="Screenshot 2024-03-13 at 1 12 02 PM" src="https://github.com/terraware/terraware-web/assets/104874529/266159b2-0196-44a3-828d-1acc6dbe358f">
