### PR TITLE
SW-5091 Fix the vertical sizing of the phase score header when there isn't a 'modifiedTime'

### DIFF
--- a/src/scenes/AcceleratorRouter/Scoring/PhaseScores/LastUpdated.tsx
+++ b/src/scenes/AcceleratorRouter/Scoring/PhaseScores/LastUpdated.tsx
@@ -1,0 +1,39 @@
+import React, { useMemo } from 'react';
+
+import { Typography } from '@mui/material';
+
+import { useLocalization } from 'src/providers';
+import strings from 'src/strings';
+import { PhaseScores, Score } from 'src/types/Score';
+import { getLongDate } from 'src/utils/dateFormatter';
+
+interface LastUpdatedProps {
+  phaseScores: PhaseScores;
+}
+
+const LastUpdated = ({ phaseScores }: LastUpdatedProps) => {
+  const { activeLocale } = useLocalization();
+
+  const modifiedTime = useMemo(
+    () =>
+      phaseScores?.scores
+        .map((score: Score) => score.modifiedTime)
+        .sort()
+        .shift(),
+    [phaseScores]
+  );
+
+  if (!(activeLocale && modifiedTime)) {
+    // Empty <p> so the height of the containers matches
+    return <Typography minHeight={'20px'}></Typography>;
+  }
+
+  return (
+    <Typography fontSize='14px' fontWeight='400' lineHeight='20px'>{`${strings.LAST_UPDATED}: ${getLongDate(
+      modifiedTime,
+      activeLocale
+    )}`}</Typography>
+  );
+};
+
+export default LastUpdated;

--- a/src/scenes/AcceleratorRouter/Scoring/PhaseScores/LastUpdated.tsx
+++ b/src/scenes/AcceleratorRouter/Scoring/PhaseScores/LastUpdated.tsx
@@ -25,7 +25,7 @@ const LastUpdated = ({ phaseScores }: LastUpdatedProps) => {
 
   if (!(activeLocale && modifiedTime)) {
     // Empty <p> so the height of the containers matches
-    return <Typography minHeight={'20px'}></Typography>;
+    return <Typography minHeight={'20px'} />;
   }
 
   return (

--- a/src/scenes/AcceleratorRouter/Scoring/PhaseScores/LastUpdated.tsx
+++ b/src/scenes/AcceleratorRouter/Scoring/PhaseScores/LastUpdated.tsx
@@ -19,7 +19,7 @@ const LastUpdated = ({ phaseScores }: LastUpdatedProps) => {
       phaseScores?.scores
         .map((score: Score) => score.modifiedTime)
         .sort()
-        .shift(),
+        .pop(),
     [phaseScores]
   );
 

--- a/src/scenes/AcceleratorRouter/Scoring/PhaseScores/index.tsx
+++ b/src/scenes/AcceleratorRouter/Scoring/PhaseScores/index.tsx
@@ -1,14 +1,12 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useRouteMatch } from 'react-router-dom';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 
 import { APP_PATHS } from 'src/constants';
-import { useLocalization } from 'src/providers';
-import strings from 'src/strings';
 import { PhaseScores as PhaseScoresType, Score, ScoreCategory, ScoreValue, getPhase } from 'src/types/Score';
-import { getLongDate } from 'src/utils/dateFormatter';
 
+import LastUpdated from './LastUpdated';
 import ScoreEntry from './ScoreEntry';
 import ScoreTotal from './ScoreTotal';
 
@@ -21,17 +19,7 @@ interface ScorecardProps {
 
 const PhaseScores = ({ editable, onChangeValue, onChangeQualitative, phaseScores }: ScorecardProps) => {
   const theme = useTheme();
-  const { activeLocale } = useLocalization();
   const isEditing = useRouteMatch(APP_PATHS.ACCELERATOR_SCORING_EDIT);
-
-  const modifiedTime = useMemo(
-    () =>
-      phaseScores?.scores
-        .map((score: Score) => score.modifiedTime)
-        .sort()
-        .shift(),
-    [phaseScores]
-  );
 
   if (!phaseScores) {
     return null;
@@ -52,12 +40,7 @@ const PhaseScores = ({ editable, onChangeValue, onChangeQualitative, phaseScores
 
         <ScoreTotal isEditing={!!isEditing} phaseScores={phaseScores} />
 
-        {modifiedTime && activeLocale && (
-          <Typography fontSize='14px' fontWeight='400' lineHeight='20px'>{`${strings.LAST_UPDATED}: ${getLongDate(
-            modifiedTime,
-            activeLocale
-          )}`}</Typography>
-        )}
+        <LastUpdated phaseScores={phaseScores} />
       </Box>
 
       <Grid container flexDirection={'column'}>


### PR DESCRIPTION
![SCR-20240320-imuk.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/b12bb19e-4865-43d7-b14f-ddf82cfee39f.png)

