### PR TITLE
SW-5151 Fix the expand/contract of scoring buttons' boundary

### DIFF
--- a/src/scenes/AcceleratorRouter/Scoring/PhaseScores/ScoreEntry/ValueControl.tsx
+++ b/src/scenes/AcceleratorRouter/Scoring/PhaseScores/ScoreEntry/ValueControl.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { Box, Typography, useTheme } from '@mui/material';
 
@@ -14,12 +14,26 @@ type ScoreControlProps = {
 
 const ValueControl = ({ disabled, onChangeValue, score }: ScoreControlProps) => {
   const theme = useTheme();
+  const ref = useRef<HTMLDivElement>(null);
 
   const [scoreValue, setScoreValue] = useState<ScoreValue | null>(score.value);
 
   const scoreLabel = getScoreValueLabel(scoreValue);
 
   const scoreColors = useMemo(() => getScoreColors(scoreValue, theme), [scoreValue, theme]);
+
+  const labelsForWidthCalculation = useMemo(
+    () => (
+      <Box display='block' visibility='hidden' position='absolute' top='-5000' ref={ref}>
+        {ScoreValues.map((value) => (
+          <Typography key={value} sx={{ color: 'white', fontSize: '14px', fontWeight: 500, margin: '4px' }}>
+            {getScoreValueLabel(value)}
+          </Typography>
+        ))}
+      </Box>
+    ),
+    [ref]
+  );
 
   const handleOnChangeValue = (value: ScoreValue) => {
     setScoreValue(value);
@@ -40,8 +54,8 @@ const ValueControl = ({ disabled, onChangeValue, score }: ScoreControlProps) => 
         padding: '12px',
       }}
     >
-      <Box display='flex' flexDirection='column'>
-        <Box display='flex' justifyContent='space-evenly'>
+      <Box display='flex' flexDirection='column' minWidth={Math.max(ref.current?.clientWidth ?? 0, 300)}>
+        <Box display='flex' justifyContent='space-between'>
           {ScoreValues.map((value) => (
             <ValueControlButton
               disabled={disabled}
@@ -56,6 +70,7 @@ const ValueControl = ({ disabled, onChangeValue, score }: ScoreControlProps) => 
           {scoreLabel}
         </Typography>
       </Box>
+      {labelsForWidthCalculation}
     </Box>
   );
 };


### PR DESCRIPTION
- the score description moves the boundary in/out based on label width
- this caused some jarring of the buttons
- using a fixed width calculated off the labels drawn off screen
- width will vary by language
- simpler alternative is to eye ball some width like 330px and use that

#### Before

![screencast 2024-04-03 13-47-59](https://github.com/terraware/terraware-web/assets/1865174/58f2627d-15e2-42ed-b7ba-087b9c821e27)

#### After

![screencast 2024-04-03 13-56-30](https://github.com/terraware/terraware-web/assets/1865174/e44794b1-5d0b-44b4-b0cf-ff49798f24a2)
