### PR TITLE
SW-4982 Create hook for centralizing "sticky tabs" logic

### DIFF
--- a/src/scenes/AcceleratorRouter/Overview/index.tsx
+++ b/src/scenes/AcceleratorRouter/Overview/index.tsx
@@ -1,5 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import React, { useMemo } from 'react';
 
 import { Box, Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
@@ -11,8 +10,7 @@ import CohortsListView from 'src/scenes/AcceleratorRouter/Cohorts/CohortsListVie
 import ParticipantProjectsList from 'src/scenes/AcceleratorRouter/ParticipantProjects/ListView';
 import ParticipantsList from 'src/scenes/AcceleratorRouter/Participants/ParticipantsList';
 import strings from 'src/strings';
-import useQuery from 'src/utils/useQuery';
-import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
+import useStickyTabs from 'src/utils/useStickyTabs';
 
 const useStyles = makeStyles((theme: Theme) => ({
   tabs: {
@@ -35,21 +33,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 const OverviewView = () => {
   const { isAllowed } = useUser();
   const { activeLocale } = useLocalization();
-  const history = useHistory();
   const classes = useStyles();
-  const query = useQuery();
-  const tab = query.get('tab') || 'projects';
-  const location = useStateLocation();
-
-  const [activeTab, setActiveTab] = useState<string>(tab);
-
-  const onTabChange = useCallback(
-    (newTab: string) => {
-      query.set('tab', newTab);
-      history.push(getLocation(location.pathname, location, query.toString()));
-    },
-    [history, location, query]
-  );
 
   const tabs = useMemo(() => {
     if (!activeLocale) {
@@ -79,13 +63,11 @@ const OverviewView = () => {
     ];
   }, [activeLocale, isAllowed]);
 
-  useEffect(() => {
-    if (tabs.some((data) => data.id === tab)) {
-      setActiveTab(tab);
-    } else if (tabs.length) {
-      setActiveTab(tabs[0].id);
-    }
-  }, [tab, tabs]);
+  const { activeTab, onTabChange } = useStickyTabs({
+    defaultTab: 'projects',
+    tabs,
+    viewIdentifier: 'accelerator-overview',
+  });
 
   return (
     <Page title={strings.OVERVIEW}>

--- a/src/utils/useStickyTabs.ts
+++ b/src/utils/useStickyTabs.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+
+import { Tab } from '@terraware/web-components';
+
+import useQuery from './useQuery';
+import useStateLocation, { getLocation } from './useStateLocation';
+
+interface StickyTabsProps {
+  defaultTab: string;
+  tabs: Tab[];
+  viewIdentifier: string;
+}
+
+const makeTabSessionKey = (viewIdentifier: string) => `tab-${viewIdentifier}`;
+
+const getTabFromSession = (viewIdentifier: string): string => {
+  try {
+    return sessionStorage.getItem(makeTabSessionKey(viewIdentifier)) || '';
+  } catch (e) {
+    return '';
+  }
+};
+
+const writeTabToSession = (viewIdentifier: string, tab: string): void => {
+  try {
+    sessionStorage.setItem(makeTabSessionKey(viewIdentifier), tab);
+    // tslint:disable-next-line:no-empty
+  } catch (e) {}
+};
+
+const useStickyTabs = ({ defaultTab, tabs, viewIdentifier }: StickyTabsProps) => {
+  const location = useStateLocation();
+  const history = useHistory();
+  const query = useQuery();
+  const tab = query.get('tab');
+
+  const [activeTab, setActiveTab] = useState<string>('');
+
+  const onTabChange = useCallback(
+    (newTab: string) => {
+      query.set('tab', newTab);
+      history.push(getLocation(location.pathname, location, query.toString()));
+      writeTabToSession(viewIdentifier, newTab);
+    },
+    [history, location, query, viewIdentifier]
+  );
+
+  useEffect(() => {
+    if (!tab) {
+      // If there is a "last viewed" tab in the session, use that, otherwise send to default
+      const sessionTab = getTabFromSession(viewIdentifier);
+      if (sessionTab) {
+        onTabChange(sessionTab);
+      } else {
+        onTabChange(defaultTab);
+      }
+      return;
+    }
+
+    if (tabs.some((data) => data.id === tab)) {
+      setActiveTab(tab);
+    } else if (tabs.length) {
+      setActiveTab(tabs[0].id);
+    }
+  }, [defaultTab, onTabChange, tab, tabs, viewIdentifier]);
+
+  return {
+    activeTab,
+    onTabChange,
+    tab,
+  };
+};
+
+export default useStickyTabs;


### PR DESCRIPTION
- Tab state is stored in the hook
- Exposes a function to pass into the tabs when the tab changes, along with the active tab
- Stores the last viewed tab in session storage
- If the tabbed view is entered without a tab, we first try to use  the tab stored in session, otherwise fall back to the default tab passed in to the hook.

