### PR TITLE
SW-5159 Fix participant project view redirecting back to participant project list even when there are votes

### DIFF
--- a/src/providers/Project/ProjectProvider.tsx
+++ b/src/providers/Project/ProjectProvider.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
+import { BusySpinner } from '@terraware/web-components';
+
+import useNavigateTo from 'src/hooks/useNavigateTo';
 import { selectProject } from 'src/redux/features/projects/projectsSelectors';
 import { requestProject } from 'src/redux/features/projects/projectsThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
@@ -15,6 +18,7 @@ const ProjectProvider = ({ children }: Props) => {
   const dispatch = useAppDispatch();
   const pathParams = useParams<{ projectId: string }>();
   const pathProjectId = Number(pathParams.projectId);
+  const { goToParticipantProjectList } = useNavigateTo();
 
   const [projectId, setProjectId] = useState<number>(-1);
   const project = useAppSelector(selectProject(projectId));
@@ -32,11 +36,13 @@ const ProjectProvider = ({ children }: Props) => {
   }, [dispatch, projectId]);
 
   useEffect(() => {
-    if (!isNaN(pathProjectId)) {
+    if (pathProjectId === -1) {
+      goToParticipantProjectList();
+    } else if (!isNaN(pathProjectId)) {
       setProjectId(pathProjectId);
       reload();
     }
-  }, [dispatch, pathProjectId, reload]);
+  }, [dispatch, goToParticipantProjectList, pathProjectId, reload]);
 
   useEffect(() => {
     setProjectData({
@@ -45,6 +51,10 @@ const ProjectProvider = ({ children }: Props) => {
       reload,
     });
   }, [project, projectId, reload]);
+
+  if (projectData.projectId === -1) {
+    return <BusySpinner withSkrim />;
+  }
 
   return <ProjectContext.Provider value={projectData}>{children}</ProjectContext.Provider>;
 };


### PR DESCRIPTION
- there was a race condition where the project id is -1 and then a valid value, the voting provider fetches votes for project -1 and fails on subsequent views
- On first visit vote request for -1 and actually project both have network latency and we had enough time to transition from project id -1 to valid project id
- On subsequent visits, the result for project id -1 votes is already in redux store and is processed right away before the transition to real project id
- added a guard in the project provider to wait until we have a valid project
- added another redirect guard in case someone actually visits a project id of -1 in the url (so we aren't spinning forever)
- tested ok for first and subsequent views (assumption here is there really are votes in the db)
- Note: I had initially set about adding -1 guards in voting provider and scoring provider.. decided it was better to handle at the root