### PR TITLE
SW-5163 Fix top/left padding on page with module timeline

### DIFF
--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -9,6 +9,7 @@ import TfMain from 'src/components/common/TfMain';
 
 export type PageProps = {
   children?: React.ReactNode;
+  containerClassName?: string;
   contentStyle?: Record<string, string | number>;
   crumbs?: Crumb[];
   hierarchicalCrumbs?: boolean;
@@ -22,6 +23,7 @@ export type PageProps = {
  */
 export default function Page({
   children,
+  containerClassName,
   contentStyle,
   crumbs,
   hierarchicalCrumbs,
@@ -41,7 +43,7 @@ export default function Page({
   }
 
   return (
-    <TfMain>
+    <TfMain className={containerClassName}>
       <PageHeaderWrapper nextElement={contentRef.current}>
         <>{crumbs && <BreadCrumbs crumbs={crumbs} hierarchical={hierarchicalCrumbs ?? true} />}</>
         <Grid container justifyContent='space-between' alignItems='center'>

--- a/src/components/common/PageWithModuleTimeline/index.tsx
+++ b/src/components/common/PageWithModuleTimeline/index.tsx
@@ -1,18 +1,29 @@
 import React from 'react';
 
 import { Grid, useTheme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
 import Page, { PageProps } from 'src/components/Page';
+import useDeviceInfo from 'src/utils/useDeviceInfo';
 
 import ModuleTimeline from './ModuleTimeline';
 
+const useStyles = makeStyles(() => ({
+  container: {
+    paddingTop: 0,
+    paddingLeft: 0,
+  },
+}));
+
 const PageWithModuleTimeline = (props: PageProps) => {
+  const classes = useStyles();
   const theme = useTheme();
+  const { isMobile } = useDeviceInfo();
 
   return (
     <Grid container spacing={theme.spacing(1)}>
       <Grid item xs style={{ flexGrow: 1 }}>
-        <Page {...props} />
+        <Page {...props} containerClassName={isMobile ? '' : classes.container} />
       </Grid>
       <Grid item>
         <ModuleTimeline activeStep={mockPhase.activeModule} steps={mockPhase.modules} title={mockPhase.title} />

--- a/src/components/common/TfMain.tsx
+++ b/src/components/common/TfMain.tsx
@@ -46,11 +46,12 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface Props {
   backgroundImageVisible?: boolean;
   children?: React.ReactNode;
+  className?: string;
 }
 
-export default function TfMain({ backgroundImageVisible, children }: Props): JSX.Element {
+export default function TfMain({ backgroundImageVisible, children, className }: Props): JSX.Element {
   const { isMobile } = useDeviceInfo();
   const classes = useStyles({ backgroundImageVisible, isMobile });
 
-  return <main className={classes.main}>{children}</main>;
+  return <main className={`${classes.main} ${className ?? ''}`}>{children}</main>;
 }


### PR DESCRIPTION
- The TfMain construction padding was reduced, to be consistent with other crumb layout views
- A cleaner option would be to support the timeline equivalent layout within the Page component as it assumes that TfMain is the root level component of the page
- I can take a look at that later

<img width="876" alt="Terraware App 2024-04-04 09-11-23" src="https://github.com/terraware/terraware-web/assets/1865174/79908e4f-d5de-4dad-9b21-01556756af42">
