### PR TITLE
SW-5142 Parsed search terms to use PhraseMatch when double-quoted

### DIFF
--- a/src/components/ProjectNewView/flow/SelectBatches.tsx
+++ b/src/components/ProjectNewView/flow/SelectBatches.tsx
@@ -22,7 +22,7 @@ import strings from 'src/strings';
 import { CreateProjectRequest } from 'src/types/Project';
 import { FieldNodePayload, SearchNodePayload, SearchSortOrder } from 'src/types/Search';
 import { getAllNurseries } from 'src/utils/organization';
-import { removeDoubleQuotes } from 'src/utils/search';
+import { parseSearchTerm } from 'src/utils/search';
 
 import { EntitySpecificFilterConfig } from './ProjectEntityFilter';
 
@@ -131,13 +131,13 @@ export default function SelectBatches(props: SelectBatchesProps): JSX.Element | 
   );
 
   const getSearchFields = useCallback((debouncedSearchTerm: string): FieldNodePayload[] => {
-    const phraseMatchQuery = removeDoubleQuotes(debouncedSearchTerm);
+    const { type, values } = parseSearchTerm(debouncedSearchTerm);
     return [
       {
         operation: 'field',
         field: 'batchNumber',
-        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-        values: [phraseMatchQuery || debouncedSearchTerm],
+        type,
+        values,
       },
     ];
   }, []);

--- a/src/components/ProjectNewView/flow/SelectBatches.tsx
+++ b/src/components/ProjectNewView/flow/SelectBatches.tsx
@@ -22,6 +22,7 @@ import strings from 'src/strings';
 import { CreateProjectRequest } from 'src/types/Project';
 import { FieldNodePayload, SearchNodePayload, SearchSortOrder } from 'src/types/Search';
 import { getAllNurseries } from 'src/utils/organization';
+import { removeDoubleQuotes } from 'src/utils/search';
 
 import { EntitySpecificFilterConfig } from './ProjectEntityFilter';
 
@@ -129,17 +130,17 @@ export default function SelectBatches(props: SelectBatchesProps): JSX.Element | 
     []
   );
 
