### PR TITLE
SW-5122 Create ParticipantProvider

### DIFF
--- a/src/providers/Participant/ParticipantContext.tsx
+++ b/src/providers/Participant/ParticipantContext.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react';
+
+import { Project } from 'src/types/Project';
+
+export type ParticipantData = {
+  participantProjects: Project[];
+  orgHasParticipants: boolean;
+};
+
+// default values pointing to nothing
+export const ParticipantContext = createContext<ParticipantData>({
+  participantProjects: [],
+  orgHasParticipants: false,
+});
+
+export const useParticipantData = () => useContext(ParticipantContext);

--- a/src/providers/Participant/ParticipantProvider.tsx
+++ b/src/providers/Participant/ParticipantProvider.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+import { useLocalization, useOrganization } from 'src/providers/hooks';
+import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
+import { requestProjects } from 'src/redux/features/projects/projectsThunks';
+import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import { Project } from 'src/types/Project';
+
+import { ParticipantContext, ParticipantData } from './ParticipantContext';
+
+export type Props = {
+  children: React.ReactNode;
+};
+
+const ParticipantProvider = ({ children }: Props) => {
+  const dispatch = useAppDispatch();
+  const { selectedOrganization } = useOrganization();
+  const { activeLocale } = useLocalization();
+
+  // State used to determine provider data
+  const projects = useAppSelector(selectProjects);
+
+  // State for provider data
+  const [participantProjects, setParticipantProjects] = useState<Project[]>([]);
+  const [participantData, setParticipantData] = useState<ParticipantData>({
+    participantProjects,
+    orgHasParticipants: false,
+  });
+
+  useEffect(() => {
+    setParticipantProjects((projects || []).filter((project) => !!project.participantId));
+  }, [projects]);
+
+  useEffect(() => {
+    if (selectedOrganization && activeLocale) {
+      dispatch(requestProjects(selectedOrganization.id, activeLocale));
+    }
+  }, [activeLocale, dispatch, selectedOrganization]);
+
+  useEffect(() => {
+    setParticipantData({
+      participantProjects,
+      orgHasParticipants: participantProjects.length > 0,
+    });
+  }, [participantProjects]);
+
+  return <ParticipantContext.Provider value={participantData}>{children}</ParticipantContext.Provider>;
+};
+
+export default ParticipantProvider;

--- a/src/scenes/Home/index.tsx
+++ b/src/scenes/Home/index.tsx
@@ -4,6 +4,7 @@ import { Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 
 import isEnabled from 'src/features';
+import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 
 import ParticipantHomeView from './ParticipantHomeView';
@@ -38,14 +39,13 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export default function Home(): JSX.Element {
   const { isMobile } = useDeviceInfo();
+  const { orgHasParticipants } = useParticipantData();
   const classes = useStyles({ isMobile });
   const featureFlagParticipantExperience = isEnabled('Participant Experience');
 
-  const isParticipant = false;
-
   return (
     <main className={classes.main}>
-      {featureFlagParticipantExperience && isParticipant ? <ParticipantHomeView /> : <TerrawareHomeView />}
+      {featureFlagParticipantExperience && orgHasParticipants ? <ParticipantHomeView /> : <TerrawareHomeView />}
     </main>
   );
 }

--- a/src/scenes/OrgRouter/index.tsx
+++ b/src/scenes/OrgRouter/index.tsx
@@ -9,6 +9,7 @@ import ProjectsRouter from 'src/components/Projects/Router';
 import ReportsRouter from 'src/components/Reports/Router';
 import { APP_PATHS } from 'src/constants';
 import { useLocalization, useOrganization, useUser } from 'src/providers';
+import ParticipantProvider from 'src/providers/Participant/ParticipantProvider';
 import { selectHasObservationsResults } from 'src/redux/features/observations/observationsSelectors';
 import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
 import { requestProjects } from 'src/redux/features/projects/projectsThunks';
@@ -211,7 +212,9 @@ const OrgRouter = ({ showNavBar, setShowNavBar }: OrgRouterProps) => {
           <Switch>
             {/* Routes, in order of their appearance down the side NavBar */}
             <Route exact path={APP_PATHS.HOME}>
-              <Home />
+              <ParticipantProvider>
+                <Home />
+              </ParticipantProvider>
             </Route>
 
             <Route exact path={APP_PATHS.SEEDS_DASHBOARD}>


### PR DESCRIPTION
- Create `ParticipantProvider` used in the Terraware frontend for retrieving participant data for an org
- Use it to determine if a user should see the regular Home page or the Participant Home page