### PR TITLE
SW-5026 Fix separator height and color

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@mui/styled-engine-sc": "^5.12.0",
     "@mui/styles": "^5.15.3",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^2.10.4",
+    "@terraware/web-components": "^2.10.5",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/src/components/TopBar/AcceleratorBreadcrumbs.tsx
+++ b/src/components/TopBar/AcceleratorBreadcrumbs.tsx
@@ -12,8 +12,8 @@ import strings from 'src/strings';
 
 const useStyles = makeStyles((theme: Theme) => ({
   link: {
-    height: '40px',
-    lineHeight: '40px',
+    height: '32px',
+    lineHeight: '32px',
     marginLeft: theme.spacing(1),
     marginRight: theme.spacing(1),
   },
@@ -66,7 +66,7 @@ export default function AcceleratorBreadcrumbs(): JSX.Element | null {
             </Link>
           </Grid>
           <Grid item>
-            <Separator height={'40px'} />
+            <Separator />
           </Grid>
         </Grid>
       </div>

--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   separator: {
     width: '1px',
     height: '32px',
-    backgroundColor: theme.palette.TwClrBgTertiary,
+    backgroundColor: theme.palette.TwClrBrdrTertiary,
     marginRight: '16px',
     marginLeft: '16px',
   },

--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   separator: {
     width: '1px',
     height: '32px',
-    backgroundColor: theme.palette.TwClrBaseGray300,
+    backgroundColor: theme.palette.TwClrBgTertiary,
     marginRight: '16px',
     marginLeft: '16px',
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4522,10 +4522,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^2.10.4":
-  version "2.10.4"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.10.4.tgz#bcf404a19bf201920f4be82223efb4d52061a4b3"
-  integrity sha512-MZYMVpm4KKT1MHsqwfF5JFymZDaB81b6zlOz1CFOtVZqAtmZNKLaM0Bq9KK/rCruD0AjnZAvQOftAkMetgTa8w==
+"@terraware/web-components@^2.10.5":
+  version "2.10.5"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.10.5.tgz#79f96483bc2b5f16a47150ce0b9dcfbaed085766"
+  integrity sha512-WWWKvrS7SIEq8ckXoULmuMe18pUby8B3Hi9urwZqtxUUYAQYHXYGbbv8/tWoJT62LMkK767xTqPq06tR3pzhLA==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.16.1"


### PR DESCRIPTION
- Use default Separator height (32px)
- Change color for logo separator to `tw-clr-brdr-tertiary`