### PR TITLE
Upgrade webpack-dev-middleware to ^5.3.4 per CVE-2024-29180

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "react-redux": "^8.0.5",
     "react-responsive": "^9.0.0-beta.6",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "^5.0.1",
     "styled-components": "^6.0.0",
     "utm": "^1.1.1",
     "web-vitals": "^3.1.1",
@@ -151,6 +150,7 @@
     "playwright": "^1.40.1",
     "prettier": "^3.0.3",
     "prop-types": "^15.8.1",
+    "react-scripts": "^5.0.1",
     "react-test-renderer": "17.0.2",
     "sass": "^1.38.0",
     "start-server-and-test": "^2.0.3",
@@ -161,7 +161,8 @@
     "tslint-plugin-cypress": "^1.0.4",
     "tslint-react": "^5.0.0",
     "tslint-react-hooks": "^2.2.2",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "webpack-dev-middleware": "^5.3.4"
   },
   "resolutions": {
     "@babel/traverse": "7.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15783,7 +15783,7 @@ webidl-conversions@^6.1.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
-webpack-dev-middleware@^5.3.1:
+webpack-dev-middleware@^5.3.1, webpack-dev-middleware@^5.3.4:
   version "5.3.4"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz#eb7b39281cbce10e104eb2b8bf2b63fce49a3517"
   integrity sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==


### PR DESCRIPTION
Looks like the dep tree was `react-scripts` -> `webpack-dev-server` -> `webpack-dev-middleware`. We are currently at the latest version for `react-scripts`, so I added `webpack-dev-middleware` as a dev dependency and bumped the version to `^5.3.4` (next acceptable minor version from the [vulnerability report]())