### PR TITLE
SW-5095: Deliverables list table projects filter pill label is incorrect

### DIFF
--- a/src/components/DeliverablesTable/index.tsx
+++ b/src/components/DeliverablesTable/index.tsx
@@ -83,6 +83,11 @@ const DeliverablesTable = ({
         }),
         label: strings.PROJECTS,
         renderOption: (id: string | number) => getProjectName(Number(id)),
+        pillValueRenderer: (values: (string | number | null)[]) =>
+          values
+            .map((value: string | number | null) => (value === null ? value : getProjectName(Number(value))))
+            .filter((value) => value)
+            .join(', '),
       });
     }
 


### PR DESCRIPTION
This PR includes a fix for an issue that resulted in an incorrect label value for the projects filter pill in the deliverables list table.

## Example

### Before

![localhost_3000_accelerator_deliverables](https://github.com/terraware/terraware-web/assets/1474361/ab61d0e7-7fb4-4f35-9be4-e40cc2a2ba2b)

### After

![localhost_3000_accelerator_deliverables (1)](https://github.com/terraware/terraware-web/assets/1474361/c4854ea1-0232-4898-8009-308d73ed0d30)
