### PR TITLE
SW-5088 Export participants list with mock data

### DIFF
--- a/src/scenes/AcceleratorRouter/Participants/DownloadParticipants.tsx
+++ b/src/scenes/AcceleratorRouter/Participants/DownloadParticipants.tsx
@@ -1,0 +1,20 @@
+import ExportCsvModal from 'src/components/common/ExportCsvModal';
+import { ParticipantsService } from 'src/services';
+import { SearchNodePayload, SearchSortOrder } from 'src/types/Search';
+
+interface DownloadParticipantsProps {
+  onClose: () => void;
+  open: boolean;
+  search?: SearchNodePayload;
+  sort?: SearchSortOrder;
+}
+
+export default function DownloadParticipants(props: DownloadParticipantsProps): JSX.Element {
+  const { onClose, open, search, sort } = props;
+
+  const onExport = async () => {
+    return await ParticipantsService.download(search, sort);
+  };
+
+  return <ExportCsvModal open={open} onExport={onExport} onClose={onClose} />;
+}

--- a/src/scenes/AcceleratorRouter/Participants/ParticipantsList.tsx
+++ b/src/scenes/AcceleratorRouter/Participants/ParticipantsList.tsx
@@ -19,6 +19,7 @@ import { SearchNodePayload, SearchSortOrder } from 'src/types/Search';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import useSnackbar from 'src/utils/useSnackbar';
 
+import DownloadParticipants from './DownloadParticipants';
 import ParticipantsCellRenderer from './ParticipantsCellRenderer';
 
 type ParticipantType = Omit<Participant, 'projects'> & {
@@ -61,6 +62,9 @@ export default function ParticipantList(): JSX.Element {
   const dispatch = useAppDispatch();
   const snackbar = useSnackbar();
 
+  const [openDownload, setOpenDownload] = useState<boolean>(false);
+  const [lastSearch, setLastSearch] = useState<SearchNodePayload>();
+  const [lastSort, setLastSort] = useState<SearchSortOrder>();
   const [hasFilters, setHasFilters] = useState<boolean>(false);
   const [participants, setParticipants] = useState<ParticipantType[]>([]);
   const [requestId, setRequestId] = useState<string>('');
@@ -90,6 +94,8 @@ export default function ParticipantList(): JSX.Element {
 
   const dispatchSearchRequest = useCallback(
     (locale: string | null, search: SearchNodePayload, sortOrder: SearchSortOrder) => {
+      setLastSearch(search);
+      setLastSort(sortOrder);
       setHasFilters(search.children.length > 0);
       const request = dispatch(requestListParticipants({ locale, search, sortOrder }));
       setRequestId(request.requestId);
@@ -161,7 +167,7 @@ export default function ParticipantList(): JSX.Element {
             size='small'
             onOptionItemClick={(item: DropdownItem) => {
               if (item.value === 'export-participants') {
-                window.alert('Export WIP');
+                setOpenDownload(true);
               }
             }}
             optionItems={[{ label: strings.EXPORT, value: 'export-participants' }]}
@@ -180,6 +186,14 @@ export default function ParticipantList(): JSX.Element {
         {actionMenus}
       </Box>
       {participantsResult?.status === 'pending' && <BusySpinner />}
+      {openDownload && (
+        <DownloadParticipants
+          onClose={() => setOpenDownload(false)}
+          open={openDownload}
+          search={lastSearch}
+          sort={lastSort}
+        />
+      )}
       {isEmptyState && <EmptyState onClick={goToNewParticipant} />}
       {!isEmptyState && (
         <TableWithSearchFilters

--- a/src/services/ParticipantsService.ts
+++ b/src/services/ParticipantsService.ts
@@ -29,6 +29,13 @@ const deleteOne = async (participantId: number): Promise<Response2<number>> => {
   };
 };
 
+/**
+ * Download csv of participants data.
+ */
+const download = async (search?: SearchNodePayload, sortOrder?: SearchSortOrder): Promise<string | null> => {
+  return 'Id,Participant,Projects Count\r1,TST_PART1,3\r2,random,1\r';
+};
+
 const mockParticipant: Participant = {
   id: 1,
   cohort_id: 1,
@@ -144,6 +151,7 @@ const update = async (participant: ParticipantUpdateRequest): Promise<Response2<
 const ParticipantsService = {
   create,
   deleteOne,
+  download,
   get,
   list,
   update,


### PR DESCRIPTION
- created a download service function currently serving mock data, to be integrated with BE at some point
- Mostly boiler plate code to show the export modal and plumb it through ParticipantsService.download

<img width="813" alt="Terraware App 2024-03-21 15-02-29" src="https://github.com/terraware/terraware-web/assets/1865174/6b732537-aac1-4883-aedd-af0bafab8735">

<img width="807" alt="Terraware App 2024-03-21 15-02-15" src="https://github.com/terraware/terraware-web/assets/1865174/34eecca4-1f78-405b-ac46-cdc24518832d">

<img width="144" alt="participantslist 2024-03-21 15-07-48" src="https://github.com/terraware/terraware-web/assets/1865174/bfce36b5-2171-4d87-8f5c-2f1e5109ba9c">
