### PR TITLE
SW-5140 Added double-quotations for Phrase Match search

### DIFF
--- a/src/utils/search.test.ts
+++ b/src/utils/search.test.ts
@@ -1,0 +1,45 @@
+import { removeDoubleQuotes, phraseMatch } from './search'
+
+describe('removeDoubleQuotes', () => {
+    it('should remove double quotes from a string if it is enclosed by double-quotes', () => {
+      
+      // Empty String
+      expect(removeDoubleQuotes('"cat"')).toEqual('cat');
+
+      // Non-double quoted
+      expect(removeDoubleQuotes('')).toBeNull();
+      expect(removeDoubleQuotes('cat')).toBeNull();
+
+      // Double-quotes not enclosing entire string
+      expect(removeDoubleQuotes('cat"meow"')).toBeNull();
+      expect(removeDoubleQuotes('"cat"meow')).toBeNull();
+
+      // Non-matching quotes
+      expect(removeDoubleQuotes('"cat"meow"')).toBeNull();
+
+      // Two quotes
+      expect(removeDoubleQuotes('"cat""meow"')).toBeNull();
+    });
+  });
+
+describe('phraseMatch', () => {
+    it('should return true if the input word/phrase appears in the target string', () => {
+      
+      // Empty String never matches
+      expect(phraseMatch('', '')).toBeFalsy()
+      expect(phraseMatch('abc', '')).toBeFalsy()
+
+      // One word
+      expect(phraseMatch('apple', 'apple')).toBeTruthy()
+      expect(phraseMatch('apple tree', 'apple')).toBeTruthy()
+      expect(phraseMatch('green apple', 'apple')).toBeTruthy()
+      expect(phraseMatch('applesauce', 'apple')).toBeFalsy()
+
+      // One phrase
+      expect(phraseMatch('apple tree', 'apple tree')).toBeTruthy()
+      expect(phraseMatch('green apple tree', 'apple tree')).toBeTruthy()
+      expect(phraseMatch('apple banana tree', 'apple tree')).toBeFalsy()
+      expect(phraseMatch('honeyapple tree', 'apple tree')).toBeFalsy()
+      expect(phraseMatch('apple treehouse', 'apple tree')).toBeFalsy()
+    });
+  });

