### PR TITLE
SW-4795 Bump web-components version to correctly show right-aligned table headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@mui/styled-engine-sc": "^5.12.0",
     "@mui/styles": "^5.15.3",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^2.12.4",
+    "@terraware/web-components": "^2.12.5",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4519,10 +4519,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^2.12.4":
-  version "2.12.4"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.12.4.tgz#9ae72bdef37bd4b4c09d1f27b2ff139c8cff2f63"
-  integrity sha512-uOWxKBOVG0ibCeZCoq0lkzicPWxePz6eBVVbbFKlgAywGvDx6wBTdPrE09hoyqMZIMS/L73bBr5aGSCwBsPFNw==
+"@terraware/web-components@^2.12.5":
+  version "2.12.5"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-2.12.5.tgz#4560b25ec62cc3eaf25d1557a50ebebf13e8f037"
+  integrity sha512-uuO4bExLf0rFGY+XZtf21Xy9/EjUkF0BQdc/4TqUnj0eSiyzPfNTFCJ5eTviUxEloNaPpT2RAupFKVBwFDDBEQ==
   dependencies:
     "@date-io/date-fns" "^2.14.0"
     "@date-io/moment" "^2.16.1"


### PR DESCRIPTION
Before:
<img width="356" alt="Screenshot 2024-04-05 at 12 52 41" src="https://github.com/terraware/terraware-web/assets/5919083/26c0180e-5a95-44f6-a630-c748082e0c98">



After:
<img width="391" alt="Screenshot 2024-04-05 at 12 50 46" src="https://github.com/terraware/terraware-web/assets/5919083/8e86ae34-14d2-423b-a4c7-94b7eff0c66e">