-  const getSearchFields = useCallback(
-    (debouncedSearchTerm: string): FieldNodePayload[] => [
+  const getSearchFields = useCallback((debouncedSearchTerm: string): FieldNodePayload[] => {
+    const phraseMatchQuery = removeDoubleQuotes(debouncedSearchTerm);
+    return [
       {
         operation: 'field',
         field: 'batchNumber',
-        type: 'Fuzzy',
-        values: [debouncedSearchTerm],
+        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+        values: [phraseMatchQuery || debouncedSearchTerm],
       },
-    ],
-    []
-  );
+    ];
+  }, []);
 
   const {
     entities,

--- a/src/components/ProjectNewView/flow/SelectPlantingSites.tsx
+++ b/src/components/ProjectNewView/flow/SelectPlantingSites.tsx
@@ -18,6 +18,7 @@ import strings from 'src/strings';
 import { CreateProjectRequest } from 'src/types/Project';
 import { FieldNodePayload, SearchNodePayload, SearchSortOrder } from 'src/types/Search';
 import { PlantingSiteSearchResult } from 'src/types/Tracking';
+import { removeDoubleQuotes } from 'src/utils/search';
 
 type SelectPlantingSitesProps = {
   project: CreateProjectRequest;
@@ -92,17 +93,17 @@ export default function SelectPlantingSites(props: SelectPlantingSitesProps): JS
     []
   );
 
-  const getSearchFields = useCallback(
-    (debouncedSearchTerm: string): FieldNodePayload[] => [
+  const getSearchFields = useCallback((debouncedSearchTerm: string): FieldNodePayload[] => {
+    const phraseMatchQuery = removeDoubleQuotes(debouncedSearchTerm);
+    return [
       {
         operation: 'field',
         field: 'name',
-        type: 'Fuzzy',
-        values: [debouncedSearchTerm],
+        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+        values: [phraseMatchQuery || debouncedSearchTerm],
       },
-    ],
-    []
-  );
+    ];
+  }, []);
 
   const {
     entities,

--- a/src/components/ProjectNewView/flow/SelectPlantingSites.tsx
+++ b/src/components/ProjectNewView/flow/SelectPlantingSites.tsx
@@ -18,7 +18,7 @@ import strings from 'src/strings';
 import { CreateProjectRequest } from 'src/types/Project';
 import { FieldNodePayload, SearchNodePayload, SearchSortOrder } from 'src/types/Search';
 import { PlantingSiteSearchResult } from 'src/types/Tracking';
-import { removeDoubleQuotes } from 'src/utils/search';
+import { parseSearchTerm } from 'src/utils/search';
 
 type SelectPlantingSitesProps = {
   project: CreateProjectRequest;
@@ -94,13 +94,13 @@ export default function SelectPlantingSites(props: SelectPlantingSitesProps): JS
   );
 
   const getSearchFields = useCallback((debouncedSearchTerm: string): FieldNodePayload[] => {
-    const phraseMatchQuery = removeDoubleQuotes(debouncedSearchTerm);
+    const { type, values } = parseSearchTerm(debouncedSearchTerm);
     return [
       {
         operation: 'field',
         field: 'name',
-        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-        values: [phraseMatchQuery || debouncedSearchTerm],
+        type,
+        values,
       },
     ];
   }, []);

--- a/src/components/TableWithSearchFilters/index.tsx
+++ b/src/components/TableWithSearchFilters/index.tsx
@@ -9,6 +9,7 @@ import SearchFiltersWrapperV2, { FilterConfig } from 'src/components/common/Sear
 import { default as OrderPreservedTable, OrderPreservedTablePropsFull } from 'src/components/common/table';
 import { useLocalization } from 'src/providers';
 import { FieldNodePayload, SearchNodePayload, SearchSortOrder } from 'src/types/Search';
+import { removeDoubleQuotes } from 'src/utils/search';
 import useDebounce from 'src/utils/useDebounce';
 
 interface TableWithSearchFiltersProps extends Omit<OrderPreservedTablePropsFull<TableRowType>, 'columns' | 'orderBy'> {
@@ -64,12 +65,13 @@ const TableWithSearchFilters = (props: TableWithSearchFiltersProps) => {
 
     // Apply search field to search API payload
     if (debouncedSearchTerm && fuzzySearchColumns) {
+      const phraseMatchQuery = removeDoubleQuotes(debouncedSearchTerm);
       const fuzzySearchValueChildren = fuzzySearchColumns.map(
         (field: string): FieldNodePayload => ({
           operation: 'field',
           field,
-          type: 'Fuzzy',
-          values: [debouncedSearchTerm],
+          type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+          values: [phraseMatchQuery || debouncedSearchTerm],
         })
       );
 

--- a/src/components/TableWithSearchFilters/index.tsx
+++ b/src/components/TableWithSearchFilters/index.tsx
@@ -9,7 +9,7 @@ import SearchFiltersWrapperV2, { FilterConfig } from 'src/components/common/Sear
 import { default as OrderPreservedTable, OrderPreservedTablePropsFull } from 'src/components/common/table';
 import { useLocalization } from 'src/providers';
 import { FieldNodePayload, SearchNodePayload, SearchSortOrder } from 'src/types/Search';
-import { removeDoubleQuotes } from 'src/utils/search';
+import { parseSearchTerm } from 'src/utils/search';
 import useDebounce from 'src/utils/useDebounce';
 
 interface TableWithSearchFiltersProps extends Omit<OrderPreservedTablePropsFull<TableRowType>, 'columns' | 'orderBy'> {
@@ -65,13 +65,13 @@ const TableWithSearchFilters = (props: TableWithSearchFiltersProps) => {
 
     // Apply search field to search API payload
     if (debouncedSearchTerm && fuzzySearchColumns) {
-      const phraseMatchQuery = removeDoubleQuotes(debouncedSearchTerm);
+      const { type, values } = parseSearchTerm(debouncedSearchTerm);
       const fuzzySearchValueChildren = fuzzySearchColumns.map(
         (field: string): FieldNodePayload => ({
-          operation: 'field',
           field,
-          type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-          values: [phraseMatchQuery || debouncedSearchTerm],
+          operation: 'field',
+          type,
+          values,
         })
       );
 

--- a/src/components/common/FilterGroup/filters/FilterSearch.tsx
+++ b/src/components/common/FilterGroup/filters/FilterSearch.tsx
@@ -5,6 +5,7 @@ import { makeStyles } from '@mui/styles';
 
 import strings from 'src/strings';
 import { FieldNodePayload } from 'src/types/Search';
+import { removeDoubleQuotes } from 'src/utils/search';
 
 const useStyles = makeStyles((theme: Theme) => ({
   box: {
@@ -30,12 +31,13 @@ export default function Search(props: Props): JSX.Element {
 
   const onSearch = (searchVal: string) => {
     if (searchVal && searchVal !== '') {
-      const values = [searchVal];
+      const phraseMatchQuery = removeDoubleQuotes(searchVal);
+      const values = [phraseMatchQuery || searchVal];
 
       const newFilter: FieldNodePayload = {
         field: props.field,
         values,
-        type: 'Fuzzy',
+        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
         operation: 'field',
       };
 

--- a/src/components/common/FilterGroup/filters/FilterSearch.tsx
+++ b/src/components/common/FilterGroup/filters/FilterSearch.tsx
@@ -5,7 +5,7 @@ import { makeStyles } from '@mui/styles';
 
 import strings from 'src/strings';
 import { FieldNodePayload } from 'src/types/Search';
-import { removeDoubleQuotes } from 'src/utils/search';
+import { parseSearchTerm } from 'src/utils/search';
 
 const useStyles = makeStyles((theme: Theme) => ({
   box: {
@@ -31,14 +31,13 @@ export default function Search(props: Props): JSX.Element {
 
   const onSearch = (searchVal: string) => {
     if (searchVal && searchVal !== '') {
-      const phraseMatchQuery = removeDoubleQuotes(searchVal);
-      const values = [phraseMatchQuery || searchVal];
+      const { type, values } = parseSearchTerm(searchVal);
 
       const newFilter: FieldNodePayload = {
         field: props.field,
-        values,
-        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
         operation: 'field',
+        type,
+        values,
       };
 
       props.onChange(newFilter);

--- a/src/scenes/InventoryRouter/view/InventorySeedlingsTableForNursery.tsx
+++ b/src/scenes/InventoryRouter/view/InventorySeedlingsTableForNursery.tsx
@@ -8,7 +8,7 @@ import InventorySeedlingsTable, {
 import { NurseryBatchService } from 'src/services';
 import strings from 'src/strings';
 import { FieldNodePayload, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
-import { removeDoubleQuotes } from 'src/utils/search';
+import { parseSearchTerm } from 'src/utils/search';
 
 interface InventorySeedlingsTableForNurseryProps
   extends Omit<
@@ -47,13 +47,13 @@ export default function InventorySeedlingsTableForNursery(props: InventorySeedli
   const facilityId = props.nurseryId;
 
   const getFuzzySearchFields = useCallback((debouncedSearchTerm: string): FieldNodePayload[] => {
-    const phraseMatchQuery = removeDoubleQuotes(debouncedSearchTerm);
+    const { type, values } = parseSearchTerm(debouncedSearchTerm);
     return [
       {
         operation: 'field',
         field: 'species_scientificName',
-        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-        values: [phraseMatchQuery || debouncedSearchTerm],
+        type,
+        values,
       },
     ];
   }, []);

--- a/src/scenes/InventoryRouter/view/InventorySeedlingsTableForNursery.tsx
+++ b/src/scenes/InventoryRouter/view/InventorySeedlingsTableForNursery.tsx
@@ -8,6 +8,7 @@ import InventorySeedlingsTable, {
 import { NurseryBatchService } from 'src/services';
 import strings from 'src/strings';
 import { FieldNodePayload, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
+import { removeDoubleQuotes } from 'src/utils/search';
 
 interface InventorySeedlingsTableForNurseryProps
   extends Omit<
@@ -45,17 +46,17 @@ const columns = (): TableColumnType[] => [
 export default function InventorySeedlingsTableForNursery(props: InventorySeedlingsTableForNurseryProps): JSX.Element {
   const facilityId = props.nurseryId;
 
-  const getFuzzySearchFields = useCallback(
-    (debouncedSearchTerm: string): FieldNodePayload[] => [
+  const getFuzzySearchFields = useCallback((debouncedSearchTerm: string): FieldNodePayload[] => {
+    const phraseMatchQuery = removeDoubleQuotes(debouncedSearchTerm);
+    return [
       {
         operation: 'field',
         field: 'species_scientificName',
-        type: 'Fuzzy',
-        values: [debouncedSearchTerm],
+        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+        values: [phraseMatchQuery || debouncedSearchTerm],
       },
-    ],
-    []
-  );
+    ];
+  }, []);
 
   const getBatchesSearch = useCallback(
     async (

--- a/src/scenes/InventoryRouter/view/InventorySeedlingsTableForSpecies.tsx
+++ b/src/scenes/InventoryRouter/view/InventorySeedlingsTableForSpecies.tsx
@@ -8,7 +8,7 @@ import InventorySeedlingsTable, {
 import { NurseryBatchService } from 'src/services';
 import strings from 'src/strings';
 import { FieldNodePayload, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
-import { removeDoubleQuotes } from 'src/utils/search';
+import { parseSearchTerm } from 'src/utils/search';
 
 interface InventorySeedlingsTableForSpeciesProps
   extends Omit<
@@ -47,13 +47,13 @@ export default function InventorySeedlingsTableForSpecies(props: InventorySeedli
   const speciesId = props.speciesId;
 
   const getFuzzySearchFields = useCallback((debouncedSearchTerm: string): FieldNodePayload[] => {
-    const phraseMatchQuery = removeDoubleQuotes(debouncedSearchTerm);
+    const { type, values } = parseSearchTerm(debouncedSearchTerm);
     return [
       {
         operation: 'field',
         field: 'facility_name',
-        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-        values: [phraseMatchQuery || debouncedSearchTerm],
+        type,
+        values,
       },
     ];
   }, []);

--- a/src/scenes/InventoryRouter/view/InventorySeedlingsTableForSpecies.tsx
+++ b/src/scenes/InventoryRouter/view/InventorySeedlingsTableForSpecies.tsx
@@ -8,6 +8,7 @@ import InventorySeedlingsTable, {
 import { NurseryBatchService } from 'src/services';
 import strings from 'src/strings';
 import { FieldNodePayload, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
+import { removeDoubleQuotes } from 'src/utils/search';
 
 interface InventorySeedlingsTableForSpeciesProps
   extends Omit<
@@ -45,17 +46,17 @@ const columns = (): TableColumnType[] => [
 export default function InventorySeedlingsTableForSpecies(props: InventorySeedlingsTableForSpeciesProps): JSX.Element {
   const speciesId = props.speciesId;
 
-  const getFuzzySearchFields = useCallback(
-    (debouncedSearchTerm: string): FieldNodePayload[] => [
+  const getFuzzySearchFields = useCallback((debouncedSearchTerm: string): FieldNodePayload[] => {
+    const phraseMatchQuery = removeDoubleQuotes(debouncedSearchTerm);
+    return [
       {
         operation: 'field',
         field: 'facility_name',
-        type: 'Fuzzy',
-        values: [debouncedSearchTerm],
+        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+        values: [phraseMatchQuery || debouncedSearchTerm],
       },
-    ],
-    []
-  );
+    ];
+  }, []);
 
   const getBatchesSearch = useCallback(
     async (

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
@@ -29,6 +29,7 @@ import {
   SearchSortOrder,
 } from 'src/types/Search';
 import { getRequestId, setRequestId } from 'src/utils/requestsId';
+import { removeDoubleQuotes } from 'src/utils/search';
 import useDebounce from 'src/utils/useDebounce';
 import useQuery from 'src/utils/useQuery';
 import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
@@ -147,30 +148,31 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   };
 
   const getSearchChildren = useCallback(() => {
+    const phraseMatchQuery = removeDoubleQuotes(debouncedSearchTerm);
     const finalSearchValueChildren: SearchNodePayload[] = [];
     const searchValueChildren: FieldNodePayload[] = [];
     if (debouncedSearchTerm) {
       const fromNurseryNode: FieldNodePayload = {
         operation: 'field',
         field: 'facility_name',
-        type: 'Fuzzy',
-        values: [debouncedSearchTerm],
+        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+        values: [phraseMatchQuery || debouncedSearchTerm],
       };
       searchValueChildren.push(fromNurseryNode);
 
       const destinationNurseryNode: FieldNodePayload = {
         operation: 'field',
         field: 'destinationName',
-        type: 'Fuzzy',
-        values: [debouncedSearchTerm],
+        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+        values: [phraseMatchQuery || debouncedSearchTerm],
       };
       searchValueChildren.push(destinationNurseryNode);
 
       const speciesNameNode: FieldNodePayload = {
         operation: 'field',
         field: 'batchWithdrawals.batch_species_scientificName',
-        type: 'Fuzzy',
-        values: [debouncedSearchTerm],
+        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+        values: [phraseMatchQuery || debouncedSearchTerm],
       };
       searchValueChildren.push(speciesNameNode);
     }

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
@@ -29,7 +29,7 @@ import {
   SearchSortOrder,
 } from 'src/types/Search';
 import { getRequestId, setRequestId } from 'src/utils/requestsId';
-import { removeDoubleQuotes } from 'src/utils/search';
+import { parseSearchTerm } from 'src/utils/search';
 import useDebounce from 'src/utils/useDebounce';
 import useQuery from 'src/utils/useQuery';
 import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
@@ -148,31 +148,31 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   };
 
   const getSearchChildren = useCallback(() => {
-    const phraseMatchQuery = removeDoubleQuotes(debouncedSearchTerm);
+    const { type, values } = parseSearchTerm(debouncedSearchTerm);
     const finalSearchValueChildren: SearchNodePayload[] = [];
     const searchValueChildren: FieldNodePayload[] = [];
     if (debouncedSearchTerm) {
       const fromNurseryNode: FieldNodePayload = {
         operation: 'field',
         field: 'facility_name',
-        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-        values: [phraseMatchQuery || debouncedSearchTerm],
+        type,
+        values,
       };
       searchValueChildren.push(fromNurseryNode);
 
       const destinationNurseryNode: FieldNodePayload = {
         operation: 'field',
         field: 'destinationName',
-        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-        values: [phraseMatchQuery || debouncedSearchTerm],
+        type,
+        values,
       };
       searchValueChildren.push(destinationNurseryNode);
 
       const speciesNameNode: FieldNodePayload = {
         operation: 'field',
         field: 'batchWithdrawals.batch_species_scientificName',
-        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-        values: [phraseMatchQuery || debouncedSearchTerm],
+        type,
+        values,
       };
       searchValueChildren.push(speciesNameNode);
     }

--- a/src/scenes/PeopleRouter/PeopleListView.tsx
+++ b/src/scenes/PeopleRouter/PeopleListView.tsx
@@ -19,7 +19,7 @@ import { OrNodePayload, SearchRequestPayload } from 'src/types/Search';
 import { OrganizationUser } from 'src/types/User';
 import { isTfContact } from 'src/utils/organization';
 import { getRequestId, setRequestId } from 'src/utils/requestsId';
-import { removeDoubleQuotes } from 'src/utils/search';
+import { parseSearchTerm } from 'src/utils/search';
 import useDebounce from 'src/utils/useDebounce';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import useSnackbar from 'src/utils/useSnackbar';
@@ -88,7 +88,7 @@ export default function PeopleListView(): JSX.Element {
 
   const search = useCallback(
     async (searchTerm: string, skipTfContact = false) => {
-      const phraseMatchQuery = removeDoubleQuotes(searchTerm);
+      const { type, values } = parseSearchTerm(searchTerm);
       const searchField: OrNodePayload | null = searchTerm
         ? {
             operation: 'or',
@@ -96,14 +96,14 @@ export default function PeopleListView(): JSX.Element {
               {
                 operation: 'field',
                 field: 'user_firstName',
-                type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-                values: [phraseMatchQuery || searchTerm],
+                type,
+                values,
               },
               {
                 operation: 'field',
                 field: 'user_lastName',
-                type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-                values: [phraseMatchQuery || searchTerm],
+                type,
+                values,
               },
             ],
           }

--- a/src/scenes/PeopleRouter/PeopleListView.tsx
+++ b/src/scenes/PeopleRouter/PeopleListView.tsx
@@ -19,6 +19,7 @@ import { OrNodePayload, SearchRequestPayload } from 'src/types/Search';
 import { OrganizationUser } from 'src/types/User';
 import { isTfContact } from 'src/utils/organization';
 import { getRequestId, setRequestId } from 'src/utils/requestsId';
+import { removeDoubleQuotes } from 'src/utils/search';
 import useDebounce from 'src/utils/useDebounce';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import useSnackbar from 'src/utils/useSnackbar';
@@ -87,12 +88,23 @@ export default function PeopleListView(): JSX.Element {
 
   const search = useCallback(
     async (searchTerm: string, skipTfContact = false) => {
+      const phraseMatchQuery = removeDoubleQuotes(searchTerm);
       const searchField: OrNodePayload | null = searchTerm
         ? {
             operation: 'or',
             children: [
-              { operation: 'field', field: 'user_firstName', type: 'Fuzzy', values: [searchTerm] },
-              { operation: 'field', field: 'user_lastName', type: 'Fuzzy', values: [searchTerm] },
+              {
+                operation: 'field',
+                field: 'user_firstName',
+                type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+                values: [phraseMatchQuery || searchTerm],
+              },
+              {
+                operation: 'field',
+                field: 'user_lastName',
+                type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+                values: [phraseMatchQuery || searchTerm],
+              },
             ],
           }
         : null;

--- a/src/scenes/Species/SpeciesListView.tsx
+++ b/src/scenes/Species/SpeciesListView.tsx
@@ -31,7 +31,7 @@ import { FieldNodePayload, FieldOptionsMap, SearchRequestPayload, SearchSortOrde
 import { Species } from 'src/types/Species';
 import { isContributor } from 'src/utils/organization';
 import { getRequestId, setRequestId } from 'src/utils/requestsId';
-import { removeDoubleQuotes } from 'src/utils/search';
+import { parseSearchTerm } from 'src/utils/search';
 import useDebounce from 'src/utils/useDebounce';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import useForm from 'src/utils/useForm';
@@ -364,29 +364,29 @@ export default function SpeciesListView({ reloadData, species }: SpeciesListProp
     }
 
     if (debouncedSearchTerm) {
-      const phraseMatchQuery = removeDoubleQuotes(debouncedSearchTerm);
+      const { type, values } = parseSearchTerm(debouncedSearchTerm);
       const searchValueChildren: FieldNodePayload[] = [];
       const nameNode: FieldNodePayload = {
         operation: 'field',
         field: 'scientificName',
-        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-        values: [phraseMatchQuery || debouncedSearchTerm],
+        type,
+        values,
       };
       searchValueChildren.push(nameNode);
 
       const commonNameNode: FieldNodePayload = {
         operation: 'field',
         field: 'commonName',
-        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-        values: [phraseMatchQuery || debouncedSearchTerm],
+        type,
+        values,
       };
       searchValueChildren.push(commonNameNode);
 
       const familyNode: FieldNodePayload = {
         operation: 'field',
         field: 'familyName',
-        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-        values: [phraseMatchQuery || debouncedSearchTerm],
+        type,
+        values,
       };
       searchValueChildren.push(familyNode);
       params.search.children.push({

--- a/src/scenes/Species/SpeciesListView.tsx
+++ b/src/scenes/Species/SpeciesListView.tsx
@@ -31,6 +31,7 @@ import { FieldNodePayload, FieldOptionsMap, SearchRequestPayload, SearchSortOrde
 import { Species } from 'src/types/Species';
 import { isContributor } from 'src/utils/organization';
 import { getRequestId, setRequestId } from 'src/utils/requestsId';
+import { removeDoubleQuotes } from 'src/utils/search';
 import useDebounce from 'src/utils/useDebounce';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import useForm from 'src/utils/useForm';
@@ -363,28 +364,29 @@ export default function SpeciesListView({ reloadData, species }: SpeciesListProp
     }
 
     if (debouncedSearchTerm) {
+      const phraseMatchQuery = removeDoubleQuotes(debouncedSearchTerm);
       const searchValueChildren: FieldNodePayload[] = [];
       const nameNode: FieldNodePayload = {
         operation: 'field',
         field: 'scientificName',
-        type: 'Fuzzy',
-        values: [debouncedSearchTerm],
+        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+        values: [phraseMatchQuery || debouncedSearchTerm],
       };
       searchValueChildren.push(nameNode);
 
       const commonNameNode: FieldNodePayload = {
         operation: 'field',
         field: 'commonName',
-        type: 'Fuzzy',
-        values: [debouncedSearchTerm],
+        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+        values: [phraseMatchQuery || debouncedSearchTerm],
       };
       searchValueChildren.push(commonNameNode);
 
       const familyNode: FieldNodePayload = {
         operation: 'field',
         field: 'familyName',
-        type: 'Fuzzy',
-        values: [debouncedSearchTerm],
+        type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+        values: [phraseMatchQuery || debouncedSearchTerm],
       };
       searchValueChildren.push(familyNode);
       params.search.children.push({

--- a/src/services/FacilityService.ts
+++ b/src/services/FacilityService.ts
@@ -4,7 +4,7 @@ import { Facility, FacilityType } from 'src/types/Facility';
 import { Organization } from 'src/types/Organization';
 import { OrNodePayload, SearchRequestPayload } from 'src/types/Search';
 import { getAllNurseries, getAllSeedBanks } from 'src/utils/organization';
-import { removeDoubleQuotes } from 'src/utils/search';
+import { parseSearchTerm } from 'src/utils/search';
 
 import HttpService, { Response } from './HttpService';
 import SearchService from './SearchService';
@@ -114,25 +114,27 @@ const updateFacility = async (facility: Facility): Promise<Response> => {
  */
 const getFacilities = async ({ type, organizationId, query }: FacilitySearchParams): Promise<Facilities> => {
   const typeVal = type === 'Seed Bank' ? strings.SEED_BANK : strings.NURSERY;
-  const phraseMatchQuery = query ? removeDoubleQuotes(query) : null;
   const searchField: OrNodePayload | null = query
-    ? {
-        operation: 'or',
-        children: [
-          {
-            operation: 'field',
-            field: 'name',
-            type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-            values: [phraseMatchQuery || query],
-          },
-          {
-            operation: 'field',
-            field: 'description',
-            type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-            values: [phraseMatchQuery || query],
-          },
-        ],
-      }
+    ? (() => {
+        const { type: searchType, values } = parseSearchTerm(query);
+        return {
+          operation: 'or',
+          children: [
+            {
+              operation: 'field',
+              field: 'name',
+              searchType,
+              values,
+            },
+            {
+              operation: 'field',
+              field: 'description',
+              searchType,
+              values,
+            },
+          ],
+        };
+      })()
     : null;
 
   const params: SearchRequestPayload = {

--- a/src/services/FacilityService.ts
+++ b/src/services/FacilityService.ts
@@ -4,6 +4,7 @@ import { Facility, FacilityType } from 'src/types/Facility';
 import { Organization } from 'src/types/Organization';
 import { OrNodePayload, SearchRequestPayload } from 'src/types/Search';
 import { getAllNurseries, getAllSeedBanks } from 'src/utils/organization';
+import { removeDoubleQuotes } from 'src/utils/search';
 
 import HttpService, { Response } from './HttpService';
 import SearchService from './SearchService';
@@ -113,12 +114,23 @@ const updateFacility = async (facility: Facility): Promise<Response> => {
  */
 const getFacilities = async ({ type, organizationId, query }: FacilitySearchParams): Promise<Facilities> => {
   const typeVal = type === 'Seed Bank' ? strings.SEED_BANK : strings.NURSERY;
+  const phraseMatchQuery = query ? removeDoubleQuotes(query) : null;
   const searchField: OrNodePayload | null = query
     ? {
         operation: 'or',
         children: [
-          { operation: 'field', field: 'name', type: 'Fuzzy', values: [query] },
-          { operation: 'field', field: 'description', type: 'Fuzzy', values: [query] },
+          {
+            operation: 'field',
+            field: 'name',
+            type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+            values: [phraseMatchQuery || query],
+          },
+          {
+            operation: 'field',
+            field: 'description',
+            type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+            values: [phraseMatchQuery || query],
+          },
         ],
       }
     : null;

--- a/src/services/NurseryBatchService.ts
+++ b/src/services/NurseryBatchService.ts
@@ -8,6 +8,7 @@ import {
   SearchSortOrder,
 } from 'src/types/Search';
 import { OrganizationUser } from 'src/types/User';
+import { removeDoubleQuotes } from 'src/utils/search';
 import { getUserDisplayName } from 'src/utils/user';
 
 import HttpService, { Response } from './HttpService';
@@ -306,33 +307,34 @@ const getAllBatches = async (
   }
 
   if (query) {
+    const phraseMatchQuery = removeDoubleQuotes(query);
     const searchValueChildren: FieldNodePayload[] = [];
     searchValueChildren.push({
       operation: 'field',
       field: 'batchNumber',
-      type: 'Fuzzy',
-      values: [query],
+      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+      values: [phraseMatchQuery || query],
     });
 
     searchValueChildren.push({
       operation: 'field',
       field: 'species_scientificName',
-      type: 'Fuzzy',
-      values: [query],
+      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+      values: [phraseMatchQuery || query],
     });
 
     searchValueChildren.push({
       operation: 'field',
       field: 'species_commonName',
-      type: 'Fuzzy',
-      values: [query],
+      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+      values: [phraseMatchQuery || query],
     });
 
     searchValueChildren.push({
       operation: 'field',
       field: 'facility_name',
-      type: 'Fuzzy',
-      values: [query],
+      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+      values: [phraseMatchQuery || query],
     });
 
     params.search.children.push({

--- a/src/services/NurseryBatchService.ts
+++ b/src/services/NurseryBatchService.ts
@@ -8,7 +8,7 @@ import {
   SearchSortOrder,
 } from 'src/types/Search';
 import { OrganizationUser } from 'src/types/User';
-import { removeDoubleQuotes } from 'src/utils/search';
+import { parseSearchTerm } from 'src/utils/search';
 import { getUserDisplayName } from 'src/utils/user';
 
 import HttpService, { Response } from './HttpService';
@@ -307,34 +307,34 @@ const getAllBatches = async (
   }
 
   if (query) {
-    const phraseMatchQuery = removeDoubleQuotes(query);
+    const { type, values } = parseSearchTerm(query);
     const searchValueChildren: FieldNodePayload[] = [];
     searchValueChildren.push({
       operation: 'field',
       field: 'batchNumber',
-      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-      values: [phraseMatchQuery || query],
+      type,
+      values,
     });
 
     searchValueChildren.push({
       operation: 'field',
       field: 'species_scientificName',
-      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-      values: [phraseMatchQuery || query],
+      type,
+      values,
     });
 
     searchValueChildren.push({
       operation: 'field',
       field: 'species_commonName',
-      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-      values: [phraseMatchQuery || query],
+      type,
+      values,
     });
 
     searchValueChildren.push({
       operation: 'field',
       field: 'facility_name',
-      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-      values: [phraseMatchQuery || query],
+      type,
+      values,
     });
 
     params.search.children.push({

--- a/src/services/NurseryInventoryService.ts
+++ b/src/services/NurseryInventoryService.ts
@@ -10,6 +10,7 @@ import {
   SearchResponseElement,
   SearchSortOrder,
 } from 'src/types/Search';
+import { removeDoubleQuotes } from 'src/utils/search';
 
 import HttpService, { Response } from './HttpService';
 import SearchService from './SearchService';
@@ -187,27 +188,28 @@ const searchInventory = async ({
   const searchValueChildren: FieldNodePayload[] = [];
 
   if (query) {
+    const phraseMatchQuery = removeDoubleQuotes(query);
     const scientificNameNode: FieldNodePayload = {
       operation: 'field',
       field: 'species_scientificName',
-      type: 'Fuzzy',
-      values: [query],
+      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+      values: [phraseMatchQuery || query],
     };
     searchValueChildren.push(scientificNameNode);
 
     const commonNameNode: FieldNodePayload = {
       operation: 'field',
       field: 'species_commonName',
-      type: 'Fuzzy',
-      values: [query],
+      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+      values: [phraseMatchQuery || query],
     };
     searchValueChildren.push(commonNameNode);
 
     const facilityNameNode: FieldNodePayload = {
       operation: 'field',
       field: forSpecificFacilities ? 'facility_name' : 'facilityInventories.facility_name',
-      type: 'Fuzzy',
-      values: [query],
+      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+      values: [phraseMatchQuery || query],
     };
     searchValueChildren.push(facilityNameNode);
   }
@@ -291,19 +293,20 @@ const searchInventoryByNursery = async ({
   const searchValueChildren: FieldNodePayload[] = [];
 
   if (query) {
+    const phraseMatchQuery = removeDoubleQuotes(query);
     const scientificNameNode: FieldNodePayload = {
       operation: 'field',
       field: 'facilityInventories.species_scientificName',
-      type: 'Fuzzy',
-      values: [query],
+      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+      values: [phraseMatchQuery || query],
     };
     searchValueChildren.push(scientificNameNode);
 
     const facilityNameNode: FieldNodePayload = {
       operation: 'field',
       field: 'facility_name',
-      type: 'Fuzzy',
-      values: [query],
+      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+      values: [phraseMatchQuery || query],
     };
     searchValueChildren.push(facilityNameNode);
   }
@@ -368,27 +371,28 @@ const downloadInventory = async ({
   const searchValueChildren: FieldNodePayload[] = [];
 
   if (query) {
+    const phraseMatchQuery = removeDoubleQuotes(query);
     const scientificNameNode: FieldNodePayload = {
       operation: 'field',
       field: 'species_scientificName',
-      type: 'Fuzzy',
-      values: [query],
+      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+      values: [phraseMatchQuery || query],
     };
     searchValueChildren.push(scientificNameNode);
 
     const commonNameNode: FieldNodePayload = {
       operation: 'field',
       field: 'species_commonName',
-      type: 'Fuzzy',
-      values: [query],
+      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+      values: [phraseMatchQuery || query],
     };
     searchValueChildren.push(commonNameNode);
 
     const facilityNameNode: FieldNodePayload = {
       operation: 'field',
       field: forSpecificFacilities ? 'facility_name' : 'facilityInventories.facility_name',
-      type: 'Fuzzy',
-      values: [query],
+      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+      values: [phraseMatchQuery || query],
     };
     searchValueChildren.push(facilityNameNode);
   }

--- a/src/services/NurseryInventoryService.ts
+++ b/src/services/NurseryInventoryService.ts
@@ -10,7 +10,7 @@ import {
   SearchResponseElement,
   SearchSortOrder,
 } from 'src/types/Search';
-import { removeDoubleQuotes } from 'src/utils/search';
+import { parseSearchTerm } from 'src/utils/search';
 
 import HttpService, { Response } from './HttpService';
 import SearchService from './SearchService';
@@ -188,28 +188,28 @@ const searchInventory = async ({
   const searchValueChildren: FieldNodePayload[] = [];
 
   if (query) {
-    const phraseMatchQuery = removeDoubleQuotes(query);
+    const { type, values } = parseSearchTerm(query);
     const scientificNameNode: FieldNodePayload = {
       operation: 'field',
       field: 'species_scientificName',
-      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-      values: [phraseMatchQuery || query],
+      type,
+      values,
     };
     searchValueChildren.push(scientificNameNode);
 
     const commonNameNode: FieldNodePayload = {
       operation: 'field',
       field: 'species_commonName',
-      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-      values: [phraseMatchQuery || query],
+      type,
+      values,
     };
     searchValueChildren.push(commonNameNode);
 
     const facilityNameNode: FieldNodePayload = {
       operation: 'field',
       field: forSpecificFacilities ? 'facility_name' : 'facilityInventories.facility_name',
-      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-      values: [phraseMatchQuery || query],
+      type,
+      values,
     };
     searchValueChildren.push(facilityNameNode);
   }
@@ -293,20 +293,20 @@ const searchInventoryByNursery = async ({
   const searchValueChildren: FieldNodePayload[] = [];
 
   if (query) {
-    const phraseMatchQuery = removeDoubleQuotes(query);
+    const { type, values } = parseSearchTerm(query);
     const scientificNameNode: FieldNodePayload = {
       operation: 'field',
       field: 'facilityInventories.species_scientificName',
-      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-      values: [phraseMatchQuery || query],
+      type,
+      values,
     };
     searchValueChildren.push(scientificNameNode);
 
     const facilityNameNode: FieldNodePayload = {
       operation: 'field',
       field: 'facility_name',
-      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-      values: [phraseMatchQuery || query],
+      type,
+      values,
     };
     searchValueChildren.push(facilityNameNode);
   }
@@ -371,28 +371,28 @@ const downloadInventory = async ({
   const searchValueChildren: FieldNodePayload[] = [];
 
   if (query) {
-    const phraseMatchQuery = removeDoubleQuotes(query);
+    const { type, values } = parseSearchTerm(query);
     const scientificNameNode: FieldNodePayload = {
       operation: 'field',
       field: 'species_scientificName',
-      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-      values: [phraseMatchQuery || query],
+      type,
+      values,
     };
     searchValueChildren.push(scientificNameNode);
 
     const commonNameNode: FieldNodePayload = {
       operation: 'field',
       field: 'species_commonName',
-      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-      values: [phraseMatchQuery || query],
+      type,
+      values,
     };
     searchValueChildren.push(commonNameNode);
 
     const facilityNameNode: FieldNodePayload = {
       operation: 'field',
       field: forSpecificFacilities ? 'facility_name' : 'facilityInventories.facility_name',
-      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-      values: [phraseMatchQuery || query],
+      type,
+      values,
     };
     searchValueChildren.push(facilityNameNode);
   }

--- a/src/services/ProjectsService.ts
+++ b/src/services/ProjectsService.ts
@@ -3,7 +3,7 @@ import HttpService, { Response, Response2 } from 'src/services/HttpService';
 import SearchService from 'src/services/SearchService';
 import { CreateProjectRequest, Project, UpdateProjectRequest } from 'src/types/Project';
 import { OrNodePayload, SearchRequestPayload } from 'src/types/Search';
-import { removeDoubleQuotes } from 'src/utils/search';
+import { parseSearchTerm } from 'src/utils/search';
 
 /**
  * Projects related services
@@ -59,25 +59,27 @@ const listProjects = async (organizationId?: number, locale?: string | null): Pr
  * Search projects
  */
 const searchProjects = async (organizationId: number, query?: string): Promise<Project[] | null> => {
-  const phraseMatchQuery = query ? removeDoubleQuotes(query) : null;
   const searchField: OrNodePayload | null = query
-    ? {
-        operation: 'or',
-        children: [
-          {
-            operation: 'field',
-            field: 'name',
-            type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-            values: [phraseMatchQuery || query],
-          },
-          {
-            operation: 'field',
-            field: 'description',
-            type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-            values: [phraseMatchQuery || query],
-          },
-        ],
-      }
+    ? (() => {
+        const { type, values } = parseSearchTerm(query);
+        return {
+          operation: 'or',
+          children: [
+            {
+              operation: 'field',
+              field: 'name',
+              type,
+              values,
+            },
+            {
+              operation: 'field',
+              field: 'description',
+              type,
+              values,
+            },
+          ],
+        };
+      })()
     : null;
 
   const searchParams: SearchRequestPayload = {

--- a/src/services/ProjectsService.ts
+++ b/src/services/ProjectsService.ts
@@ -3,6 +3,7 @@ import HttpService, { Response, Response2 } from 'src/services/HttpService';
 import SearchService from 'src/services/SearchService';
 import { CreateProjectRequest, Project, UpdateProjectRequest } from 'src/types/Project';
 import { OrNodePayload, SearchRequestPayload } from 'src/types/Search';
+import { removeDoubleQuotes } from 'src/utils/search';
 
 /**
  * Projects related services
@@ -58,12 +59,23 @@ const listProjects = async (organizationId?: number, locale?: string | null): Pr
  * Search projects
  */
 const searchProjects = async (organizationId: number, query?: string): Promise<Project[] | null> => {
+  const phraseMatchQuery = query ? removeDoubleQuotes(query) : null;
   const searchField: OrNodePayload | null = query
     ? {
         operation: 'or',
         children: [
-          { operation: 'field', field: 'name', type: 'Fuzzy', values: [query] },
-          { operation: 'field', field: 'description', type: 'Fuzzy', values: [query] },
+          {
+            operation: 'field',
+            field: 'name',
+            type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+            values: [phraseMatchQuery || query],
+          },
+          {
+            operation: 'field',
+            field: 'description',
+            type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+            values: [phraseMatchQuery || query],
+          },
         ],
       }
     : null;

--- a/src/services/SearchService.ts
+++ b/src/services/SearchService.ts
@@ -4,10 +4,6 @@ import {
   SearchNodePayload,
   SearchResponseElement,
   SearchValuesResponseElement,
-  isAndNodePayload,
-  isFieldNodePayload,
-  isNotNodePayload,
-  isOrNodePayload,
 } from 'src/types/Search';
 import { removeDoubleQuotes } from 'src/utils/search';
 

--- a/src/services/SearchService.ts
+++ b/src/services/SearchService.ts
@@ -4,7 +4,12 @@ import {
   SearchNodePayload,
   SearchResponseElement,
   SearchValuesResponseElement,
+  isAndNodePayload,
+  isFieldNodePayload,
+  isNotNodePayload,
+  isOrNodePayload,
 } from 'src/types/Search';
+import { removeDoubleQuotes } from 'src/utils/search';
 
 import HttpService, { Response } from './HttpService';
 

--- a/src/services/SearchService.ts
+++ b/src/services/SearchService.ts
@@ -5,7 +5,6 @@ import {
   SearchResponseElement,
   SearchValuesResponseElement,
 } from 'src/types/Search';
-import { removeDoubleQuotes } from 'src/utils/search';
 
 import HttpService, { Response } from './HttpService';
 

--- a/src/services/SpeciesService.ts
+++ b/src/services/SpeciesService.ts
@@ -2,6 +2,7 @@ import { paths } from 'src/api/types/generated-schema';
 import { GetUploadStatusResponsePayload, UploadFileResponse } from 'src/types/File';
 import { FieldNodePayload, SearchRequestPayload, SearchResponseElement } from 'src/types/Search';
 import { Species, SpeciesDetails, SuggestedSpecies } from 'src/types/Species';
+import { removeDoubleQuotes } from 'src/utils/search';
 
 import HttpService, { Response, ServerData } from './HttpService';
 import SearchService from './SearchService';
@@ -317,20 +318,21 @@ const suggestSpecies = async (organizationId: number, query: string): Promise<Su
 
   if (query) {
     const searchValueChildren: FieldNodePayload[] = [];
+    const phraseMatchQuery = removeDoubleQuotes(query);
 
     const nameNode: FieldNodePayload = {
       operation: 'field',
       field: 'scientificName',
-      type: 'Fuzzy',
-      values: [query],
+      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+      values: [phraseMatchQuery || query],
     };
     searchValueChildren.push(nameNode);
 
     const commonNameNode: FieldNodePayload = {
       operation: 'field',
       field: 'commonName',
-      type: 'Fuzzy',
-      values: [query],
+      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+      values: [phraseMatchQuery || query],
     };
     searchValueChildren.push(commonNameNode);
 

--- a/src/services/SpeciesService.ts
+++ b/src/services/SpeciesService.ts
@@ -2,7 +2,7 @@ import { paths } from 'src/api/types/generated-schema';
 import { GetUploadStatusResponsePayload, UploadFileResponse } from 'src/types/File';
 import { FieldNodePayload, SearchRequestPayload, SearchResponseElement } from 'src/types/Search';
 import { Species, SpeciesDetails, SuggestedSpecies } from 'src/types/Species';
-import { removeDoubleQuotes } from 'src/utils/search';
+import { parseSearchTerm } from 'src/utils/search';
 
 import HttpService, { Response, ServerData } from './HttpService';
 import SearchService from './SearchService';
@@ -318,21 +318,21 @@ const suggestSpecies = async (organizationId: number, query: string): Promise<Su
 
   if (query) {
     const searchValueChildren: FieldNodePayload[] = [];
-    const phraseMatchQuery = removeDoubleQuotes(query);
+    const { type, values } = parseSearchTerm(query);
 
     const nameNode: FieldNodePayload = {
       operation: 'field',
       field: 'scientificName',
-      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-      values: [phraseMatchQuery || query],
+      type,
+      values,
     };
     searchValueChildren.push(nameNode);
 
     const commonNameNode: FieldNodePayload = {
       operation: 'field',
       field: 'commonName',
-      type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
-      values: [phraseMatchQuery || query],
+      type,
+      values,
     };
     searchValueChildren.push(commonNameNode);
 

--- a/src/types/Search.ts
+++ b/src/types/Search.ts
@@ -8,6 +8,7 @@ export type SearchNodePayload = AndNodePayload | FieldNodePayload | NotNodePaylo
 export type FieldValuesPayload = { [key: string]: components['schemas']['FieldValuesPayload'] };
 export type SearchCriteria = { [key: string]: SearchNodePayload };
 export type SearchSortOrder = components['schemas']['SearchSortOrderElement'];
+export type SearchType = components['schemas']['FieldNodePayload']['type'];
 export type SearchResponseElement = components['schemas']['SearchResponsePayload']['results'][0];
 export type SearchResponseElementWithId = SearchResponseElement & { id: string };
 export type SearchValuesResponseElement = components['schemas']['SearchValuesResponsePayload']['results'];

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,9 +1,23 @@
+import { SearchType } from 'src/types/Search';
+
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#escaping
  */
 function escapeRegExp(input: string) {
   return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }
+
+/**
+ * Parse the text search term and return the query and the type of search, Fuzzy or PhraseMatch.
+ */
+const parseSearchTerm = (searchTerm: string): { type: SearchType; values: string[] } => {
+  const phraseMatchQuery = removeDoubleQuotes(searchTerm);
+
+  return {
+    type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+    values: [phraseMatchQuery || searchTerm],
+  };
+};
 
 /**
  * Checks an exact sequence of words or characters within a given string
@@ -37,4 +51,4 @@ const removeDoubleQuotes = (str: string): string | null => {
   }
 };
 
-export { phraseMatch, regexMatch, removeDoubleQuotes };
+export { parseSearchTerm, phraseMatch, regexMatch, removeDoubleQuotes };


### PR DESCRIPTION
Every instance we have a searchbox, where user can specify an input. We will try to `removeDoubleQuotes` and use PhraseMatching. Most file changed here are just wholesale changes to implement this behavior. 