### PR TITLE
SW-5145 Fix participants edit crash

### DIFF
--- a/src/scenes/AcceleratorRouter/Participants/ParticipantForm.tsx
+++ b/src/scenes/AcceleratorRouter/Participants/ParticipantForm.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Box, Grid, useTheme } from '@mui/material';
 import { Dropdown, Textfield } from '@terraware/web-components';
+import _ from 'lodash';
 
 import AddLink from 'src/components/common/AddLink';
 import Card from 'src/components/common/Card';
@@ -50,7 +51,10 @@ export default function ParticipantForm<T extends ParticipantCreateRequest | Par
       .filter((org) => org.projects.length > 0)
       .reduce(
         (acc, org) => {
-          return { ...acc, [org.id]: org };
+          // The org by default is immutable (from redux store).
+          // The local copy of org will be merged with existing participant projects' data,
+          // and needs to be mutable, hence the clone.
+          return { ...acc, [org.id]: _.cloneDeep(org) };
         },
         {} as Record<string, AcceleratorOrg>
       );


### PR DESCRIPTION
- If the list of unassociated accelerator org/projects are [{org: ABC, projects: [DEF]}]
- and
- If the participant had an org/project association [{org: ABC, projects: [XYZ]}, {org: ...}]
- we merged the ABC org's projects list to contain both DEF and XYZ (for the multiselect)
- The projects array from redux is immutable, hence the crash (and also not wise to edit redux store data)
- Updated code to make a copy instead.

Original error:
```
 Cannot add property 1, object is not extensible
    at Array.push (<anonymous>)
    at ParticipantForm.tsx:65:29
```