### PR TITLE
SW-5086 Add participant workflow with mock data

### DIFF
--- a/src/hooks/useAcceleratorOrgs.ts
+++ b/src/hooks/useAcceleratorOrgs.ts
@@ -1,0 +1,41 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { useLocalization } from 'src/providers';
+import { requestAcceleratorOrgs } from 'src/redux/features/accelerator/acceleratorAsyncThunks';
+import { selectAcceleratorOrgsRequest } from 'src/redux/features/accelerator/acceleratorSelectors';
+import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import { AcceleratorOrg } from 'src/types/Accelerator';
+import useSnackbar from 'src/utils/useSnackbar';
+
+export type Response = {
+  acceleratorOrgs?: AcceleratorOrg[];
+  isBusy: boolean;
+};
+
+export const useAcceleratorOrgs = (cohortId?: number): Response => {
+  const { activeLocale } = useLocalization();
+  const dispatch = useAppDispatch();
+  const snackbar = useSnackbar();
+
+  const [requestId, setRequestId] = useState<string>('');
+  const result = useAppSelector(selectAcceleratorOrgsRequest(requestId));
+
+  useEffect(() => {
+    const request = dispatch(requestAcceleratorOrgs({ locale: activeLocale }));
+    setRequestId(request.requestId);
+  }, [activeLocale, dispatch]);
+
+  useEffect(() => {
+    if (result?.status === 'error') {
+      snackbar.toastError();
+    }
+  }, [result?.status, snackbar]);
+
+  return useMemo<Response>(
+    () => ({
+      acceleratorOrgs: result?.data,
+      isBusy: result?.status === 'pending',
+    }),
+    [result]
+  );
+};

--- a/src/hooks/useCohorts.ts
+++ b/src/hooks/useCohorts.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useLocalization } from 'src/providers';
+import { requestCohorts } from 'src/redux/features/cohorts/cohortsAsyncThunks';
+import { selectCohortsRequest } from 'src/redux/features/cohorts/cohortsSelectors';
+import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import { Cohort } from 'src/types/Cohort';
+import useSnackbar from 'src/utils/useSnackbar';
+
+export type Response = {
+  availableCohorts?: Cohort[];
+  fetch: () => void;
+  selectedCohort?: Cohort;
+};
+
+export const useCohorts = (cohortId?: number): Response => {
+  const { activeLocale } = useLocalization();
+  const dispatch = useAppDispatch();
+  const snackbar = useSnackbar();
+
+  const [availableCohorts, setAvailableCohorts] = useState<Cohort[] | undefined>();
+  const [selectedCohort, setSelectedCohort] = useState<Cohort | undefined>();
+  const result = useAppSelector(selectCohortsRequest);
+
+  useEffect(() => {
+    if (availableCohorts && cohortId) {
+      setSelectedCohort(availableCohorts.find((cohort) => cohort.id === cohortId));
+    } else {
+      setSelectedCohort(undefined);
+    }
+  }, [availableCohorts, cohortId]);
+
+  useEffect(() => {
+    if (result.cohorts) {
+      setAvailableCohorts(result.cohorts);
+    } else if (result.error) {
+      snackbar.toastError();
+    }
+  }, [result, snackbar]);
+
+  const fetch = useCallback(() => {
+    dispatch(requestCohorts({ locale: activeLocale }));
+  }, [activeLocale, dispatch]);
+
+  useEffect(() => {
+    if (!availableCohorts) {
+      fetch();
+    }
+  }, [availableCohorts, fetch]);
+
+  return useMemo<Response>(
+    () => ({
+      availableCohorts,
+      fetch,
+      selectedCohort,
+    }),
+    [availableCohorts, fetch, selectedCohort]
+  );
+};