--- a/src/utils/search.test.ts
+++ b/src/utils/search.test.ts
@@ -1,4 +1,4 @@
-import { removeDoubleQuotes, phraseMatch } from './search'
+import { removeDoubleQuotes, phraseMatch } from './search';
 
 describe('removeDoubleQuotes', () => {
     it('should remove double quotes from a string if it is enclosed by double-quotes', () => {
@@ -26,20 +26,20 @@ describe('phraseMatch', () => {
     it('should return true if the input word/phrase appears in the target string', () => {
       
       // Empty String never matches
-      expect(phraseMatch('', '')).toBeFalsy()
-      expect(phraseMatch('abc', '')).toBeFalsy()
+      expect(phraseMatch('', '')).toBeFalsy();
+      expect(phraseMatch('abc', '')).toBeFalsy();
 
       // One word
-      expect(phraseMatch('apple', 'apple')).toBeTruthy()
-      expect(phraseMatch('apple tree', 'apple')).toBeTruthy()
-      expect(phraseMatch('green apple', 'apple')).toBeTruthy()
-      expect(phraseMatch('applesauce', 'apple')).toBeFalsy()
+      expect(phraseMatch('apple', 'apple')).toBeTruthy();
+      expect(phraseMatch('apple tree', 'apple')).toBeTruthy();
+      expect(phraseMatch('green apple', 'apple')).toBeTruthy();
+      expect(phraseMatch('applesauce', 'apple')).toBeFalsy();
 
       // One phrase
-      expect(phraseMatch('apple tree', 'apple tree')).toBeTruthy()
-      expect(phraseMatch('green apple tree', 'apple tree')).toBeTruthy()
-      expect(phraseMatch('apple banana tree', 'apple tree')).toBeFalsy()
-      expect(phraseMatch('honeyapple tree', 'apple tree')).toBeFalsy()
-      expect(phraseMatch('apple treehouse', 'apple tree')).toBeFalsy()
+      expect(phraseMatch('apple tree', 'apple tree')).toBeTruthy();
+      expect(phraseMatch('green apple tree', 'apple tree')).toBeTruthy();
+      expect(phraseMatch('apple banana tree', 'apple tree')).toBeFalsy();
+      expect(phraseMatch('honeyapple tree', 'apple tree')).toBeFalsy();
+      expect(phraseMatch('apple treehouse', 'apple tree')).toBeFalsy();
     });
   });

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -9,10 +9,12 @@ function escapeRegExp(input: string) {
  * Checks an exact sequence of words or characters within a given string
  */
 const phraseMatch = (input: string, word: string): boolean => {
-  if (word.length == 0) return false;
-  const regex = new RegExp("\\b" + word + "\\b", "i");
-  return !!input.match(regex)
-}
+  if (word.length === 0) {
+    return false;
+  }
+  const regex = new RegExp('\\b' + word + '\\b', 'i');
+  return !!input.match(regex);
+};
 
 /**
  * Check if a string matches a regex pattern
@@ -21,7 +23,6 @@ const regexMatch = (input: string, stringToMatch: string): boolean => {
   const regex = new RegExp(escapeRegExp(stringToMatch), 'i');
   return !!input.match(regex);
 };
-
 
 /**
  *   Return inner string if a string is double-quoted, otherwsie null
@@ -36,8 +37,4 @@ const removeDoubleQuotes = (str: string): string | null => {
   }
 };
 
-export {
-  phraseMatch,
-  regexMatch,
-  removeDoubleQuotes
-}
+export { phraseMatch, regexMatch, removeDoubleQuotes };

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -20,8 +20,8 @@ export const removeDoubleQuotes = (str: string): string | null => {
   const pattern = /^"([^"]*)"$/;
   const match = pattern.exec(str);
   if (match) {
-      return match[1]; // Return the string inside the double quotes
+    return match[1]; // Return the string inside the double quotes
   } else {
-      return null; // Return null if the string is not properly double-quoted
+    return null; // Return null if the string is not properly double-quoted
   }
-}
+};

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -14,6 +14,14 @@ export const regexMatch = (input: string, stringToMatch: string): boolean => {
 };
 
 /**
+ * Checks an exact sequence of words or characters within a given string
+ */
+export const phraseMatch = (input: string, word: string): boolean => {
+  const regex = new RegExp("\\b" + word + "\\b", "i");
+  return !!input.match(regex)
+}
+
+/**
  *   Return inner string if a string is double-quoted, otherwsie null
  */
 export const removeDoubleQuotes = (str: string): string | null => {

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -12,3 +12,16 @@ export const regexMatch = (input: string, stringToMatch: string): boolean => {
   const regex = new RegExp(escapeRegExp(stringToMatch), 'i');
   return !!input.match(regex);
 };
+
+/**
+ *   Return inner string if a string is double-quoted, otherwsie null
+ */
+export const removeDoubleQuotes = (str: string): string | null => {
+  const pattern = /^"([^"]*)"$/;
+  const match = pattern.exec(str);
+  if (match) {
+      return match[1]; // Return the string inside the double quotes
+  } else {
+      return null; // Return null if the string is not properly double-quoted
+  }
+}

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -6,25 +6,27 @@ function escapeRegExp(input: string) {
 }
 
 /**
- * Check if a string matches a regex pattern
- */
-export const regexMatch = (input: string, stringToMatch: string): boolean => {
-  const regex = new RegExp(escapeRegExp(stringToMatch), 'i');
-  return !!input.match(regex);
-};
-
-/**
  * Checks an exact sequence of words or characters within a given string
  */
-export const phraseMatch = (input: string, word: string): boolean => {
+const phraseMatch = (input: string, word: string): boolean => {
+  if (word.length == 0) return false;
   const regex = new RegExp("\\b" + word + "\\b", "i");
   return !!input.match(regex)
 }
 
 /**
+ * Check if a string matches a regex pattern
+ */
+const regexMatch = (input: string, stringToMatch: string): boolean => {
+  const regex = new RegExp(escapeRegExp(stringToMatch), 'i');
+  return !!input.match(regex);
+};
+
+
+/**
  *   Return inner string if a string is double-quoted, otherwsie null
  */
-export const removeDoubleQuotes = (str: string): string | null => {
+const removeDoubleQuotes = (str: string): string | null => {
   const pattern = /^"([^"]*)"$/;
   const match = pattern.exec(str);
   if (match) {
@@ -33,3 +35,9 @@ export const removeDoubleQuotes = (str: string): string | null => {
     return null; // Return null if the string is not properly double-quoted
   }
 };
+
+export {
+  phraseMatch,
+  regexMatch,
+  removeDoubleQuotes
+}

--- a/src/utils/searchAndSort.ts
+++ b/src/utils/searchAndSort.ts
@@ -76,14 +76,15 @@ const searchConditionMet = <T extends Record<string, unknown>>(result: T, condit
       .filter((value: string | null): value is string => value !== null)
       .map((value) => value.toLowerCase());
 
+    const exactValues = searchValues.map(removeDoubleQuotes).filter((value) => value !== null);
+    if (exactValues.length) {
+      return exactValues.some((value) => resultValue === value);
+    }
+
     if (condition.type === 'Exact') {
       return searchValues.some((value) => resultValue.includes(value));
     } else if (condition.type === 'Fuzzy') {
       return searchValues.some((searchValue) => {
-        const exactValue = removeDoubleQuotes(searchValue);
-        if (exactValue !== null) {
-          return resultValue.includes(exactValue);
-        }
         // Trigrams don't work with single letter searches
         if (searchValue.length === 1) {
           return resultValue.includes(searchValue);

--- a/src/utils/searchAndSort.ts
+++ b/src/utils/searchAndSort.ts
@@ -7,7 +7,7 @@ import {
   isOrNodePayload,
 } from 'src/types/Search';
 
-import { removeDoubleQuotes } from './search';
+import { regexMatch, removeDoubleQuotes } from './search';
 
 export type SearchOrderConfig = {
   locale: string | null;
@@ -78,7 +78,7 @@ const searchConditionMet = <T extends Record<string, unknown>>(result: T, condit
 
     const exactValues = searchValues.map(removeDoubleQuotes).filter((value) => value !== null);
     if (exactValues.length) {
-      return exactValues.some((value) => resultValue === value);
+      return exactValues.some((value) => regexMatch(resultValue, value));
     }
 
     if (condition.type === 'Exact') {

--- a/src/utils/searchAndSort.ts
+++ b/src/utils/searchAndSort.ts
@@ -78,7 +78,7 @@ const searchConditionMet = <T extends Record<string, unknown>>(result: T, condit
 
     const exactValues = searchValues.map(removeDoubleQuotes).filter((value) => value !== null);
     if (exactValues.length) {
-      return exactValues.some((value: string) => value && phraseMatch(resultValue, value));
+      return exactValues.some((value) => value !== null && phraseMatch(resultValue, value));
     }
 
     if (condition.type === 'Exact') {

--- a/src/utils/searchAndSort.ts
+++ b/src/utils/searchAndSort.ts
@@ -1,4 +1,3 @@
-import { removeDoubleQuotes } from './search'
 import {
   SearchNodePayload,
   SearchSortOrder,
@@ -7,6 +6,8 @@ import {
   isNotNodePayload,
   isOrNodePayload,
 } from 'src/types/Search';
+
+import { removeDoubleQuotes } from './search';
 
 export type SearchOrderConfig = {
   locale: string | null;
@@ -79,16 +80,15 @@ const searchConditionMet = <T extends Record<string, unknown>>(result: T, condit
       return searchValues.some((value) => resultValue.includes(value));
     } else if (condition.type === 'Fuzzy') {
       return searchValues.some((searchValue) => {
-        const exactValue = removeDoubleQuotes(searchValue)
-        if (exactValue != null) {
-          return resultValue.includes(exactValue)
-        } else {
-          // Trigrams don't work with single letter searches
-          if (searchValue.length === 1) {
-            return resultValue.includes(searchValue);
-          }
-          return trigramWordSimilarity(searchValue, resultValue) > TRIGRAM_SIMILARITY_THRESHOLD;
+        const exactValue = removeDoubleQuotes(searchValue);
+        if (exactValue !== null) {
+          return resultValue.includes(exactValue);
         }
+        // Trigrams don't work with single letter searches
+        if (searchValue.length === 1) {
+          return resultValue.includes(searchValue);
+        }
+        return trigramWordSimilarity(searchValue, resultValue) > TRIGRAM_SIMILARITY_THRESHOLD;
       });
     }
   }

--- a/src/utils/searchAndSort.ts
+++ b/src/utils/searchAndSort.ts
@@ -7,7 +7,7 @@ import {
   isOrNodePayload,
 } from 'src/types/Search';
 
-import { regexMatch, removeDoubleQuotes } from './search';
+import { phraseMatch, removeDoubleQuotes } from './search';
 
 export type SearchOrderConfig = {
   locale: string | null;
@@ -78,7 +78,7 @@ const searchConditionMet = <T extends Record<string, unknown>>(result: T, condit
 
     const exactValues = searchValues.map(removeDoubleQuotes).filter((value) => value !== null);
     if (exactValues.length) {
-      return exactValues.some((value) => regexMatch(resultValue, value));
+      return exactValues.some((value: string) => value && phraseMatch(resultValue, value));
     }
 
     if (condition.type === 'Exact') {

--- a/src/utils/searchAndSort.ts
+++ b/src/utils/searchAndSort.ts
@@ -1,3 +1,4 @@
+import { removeDoubleQuotes } from './search'
 import {
   SearchNodePayload,
   SearchSortOrder,
@@ -78,12 +79,16 @@ const searchConditionMet = <T extends Record<string, unknown>>(result: T, condit
       return searchValues.some((value) => resultValue.includes(value));
     } else if (condition.type === 'Fuzzy') {
       return searchValues.some((searchValue) => {
-        // Trigrams don't work with single letter searches
-        if (searchValue.length === 1) {
-          return resultValue.includes(searchValue);
+        const exactValue = removeDoubleQuotes(searchValue)
+        if (exactValue != null) {
+          return resultValue.includes(exactValue)
+        } else {
+          // Trigrams don't work with single letter searches
+          if (searchValue.length === 1) {
+            return resultValue.includes(searchValue);
+          }
+          return trigramWordSimilarity(searchValue, resultValue) > TRIGRAM_SIMILARITY_THRESHOLD;
         }
-
-        return trigramWordSimilarity(searchValue, resultValue) > TRIGRAM_SIMILARITY_THRESHOLD;
       });
     }
   }


### PR DESCRIPTION
For testing `searchAndSort`, I navigated to deliverables. Searching for `company formation` includes matches with `information` as expected with Fuzzy search functions. With double quotes `"company formation"`, only `company formation document` is returned. 
