### PR TITLE
SW-5152 / SW-5169 Redirect to score edit if there is no scores/qualitative data

### DIFF
--- a/src/redux/features/scores/scoresSelectors.ts
+++ b/src/redux/features/scores/scoresSelectors.ts
@@ -1,5 +1,6 @@
 import { RootState } from 'src/redux/rootReducer';
 
 export const selectScoreList = (projectId: number) => (state: RootState) => state.scoreList[projectId];
+export const selectScoreListByRequest = (requestId: string) => (state: RootState) => state.scoreList[requestId];
 
 export const selectScoresUpdateRequest = (requestId: string) => (state: RootState) => state.scoresUpdate[requestId];

--- a/src/scenes/AcceleratorRouter/Scoring/EditView.tsx
+++ b/src/scenes/AcceleratorRouter/Scoring/EditView.tsx
@@ -28,7 +28,7 @@ const ScorecardEditView = () => {
   const history = useHistory();
   const classes = useStyles();
   const { crumbs, hasData, phase0Scores, phase1Scores, projectId, projectName, status } = useScoringData();
-  const { update, status: updateStatus, listStatus } = useScoresUpdate(projectId);
+  const { update, status: updateStatus } = useScoresUpdate(projectId);
   const { goToParticipantProject } = useNavigateTo();
 
   const [scores, setScores] = useState<Score[]>([]);
@@ -83,10 +83,10 @@ const ScorecardEditView = () => {
   }, [phase1Scores]);
 
   useEffect(() => {
-    if (updateStatus === 'success' && listStatus === 'success') {
+    if (updateStatus === 'success') {
       goToScorecardView();
     }
-  }, [updateStatus, goToScorecardView, listStatus]);
+  }, [updateStatus, goToScorecardView]);
 
   return (
     <Page title={`Edit Scoring for project ${projectName}`} crumbs={crumbs} hierarchicalCrumbs={false}>

--- a/src/scenes/AcceleratorRouter/Scoring/ScoresView.tsx
+++ b/src/scenes/AcceleratorRouter/Scoring/ScoresView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { Box, Grid, useTheme } from '@mui/material';
@@ -17,7 +17,7 @@ const ScorecardView = () => {
   const { activeLocale } = useLocalization();
   const theme = useTheme();
   const history = useHistory();
-  const { crumbs, phase0Scores, phase1Scores, projectId, projectName, status } = useScoringData();
+  const { crumbs, hasData, phase0Scores, phase1Scores, projectId, projectName, status } = useScoringData();
 
   const goToScoresEdit = useCallback(() => {
     history.push({ pathname: APP_PATHS.ACCELERATOR_SCORING_EDIT.replace(':projectId', `${projectId}`) });
@@ -45,6 +45,12 @@ const ScorecardView = () => {
     [activeLocale, goToScoresEdit, theme]
   );
 
+  useEffect(() => {
+    if (hasData === false) {
+      goToScoresEdit();
+    }
+  }, [goToScoresEdit, hasData]);
+
   return (
     <PageWithModuleTimeline
       title={`${projectName} ${strings.SCORES}`}
@@ -53,29 +59,31 @@ const ScorecardView = () => {
       rightComponent={rightComponent}
     >
       {status === 'pending' && <BusySpinner />}
-      <Card style={{ width: '100%' }}>
-        <Box display='flex' flexDirection='row' flexGrow={0} margin={theme.spacing(3)} justifyContent='right'>
-          <Button
-            id='goToVotes'
-            label={strings.SEE_IC_VOTES}
-            priority='secondary'
-            onClick={goToVoting}
-            size='medium'
-            type='productive'
-          />
-        </Box>
+      {hasData && (
+        <Card style={{ width: '100%' }}>
+          <Box display='flex' flexDirection='row' flexGrow={0} margin={theme.spacing(3)} justifyContent='right'>
+            <Button
+              id='goToVotes'
+              label={strings.SEE_IC_VOTES}
+              priority='secondary'
+              onClick={goToVoting}
+              size='medium'
+              type='productive'
+            />
+          </Box>
 
-        {activeLocale && (
-          <Grid container spacing={theme.spacing(2)}>
-            <Grid item xs={6}>
-              <PhaseScores phaseScores={phase0Scores} />
+          {activeLocale && (
+            <Grid container spacing={theme.spacing(2)}>
+              <Grid item xs={6}>
+                <PhaseScores phaseScores={phase0Scores} />
+              </Grid>
+              <Grid item xs={6}>
+                <PhaseScores phaseScores={phase1Scores} />
+              </Grid>
             </Grid>
-            <Grid item xs={6}>
-              <PhaseScores phaseScores={phase1Scores} />
-            </Grid>
-          </Grid>
-        )}
-      </Card>
+          )}
+        </Card>
+      )}
     </PageWithModuleTimeline>
   );
 };

--- a/src/scenes/AcceleratorRouter/Scoring/ScoringContext.tsx
+++ b/src/scenes/AcceleratorRouter/Scoring/ScoringContext.tsx
@@ -6,6 +6,7 @@ import { PhaseScores } from 'src/types/Score';
 
 export type ScoringData = {
   crumbs: Crumb[];
+  hasData?: boolean;
   phase0Scores?: PhaseScores;
   phase1Scores?: PhaseScores;
   projectId: number;

--- a/src/scenes/AcceleratorRouter/Scoring/ScoringProvider.tsx
+++ b/src/scenes/AcceleratorRouter/Scoring/ScoringProvider.tsx
@@ -61,6 +61,16 @@ const ScoringProvider = ({ children }: Props) => {
     [phaseScores]
   );
 
+  const hasData = useMemo<boolean | undefined>(
+    () =>
+      scoreListResult?.status === 'success' && (phase0Scores || phase1Scores)
+        ? [phase0Scores, phase1Scores].filter(
+            (data) => data?.scores.some((score) => score.qualitative !== undefined || score.value !== undefined)
+          ).length > 0
+        : undefined,
+    [phase0Scores, phase1Scores, scoreListResult?.status]
+  );
+
   useEffect(() => {
     if (!isNaN(projectId)) {
       void dispatch(requestProject(projectId));
@@ -83,19 +93,22 @@ const ScoringProvider = ({ children }: Props) => {
       snackbar.toastError(strings.GENERIC_ERROR);
     } else if (scoreListResult?.status === 'success' && scoreListResult?.data?.phases) {
       setPhaseScores(scoreListResult.data.phases);
+    } else if (scoreListResult?.status === 'pending') {
+      setPhaseScores([]);
     }
   }, [scoreListResult, snackbar]);
 
   useEffect(() => {
     setScoringData({
       crumbs,
+      hasData,
       phase0Scores,
       phase1Scores,
       projectId,
       projectName,
       status: scoreListResult?.status ?? 'pending',
     });
-  }, [crumbs, phase0Scores, phase1Scores, projectId, projectName, scoreListResult]);
+  }, [crumbs, hasData, phase0Scores, phase1Scores, projectId, projectName, scoreListResult?.status]);
 
   return <ScoringContext.Provider value={scoringData}>{children}</ScoringContext.Provider>;
 };

--- a/src/scenes/AcceleratorRouter/Scoring/useScoresUpdate.ts
+++ b/src/scenes/AcceleratorRouter/Scoring/useScoresUpdate.ts
@@ -9,7 +9,6 @@ import { Phase, Score } from 'src/types/Score';
 import useSnackbar from 'src/utils/useSnackbar';
 
 export type Response = {
-  listStatus?: Statuses;
   status?: Statuses;
   update: (phase: Phase, scores: Score[]) => void;
 };
@@ -47,8 +46,9 @@ export default function useScoresUpdate(projectId: number): Response {
 
   return useMemo<Response>(
     () => ({
-      listStatus: scoreListResult?.status,
-      status: result?.status,
+      // Update is considered successful if both update and refresh list are successful.
+      // This is to help with provider data state.
+      status: result?.status === 'success' ? scoreListResult?.status : result?.status,
       update,
     }),
     [scoreListResult?.status, result?.status, update]


### PR DESCRIPTION
- added a `hasData` property on the context which checks if there is data
- in read-only view, redirect to edit if there is no data
- in edit-view, redirect to project details on cancel if there is no data (to avoid ending up back in edit view)
- since we need to deterministically identify if there is no data, added blocking checks in the update code to wait until the refresh list completes
- this is a tad ugly but needed, otherwise redirecting back to read-only view after save will only end up back in edit view (hasData hasn't had a chance to update)
- also fixed bug 5169 where a new score entry only keeps the latest edit (was using originalScore as copy instead of updated score), fixed that