--- a/src/hooks/useParticipants.ts
+++ b/src/hooks/useParticipants.ts
@@ -34,11 +34,9 @@ export const useParticipants = (participantId?: number) => {
   }, [availableParticipants, participantId]);
 
   useEffect(() => {
-    if (!availableParticipants) {
-      const request = dispatch(requestListParticipants({}));
-      setRequestId(request.requestId);
-    }
-  }, [availableParticipants, dispatch]);
+    const request = dispatch(requestListParticipants({}));
+    setRequestId(request.requestId);
+  }, [dispatch]);
 
   useEffect(() => {
     if (!participantListRequest) {

--- a/src/hooks/useParticipants.ts
+++ b/src/hooks/useParticipants.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { requestListParticipants } from 'src/redux/features/participants/participantsAsyncThunks';
 import { selectParticipantListRequest } from 'src/redux/features/participants/participantsSelectors';
@@ -6,6 +6,12 @@ import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 import { Participant } from 'src/types/Participant';
 import useSnackbar from 'src/utils/useSnackbar';
+
+export type Response = {
+  availableParticipants?: Participant[];
+  isBusy: boolean;
+  selectedParticipant?: Participant;
+};
 
 export const useParticipants = (participantId?: number) => {
   const dispatch = useAppDispatch();
@@ -46,5 +52,8 @@ export const useParticipants = (participantId?: number) => {
     }
   }, [participantListRequest, snackbar]);
 
-  return { availableParticipants, selectedParticipant, isBusy };
+  return useMemo(
+    () => ({ availableParticipants, selectedParticipant, isBusy }),
+    [availableParticipants, selectedParticipant, isBusy]
+  );
 };

--- a/src/redux/features/cohorts/cohortsSelectors.ts
+++ b/src/redux/features/cohorts/cohortsSelectors.ts
@@ -2,6 +2,7 @@ import { RootState } from 'src/redux/rootReducer';
 import { Cohort } from 'src/types/Cohort';
 
 export const selectCohorts = (state: RootState) => state.cohorts.cohorts;
+export const selectCohortsRequest = (state: RootState) => state.cohorts;
 
 export const selectCohort =
   (cohortId: number) =>

--- a/src/scenes/AcceleratorRouter/Participants/OrgProjectsSectionEdit.tsx
+++ b/src/scenes/AcceleratorRouter/Participants/OrgProjectsSectionEdit.tsx
@@ -1,0 +1,106 @@
+import React, { useCallback, useMemo } from 'react';
+
+import { Grid, useTheme } from '@mui/material';
+import { Dropdown, MultiSelect } from '@terraware/web-components';
+
+import { useLocalization } from 'src/providers';
+import strings from 'src/strings';
+import { AcceleratorOrg } from 'src/types/Accelerator';
+
+export type OrgProjectsSection = {
+  id: number;
+  org?: AcceleratorOrg;
+  selectedProjectIds: number[];
+};
+
+export type OrgProjectsSectionEditProps = {
+  availableOrgs: AcceleratorOrg[];
+  onOrgSelect: (sectionId: number, orgId: number) => void;
+  onProjects: (sectionId: number, projectIds: number[]) => void;
+  section: OrgProjectsSection;
+};
+
+const OrgProjectsSectionEdit = ({
+  availableOrgs,
+  onOrgSelect,
+  onProjects,
+  section,
+}: OrgProjectsSectionEditProps): JSX.Element => {
+  const { activeLocale } = useLocalization();
+  const theme = useTheme();
+
+  const onOrgChange = useCallback(
+    (id: string) => {
+      onOrgSelect(section.id, Number(id));
+    },
+    [onOrgSelect, section.id]
+  );
+
+  const onAddProjectId = useCallback(
+    (id: number) => {
+      const projectIds = [...section.selectedProjectIds, id];
+      onProjects(section.id, projectIds);
+    },
+    [onProjects, section]
+  );
+
+  const onRemoveProjectId = useCallback(
+    (id: number) => {
+      const projectIds = section.selectedProjectIds.filter((projectId) => projectId !== id);
+      onProjects(section.id, projectIds);
+    },
+    [onProjects, section]
+  );
+
+  const orgOptions = useMemo(() => {
+    const orgs = [...availableOrgs];
+    if (section.org) {
+      orgs.push(section.org);
+    }
+    return orgs
+      .sort((a, b) => a.name.localeCompare(b.name, activeLocale || undefined))
+      .map((o) => ({ label: o.name, value: o.id }));
+  }, [activeLocale, availableOrgs, section.org]);
+
+  const projectOptions = useMemo(() => {
+    const options = new Map<number, string>([]);
+    section.org?.availableProjects.forEach((project) => {
+      options.set(project.id, project.name);
+    });
+    return options;
+  }, [section.org]);
+
+  return (
+    <Grid
+      container
+      sx={{
+        borderBottom: `1px solid ${theme.palette.TwClrBrdrTertiary}`,
+        paddingBottom: theme.spacing(3),
+      }}
+    >
+      <Grid item xs={12} sx={{ marginTop: theme.spacing(2) }}>
+        <Dropdown
+          fullWidth={true}
+          label={strings.ORGANIZATION}
+          onChange={onOrgChange}
+          options={orgOptions}
+          selectedValue={section.org?.id}
+        />
+      </Grid>
+      <Grid item xs={12} sx={{ marginTop: theme.spacing(2) }}>
+        <MultiSelect<number, string>
+          fullWidth
+          onAdd={onAddProjectId}
+          onRemove={onRemoveProjectId}
+          options={projectOptions}
+          placeHolder={strings.SELECT}
+          valueRenderer={(v) => v}
+          selectedOptions={section.selectedProjectIds}
+          label={strings.PROJECTS}
+        />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default OrgProjectsSectionEdit;

--- a/src/scenes/AcceleratorRouter/Participants/ParticipantForm.tsx
+++ b/src/scenes/AcceleratorRouter/Participants/ParticipantForm.tsx
@@ -1,0 +1,204 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { Box, Grid, useTheme } from '@mui/material';
+import { Dropdown, Textfield } from '@terraware/web-components';
+
+import AddLink from 'src/components/common/AddLink';
+import Card from 'src/components/common/Card';
+import PageForm from 'src/components/common/PageForm';
+import { useAcceleratorOrgs } from 'src/hooks/useAcceleratorOrgs';
+import { useCohorts } from 'src/hooks/useCohorts';
+import strings from 'src/strings';
+import { AcceleratorOrg } from 'src/types/Accelerator';
+import { Cohort } from 'src/types/Cohort';
+import { ParticipantCreateRequest, ParticipantUpdateRequest } from 'src/types/Participant';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
+
+import OrgProjectsSectionEdit, { OrgProjectsSection } from './OrgProjectsSectionEdit';
+
+type ParticipantFormProps<T extends ParticipantCreateRequest | ParticipantUpdateRequest> = {
+  busy?: boolean;
+  participant: T;
+  onCancel: () => void;
+  onSave: (participant: T) => void;
+};
+
+export default function ParticipantForm<T extends ParticipantCreateRequest | ParticipantUpdateRequest>(
+  props: ParticipantFormProps<T>
+): JSX.Element {
+  const { busy, participant, onCancel, onSave } = props;
+  const { isMobile } = useDeviceInfo();
+  const theme = useTheme();
+  const { availableCohorts } = useCohorts();
+  const { acceleratorOrgs: allAcceleratorOrgs } = useAcceleratorOrgs();
+
+  const [localRecord, setLocalRecord] = useState<T>(participant);
+  const [validateFields, setValidateFields] = useState<boolean>(false);
+  // initialize with one org selection enabled
+  const [orgProjectsSections, setOrgProjectsSections] = useState<OrgProjectsSection[]>([
+    { id: 1, selectedProjectIds: [] },
+  ]);
+  // orgs available for selection in the dropdowns, does not included already selected orgs
+  const [availableOrgs, setAvailableOrgs] = useState<AcceleratorOrg[]>([]);
+
+  const acceleratorOrgs = useMemo<AcceleratorOrg[]>(
+    () => (allAcceleratorOrgs || []).filter((org) => org.availableProjects.length > 0),
+    [allAcceleratorOrgs]
+  );
+
+  const cohortOptions = useMemo(
+    () => (availableCohorts || []).map((cohort: Cohort) => ({ label: cohort.name, value: cohort.id })),
+    [availableCohorts]
+  );
+
+  const updateField = useCallback((field: keyof T, value: any) => {
+    setLocalRecord((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  }, []);
+
+  const validateForm = () => {
+    if (!localRecord.name) {
+      return false;
+    }
+
+    if (!localRecord.cohort_id) {
+      return false;
+    }
+
+    return true;
+  };
+
+  const onSaveHandler = () => {
+    if (!validateForm()) {
+      setValidateFields(true);
+      return;
+    }
+
+    onSave({
+      ...localRecord,
+    });
+  };
+
+  const onOrgSelect = useCallback(
+    (sectionId: number, orgId: number) => {
+      const org = acceleratorOrgs?.find((o) => o.id === orgId);
+      if (!org) {
+        return;
+      }
+      setOrgProjectsSections((prev) => {
+        const updated = [...prev];
+        updated[sectionId - 1].org = org;
+        updated[sectionId - 1].selectedProjectIds = [];
+        updateField(
+          'project_ids',
+          updated.flatMap((data) => data.selectedProjectIds)
+        );
+        setAvailableOrgs((acceleratorOrgs || []).filter((o) => !updated.some((data) => data.org?.id === o.id)));
+        return updated;
+      });
+    },
+    [acceleratorOrgs, updateField]
+  );
+
+  const onProjects = useCallback(
+    (sectionId: number, selectedProjectIds: number[]) => {
+      setOrgProjectsSections((prev) => {
+        const updated = [...prev];
+        updated[sectionId - 1].selectedProjectIds = [...selectedProjectIds];
+        updateField(
+          'project_ids',
+          updated.flatMap((data) => data.selectedProjectIds)
+        );
+        return updated;
+      });
+    },
+    [updateField]
+  );
+
+  const addOrgProjectsSection = useCallback(() => {
+    setOrgProjectsSections((prev) => [...prev, { id: prev.length + 1, selectedProjectIds: [] }]);
+  }, []);
+
+  useEffect(() => {
+    // update local record when participant changes
+    setLocalRecord(participant);
+  }, [participant]);
+
+  useEffect(() => {
+    if (acceleratorOrgs) {
+      setAvailableOrgs(acceleratorOrgs);
+    }
+  }, [acceleratorOrgs]);
+
+  return (
+    <PageForm
+      busy={busy}
+      cancelID='cancelParticipantForm'
+      onCancel={onCancel}
+      onSave={onSaveHandler}
+      saveID='saveParticipantForm'
+    >
+      <Card
+        flushMobile
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          margin: '0 auto',
+          maxWidth: isMobile ? 'auto' : '592px',
+        }}
+      >
+        <Grid
+          container
+          sx={{
+            borderBottom: `1px solid ${theme.palette.TwClrBrdrTertiary}`,
+            paddingBottom: theme.spacing(3),
+          }}
+        >
+          <Grid item xs={12} sx={{ marginTop: theme.spacing(2) }}>
+            <Textfield
+              errorText={validateFields && !localRecord?.name ? strings.REQUIRED_FIELD : ''}
+              id='name'
+              label={strings.NAME}
+              onChange={(value) => updateField('name', value)}
+              required
+              type='text'
+              value={localRecord.name}
+            />
+          </Grid>
+          <Grid item xs={12} sx={{ marginTop: theme.spacing(2) }}>
+            <Dropdown
+              errorText={validateFields && !localRecord?.cohort_id ? strings.REQUIRED_FIELD : ''}
+              fullWidth={true}
+              label={strings.COHORT}
+              onChange={(value) => updateField('cohort_id', value)}
+              options={cohortOptions}
+              required
+              selectedValue={localRecord.cohort_id}
+            />
+          </Grid>
+        </Grid>
+        {orgProjectsSections.map((section, index) => (
+          <OrgProjectsSectionEdit
+            availableOrgs={availableOrgs}
+            key={section.id}
+            onOrgSelect={onOrgSelect}
+            onProjects={onProjects}
+            section={section}
+          />
+        ))}
+        {orgProjectsSections.length < acceleratorOrgs.length && (
+          <Box display='flex' marginTop={theme.spacing(2)}>
+            <AddLink
+              id='add-org-project'
+              large={true}
+              onClick={addOrgProjectsSection}
+              text={strings.ADD_PROJECTS_BY_ORGANIZATION}
+            />
+          </Box>
+        )}
+      </Card>
+    </PageForm>
+  );
+}

--- a/src/scenes/AcceleratorRouter/Participants/ParticipantForm.tsx
+++ b/src/scenes/AcceleratorRouter/Participants/ParticipantForm.tsx
@@ -81,6 +81,11 @@ export default function ParticipantForm<T extends ParticipantCreateRequest | Par
     });
   };
 
