### PR TITLE
SW-5191: Sorting Project tables in Console Overview crashes

### DIFF
--- a/src/scenes/AcceleratorRouter/ParticipantProjects/CellRenderer.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/CellRenderer.tsx
@@ -35,11 +35,11 @@ export default function ParticipantProjectsCellRenderer(props: RendererProps<Tab
     return <CellRenderer {...props} value={getPhaseString(value as CohortPhaseType)} />;
   }
 
-  if (column.key === 'restorableLandRaw') {
-    return <CellRenderer {...props} value={row.restorableLand} />;
+  if (column.key === 'acceleratorDetails_confirmedReforestableLand') {
+    return <CellRenderer {...props} value={row.acceleratorDetails_confirmedReforestableLand} />;
   }
 
-  if (column.key === 'landUseModelType') {
+  if (column.key === 'landUseModelTypes.landUseModelType') {
     return <CellRenderer {...props} value={<TextTruncated stringList={value as string[]} />} />;
   }
 

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/ListView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/ListView.tsx
@@ -27,12 +27,12 @@ const columns = (activeLocale: string | null): TableColumnType[] =>
           type: 'string',
         },
         {
-          key: 'participantName',
+          key: 'participant_name',
           name: strings.PARTICIPANT,
           type: 'string',
         },
         {
-          key: 'cohortName',
+          key: 'participant_cohort_name',
           name: strings.COHORT,
           type: 'string',
         },
@@ -42,22 +42,22 @@ const columns = (activeLocale: string | null): TableColumnType[] =>
           type: 'string',
         },
         {
-          key: 'country',
+          key: 'country_name',
           name: strings.COUNTRY,
           type: 'string',
         },
         {
-          key: 'region',
+          key: 'country_region',
           name: strings.REGION,
           type: 'string',
         },
         {
-          key: 'restorableLandRaw',
+          key: 'acceleratorDetails_confirmedReforestableLand',
           name: strings.RESTORABLE_LAND,
           type: 'string',
         },
         {
-          key: 'landUseModelType',
+          key: 'landUseModelTypes.landUseModelType',
           name: strings.LAND_USE_MODEL_TYPE,
           type: 'string',
         },
