### PR TITLE
SW-5059 Increase request size limit to 200MB

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -15,8 +15,8 @@ server {
         text/html
         text/plain;
 
-    # Allow large photo uploads. The default maximum request size is 1MB.
-    client_max_body_size 50M;
+    # Allow large file uploads. The default maximum request size is 1MB.
+    client_max_body_size 200M;
 
     location / {
         root   /usr/share/nginx/html;


### PR DESCRIPTION
We need to support uploads of larger deliverable documents, e.g., zipfiles with
collections of smaller files. Increase the request size limit to 200MB.