### PR TITLE
SW-5052 Deliverables Internal Comments layout changes

### DIFF
--- a/src/components/DeliverableView/InternalComment.tsx
+++ b/src/components/DeliverableView/InternalComment.tsx
@@ -1,16 +1,23 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { Grid, Typography } from '@mui/material';
+import { Box, Grid } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import TextField from '@terraware/web-components/components/Textfield/Textfield';
 
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
 import strings from 'src/strings';
-import theme from 'src/theme';
 import { Deliverable } from 'src/types/Deliverables';
 import useSnackbar from 'src/utils/useSnackbar';
 
 import useUpdateDeliverable from './useUpdateDeliverable';
+
+const useStyles = makeStyles(() => ({
+  icon: {
+    marginLeft: '-1px',
+    marginTop: '-1px',
+  },
+}));
 
 interface InternalCommentProps {
   deliverable: Deliverable;
@@ -18,6 +25,7 @@ interface InternalCommentProps {
 
 const InternalComment = ({ deliverable }: InternalCommentProps) => {
   const snackbar = useSnackbar();
+  const classes = useStyles();
   const { status, update } = useUpdateDeliverable();
 
   const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
@@ -42,11 +50,26 @@ const InternalComment = ({ deliverable }: InternalCommentProps) => {
 
   return (
     <>
-      <strong>{strings.INTERNAL_COMMENTS}</strong>{' '}
-      <Typography sx={{ marginLeft: theme.spacing(1) }} component={'span'}>
-        {deliverable.internalComment ?? strings.NO_COMMENTS_ADDED}
-      </Typography>
-      <Button onClick={toggleDialog} icon='iconEdit' type='passive' priority='ghost' size='small' />
+      <Box display='flex' alignItems='center'>
+        <strong>{strings.INTERNAL_COMMENTS}</strong>
+        <Button
+          className={classes.icon}
+          icon='iconEdit'
+          onClick={toggleDialog}
+          priority='ghost'
+          size='small'
+          type='passive'
+        />
+      </Box>
+      <TextField
+        display
+        id='internalComment'
+        label={''}
+        onChange={(value) => setInternalComment(value as string)}
+        preserveNewlines
+        type='textarea'
+        value={deliverable.internalComment ?? strings.NO_COMMENTS_ADDED}
+      />
       <DialogBox
         onClose={toggleDialog}
         open={isDialogOpen}

--- a/src/components/DeliverableView/Metadata.tsx
+++ b/src/components/DeliverableView/Metadata.tsx
@@ -22,13 +22,12 @@ const Metadata = (props: ViewProps): JSX.Element => {
           marginBottom='16px'
           padding='16px'
         >
-          <InternalComment deliverable={deliverable} />
-
           {deliverable.status !== 'Rejected' && (
             <div style={{ float: 'right', marginBottom: '0px', marginLeft: '16px' }}>
               <DeliverableStatusBadge status={deliverable.status} />
             </div>
           )}
+          <InternalComment deliverable={deliverable} />
         </Box>
       )}
 


### PR DESCRIPTION
- moved text below the heading
- using text area to show paragraphs

<img width="729" alt="Terraware App 2024-03-14 13-52-48" src="https://github.com/terraware/terraware-web/assets/1865174/65e4caf6-933b-483f-aa38-0e069bf8c7ea">

<img width="730" alt="Terraware App 2024-03-14 13-57-33" src="https://github.com/terraware/terraware-web/assets/1865174/8d6ad02c-815b-43c2-83b2-1d22aedb8b8c">