@@ -108,7 +108,7 @@ export default function ListView(): JSX.Element {
     () =>
       (projects || []).reduce(
         (acc, project) => {
-          acc[project.participant_cohort_id] = project.cohortName;
+          acc[project.participant_cohort_id] = project.participant_cohort_name;
           return acc;
         },
         {} as Record<string, string>
@@ -178,7 +178,7 @@ export default function ListView(): JSX.Element {
         dispatchSearchRequest={dispatchSearchRequest}
         featuredFilters={featuredFilters}
         fuzzySearchColumns={fuzzySearchColumns}
-        id='accelerator-participan-projects-table'
+        id='accelerator-participant-projects-table'
         Renderer={CellRenderer}
         rightComponent={actionMenus}
         rows={projects}

--- a/src/services/ParticipantProjectService.ts
+++ b/src/services/ParticipantProjectService.ts
@@ -123,7 +123,7 @@ const get = async (participantProjectId: number): Promise<Response2<ParticipantP
   });
 
 const downloadList = async (search?: SearchNodePayload, sortOrder?: SearchSortOrder): Promise<string | null> =>
-  await SearchService.searchCsv(getSearchParams(search, sortOrder, true));
+  await SearchService.searchCsv(getSearchParams(search, sortOrder));
 
 const list = async (
   search?: SearchNodePayload,

--- a/src/services/ParticipantProjectService.ts
+++ b/src/services/ParticipantProjectService.ts
@@ -39,11 +39,7 @@ const COHORT_ID_EXISTS_PREDICATE: SearchNodePayload = {
   },
 };
 
-const getSearchParams = (
-  search?: SearchNodePayload,
-  sortOrder?: SearchSortOrder,
-  isCsv?: boolean
-): SearchRequestPayload => {
+const getSearchParams = (search?: SearchNodePayload, sortOrder?: SearchSortOrder): SearchRequestPayload => {
   const searchParams: SearchRequestPayload = {
     prefix: 'projects',
     fields: [

--- a/src/services/ParticipantProjectService.ts
+++ b/src/services/ParticipantProjectService.ts
@@ -56,7 +56,6 @@ const getSearchParams = (
       'country_name',
       'country_region',
       'acceleratorDetails_confirmedReforestableLand',
-      ...(isCsv ? [] : ['acceleratorDetails_confirmedReforestableLand(raw)']),
       'landUseModelTypes.landUseModelType',
     ],
     search: {
@@ -157,9 +156,6 @@ const list = async (
 
     return {
       acceleratorDetails_confirmedReforestableLand,
-      'acceleratorDetails_confirmedReforestableLand(raw)': Number(
-        result['acceleratorDetails_confirmedReforestableLand(raw)']
-      ),
       country_name,
       country_region,
       id: Number(id),

--- a/src/services/ParticipantProjectService.ts
+++ b/src/services/ParticipantProjectService.ts
@@ -156,17 +156,21 @@ const list = async (
     type LandUse = { landUseModelType: string };
 
     return {
-      cohortName: participant_cohort_name,
-      country: country_name,
+      acceleratorDetails_confirmedReforestableLand,
+      'acceleratorDetails_confirmedReforestableLand(raw)': Number(
+        result['acceleratorDetails_confirmedReforestableLand(raw)']
+      ),
+      country_name,
+      country_region,
       id: Number(id),
-      landUseModelType: ((result.landUseModelTypes || []) as LandUse[]).map((type: LandUse) => type.landUseModelType),
+      'landUseModelTypes.landUseModelType': ((result.landUseModelTypes || []) as LandUse[]).map(
+        (type: LandUse) => type.landUseModelType
+      ),
       name,
       participant_cohort_id: Number(participant_cohort_id),
+      participant_cohort_name,
       participant_cohort_phase,
-      participantName: participant_name,
-      region: country_region,
-      restorableLand: acceleratorDetails_confirmedReforestableLand,
-      restorableLandRaw: Number(result['acceleratorDetails_confirmedReforestableLand(raw)']),
+      participant_name,
     } as ParticipantProjectSearchResult;
   });
 };

--- a/src/types/ParticipantProject.ts
+++ b/src/types/ParticipantProject.ts
@@ -7,7 +7,6 @@ import { CohortPhaseType } from './Cohort';
 export type ParticipantProject = components['schemas']['ProjectAcceleratorDetailsPayload'];
 
 export type ParticipantProjectSearchResult = {
-  'acceleratorDetails_confirmedReforestableLand(raw)': number;
   acceleratorDetails_confirmedReforestableLand: string;
   country_name: string;
   country_region: string;

--- a/src/types/ParticipantProject.ts
+++ b/src/types/ParticipantProject.ts
@@ -7,17 +7,17 @@ import { CohortPhaseType } from './Cohort';
 export type ParticipantProject = components['schemas']['ProjectAcceleratorDetailsPayload'];
 
 export type ParticipantProjectSearchResult = {
-  cohortName: string;
-  country: string;
+  'acceleratorDetails_confirmedReforestableLand(raw)': number;
+  acceleratorDetails_confirmedReforestableLand: string;
+  country_name: string;
+  country_region: string;
   id: number;
-  landUseModelType: string[];
+  'landUseModelTypes.landUseModelType': string[];
   name: string;
   participant_cohort_id: number;
+  participant_cohort_name: string;
   participant_cohort_phase: CohortPhaseType;
-  participantName: string;
-  region: string;
-  restorableLand: string;
-  restorableLandRaw: number;
+  participant_name: string;
 };
 
 export type LandUseModelType = ParticipantProject['landUseModelTypes'][0];


### PR DESCRIPTION
This PR includes changes to fix the crash that was occurring when sorting by column in the Console Overview Projects table.

I removed some mapping that looked like it was in-place to replace long/awkward keys and possibly reduce the differences between `ParticipantProject` and `ParticipantProjectSearchResult`, but that mapping seemed to be what was causing the crash as the updated field names weren't recognized by the BE when performing the sort function.

I'm not sure if there was another way to fix this crash without removing the mapping, but I'm happy to make changes if there's another way we'd prefer to approach this issue.

### Before

https://github.com/terraware/terraware-web/assets/1474361/f64b3a72-bbd9-4ff3-a28c-402e1eb9d1c5

### After

https://github.com/terraware/terraware-web/assets/1474361/10047fc1-b383-4f34-aea4-40ffa49677e0
