### PR TITLE
SW-4529 Show org creation success banner after page change

### DIFF
--- a/src/components/AddNewOrganizationModal.tsx
+++ b/src/components/AddNewOrganizationModal.tsx
@@ -149,12 +149,12 @@ export default function AddNewOrganizationModal(props: AddNewOrganizationModalPr
       ManagedLocationTypes.filter((locationType: ManagedLocationType) => locationTypes[locationType])
     );
     if (response.requestSucceeded && response.organization) {
+      reloadOrganizations();
+      history.push({ pathname: APP_PATHS.HOME });
       snackbar.pageSuccess(
         isDesktop ? strings.ORGANIZATION_CREATED_MSG_DESKTOP : strings.ORGANIZATION_CREATED_MSG,
         strings.formatString(strings.ORGANIZATION_CREATED_TITLE, response.organization.name)
       );
-      reloadOrganizations();
-      history.push({ pathname: APP_PATHS.HOME });
     } else {
       snackbar.toastError(strings.GENERIC_ERROR, strings.ORGANIZATION_CREATE_FAILED);
     }


### PR DESCRIPTION
Previously if you were on a different page prior to creating an org the banner would not show up because it the redirect would happen after the banner was drawn.