### PR TITLE
SW-5111 Gate overview/people views with 'Console' flag

### DIFF
--- a/src/scenes/AcceleratorRouter/Cohorts/CohortListView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortListView.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 
-import { Grid, Theme } from '@mui/material';
+import { Grid } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
 import { useDeviceInfo } from '@terraware/web-components/utils';
 

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortListView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortListView.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { Grid, Theme } from '@mui/material';
-import { makeStyles } from '@mui/styles';
 import { TableColumnType } from '@terraware/web-components';
 import { useDeviceInfo } from '@terraware/web-components/utils';
 
@@ -18,14 +17,6 @@ import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 
 import CohortCellRenderer from './CohortCellRenderer';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  title: {
-    margin: 0,
-    fontSize: '24px',
-    fontWeight: 600,
-  },
-}));
 
 const columns = (activeLocale: string | null): TableColumnType[] =>
   activeLocale
@@ -47,7 +38,6 @@ const CohortListView = () => {
   const dispatch = useAppDispatch();
   const { activeLocale } = useLocalization();
   const { isMobile } = useDeviceInfo();
-  const classes = useStyles();
   const history = useHistory();
   const { isAllowed } = useUser();
   const canCreateCohorts = isAllowed('CREATE_COHORTS');

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortListView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortListView.tsx
@@ -25,10 +25,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontSize: '24px',
     fontWeight: 600,
   },
-  right: {
-    float: 'right',
-    marginRight: theme.spacing(2),
-  },
 }));
 
 const columns = (activeLocale: string | null): TableColumnType[] =>
@@ -74,13 +70,13 @@ const CohortListView = () => {
       title={strings.COHORTS}
       rightComponent={
         canCreateCohorts && (
-          <Grid item xs={4} className={classes.right}>
+          <>
             {isMobile ? (
               <Button id='new-cohort' icon='plus' onClick={goToNewCohort} size='medium' />
             ) : (
               <Button id='new-cohort' label={strings.ADD_COHORT} icon='plus' onClick={goToNewCohort} size='medium' />
             )}
-          </Grid>
+          </>
         )
       }
       contentStyle={{ display: 'flex', flexGrow: 1, flexDirection: 'column' }}

--- a/src/scenes/AcceleratorRouter/index.tsx
+++ b/src/scenes/AcceleratorRouter/index.tsx
@@ -5,8 +5,10 @@ import { Slide, Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 
 import ErrorBoundary from 'src/ErrorBoundary';
+import Page from 'src/components/Page';
 import { APP_PATHS } from 'src/constants';
 import isEnabled from 'src/features';
+import strings from 'src/strings';
 import { getRgbaFromHex } from 'src/utils/color';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import useStateLocation from 'src/utils/useStateLocation';
@@ -80,7 +82,7 @@ const AcceleratorRouter = ({ showNavBar, setShowNavBar }: AcceleratorRouterProps
         <ErrorBoundary setShowNavBar={setShowNavBar}>
           <Switch>
             <Route path={APP_PATHS.ACCELERATOR_OVERVIEW}>
-              <Overview />
+              {consoleEnabled ? <Overview /> : <Page title={strings.OVERVIEW} />}
             </Route>
             <Route path={APP_PATHS.ACCELERATOR_COHORTS}>
               <Cohorts />
@@ -92,7 +94,7 @@ const AcceleratorRouter = ({ showNavBar, setShowNavBar }: AcceleratorRouterProps
               <ModuleContent />
             </Route>
             <Route path={APP_PATHS.ACCELERATOR_PEOPLE}>
-              <People />
+              {consoleEnabled ? <People /> : <Page title={strings.PEOPLE} />}
             </Route>
             {consoleEnabled && (
               <Route path={APP_PATHS.ACCELERATOR_SCORING}>


### PR DESCRIPTION
- kept the nav since Overview nav was always being shown
- also fixed the + Add Cohort button which was allocated less space

<img width="612" alt="Terraware App 2024-03-21 13-54-44" src="https://github.com/terraware/terraware-web/assets/1865174/7a43768f-7efb-4c69-a8db-d9bb4e5e3e7a">
<img width="607" alt="Terraware App 2024-03-21 13-54-31" src="https://github.com/terraware/terraware-web/assets/1865174/9bee9865-2335-4caa-b0ee-f7124dd10146">
<img width="610" alt="Terraware App 2024-03-21 13-54-09" src="https://github.com/terraware/terraware-web/assets/1865174/e65c4c87-8cc5-4725-9094-f431d0f7b993">
