### PR TITLE
SW-5176 Reconcile 'accession collecting site' labels across create/edit/view flows

### DIFF
--- a/src/scenes/AccessionsRouter/edit/Accession2EditModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/Accession2EditModal.tsx
@@ -137,7 +137,7 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
           <Textfield
             id='collectionSiteName'
             type='text'
-            label={strings.COLLECTING_SITE}
+            label={strings.COLLECTION_SITE}
             value={record?.collectionSiteName}
             onChange={(value) => onChange('collectionSiteName', value)}
             tooltipTitle={strings.TOOLTIP_ACCESSIONS_ADD_COLLECTING_SITE}

--- a/src/scenes/AccessionsRouter/view/DetailPanel.tsx
+++ b/src/scenes/AccessionsRouter/view/DetailPanel.tsx
@@ -152,7 +152,7 @@ export default function DetailPanel(props: DetailPanelProps): JSX.Element {
           </Grid>
           <Grid item xs={12} sx={gridRowStyle}>
             <Grid item xs={gridLeftSide} sx={categoryStyle}>
-              {strings.COLLECTING_LOCATION}
+              {strings.COLLECTION_SITE}
             </Grid>
             <Grid item xs={gridRightSide} sx={valueStyle}>
               {accession.collectionSiteName}


### PR DESCRIPTION
- we were using three different labels, reconciled them to use same label (as per latest requirements)
- we do have 2 unused labels at this point

<img width="404" alt="Terraware App 2024-04-09 10-16-12" src="https://github.com/terraware/terraware-web/assets/1865174/f75ebbaa-5a4c-45ff-b339-818c92fbc3d7">

<img width="751" alt="Terraware App 2024-04-09 10-15-56" src="https://github.com/terraware/terraware-web/assets/1865174/d38f5ff0-c23d-4217-a38d-4ccfd7190fa8">

<img width="664" alt="Terraware App 2024-04-09 10-14-33" src="https://github.com/terraware/terraware-web/assets/1865174/25f279d6-f5e0-48d2-87bc-024958113b08">
