### PR TITLE
SW-5096: FE - Vertical Stepper Component

### DIFF
--- a/src/scenes/AcceleratorRouter/ModuleTimeline.tsx
+++ b/src/scenes/AcceleratorRouter/ModuleTimeline.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { useTheme } from '@mui/material';
+import Box from '@mui/material/Box';
+import Step from '@mui/material/Step';
+import StepLabel from '@mui/material/StepLabel';
+import Stepper from '@mui/material/Stepper';
+import Typography from '@mui/material/Typography';
+import { Badge } from '@terraware/web-components';
+
+type AltStepIconProps = {
+  activeStep: number;
+  index: number;
+};
+
+const AltStepIcon = ({ activeStep, index }: AltStepIconProps) => {
+  const theme = useTheme();
+  const stepNumber = index + 1;
+
+  return (
+    <Box
+      sx={{
+        alignItems: 'center',
+        bgcolor: index === activeStep ? theme.palette.TwClrBaseGreen500 : theme.palette.TwClrBaseGray300,
+        borderRadius: '50%',
+        color: theme.palette.TwClrBaseWhite,
+        display: 'flex',
+        height: 24,
+        justifyContent: 'center',
+        width: 24,
+      }}
+    >
+      <Typography variant='caption'>{stepNumber}</Typography>
+    </Box>
+  );
+};
+
+type ModuleTimelineProps = {
+  activeStep: number;
+  steps: Array<{ label: string; description: string }>;
+  title: string;
+};
+
+const ModuleTimeline = ({ activeStep, steps, title }: ModuleTimelineProps) => {
+  return (
+    <Box>
+      <Box sx={{ marginBottom: '24px', paddingRight: '16px' }}>
+        <Badge label={title} />
+      </Box>
+
+      <Box sx={{ width: 180 }}>
+        <Stepper activeStep={activeStep} orientation='vertical'>
+          {steps.map((step, index) => (
+            <Step key={step.label}>
+              <StepLabel
+                icon={<AltStepIcon activeStep={activeStep} index={index} />}
+                sx={{ fontWeight: 600, '.MuiStepLabel-label.Mui-disabled': { fontWeight: 600 } }}
+              >
+                {step.label}
+                <br />
+                <Typography component='span' style={{ fontSize: '14px', fontWeight: 400 }}>
+                  {step.description}
+                </Typography>
+              </StepLabel>
+            </Step>
+          ))}
+        </Stepper>
+      </Box>
+    </Box>
+  );
+};
+
+export default ModuleTimeline;

--- a/src/scenes/AcceleratorRouter/PageWithModuleTimeline.tsx
+++ b/src/scenes/AcceleratorRouter/PageWithModuleTimeline.tsx
@@ -4,19 +4,68 @@ import { Grid, useTheme } from '@mui/material';
 
 import Page, { PageProps } from 'src/components/Page';
 
+import ModuleTimeline from './ModuleTimeline';
+
 const PageWithModuleTimeline = (props: PageProps) => {
   const theme = useTheme();
 
   return (
     <Grid container spacing={theme.spacing(1)}>
-      <Grid item xs={10}>
+      <Grid item xs style={{ flexGrow: 1 }}>
         <Page {...props} />
       </Grid>
-      <Grid item xs={2}>
-        Stubbed module timeline
+      <Grid item>
+        <ModuleTimeline activeStep={mockPhase.activeModule} steps={mockPhase.modules} title={mockPhase.title} />
       </Grid>
     </Grid>
   );
+};
+
+const mockPhase = {
+  title: 'Phase 1: Feasibility Study',
+  activeModule: 1,
+  modules: [
+    {
+      label: 'Module 1',
+      description: 'Kick-Off',
+    },
+    {
+      label: 'Module 2',
+      description: 'Introduction to Carbon Projects',
+    },
+    {
+      label: 'Module 3',
+      description: 'Legal Eligibility',
+    },
+    {
+      label: 'Module 4',
+      description: 'Proposed Restoration Activities Part 1',
+    },
+    {
+      label: 'Module 5',
+      description: 'Proposed Restoration Activities Part 2',
+    },
+    {
+      label: 'Module 6',
+      description: 'Financial Viability',
+    },
+    {
+      label: 'Module 7',
+      description: 'Stakeholders and Co-Benefits',
+    },
+    {
+      label: 'Module 8',
+      description: 'Finalizing Deliverables',
+    },
+    {
+      label: 'Module 9',
+      description: 'Carbon Sales Process',
+    },
+    {
+      label: 'Module 10',
+      description: 'Close Phase 1',
+    },
+  ],
 };
 
 export default PageWithModuleTimeline;


### PR DESCRIPTION
This PR adds a new `ModuleTimeline` component that displays the current phase and related modules.

## Examples

### Before

![staging terraware io_accelerator_cohorts_1](https://github.com/terraware/terraware-web/assets/1474361/95cab93a-0966-4834-832d-13add06c0513)

### After

![localhost_accelerator_cohorts_1 (5)](https://github.com/terraware/terraware-web/assets/1474361/b30f5ef1-493b-4528-a931-d96398f6188f)

