### PR TITLE
SW-5066 Allow all file types in document upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@mui/styled-engine-sc": "^5.12.0",
     "@mui/styles": "^5.15.3",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^2.10.3",
+    "@terraware/web-components": "^2.10.4",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/src/components/DeliverableView/DocumentsUploader.tsx
+++ b/src/components/DeliverableView/DocumentsUploader.tsx
@@ -66,7 +66,6 @@ const DocumentsUploader = ({
           <FileUploadDialog deliverable={deliverable} files={files} onClose={onCloseDialog} />
         ))}
       <FileChooser
-        acceptFileType='image/*,application/*'
         chooseFileText={strings.CHOOSE_FILE}
         maxFiles={maxFiles}
         multipleSelection

--- a/yarn.lock
+++ b/yarn.lock
@@ -4522,10 +4522,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^2.10.3":
-  version "2.10.3"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.10.3.tgz#eab95c1d311ffacce5995c2dcd277d252808958a"
-  integrity sha512-6YQyDT62Jhtha53CuMGCIKIryWUPBB5t2VViOAUDF773SVBRRourWkBZtP+PfXxHewP5qNNI65DWHWLFnxAt2g==
+"@terraware/web-components@^2.10.4":
+  version "2.10.4"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.10.4.tgz#bcf404a19bf201920f4be82223efb4d52061a4b3"
+  integrity sha512-MZYMVpm4KKT1MHsqwfF5JFymZDaB81b6zlOz1CFOtVZqAtmZNKLaM0Bq9KK/rCruD0AjnZAvQOftAkMetgTa8w==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.16.1"


### PR DESCRIPTION
We don't want to restrict which types of files users can send us
for document deliverables. Remove the restricted list of MIME types
on the file chooser.