### PR TITLE
 SW-5186 Batches at Nursery table view: Withdrawn column is not populated

### DIFF
--- a/src/services/NurseryBatchService.ts
+++ b/src/services/NurseryBatchService.ts
@@ -111,6 +111,8 @@ const NURSERY_BATCHES_FIELDS = [
   'subLocations.subLocation_name',
   'totalQuantity',
   'totalQuantity(raw)',
+  'totalQuantityWithdrawn',
+  'totalQuantityWithdrawn(raw)',
   'version',
   'project_name',
   'project_id',


### PR DESCRIPTION
Withdrawn column was not populated because we were not requiring the value in the search request