### PR TITLE
SW-5175: Project: Deal Stage field should show "Phase 1" instead of N/A

### DIFF
--- a/src/scenes/AcceleratorRouter/ParticipantProjects/EditView/index.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/EditView/index.tsx
@@ -248,7 +248,6 @@ const EditView = () => {
               type={'number'}
               value={participantProjectRecord?.numCommunities}
             />
-            <ProjectFieldDisplay label={strings.DEAL_STAGE} value={participantProjectRecord?.dealStage} />
             <ProjectFieldMeta
               date={project?.createdTime}
               dateLabel={strings.CREATED_ON}

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/SingleView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/SingleView.tsx
@@ -175,11 +175,6 @@ const SingleView = () => {
                 value={participantProject?.numCommunities}
                 rightBorder={!isMobile}
               />
-              <ProjectFieldDisplay
-                label={strings.DEAL_STAGE}
-                value={participantProject?.dealStage}
-                rightBorder={!isMobile}
-              />
               <ProjectFieldMeta
                 date={project?.createdTime}
                 dateLabel={strings.CREATED_ON}


### PR DESCRIPTION
This PR removes the Deal Stage field from the Participant Project View & Edit Views, per a request from Jennifer. See [Jira ticket](https://terraformation.atlassian.net/browse/SW-5175) comments for more info.

## Screenshots

### Before

![localhost_accelerator_projects_20 (1)](https://github.com/terraware/terraware-web/assets/1474361/3d602fe9-d7d7-4271-bc40-25cd4211adea)

### After

![localhost_accelerator_projects_20 (2)](https://github.com/terraware/terraware-web/assets/1474361/22565880-b251-4cbe-85b2-29b33977f7c4)
