### PR TITLE
SW-5053 Updated voting screens to use API data 

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -47,10 +47,10 @@ export interface paths {
     put: operations["updateSubmission"];
   };
   "/api/v1/accelerator/projects/{projectId}/scores": {
-    /** Gets vote selections for a single project. */
+    /** Gets score selections for a single project. */
     get: operations["getProjectScores"];
     /**
-     * Upserts vote selections for a single project.
+     * Upserts score selections for a single project.
      * @description Update the scores for the project phase. If the (project, phase, category) does not exist, a new entry is created. Setting a `score` to `null` removes the score.
      */
     put: operations["upsertProjectScores"];
@@ -1055,10 +1055,6 @@ export interface components {
     };
     /** @description A change to the non-quantity-related details of a batch. */
     BatchHistoryDetailsEditedPayload: WithRequired<components["schemas"]["BatchHistoryPayloadCommonProps"] & ({
-      /** Format: int64 */
-      createdBy?: number;
-      /** Format: date-time */
-      createdTime?: string;
       notes?: string;
       /**
        * Format: int64
@@ -1078,15 +1074,9 @@ export interface components {
       treatmentNotes?: string;
       /** @enum {string} */
       type?: "DetailsEdited";
-      /** Format: int32 */
-      version?: number;
     }), "createdBy" | "createdTime" | "subLocations" | "type" | "version">;
     /** @description A nursery transfer withdrawal from another batch that added seedlings to this batch. */
     BatchHistoryIncomingWithdrawalPayload: WithRequired<components["schemas"]["BatchHistoryPayloadCommonProps"] & {
-      /** Format: int64 */
-      createdBy?: number;
-      /** Format: date-time */
-      createdTime?: string;
       /** Format: int64 */
       fromBatchId?: number;
       /** Format: int32 */
@@ -1097,8 +1087,6 @@ export interface components {
       readyQuantityAdded?: number;
       /** @enum {string} */
       type?: "IncomingWithdrawal";
-      /** Format: int32 */
-      version?: number;
       /** Format: int64 */
       withdrawalId?: number;
       /** Format: date */
@@ -1106,10 +1094,6 @@ export interface components {
     }, "createdBy" | "createdTime" | "fromBatchId" | "germinatingQuantityAdded" | "notReadyQuantityAdded" | "readyQuantityAdded" | "type" | "version" | "withdrawalId" | "withdrawnDate">;
     /** @description A withdrawal that removed seedlings from this batch. This does not include the full details of the withdrawal; they can be retrieved using the withdrawal ID. */
     BatchHistoryOutgoingWithdrawalPayload: WithRequired<components["schemas"]["BatchHistoryPayloadCommonProps"] & ({
-      /** Format: int64 */
-      createdBy?: number;
-      /** Format: date-time */
-      createdTime?: string;
       /** Format: int32 */
       germinatingQuantityWithdrawn?: number;
       /** Format: int32 */
@@ -1120,8 +1104,6 @@ export interface components {
       readyQuantityWithdrawn?: number;
       /** @enum {string} */
       type?: "OutgoingWithdrawal";
-      /** Format: int32 */
-      version?: number;
       /** Format: int64 */
       withdrawalId?: number;
       /** Format: date */
@@ -1137,10 +1119,6 @@ export interface components {
       version?: number;
     };
     BatchHistoryPhotoCreatedPayload: WithRequired<components["schemas"]["BatchHistoryPayloadCommonProps"] & {
-      /** Format: int64 */
-      createdBy?: number;
-      /** Format: date-time */
-      createdTime?: string;
       /**
        * Format: int64
        * @description ID of the photo if it exists. Null if the photo has been deleted.
@@ -1150,19 +1128,11 @@ export interface components {
       type?: "PhotoCreated";
     }, "createdBy" | "createdTime" | "type">;
     BatchHistoryPhotoDeletedPayload: WithRequired<components["schemas"]["BatchHistoryPayloadCommonProps"] & {
-      /** Format: int64 */
-      createdBy?: number;
-      /** Format: date-time */
-      createdTime?: string;
       /** @enum {string} */
       type?: "PhotoDeleted";
     }, "createdBy" | "createdTime" | "type">;
     /** @description A manual edit of a batch's remaining quantities. */
     BatchHistoryQuantityEditedPayload: WithRequired<components["schemas"]["BatchHistoryPayloadCommonProps"] & {
-      /** Format: int64 */
-      createdBy?: number;
-      /** Format: date-time */
-      createdTime?: string;
       /** Format: int32 */
       germinatingQuantity?: number;
       /** Format: int32 */
@@ -1171,15 +1141,9 @@ export interface components {
       readyQuantity?: number;
       /** @enum {string} */
       type?: "QuantityEdited";
-      /** Format: int32 */
-      version?: number;
     }, "createdBy" | "createdTime" | "germinatingQuantity" | "notReadyQuantity" | "readyQuantity" | "type" | "version">;
     /** @description The new quantities resulting from changing the statuses of seedlings in a batch. The values here are the total quantities remaining after the status change, not the number of seedlings whose statuses were changed. */
     BatchHistoryStatusChangedPayload: WithRequired<components["schemas"]["BatchHistoryPayloadCommonProps"] & {
-      /** Format: int64 */
-      createdBy?: number;
-      /** Format: date-time */
-      createdTime?: string;
       /** Format: int32 */
       germinatingQuantity?: number;
       /** Format: int32 */
@@ -1188,8 +1152,6 @@ export interface components {
       readyQuantity?: number;
       /** @enum {string} */
       type?: "StatusChanged";
-      /** Format: int32 */
-      version?: number;
     }, "createdBy" | "createdTime" | "germinatingQuantity" | "notReadyQuantity" | "readyQuantity" | "type" | "version">;
     BatchHistorySubLocationPayload: {
       /**
@@ -2195,9 +2157,6 @@ export interface components {
     };
     GetProjectScoresResponsePayload: {
       phases: components["schemas"]["PhaseScores"][];
-      /** Format: int64 */
-      projectId: number;
-      projectName: string;
       status: components["schemas"]["SuccessOrError"];
     };
     GetProjectVotesResponsePayload: {
@@ -3040,7 +2999,7 @@ export interface components {
       /** @enum {string} */
       phase: "Phase 0 - Due Diligence" | "Phase 1 - Feasibility Study" | "Phase 2 - Plan and Scale" | "Phase 3 - Implement and Monitor";
       scores: components["schemas"]["Score"][];
-      systemScore?: number;
+      totalScore?: number;
     };
     PhaseVotes: {
       /** @enum {string} */
@@ -3184,9 +3143,6 @@ export interface components {
     };
     ProjectVotesPayload: {
       phases: components["schemas"]["PhaseVotes"][];
-      /** Format: int64 */
-      projectId: number;
-      projectName: string;
     };
     PutNurseryV1: {
       /** Format: date */
@@ -3356,7 +3312,7 @@ export interface components {
       qualitative?: string;
       /**
        * Format: int32
-       * @description Must be between -2 to 2. If `null`, a score has not been selected.
+       * @description If `null`, a score has not been selected.
        */
       value?: number;
     };
@@ -3368,7 +3324,7 @@ export interface components {
        * @description Maximum number of top-level search results to return. The system may impose a limit on this value. A separate system-imposed limit may also be applied to lists of child objects inside the top-level results. Use a value of 0 to return the maximum number of allowed results.
        * @default 25
        */
-      count: number;
+      count?: number;
       /** @description Starting point for search results. If present, a previous search will be continued from where it left off. This should be the value of the cursor that was returned in the response to a previous search. */
       cursor?: string;
       /**
@@ -4110,15 +4066,6 @@ export interface components {
       phase: "Phase 0 - Due Diligence" | "Phase 1 - Feasibility Study" | "Phase 2 - Plan and Scale" | "Phase 3 - Implement and Monitor";
       scores: components["schemas"]["UpsertScore"][];
     };
-    UpsertProjectScoresResponsePayload: {
-      /** @enum {string} */
-      phaseId: "Phase 0 - Due Diligence" | "Phase 1 - Feasibility Study" | "Phase 2 - Plan and Scale" | "Phase 3 - Implement and Monitor";
-      /** Format: int64 */
-      projectId: number;
-      scores: components["schemas"]["Score"][];
-      status: components["schemas"]["SuccessOrError"];
-      systemScore?: number;
-    };
     UpsertProjectVotesRequestPayload: {
       /** @enum {string} */
       phase: "Phase 0 - Due Diligence" | "Phase 1 - Feasibility Study" | "Phase 2 - Plan and Scale" | "Phase 3 - Implement and Monitor";
@@ -4130,7 +4077,7 @@ export interface components {
       qualitative?: string;
       /**
        * Format: int32
-       * @description Must be between -2 to 2. If set to `null`, remove the selected score.
+       * @description If set to `null`, remove the selected score.
        */
       value?: number;
     };
@@ -4464,7 +4411,7 @@ export interface operations {
       };
     };
   };
-  /** Gets vote selections for a single project. */
+  /** Gets score selections for a single project. */
   getProjectScores: {
     parameters: {
       path: {
@@ -4487,7 +4434,7 @@ export interface operations {
     };
   };
   /**
-   * Upserts vote selections for a single project.
+   * Upserts score selections for a single project.
    * @description Update the scores for the project phase. If the (project, phase, category) does not exist, a new entry is created. Setting a `score` to `null` removes the score.
    */
   upsertProjectScores: {
@@ -4505,7 +4452,7 @@ export interface operations {
       /** @description The requested operation succeeded. */
       200: {
         content: {
-          "application/json": components["schemas"]["UpsertProjectScoresResponsePayload"];
+          "application/json": components["schemas"]["SimpleSuccessResponsePayload"];
         };
       };
       /** @description The requested resource was not found. */

--- a/src/redux/features/votes/votesAsyncThunks.ts
+++ b/src/redux/features/votes/votesAsyncThunks.ts
@@ -3,10 +3,10 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { Response, Response2 } from 'src/services/HttpService';
 import VotesService from 'src/services/VotesService';
 import strings from 'src/strings';
-import { UpsertProjectVotesRequestPayload, VotingRecordsData } from 'src/types/Votes';
+import { GetProjectVotesResponsePayload, UpsertProjectVotesRequestPayload } from 'src/types/Votes';
 
 export const requestProjectVotesGet = createAsyncThunk('votes/get', async (projectId: number, { rejectWithValue }) => {
-  const response: Response2<VotingRecordsData> = await VotesService.getProjectVotes(projectId);
+  const response: Response2<GetProjectVotesResponsePayload> = await VotesService.getProjectVotes(projectId);
 
   if (response.requestSucceeded) {
     return response.data?.votes;
@@ -22,7 +22,7 @@ export const requestProjectVotesUpdate = createAsyncThunk(
 
     if (response.requestSucceeded) {
       dispatch(requestProjectVotesGet(request.projectId));
-      return response?.data?.status === 'ok' ? true : false;
+      return true;
     }
 
     return rejectWithValue(strings.GENERIC_ERROR);

--- a/src/redux/features/votes/votesAsyncThunks.ts
+++ b/src/redux/features/votes/votesAsyncThunks.ts
@@ -17,10 +17,11 @@ export const requestProjectVotesGet = createAsyncThunk('votes/get', async (proje
 
 export const requestProjectVotesUpdate = createAsyncThunk(
   'votes/update',
-  async (request: { projectId: number; payload: UpsertProjectVotesRequestPayload }, { rejectWithValue }) => {
+  async (request: { projectId: number; payload: UpsertProjectVotesRequestPayload }, { dispatch, rejectWithValue }) => {
     const response: Response = await VotesService.setProjectVotes(request.projectId, request.payload);
 
     if (response.requestSucceeded) {
+      dispatch(requestProjectVotesGet(request.projectId));
       return response?.data?.status === 'ok' ? true : false;
     }
 

--- a/src/scenes/AcceleratorRouter/Voting/VotingProvider.tsx
+++ b/src/scenes/AcceleratorRouter/Voting/VotingProvider.tsx
@@ -63,10 +63,10 @@ const VotingProvider = ({ children }: Props): JSX.Element => {
     setVotingData({
       phaseVotes,
       projectId,
-      projectName: votes?.data?.projectName,
+      projectName: 'Participant Project Name', // TODO: Change this when participant project name is available
       status: votes?.status ?? 'pending',
     });
-  }, [phaseVotes, projectId, votes?.data?.projectName, votes?.status]);
+  }, [phaseVotes, projectId, votes?.status]);
 
   return <VotingContext.Provider value={votingData}>{children}</VotingContext.Provider>;
 };

--- a/src/services/HttpService.ts
+++ b/src/services/HttpService.ts
@@ -114,6 +114,15 @@ function RequestsHandler(url: string = '') {
     return await handleRequest(axios.get<I>(replace(url, request), { params, headers }), transform);
   }
 
+  const get2 = async <T extends ServerData>(request: GetRequest = {}): Promise<Response2<T>> => {
+    const { params, headers } = request;
+
+    return await handleRequest<T, { data: T | undefined }>(
+      axios.get<T>(replace(url, request), { params, headers }),
+      (data: T | undefined) => ({ data })
+    );
+  };
+
   const post = async (request: PostRequest = {}): Promise<Response> => {
     const { entity, params, headers } = request;
 
@@ -163,7 +172,7 @@ function RequestsHandler(url: string = '') {
     );
   };
 
-  return { get, post, post2, put, put2, delete: _delete, delete2 };
+  return { get, get2, post, post2, put, put2, delete: _delete, delete2 };
 }
 
 /**

--- a/src/services/VotesService.ts
+++ b/src/services/VotesService.ts
@@ -5,40 +5,23 @@ import { GetProjectVotesResponsePayload, UpsertProjectVotesRequestPayload, Votin
  * Accelerator "voting" related services
  */
 
-// TODO: remove this constant and promises below once BE is ready
-const RETURN_MOCK_VOTING_DATA = true;
-
 const ENDPOINT_VOTES = '/api/v1/accelerator/projects/{projectId}/votes';
 
 const httpVoting = HttpService.root(ENDPOINT_VOTES);
 
-let mockGetProjectVotesResponseData: VotingRecordsData;
-
 const getProjectVotes = async (projectId: number): Promise<Response2<VotingRecordsData>> =>
-  RETURN_MOCK_VOTING_DATA
-    ? new Promise((resolve) => {
-        setTimeout(() => {
-          resolve({ data: mockGetProjectVotesResponseData, requestSucceeded: true });
-        }, 300);
-      })
-    : await httpVoting.get<GetProjectVotesResponsePayload, VotingRecordsData>(
-        {
-          urlReplacements: { '{projectId}': `${projectId}` },
-        },
-        (data) => ({ votes: data?.votes })
-      );
+  await httpVoting.get<GetProjectVotesResponsePayload, Response2<VotingRecordsData>>(
+    {
+      urlReplacements: { '{projectId}': `${projectId}` },
+    },
+    (data) => ({ data: { votes: data?.votes }, requestSucceeded: true })
+  );
 
 const setProjectVotes = async (projectId: number, payload: UpsertProjectVotesRequestPayload): Promise<Response> =>
-  RETURN_MOCK_VOTING_DATA
-    ? new Promise<Response>((resolve) => {
-        setTimeout(() => {
-          resolve({ requestSucceeded: true });
-        }, 300);
-      })
-    : await httpVoting.put({
-        urlReplacements: { '{projectId}': `${projectId}` },
-        entity: payload,
-      });
+  await httpVoting.put({
+    urlReplacements: { '{projectId}': `${projectId}` },
+    entity: payload,
+  });
 
 const VotesService = {
   getProjectVotes,
@@ -46,41 +29,3 @@ const VotesService = {
 };
 
 export default VotesService;
-
-// TODO: remove mock data once BE is ready
-mockGetProjectVotesResponseData = {
-  votes: {
-    projectId: 1,
-    projectName: 'Project 1',
-    phases: [
-      {
-        phase: 'Phase 1 - Feasibility Study',
-        votes: [
-          { userId: 1, voteOption: 'Yes', email: 'person1@example.com', firstName: '', lastName: '' },
-          { userId: 2, voteOption: 'No', email: 'person2@example.com', firstName: '', lastName: '' },
-          {
-            userId: 3,
-            voteOption: 'Conditional',
-            email: 'person3@example.com',
-            firstName: '',
-            lastName: '',
-            conditionalInfo:
-              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi.\n\nSed dignissim lacinia nunc. Curabitur tortor. Pellentesque nibh. Aenean quam.',
-          },
-          { userId: 4, voteOption: 'Yes', email: 'person4@example.com', firstName: '', lastName: '' },
-          { userId: 5, voteOption: 'No', email: 'person5@example.com', firstName: '', lastName: '' },
-        ],
-      },
-      {
-        phase: 'Phase 2 - Plan and Scale',
-        votes: [
-          { userId: 1, voteOption: 'Yes', email: 'person1@example.com', firstName: '', lastName: '' },
-          { userId: 2, voteOption: 'No', email: 'person2@example.com', firstName: '', lastName: '' },
-          { userId: 3, voteOption: 'Yes', email: 'person3@example.com', firstName: '', lastName: '' },
-          { userId: 4, voteOption: 'Yes', email: 'person4@example.com', firstName: '', lastName: '' },
-          { userId: 5, voteOption: 'Yes', email: 'person5@example.com', firstName: '', lastName: '' },
-        ],
-      },
-    ],
-  },
-};

--- a/src/services/VotesService.ts
+++ b/src/services/VotesService.ts
@@ -1,5 +1,5 @@
 import HttpService, { Response, Response2 } from 'src/services/HttpService';
-import { GetProjectVotesResponsePayload, UpsertProjectVotesRequestPayload, VotingRecordsData } from 'src/types/Votes';
+import { GetProjectVotesResponsePayload, UpsertProjectVotesRequestPayload } from 'src/types/Votes';
 
 /**
  * Accelerator "voting" related services
@@ -9,13 +9,10 @@ const ENDPOINT_VOTES = '/api/v1/accelerator/projects/{projectId}/votes';
 
 const httpVoting = HttpService.root(ENDPOINT_VOTES);
 
-const getProjectVotes = async (projectId: number): Promise<Response2<VotingRecordsData>> =>
-  await httpVoting.get<GetProjectVotesResponsePayload, Response2<VotingRecordsData>>(
-    {
-      urlReplacements: { '{projectId}': `${projectId}` },
-    },
-    (data) => ({ data: { votes: data?.votes }, requestSucceeded: true })
-  );
+const getProjectVotes = async (projectId: number): Promise<Response2<GetProjectVotesResponsePayload>> =>
+  await httpVoting.get2<GetProjectVotesResponsePayload>({
+    urlReplacements: { '{projectId}': `${projectId}` },
+  });
 
 const setProjectVotes = async (projectId: number, payload: UpsertProjectVotesRequestPayload): Promise<Response> =>
   await httpVoting.put({

--- a/src/types/Votes.ts
+++ b/src/types/Votes.ts
@@ -17,7 +17,3 @@ export type UpsertProjectVotesRequestPayload = components['schemas']['UpsertProj
 export type UpsertVoteSelection = components['schemas']['UpsertVoteSelection'];
 
 export type ProjectVotesPayload = components['schemas']['ProjectVotesPayload'];
-
-export type VotingRecordsData = {
-  votes?: ProjectVotesPayload;
-};


### PR DESCRIPTION
Screenshots: 
<img width="1492" alt="Screenshot 2024-03-15 at 5 24 29 PM" src="https://github.com/terraware/terraware-web/assets/8563294/9125f2db-9a80-4b89-b89a-85019472eb1e">
<img width="1498" alt="Screenshot 2024-03-15 at 5 24 56 PM" src="https://github.com/terraware/terraware-web/assets/8563294/56b73ec0-a0ec-4185-a3fd-4158d50bb98a">
<img width="1501" alt="Screenshot 2024-03-15 at 5 27 50 PM" src="https://github.com/terraware/terraware-web/assets/8563294/ada078a1-bc16-4845-8016-81f7e277893a">
<img width="1494" alt="Screenshot 2024-03-15 at 5 25 10 PM" src="https://github.com/terraware/terraware-web/assets/8563294/f19596cb-ed8e-4582-aac2-0995a7830fcc">

Steps to test out screen:
1. Create users to be voters (or use existing users). Make sure you know their `id`.
2. Create project and add project to a participant. Make sure participant's cohort is in Phase 1
3. In the `project_votes` table, add (project, phase, user) entry.
4. Then, the `/accelerator/projects/{project_id}/votes` endpoint should show the voters. Edit their option and hit submit.
