### PR TITLE
SW-5144 Fix initial value for accession remaining quantity changed description text

### DIFF
--- a/src/scenes/AccessionsRouter/edit/QuantityModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/QuantityModal.tsx
@@ -349,7 +349,7 @@ export default function QuantityModal(props: QuantityModalProps): JSX.Element {
             <Grid item xs={12} textAlign='left'>
               <Textfield
                 id='notes'
-                value={record?.notes}
+                value={remainingQuantityNotes}
                 onChange={(value) => onChangeRemainingQuantityNotes(value as string)}
                 type='textarea'
                 label={strings.NOTES}


### PR DESCRIPTION
- description should not be initialized to any existing value, should be empty by default
- intention is to capture 'quantity changed' description when quantity changes
- was erroneously initialized to the 'notes' values (plant description), result of copy/pasta, leading to some ux issues
- edit/save and history values still work as expected