### PR TITLE
SW-5054 Update project name property in search fields

### DIFF
--- a/src/components/DeliverablesTable/index.tsx
+++ b/src/components/DeliverablesTable/index.tsx
@@ -25,7 +25,7 @@ interface DeliverablesTableProps {
   tableId: string;
 }
 
-const fuzzySearchColumns = ['name', 'project_name'];
+const fuzzySearchColumns = ['name', 'projectName'];
 const defaultSearchOrder: SearchSortOrder = {
   field: 'name',
   direction: 'Ascending',


### PR DESCRIPTION
- updated to `projectName` from `project_name`
- the search results are still fuzzy, not sure if the jira ticket will be addressed completely