### PR TITLE
Use the project's cohort phase to determine the active votes

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -3239,6 +3239,10 @@ export interface components {
     };
     ProjectPayload: {
       /** Format: int64 */
+      cohortId?: number;
+      /** @enum {string} */
+      cohortPhase?: "Phase 0 - Due Diligence" | "Phase 1 - Feasibility Study" | "Phase 2 - Plan and Scale" | "Phase 3 - Implement and Monitor";
+      /** Format: int64 */
       createdBy?: number;
       /** Format: date-time */
       createdTime?: string;
@@ -3252,6 +3256,8 @@ export interface components {
       name: string;
       /** Format: int64 */
       organizationId: number;
+      /** Format: int64 */
+      participantId?: number;
     };
     ProjectReportSettingsPayload: {
       /** @description If true, reports are enabled for this project. */

--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -2020,8 +2020,8 @@ export interface components {
     } & Omit<components["schemas"]["SearchNodePayload"], "operation"> & ({
       field?: string;
       /** @enum {string} */
-      type?: "Exact" | "ExactOrFuzzy" | "Fuzzy" | "Range";
-      /** @description List of values to match. For exact and fuzzy searches, a list of at least one value to search for; the list may include null to match accessions where the field does not have a value. For range searches, the list must contain exactly two values, the minimum and maximum; one of the values may be null to search for all values above a minimum or below a maximum. */
+      type?: "Exact" | "ExactOrFuzzy" | "Fuzzy" | "PhraseMatch" | "Range";
+      /** @description List of values to match. For exact, fuzzy and phrase match searches, a list of at least one value to search for; the list may include null to match accessions where the field does not have a value. For range searches, the list must contain exactly two values, the minimum and maximum; one of the values may be null to search for all values above a minimum or below a maximum. */
       values?: (string | null)[];
     }), "field" | "type" | "values">;
     FieldValuesPayload: {

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/ParticipantProjectProvider.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/ParticipantProjectProvider.tsx
@@ -1,15 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
 
 import { Crumb } from 'src/components/BreadCrumbs';
 import { APP_PATHS } from 'src/constants';
 import { useLocalization } from 'src/providers';
+import { useProjectData } from 'src/providers/Project/ProjectContext';
 import { requestAcceleratorOrgs } from 'src/redux/features/accelerator/acceleratorAsyncThunks';
 import { selectAcceleratorOrgsRequest } from 'src/redux/features/accelerator/acceleratorSelectors';
 import { requestGetParticipantProject } from 'src/redux/features/participantProjects/participantProjectsAsyncThunks';
 import { selectParticipantProjectRequest } from 'src/redux/features/participantProjects/participantProjectsSelectors';
-import { selectProject } from 'src/redux/features/projects/projectsSelectors';
-import { requestProject } from 'src/redux/features/projects/projectsThunks';
 import { requestGetUser } from 'src/redux/features/user/usersAsyncThunks';
 import { selectUser } from 'src/redux/features/user/usersSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
@@ -30,8 +28,7 @@ const ParticipantProjectProvider = ({ children }: Props) => {
   const dispatch = useAppDispatch();
   const snackbar = useSnackbar();
   const { activeLocale } = useLocalization();
-  const pathParams = useParams<{ projectId: string }>();
-  const projectId = Number(pathParams.projectId);
+  const { project, projectId } = useProjectData();
 
   const [participantProject, setParticipantProject] = useState<ParticipantProject>();
   const [participantProjectData, setParticipantProjectData] = useState<ParticipantProjectData>({
@@ -42,7 +39,6 @@ const ParticipantProjectProvider = ({ children }: Props) => {
   });
 
   const getParticipantProjectResult = useAppSelector(selectParticipantProjectRequest(projectId));
-  const project = useAppSelector(selectProject(projectId));
 
   const createdByUser = useAppSelector(selectUser(project?.createdBy));
   const modifiedByUser = useAppSelector(selectUser(project?.modifiedBy));
@@ -66,8 +62,9 @@ const ParticipantProjectProvider = ({ children }: Props) => {
   );
 
   const reload = useCallback(() => {
-    void dispatch(requestGetParticipantProject(projectId));
-    void dispatch(requestProject(projectId));
+    if (projectId !== -1) {
+      void dispatch(requestGetParticipantProject(projectId));
+    }
   }, [dispatch, projectId]);
 
   useEffect(() => {

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/index.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/index.tsx
@@ -1,6 +1,7 @@
 import { Redirect, Route, Switch } from 'react-router-dom';
 
 import { APP_PATHS } from 'src/constants';
+import ProjectProvider from 'src/providers/Project/ProjectProvider';
 
 import ScoringProvider from '../Scoring/ScoringProvider';
 import VotingProvider from '../Voting/VotingProvider';
@@ -10,23 +11,25 @@ import SingleView from './SingleView';
 
 const ParticipantProjectsRouter = () => {
   return (
-    <VotingProvider>
-      <ScoringProvider>
-        <ParticipantProjectProvider>
-          <Switch>
-            <Route exact path={APP_PATHS.ACCELERATOR_PROJECT_VIEW}>
-              <SingleView />
-            </Route>
-            <Route exact path={APP_PATHS.ACCELERATOR_PROJECT_EDIT}>
-              <EditView />
-            </Route>
-            <Route path={'*'}>
-              <Redirect to={APP_PATHS.ACCELERATOR_OVERVIEW} />
-            </Route>
-          </Switch>
-        </ParticipantProjectProvider>
-      </ScoringProvider>
-    </VotingProvider>
+    <ProjectProvider>
+      <VotingProvider>
+        <ScoringProvider>
+          <ParticipantProjectProvider>
+            <Switch>
+              <Route exact path={APP_PATHS.ACCELERATOR_PROJECT_VIEW}>
+                <SingleView />
+              </Route>
+              <Route exact path={APP_PATHS.ACCELERATOR_PROJECT_EDIT}>
+                <EditView />
+              </Route>
+              <Route path={'*'}>
+                <Redirect to={APP_PATHS.ACCELERATOR_OVERVIEW} />
+              </Route>
+            </Switch>
+          </ParticipantProjectProvider>
+        </ScoringProvider>
+      </VotingProvider>
+    </ProjectProvider>
   );
 };
 

--- a/src/scenes/AcceleratorRouter/Voting/VotingProvider.tsx
+++ b/src/scenes/AcceleratorRouter/Voting/VotingProvider.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 
 import { APP_PATHS } from 'src/constants';
+import { useProjectData } from 'src/providers/Project/ProjectContext';
 import { requestProjectVotesGet } from 'src/redux/features/votes/votesAsyncThunks';
 import { selectProjectVotes } from 'src/redux/features/votes/votesSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
@@ -20,10 +21,9 @@ const VotingProvider = ({ children }: Props): JSX.Element => {
   const query = useQuery();
   const dispatch = useAppDispatch();
   const snackbar = useSnackbar();
+  const { project, projectId } = useProjectData();
 
-  const pathParams = useParams<{ projectId: string }>();
-  const projectId = Number(pathParams.projectId);
-  const phase: Phase = (query.get('phase') as Phase) || 'Phase 1 - Feasibility Study'; // default to phase 1?
+  const phase: Phase = (query.get('phase') as Phase) || project?.cohortPhase || 'Phase 1 - Feasibility Study'; // default to phase 1?
 
   const votes = useAppSelector((state) => selectProjectVotes(state, projectId));
 

--- a/src/scenes/AcceleratorRouter/Voting/VotingProvider.tsx
+++ b/src/scenes/AcceleratorRouter/Voting/VotingProvider.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useHistory, useParams } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 import { APP_PATHS } from 'src/constants';
 import { useProjectData } from 'src/providers/Project/ProjectContext';

--- a/src/scenes/AcceleratorRouter/Voting/index.tsx
+++ b/src/scenes/AcceleratorRouter/Voting/index.tsx
@@ -1,6 +1,7 @@
 import { Redirect, Route, Switch } from 'react-router-dom';
 
 import { APP_PATHS } from 'src/constants';
+import ProjectProvider from 'src/providers/Project/ProjectProvider';
 
 import VotingEdit from './VotingEdit';
 import VotingProvider from './VotingProvider';
@@ -8,19 +9,21 @@ import VotingView from './VotingView';
 
 const VotingRouter = () => {
   return (
-    <VotingProvider>
-      <Switch>
-        <Route exact path={APP_PATHS.ACCELERATOR_VOTING}>
-          <VotingView />
-        </Route>
-        <Route exact path={APP_PATHS.ACCELERATOR_VOTING_EDIT}>
-          <VotingEdit />
-        </Route>
-        <Route path={'*'}>
-          <Redirect to={APP_PATHS.ACCELERATOR_VOTING} />
-        </Route>
-      </Switch>
-    </VotingProvider>
+    <ProjectProvider>
+      <VotingProvider>
+        <Switch>
+          <Route exact path={APP_PATHS.ACCELERATOR_VOTING}>
+            <VotingView />
+          </Route>
+          <Route exact path={APP_PATHS.ACCELERATOR_VOTING_EDIT}>
+            <VotingEdit />
+          </Route>
+          <Route path={'*'}>
+            <Redirect to={APP_PATHS.ACCELERATOR_VOTING} />
+          </Route>
+        </Switch>
+      </VotingProvider>
+    </ProjectProvider>
   );
 };
 


### PR DESCRIPTION
- The `VotingProvider` forwards back to the projects page if the votes that come back from the voting API don't match up with the "default" Phase (phase 1). 
- Use the project's `cohortPhase` as the next fallback in the provider if there is no `phase` query param.
- Wrap the usages of the `VotingProvider` with the `ProjectProvider` 