### PR TITLE
SW-4916 Require accession quantity to do a viability test

### DIFF
--- a/src/scenes/AccessionsRouter/Accession2View.tsx
+++ b/src/scenes/AccessionsRouter/Accession2View.tsx
@@ -384,7 +384,7 @@ export default function Accession2View(): JSX.Element {
   const overviewGridSize = isMobile ? '100%' : isTablet ? '50%' : overviewItemCount <= 6 ? '33%' : '25%';
 
   const quantityEditable = userCanEdit && (accession?.state === 'Drying' || accession?.state === 'In Storage');
-  const viabilityEditable = userCanEdit && accession?.state !== 'Used Up';
+  const viabilityEditable = userCanEdit && accession?.estimatedCount !== undefined && accession?.state !== 'Used Up';
   const isAwaitingCheckin = accession?.state === 'Awaiting Check-In';
 
   return (
@@ -718,7 +718,7 @@ export default function Accession2View(): JSX.Element {
               <ViabilityTestingPanel
                 accession={accession}
                 reload={reloadData}
-                canAddTest={userCanEdit}
+                canAddTest={viabilityEditable}
                 setNewViabilityTestOpened={setOpenNewViabilityTest}
                 setViewViabilityTestModalOpened={setOpenViewViabilityTestModal}
                 setSelectedTest={setSelectedTest}


### PR DESCRIPTION
Since performing a viability test does a withdrawal, we need to have a positive quantity or estimated quantity in order to add a test.