### PR TITLE
SW-5120 Fix flashing of app when searching for species

### DIFF
--- a/src/scenes/Species/SpeciesListView.tsx
+++ b/src/scenes/Species/SpeciesListView.tsx
@@ -3,7 +3,7 @@ import { useHistory } from 'react-router';
 
 import { Grid, Popover, Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import { BusySpinner, DropdownItem, SortOrder } from '@terraware/web-components';
+import { DropdownItem, SortOrder } from '@terraware/web-components';
 import { PillList, PillListItem, Tooltip } from '@terraware/web-components';
 import _ from 'lodash';
 
@@ -137,7 +137,6 @@ export default function SpeciesListView({ reloadData, species }: SpeciesListProp
   const [searchValue, setSearchValue] = useState('');
   const debouncedSearchTerm = useDebounce(searchValue, 250);
   const [results, setResults] = useState<SpeciesSearchResultRow[]>();
-  const [isBusy, setIsBusy] = useState<boolean>(false);
   const query = useQuery();
   const history = useHistory();
 
@@ -308,9 +307,7 @@ export default function SpeciesListView({ reloadData, species }: SpeciesListProp
         count: 1000,
       };
 
-      setIsBusy(true);
       const data = await SearchService.searchValues(searchParams);
-      setIsBusy(false);
 
       const result = (data || {}) as FieldOptionsMap;
 
@@ -654,7 +651,6 @@ export default function SpeciesListView({ reloadData, species }: SpeciesListProp
 
   return (
     <TfMain>
-      {isBusy && <BusySpinner withSkrim={true} />}
       <CheckDataModal
         open={checkDataModalOpen}
         onClose={() => setCheckDataModalOpen(false)}

--- a/src/scenes/Species/index.tsx
+++ b/src/scenes/Species/index.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect } from 'react';
 import { Route, Switch } from 'react-router-dom';
 
+import { BusySpinner } from '@terraware/web-components';
+
 import EmptyStatePage from 'src/components/emptyStatePages/EmptyStatePage';
 import { APP_PATHS } from 'src/constants';
 import { useOrganization } from 'src/providers';
@@ -29,9 +31,14 @@ const SpeciesRouter = () => {
   }, [species, reloadSpecies]);
 
   const getSpeciesView = useCallback((): JSX.Element => {
+    if (species === undefined) {
+      return <BusySpinner withSkrim />;
+    }
+
     if ((species || []).length > 0) {
       return <SpeciesListView reloadData={reloadSpecies} species={species || []} />;
     }
+
     return <EmptyStatePage pageName={'Species'} reloadData={reloadSpecies} />;
   }, [species, reloadSpecies]);
 


### PR DESCRIPTION
- search was also populating filters and showing the spinner for a tiny fraction of a second, causing the flashing
- we don't need to show a spinner for these quick searches to populate filters, removed that spinner
- also fixed the flashing of empty state before we get species data