### PR TITLE
SW-5121: FE - Uncomment meta info in Cohorts Views when createdTime & modifiedTime are available from BE

### DIFF
--- a/src/scenes/AcceleratorRouter/Cohorts/CohortForm.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortForm.tsx
@@ -4,7 +4,6 @@ import { Container, Grid, useTheme } from '@mui/material';
 import { Dropdown, Textfield } from '@terraware/web-components';
 
 import PageForm from 'src/components/common/PageForm';
-// import ProjectFieldMeta from 'src/components/ProjectField/Meta';
 import { useLocalization } from 'src/providers/hooks';
 import strings from 'src/strings';
 import { CreateCohortRequestPayload, UpdateCohortRequestPayload } from 'src/types/Cohort';
@@ -128,22 +127,6 @@ export default function CohortForm<T extends CreateCohortRequestPayload | Update
               />
             </Grid>
           </Grid>
-
-          {/* TODO: uncomment this section once createdTime & modifiedTime are available in Cohort records */}
-          {/* <Grid container>
-            <ProjectFieldMeta
-              date={cohort.createdTime || 'Mar 2, 2024'}
-              dateLabel={strings.CREATED_ON}
-              user={cohort.createdBy || 'Weese Ritherspoon'}
-              userLabel={strings.CREATED_BY}
-            />
-            <ProjectFieldMeta
-              date={cohort.modifiedTime || 'Mar 2, 2024'}
-              dateLabel={strings.LAST_MODIFIED_ON}
-              user={cohort.modifiedBy || 'Weese Ritherspoon'}
-              userLabel={strings.LAST_MODIFIED_BY}
-            />
-          </Grid> */}
         </Grid>
       </Container>
     </PageForm>

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortView.tsx
@@ -6,7 +6,6 @@ import { Grid, useTheme } from '@mui/material';
 
 import { Crumb } from 'src/components/BreadCrumbs';
 import ProjectFieldDisplay from 'src/components/ProjectField/Display';
-// import ProjectFieldMeta from 'src/components/ProjectField/Meta';
 import Card from 'src/components/common/Card';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
@@ -83,22 +82,6 @@ const CohortView = () => {
               <ProjectFieldDisplay label={strings.COHORT_NAME} value={cohort.name} rightBorder={true} />
               <ProjectFieldDisplay label={strings.PHASE} value={cohort.phase} rightBorder={true} />
             </Grid>
-
-            {/* TODO: uncomment this section once createdTime & modifiedTime are available in Cohort records */}
-            {/* <Grid container>
-              <ProjectFieldMeta
-                date={cohort.createdTime}
-                dateLabel={strings.CREATED_ON}
-                user={cohort.createdBy}
-                userLabel={strings.CREATED_BY}
-              />
-              <ProjectFieldMeta
-                date={cohort.modifiedTime}
-                dateLabel={strings.LAST_MODIFIED_ON}
-                user={cohort.modifiedBy}
-                userLabel={strings.LAST_MODIFIED_BY}
-              />
-            </Grid> */}
           </Card>
         </>
       )}


### PR DESCRIPTION
This PR removes commented meta info components that show created & modified times from Cohort views, as Product confirmed they were not included in the PRD and are not required for MVP.