### PR TITLE
SW-4591 Update OrderPreservedTable user preference name that stores columns ordering when shuffled by user

### DIFF
--- a/src/components/common/table/index.tsx
+++ b/src/components/common/table/index.tsx
@@ -85,18 +85,20 @@ export function BaseTable<T extends TableRowType>(props: TableProps<T>): JSX.Ele
  */
 
 export type OrderPreserveableTableProps = {
-  setColumns: (columns: TableColumnType[]) => void;
+  // user preference name to store the columns order
+  columnsPreferenceName?: string;
   id: string;
+  setColumns: (columns: TableColumnType[]) => void;
 };
 
 export function OrderPreserveableTable<T extends TableRowType>(
   props: TableProps<T> & OrderPreserveableTableProps
 ): JSX.Element {
   const [initialized, setInitialized] = useState<boolean>(false);
-  const { setColumns, onReorderEnd, columns, id, ...tableProps } = props;
+  const { columns, columnsPreferenceName, id, onReorderEnd, setColumns, ...tableProps } = props;
   const { selectedOrganization, orgPreferences, reloadOrgPreferences } = useOrganization();
 
-  const getPreferenceName = useCallback(() => `${id}-columns`, [id]);
+  const getPreferenceName = useCallback(() => columnsPreferenceName || `${id}-columns`, [columnsPreferenceName, id]);
 
   const getTableColumns = useCallback(
     (columnNames: string[]): TableColumnType[] =>
@@ -181,9 +183,18 @@ export default function OrderPreservedTable<T extends TableRowType>(
     }
   }, [activeLocale, columns, tableColumns]);
 
+  const columnsPreferenceName = useMemo<string>(() => {
+    const columnNames = columns()
+      .map((column) => column.key)
+      .sort()
+      .join('_');
+    return `${props.id}_columns_${columnNames}`;
+  }, [columns, props.id]);
+
   return OrderPreserveableTable<T>({
     ...tableProps,
     columns: tableColumns,
+    columnsPreferenceName,
     setColumns: (columnsToSet: TableColumnType[]) => setTableColumns(columnsToSet),
   });
 }


### PR DESCRIPTION
- previously the preference name was `<table-id>-columns`
- this was problematic if 
    1) two tables shared the same id (which is currently not prevented at compile or run time), if one of those tables had its columns shuffled, the value of the order would be picked up by the other table, which would end up rendering incorrect columns
    2) another failed case is if one of the table's had it's columns refactored/updated and was previously shuffled by the user.. it would end up rendering incorrect/stale columns
- the new approach now generates the preference name based on the table's column names
- this protects from rendering incorrect data for either of the cases described above
- if a table had it's columns refactored (added/removed, etc.) the table would now use a new preference name
- if 2 tables shared the same id by mistake, the preference name would still be different based on column names.. unless both tables shared same column configurations, in which case sharing the same preference name wouldn't break anything, it would still render correct columns just maybe shuffled a bit based on user's previous action
- the downside to this approach is the preference names can be long, this is not user facing and only programmatic so maybe it's ok 
example: `people-table_columns_addedTime_email_firstName_lastName_role` and `org-observations-table_columns_actionsMenu_completedDate_endDate_mortalityRate_plantingDensity_plantingSiteName_plantingZones_state_totalPlants_totalSpecies` Note: accessions table which has numerous columns, does not use this order preserved table. Accessions table does it's own persistence handling.