+  /**
+   * The orgProjectsSection is an array of org/projects sections
+   * ordered by the section id. The id is also the index into the array
+   * and has positional relevance in the rendered layout.
+   */
   const onOrgSelect = useCallback(
     (sectionId: number, orgId: number) => {
       const org = acceleratorOrgs?.find((o) => o.id === orgId);
@@ -88,9 +93,15 @@ export default function ParticipantForm<T extends ParticipantCreateRequest | Par
         return;
       }
       setOrgProjectsSections((prev) => {
-        const updated = [...prev];
-        updated[sectionId - 1].org = org;
-        updated[sectionId - 1].selectedProjectIds = [];
+        const updated = [...prev].map((section) =>
+          section.id !== sectionId
+            ? section
+            : {
+                ...section,
+                org,
+                selectedProjects: [],
+              }
+        );
         updateField(
           'project_ids',
           updated.flatMap((data) => data.selectedProjectIds)
@@ -105,8 +116,14 @@ export default function ParticipantForm<T extends ParticipantCreateRequest | Par
   const onProjects = useCallback(
     (sectionId: number, selectedProjectIds: number[]) => {
       setOrgProjectsSections((prev) => {
-        const updated = [...prev];
-        updated[sectionId - 1].selectedProjectIds = [...selectedProjectIds];
+        const updated = [...prev].map((section) =>
+          section.id !== sectionId
+            ? section
+            : {
+                ...section,
+                selectedProjectIds,
+              }
+        );
         updateField(
           'project_ids',
           updated.flatMap((data) => data.selectedProjectIds)

--- a/src/scenes/AcceleratorRouter/Participants/ParticipantsNew.tsx
+++ b/src/scenes/AcceleratorRouter/Participants/ParticipantsNew.tsx
@@ -1,5 +1,66 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+
 import Page from 'src/components/Page';
+import { APP_PATHS } from 'src/constants';
+import { requestCreateParticipant } from 'src/redux/features/participants/participantsAsyncThunks';
+import { selectParticipantCreateRequest } from 'src/redux/features/participants/participantsSelectors';
+import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import strings from 'src/strings';
+import { ParticipantCreateRequest } from 'src/types/Participant';
+import useSnackbar from 'src/utils/useSnackbar';
+
+import ParticipantForm from './ParticipantForm';
 
 export default function ParticipantsNew(): JSX.Element {
-  return <Page title='Participants New WIP!' />;
+  const history = useHistory();
+  const snackbar = useSnackbar();
+  const dispatch = useAppDispatch();
+
+  const [requestId, setRequestId] = useState<string>('');
+  const result = useAppSelector(selectParticipantCreateRequest(requestId));
+
+  const goToParticipantsList = useCallback(() => {
+    history.push({
+      pathname: APP_PATHS.ACCELERATOR_OVERVIEW,
+      search: 'tab=participants',
+    });
+  }, [history]);
+
+  const onSave = useCallback(
+    (createRequest: ParticipantCreateRequest) => {
+      const request = dispatch(requestCreateParticipant(createRequest));
+      setRequestId(request.requestId);
+    },
+    [dispatch]
+  );
+
+  const participant = useMemo<ParticipantCreateRequest>(
+    () => ({
+      name: '',
+      cohort_id: 0,
+      project_ids: [],
+    }),
+    []
+  );
+
+  useEffect(() => {
+    if (result?.status === 'error') {
+      snackbar.toastError();
+    } else if (result?.status === 'success') {
+      goToParticipantsList();
+      snackbar.toastSuccess(strings.CHANGES_SAVED);
+    }
+  }, [goToParticipantsList, result?.status, snackbar]);
+
+  return (
+    <Page title={strings.ADD_PARTICIPANT} contentStyle={{ display: 'flex', flexDirection: 'column' }}>
+      <ParticipantForm<ParticipantCreateRequest>
+        busy={result?.status === 'pending'}
+        onCancel={goToParticipantsList}
+        onSave={onSave}
+        participant={participant}
+      />
+    </Page>
+  );
 }

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -67,6 +67,7 @@ ADD_PLANTING_SITE_SIMPLE_SITE,"If your planting site is less than TBD ha, you ar
 ADD_PLANTING_SITE_TITLE,Before You Start,
 ADD_PROJECT,Add Project,
 ADD_PROJECT_SUBTITLE,Organize your data by projects.,
+ADD_PROJECTS_BY_ORGANIZATION,Add Project(s) by Organization,
 ADD_QUANTITY,Add Quantity,
 ADD_SEED_BANK,Add Seed Bank,
 ADD_SEED_BANK_SUBTITLE,How do you process and store your seeds? Set up your seed bank so you can keep track of where your seeds are stored.,


### PR DESCRIPTION
- added 'Add Participant' action menu in participants list (for non-empty state)
- added hooks to fetch cohorts and accelerator orgs
- added ParticipantForm (leveraged CohortForm as a template)
- implemented the sections for org/projects selection
- plumbed save back to ParticipantsNew component
- ParticipantForm can be reused for edit Participant
- TODO: sync with BE types when ready (follow up)
- TODO: add permission checks in the UI (follow up)

<img width="778" alt="Terraware App 2024-03-20 11-29-58" src="https://github.com/terraware/terraware-web/assets/1865174/37d58350-7ee2-41d7-a45a-01b19618c5e1">
