### PR TITLE
SW-5147 Fix participant dropdown

### DIFF
--- a/src/components/ParticipantsDropdown/index.tsx
+++ b/src/components/ParticipantsDropdown/index.tsx
@@ -6,7 +6,7 @@ import { useLocalization } from 'src/providers';
 import strings from 'src/strings';
 import { ParticipantSearchResult } from 'src/types/Participant';
 
-type ParticipantsDropdownProps<T extends { participantId?: number } | undefined> = {
+type ParticipantsDropdownProps<T extends { id?: number } | undefined> = {
   allowUnselect?: boolean;
   availableParticipants: ParticipantSearchResult[] | undefined;
   label?: string | undefined;
@@ -14,7 +14,7 @@ type ParticipantsDropdownProps<T extends { participantId?: number } | undefined>
   setRecord: (setFn: (previousValue: T) => T) => void;
 };
 
-function ParticipantsDropdown<T extends { participantId?: number } | undefined>({
+function ParticipantsDropdown<T extends { id?: number } | undefined>({
   allowUnselect,
   availableParticipants,
   label,
@@ -50,7 +50,7 @@ function ParticipantsDropdown<T extends { participantId?: number } | undefined>(
     <Dropdown
       id='participantId'
       label={label === '' ? label : strings.PARTICIPANT}
-      selectedValue={record?.participantId}
+      selectedValue={record?.id}
       options={participantOptions}
       onChange={(participantId: string) => {
         setRecord((previousValue: T): T => {
@@ -58,7 +58,7 @@ function ParticipantsDropdown<T extends { participantId?: number } | undefined>(
             if (previousValue) {
               return {
                 ...previousValue,
-                participantId: undefined,
+                id: undefined,
               };
             } else {
               return previousValue;
@@ -67,7 +67,7 @@ function ParticipantsDropdown<T extends { participantId?: number } | undefined>(
 
           return {
             ...previousValue,
-            participantId: Number(participantId),
+            id: Number(participantId),
           };
         });
       }}

--- a/src/scenes/AcceleratorRouter/Deliverables/DeliverablesList.tsx
+++ b/src/scenes/AcceleratorRouter/Deliverables/DeliverablesList.tsx
@@ -55,17 +55,17 @@ const DeliverablesList = () => {
   const { availableParticipants } = useParticipants();
   const contentRef = useRef(null);
 
-  const [participantFilter, setParticipantFilter] = useState<{ participantId?: number }>({ participantId: undefined });
+  const [participantFilter, setParticipantFilter] = useState<{ id?: number }>({ id: undefined });
 
   const extraTableFilters: SearchNodePayload[] = useMemo(
     () =>
-      participantFilter.participantId
+      participantFilter.id
         ? [
             {
               operation: 'field',
               field: 'participantId',
               type: 'Exact',
-              values: [`${participantFilter.participantId}`],
+              values: [`${participantFilter.id}`],
             },
           ]
         : [],
@@ -112,7 +112,7 @@ const DeliverablesList = () => {
         extraTableFilters={extraTableFilters}
         isAcceleratorRoute={true}
         organizationId={-1}
-        participantId={participantFilter.participantId}
+        participantId={participantFilter.id}
         tableId={'acceleratorDeliverablesTable'}
       />
     </AcceleratorMain>

--- a/src/services/ParticipantsService.ts
+++ b/src/services/ParticipantsService.ts
@@ -2,6 +2,7 @@ import HttpService, { Response, Response2, ServerData } from 'src/services/HttpS
 import {
   Participant,
   ParticipantCreateRequest,
+  ParticipantProjectSearchResult,
   ParticipantSearchResult,
   ParticipantUpdateRequest,
 } from 'src/types/Participant';
@@ -66,11 +67,14 @@ const list = async (
     const { cohort_id, cohort_name, id, name, projects } = result;
 
     return {
-      cohort_id,
+      cohort_id: cohort_id ? Number(cohort_id) : null,
       cohort_name,
-      id,
+      id: Number(id),
       name,
-      projects: projects || [],
+      projects: ((projects || []) as ParticipantProjectSearchResult[]).map((project) => ({
+        ...project,
+        id: Number(project.id),
+      })),
     } as ParticipantSearchResult;
   });
 };


### PR DESCRIPTION
-  Cast the search result IDs to numbers 
- Changing the dropdown to reference the record's `id` instead of `participantId` because that is the property on the participant record



