### PR TITLE
SW-5194 Clean up redux/rootReducer

### DIFF
--- a/src/redux/features/accelerator/acceleratorSlice.ts
+++ b/src/redux/features/accelerator/acceleratorSlice.ts
@@ -19,4 +19,8 @@ export const acceleratorOrgsSlice = createSlice({
   },
 });
 
-export const acceleratorOrgsReducer = acceleratorOrgsSlice.reducer;
+const acceleratorReducers = {
+  acceleratorOrgs: acceleratorOrgsSlice.reducer,
+};
+
+export default acceleratorReducers;

--- a/src/redux/features/accessions/accessionsSlice.ts
+++ b/src/redux/features/accessions/accessionsSlice.ts
@@ -26,4 +26,8 @@ export const accessionsSlice = createSlice({
 
 export const { setAccessionsAction } = accessionsSlice.actions;
 
-export const accessionsReducer = accessionsSlice.reducer;
+const accessionsReducers = {
+  accessions: accessionsSlice.reducer,
+};
+
+export default accessionsReducers;

--- a/src/redux/features/appVersion/appVersionSlice.ts
+++ b/src/redux/features/appVersion/appVersionSlice.ts
@@ -20,4 +20,8 @@ export const appVersionSlice = createSlice({
 
 export const { setVersionAction } = appVersionSlice.actions;
 
-export const appVersionReducer = appVersionSlice.reducer;
+const appVersionReducers = {
+  appVersion: appVersionSlice.reducer,
+};
+
+export default appVersionReducers;

--- a/src/redux/features/batches/batchesSlice.ts
+++ b/src/redux/features/batches/batchesSlice.ts
@@ -48,5 +48,9 @@ export const batchesSlice = createSlice({
   },
 });
 
-export const batchesRequestsReducer = batchesRequestsSlice.reducer;
-export const batchesReducer = batchesSlice.reducer;
+const batchesReducers = {
+  batches: batchesSlice.reducer,
+  batchesRequests: batchesRequestsSlice.reducer,
+};
+
+export default batchesReducers;

--- a/src/redux/features/cohorts/cohortsSlice.ts
+++ b/src/redux/features/cohorts/cohortsSlice.ts
@@ -37,7 +37,6 @@ export const cohortsSlice = createSlice({
 });
 
 export const { setCohortsAction, setCohortAction } = cohortsSlice.actions;
-export const cohortsReducer = cohortsSlice.reducer;
 
 type CohortsResponsesUnion = UpdateCohortResponsePayload;
 type CohortsRequestsState = Record<string, StatusT<CohortsResponsesUnion>>;
@@ -54,4 +53,9 @@ export const cohortsRequestsSlice = createSlice({
   },
 });
 
-export const cohortsRequestsReducer = cohortsRequestsSlice.reducer;
+const cohortsReducers = {
+  cohorts: cohortsSlice.reducer,
+  cohortsRequests: cohortsRequestsSlice.reducer,
+};
+
+export default cohortsReducers;

--- a/src/redux/features/deliverables/deliverablesSlice.ts
+++ b/src/redux/features/deliverables/deliverablesSlice.ts
@@ -23,8 +23,6 @@ export const deliverablesListSlice = createSlice({
   },
 });
 
-export const deliverablesSearchReducer = deliverablesListSlice.reducer;
-
 /**
  * Individual Deliverable
  * Can be accessed by a request ID or by a deliverable/project ID string
@@ -50,8 +48,6 @@ export const deliverablesSlice = createSlice({
   },
 });
 
-export const deliverablesReducer = deliverablesSlice.reducer;
-
 /**
  * Simple OK/response for requests such as updating deliverable status, keeps
  * state of deliverable id that was edited.
@@ -68,4 +64,10 @@ export const deliverablesEditSlice = createSlice({
   },
 });
 
-export const deliverablesEditReducer = deliverablesEditSlice.reducer;
+const deliverablesReducers = {
+  deliverablesSearch: deliverablesListSlice.reducer,
+  deliverables: deliverablesSlice.reducer,
+  deliverablesEdit: deliverablesEditSlice.reducer,
+};
+
+export default deliverablesReducers;

--- a/src/redux/features/draftPlantingSite/draftPlantingSiteSlice.ts
+++ b/src/redux/features/draftPlantingSite/draftPlantingSiteSlice.ts
@@ -65,7 +65,11 @@ const draftPlantingSiteSearchSlice = createSlice({
   },
 });
 
-export const draftPlantingSiteCreateReducer = draftPlantingSiteCreateSlice.reducer;
-export const draftPlantingSiteEditReducer = draftPlantingSiteEditSlice.reducer;
-export const draftPlantingSiteGetReducer = draftPlantingSiteGetSlice.reducer;
-export const draftPlantingSiteSearchReducer = draftPlantingSiteSearchSlice.reducer;
+const draftPlantingSiteReducers = {
+  draftPlantingSiteCreate: draftPlantingSiteCreateSlice.reducer,
+  draftPlantingSiteEdit: draftPlantingSiteEditSlice.reducer,
+  draftPlantingSiteGet: draftPlantingSiteGetSlice.reducer,
+  draftPlantingSiteSearch: draftPlantingSiteSearchSlice.reducer,
+};
+
+export default draftPlantingSiteReducers;

--- a/src/redux/features/globalRoles/globalRolesSlice.ts
+++ b/src/redux/features/globalRoles/globalRolesSlice.ts
@@ -23,8 +23,6 @@ export const globalRolesUsersListSlice = createSlice({
   },
 });
 
-export const globalRolesUsersListReducer = globalRolesUsersListSlice.reducer;
-
 /**
  * Simple OK/response for requests removing all global roles for a list of users, keeps
  * state of user ids that was were modified.
@@ -39,8 +37,6 @@ export const globalRolesUsersRemoveSlice = createSlice({
     buildReducers(requestDeleteGlobalRolesForUsers)(builder);
   },
 });
-
-export const globalRolesUsersRemoveReducer = globalRolesUsersRemoveSlice.reducer;
 
 /**
  * Simple OK/response for requests updating a user's global roles, keeps
@@ -57,4 +53,10 @@ export const globalRolesUserUpdateSlice = createSlice({
   },
 });
 
-export const globalRolesUserUpdateReducer = globalRolesUserUpdateSlice.reducer;
+const globalRolesReducers = {
+  globalRolesUsersList: globalRolesUsersListSlice.reducer,
+  globalRolesUsersRemove: globalRolesUsersRemoveSlice.reducer,
+  globalRolesUserUpdate: globalRolesUserUpdateSlice.reducer,
+};
+
+export default globalRolesReducers;

--- a/src/redux/features/message/messageSlice.ts
+++ b/src/redux/features/message/messageSlice.ts
@@ -26,4 +26,8 @@ export const messageSlice = createSlice({
 
 export const { sendMessage } = messageSlice.actions;
 
-export const messageReducer = messageSlice.reducer;
+const messageReducers = {
+  message: messageSlice.reducer,
+};
+
+export default messageReducers;

--- a/src/redux/features/modules/modulesSlice.ts
+++ b/src/redux/features/modules/modulesSlice.ts
@@ -19,8 +19,6 @@ export const moduleSlice = createSlice({
   },
 });
 
-export const moduleReducer = moduleSlice.reducer;
-
 /**
  * Get Module Event
  */
@@ -36,8 +34,6 @@ export const moduleEventSlice = createSlice({
   },
 });
 
-export const moduleEventReducer = moduleEventSlice.reducer;
-
 /**
  * List Modules
  */
@@ -52,4 +48,10 @@ export const moduleListSlice = createSlice({
   },
 });
 
-export const moduleListReducer = moduleListSlice.reducer;
+const moduleReducers = {
+  module: moduleSlice.reducer,
+  moduleEvent: moduleEventSlice.reducer,
+  moduleList: moduleListSlice.reducer,
+};
+
+export default moduleReducers;

--- a/src/redux/features/observations/observationsSlice.ts
+++ b/src/redux/features/observations/observationsSlice.ts
@@ -31,7 +31,6 @@ export const observationsResultsSlice = createSlice({
 });
 
 export const { setObservationsResultsAction } = observationsResultsSlice.actions;
-export const observationsResultsReducer = observationsResultsSlice.reducer;
 
 // Define a type for the slice state
 type Data = {
@@ -55,7 +54,6 @@ export const observationsSlice = createSlice({
 });
 
 export const { setObservationsAction } = observationsSlice.actions;
-export const observationsReducer = observationsSlice.reducer;
 
 type PlantingSitePayload = {
   plantingSiteId: number;
@@ -78,7 +76,6 @@ const plantingSiteObservationsResultsSlice = createSlice({
 });
 
 export const { setPlantingSiteObservationsResultsAction } = plantingSiteObservationsResultsSlice.actions;
-export const plantingSiteObservationsResultsReducer = plantingSiteObservationsResultsSlice.reducer;
 
 // Schedule/Reschedule observation
 
@@ -100,9 +97,6 @@ const rescheduleObservationSlice = createSlice({
   extraReducers: buildReducers(requestRescheduleObservation),
 });
 
-export const scheduleObservationReducer = scheduleObservationSlice.reducer;
-export const rescheduleObservationReducer = rescheduleObservationSlice.reducer;
-
 // Replace observation plot
 
 type ReplaceObservationPlotState = Record<string, StatusT<ReplaceObservationPlotResponsePayload>>;
@@ -116,4 +110,13 @@ const replaceObservationPlotSlice = createSlice({
   extraReducers: buildReducers<ReplaceObservationPlotResponsePayload>(requestReplaceObservationPlot),
 });
 
-export const replaceObservationPlotReducer = replaceObservationPlotSlice.reducer;
+const observationsReducers = {
+  observationsResults: observationsResultsSlice.reducer,
+  observations: observationsSlice.reducer,
+  plantingSiteObservationsResults: plantingSiteObservationsResultsSlice.reducer,
+  scheduleObservation: scheduleObservationSlice.reducer,
+  rescheduleObservation: rescheduleObservationSlice.reducer,
+  replaceObservationPlot: replaceObservationPlotSlice.reducer,
+};
+
+export default observationsReducers;

--- a/src/redux/features/participantProjects/participantProjectsSlice.ts
+++ b/src/redux/features/participantProjects/participantProjectsSlice.ts
@@ -23,8 +23,6 @@ export const participantProjectSlice = createSlice({
   },
 });
 
-export const participantProjectReducer = participantProjectSlice.reducer;
-
 /**
  * Get Participant Project
  */
@@ -38,8 +36,6 @@ export const participantProjectUpdateSlice = createSlice({
     buildReducers(requestUpdateParticipantProject, true)(builder);
   },
 });
-
-export const participantProjectUpdateReducer = participantProjectUpdateSlice.reducer;
 
 /**
  * List Participant Projects
@@ -55,4 +51,10 @@ export const participantProjectsListSlice = createSlice({
   },
 });
 
-export const participantProjectsListReducer = participantProjectsListSlice.reducer;
+const participantProjectsReducers = {
+  participantProject: participantProjectSlice.reducer,
+  participantProjectUpdate: participantProjectUpdateSlice.reducer,
+  participantProjectsList: participantProjectsListSlice.reducer,
+};
+
+export default participantProjectsReducers;

--- a/src/redux/features/participants/participantsSlice.ts
+++ b/src/redux/features/participants/participantsSlice.ts
@@ -26,8 +26,6 @@ export const participantCreateSlice = createSlice({
   },
 });
 
-export const participantCreateReducer = participantCreateSlice.reducer;
-
 /**
  * Delete Participant
  */
@@ -41,8 +39,6 @@ export const participantDeleteSlice = createSlice({
     buildReducers(requestDeleteParticipant)(builder);
   },
 });
-
-export const participantDeleteReducer = participantDeleteSlice.reducer;
 
 /**
  * Get Participant
@@ -58,8 +54,6 @@ export const participantSlice = createSlice({
   },
 });
 
-export const participantReducer = participantSlice.reducer;
-
 /**
  * Participant list
  */
@@ -73,8 +67,6 @@ export const participantListSlice = createSlice({
     buildReducers(requestListParticipants)(builder);
   },
 });
-
-export const participantListReducer = participantListSlice.reducer;
 
 /**
  * Participant update
@@ -90,4 +82,12 @@ export const participantUpdateSlice = createSlice({
   },
 });
 
-export const participantUpdateReducer = participantUpdateSlice.reducer;
+const participantsReducers = {
+  participantCreate: participantCreateSlice.reducer,
+  participantDelete: participantDeleteSlice.reducer,
+  participant: participantSlice.reducer,
+  participantList: participantListSlice.reducer,
+  participantUpdate: participantUpdateSlice.reducer,
+};
+
+export default participantsReducers;

--- a/src/redux/features/plantings/plantingsSlice.ts
+++ b/src/redux/features/plantings/plantingsSlice.ts
@@ -58,7 +58,11 @@ const updatePlantingsCompletedSlice = createSlice({
 });
 
 export const { setPlantingsAction } = plantingsSlice.actions;
-export const plantingsReducer = plantingsSlice.reducer;
 
-export const updatePlantingCompletedReducer = updatePlantingCompletedSlice.reducer;
-export const updatePlantingsCompletedReducer = updatePlantingsCompletedSlice.reducer;
+const plantingsReducers = {
+  plantings: plantingsSlice.reducer,
+  updatePlantingCompleted: updatePlantingCompletedSlice.reducer,
+  updatePlantingsCompleted: updatePlantingsCompletedSlice.reducer,
+};
+
+export default plantingsReducers;

--- a/src/redux/features/projects/projectsSlice.ts
+++ b/src/redux/features/projects/projectsSlice.ts
@@ -43,7 +43,6 @@ export const projectsSlice = createSlice({
 });
 
 export const { setProjectsAction, setProjectAction } = projectsSlice.actions;
-export const projectsReducer = projectsSlice.reducer;
 
 type ProjectsResponsesUnion = UpdateProjectResponsePayload;
 type ProjectsRequestsState = Record<string, StatusT<ProjectsResponsesUnion>>;
@@ -61,4 +60,9 @@ export const projectsRequestsSlice = createSlice({
   },
 });
 
-export const projectsRequestsReducer = projectsRequestsSlice.reducer;
+const projectsReducers = {
+  projects: projectsSlice.reducer,
+  projectsRequests: projectsRequestsSlice.reducer,
+};
+
+export default projectsReducers;

--- a/src/redux/features/reportsSettings/reportsSettingsSlice.ts
+++ b/src/redux/features/reportsSettings/reportsSettingsSlice.ts
@@ -28,4 +28,8 @@ export const reportsSettingsSlice = createSlice({
 
 export const { setReportsSettingsAction } = reportsSettingsSlice.actions;
 
-export const reportsSettingsReducer = reportsSettingsSlice.reducer;
+const reportsSettingsReducers = {
+  reportsSettings: reportsSettingsSlice.reducer,
+};
+
+export default reportsSettingsReducers;

--- a/src/redux/features/scores/scoresSlice.ts
+++ b/src/redux/features/scores/scoresSlice.ts
@@ -18,8 +18,6 @@ export const scoreListSlice = createSlice({
   },
 });
 
-export const scoreListReducer = scoreListSlice.reducer;
-
 /**
  * Simple response to know if the scores of the project were updated
  */
@@ -34,4 +32,9 @@ export const scoresUpdateSlice = createSlice({
   },
 });
 
-export const scoresUpdateReducer = scoresUpdateSlice.reducer;
+const scoresReducers = {
+  scoreList: scoreListSlice.reducer,
+  scoresUpdate: scoresUpdateSlice.reducer,
+};
+
+export default scoresReducers;

--- a/src/redux/features/snackbar/snackbarSlice.ts
+++ b/src/redux/features/snackbar/snackbarSlice.ts
@@ -41,4 +41,8 @@ export const snackbarSlice = createSlice({
 
 export const { sendSnackbar, clearSnackbar } = snackbarSlice.actions;
 
-export const snackbarReducer = snackbarSlice.reducer;
+const snackbarReducers = {
+  snackbar: snackbarSlice.reducer,
+};
+
+export default snackbarReducers;

--- a/src/redux/features/species/index.ts
+++ b/src/redux/features/species/index.ts
@@ -1,0 +1,9 @@
+import { speciesProjectsReducer } from './speciesProjectsSlice';
+import { speciesReducer } from './speciesSlice';
+
+const speciesReducers = {
+  species: speciesReducer,
+  speciesProjects: speciesProjectsReducer,
+};
+
+export default speciesReducers;

--- a/src/redux/features/subLocations/subLocationsSlice.ts
+++ b/src/redux/features/subLocations/subLocationsSlice.ts
@@ -24,4 +24,9 @@ export const subLocationsSlice = createSlice({
 });
 
 export const { setSubLocationsAction } = subLocationsSlice.actions;
-export const subLocationsReducer = subLocationsSlice.reducer;
+
+const subLocationsReducers = {
+  subLocations: subLocationsSlice.reducer,
+};
+
+export default subLocationsReducers;

--- a/src/redux/features/tracking/trackingSlice.ts
+++ b/src/redux/features/tracking/trackingSlice.ts
@@ -47,7 +47,6 @@ export const trackingSlice = createSlice({
 });
 
 export const { setPlantingSiteAction, setPlantingSitesAction } = trackingSlice.actions;
-export const trackingReducer = trackingSlice.reducer;
 
 // Define a type for the search slice state
 type SearchData = {
@@ -70,8 +69,6 @@ export const plantingSitesSearchResultsSlice = createSlice({
 
 export const { setPlantingSitesSearchResultsAction } = plantingSitesSearchResultsSlice.actions;
 
-export const plantingSitesSearchResultsReducer = plantingSitesSearchResultsSlice.reducer;
-
 // Planting Site Population Data Slice
 type SitePopulationData = {
   error?: string;
@@ -93,8 +90,6 @@ export const sitePopulationSlice = createSlice({
 });
 
 export const { setSitePopulationAction } = sitePopulationSlice.actions;
-
-export const sitePopulationReducer = sitePopulationSlice.reducer;
 
 // Planting Site Reported Plants Slice
 type SiteReportedPlantsData = {
@@ -122,8 +117,6 @@ export const siteReportedPlantsSlice = createSlice({
 
 export const { setSiteReportedPlantsAction } = siteReportedPlantsSlice.actions;
 
-export const siteReportedPlantsReducer = siteReportedPlantsSlice.reducer;
-
 // Monitoring plots
 
 type MonitoringPlotsState = Record<string, StatusT<MonitoringPlotsResponse>>;
@@ -137,4 +130,12 @@ const monitoringPlotsSlice = createSlice({
   extraReducers: buildReducers<MonitoringPlotsResponse>(requestMonitoringPlots),
 });
 
-export const monitoringPlotsReducer = monitoringPlotsSlice.reducer;
+const trackingReducers = {
+  tracking: trackingSlice.reducer,
+  plantingSitesSearchResults: plantingSitesSearchResultsSlice.reducer,
+  sitePopulation: sitePopulationSlice.reducer,
+  siteReportedPlantsResults: siteReportedPlantsSlice.reducer,
+  monitoringPlots: monitoringPlotsSlice.reducer,
+};
+
+export default trackingReducers;

--- a/src/redux/features/user/userAnalyticsSlice.ts
+++ b/src/redux/features/user/userAnalyticsSlice.ts
@@ -21,4 +21,8 @@ export const userAnalyticsSlice = createSlice({
 
 export const { updateGtmInstrumented } = userAnalyticsSlice.actions;
 
-export const userAnalyticsReducer = userAnalyticsSlice.reducer;
+const userAnalyticsReducers = {
+  userAnalytics: userAnalyticsSlice.reducer,
+};
+
+export default userAnalyticsReducers;

--- a/src/redux/features/user/usersSlice.ts
+++ b/src/redux/features/user/usersSlice.ts
@@ -19,8 +19,6 @@ export const usersSlice = createSlice({
   },
 });
 
-export const usersReducer = usersSlice.reducer;
-
 /**
  * Get single user by email
  */
@@ -35,4 +33,9 @@ export const usersByEmailSlice = createSlice({
   },
 });
 
-export const usersByEmailReducer = usersByEmailSlice.reducer;
+const usersReducers = {
+  users: usersSlice.reducer,
+  usersByEmail: usersByEmailSlice.reducer,
+};
+
+export default usersReducers;

--- a/src/redux/features/votes/votesSlice.ts
+++ b/src/redux/features/votes/votesSlice.ts
@@ -19,8 +19,6 @@ export const votesSlice = createSlice({
   },
 });
 
-export const votesReducer = votesSlice.reducer;
-
 type VotingEditRequestsState = Record<string, StatusT<boolean>>;
 
 const initialVotingEditRequestsState: VotingEditRequestsState = {};
@@ -34,4 +32,9 @@ export const votesRequestsSlice = createSlice({
   },
 });
 
-export const votesRequestsReducer = votesRequestsSlice.reducer;
+const votesReducers = {
+  votes: votesSlice.reducer,
+  votesRequests: votesRequestsSlice.reducer,
+};
+
+export default votesReducers;

--- a/src/redux/rootReducer.ts
+++ b/src/redux/rootReducer.ts
@@ -1,133 +1,59 @@
 import { Action, combineReducers } from '@reduxjs/toolkit';
 
-import { cohortsReducer, cohortsRequestsReducer } from 'src/redux/features/cohorts/cohortsSlice';
-import {
-  deliverablesEditReducer,
-  deliverablesReducer,
-  deliverablesSearchReducer,
-} from 'src/redux/features/deliverables/deliverablesSlice';
-import {
-  draftPlantingSiteCreateReducer,
-  draftPlantingSiteEditReducer,
-  draftPlantingSiteGetReducer,
-  draftPlantingSiteSearchReducer,
-} from 'src/redux/features/draftPlantingSite/draftPlantingSiteSlice';
-import {
-  globalRolesUserUpdateReducer,
-  globalRolesUsersListReducer,
-  globalRolesUsersRemoveReducer,
-} from 'src/redux/features/globalRoles/globalRolesSlice';
-import { projectsReducer, projectsRequestsReducer } from 'src/redux/features/projects/projectsSlice';
-import { reportsSettingsReducer } from 'src/redux/features/reportsSettings/reportsSettingsSlice';
-import { speciesProjectsReducer } from 'src/redux/features/species/speciesProjectsSlice';
+import cohortsReducers from 'src/redux/features/cohorts/cohortsSlice';
+import deliverablesReducers from 'src/redux/features/deliverables/deliverablesSlice';
+import draftPlantingSiteReducers from 'src/redux/features/draftPlantingSite/draftPlantingSiteSlice';
+import globalRolesReducers from 'src/redux/features/globalRoles/globalRolesSlice';
+import projectsReducers from 'src/redux/features/projects/projectsSlice';
+import reportsSettingsReducers from 'src/redux/features/reportsSettings/reportsSettingsSlice';
+import speciesReducers from 'src/redux/features/species';
 
-import { acceleratorOrgsReducer } from './features/accelerator/acceleratorSlice';
-import { accessionsReducer } from './features/accessions/accessionsSlice';
-import { appVersionReducer } from './features/appVersion/appVersionSlice';
-import { batchesReducer, batchesRequestsReducer } from './features/batches/batchesSlice';
+import acceleratorReducers from './features/accelerator/acceleratorSlice';
+import accessionsReducers from './features/accessions/accessionsSlice';
+import appVersionReducers from './features/appVersion/appVersionSlice';
+import batchesReducers from './features/batches/batchesSlice';
 import documentProducerReducers from './features/documentProducer';
-import { messageReducer } from './features/message/messageSlice';
-import { moduleEventReducer, moduleListReducer, moduleReducer } from './features/modules/modulesSlice';
-import {
-  observationsReducer,
-  observationsResultsReducer,
-  plantingSiteObservationsResultsReducer,
-  replaceObservationPlotReducer,
-  rescheduleObservationReducer,
-  scheduleObservationReducer,
-} from './features/observations/observationsSlice';
-import {
-  participantProjectReducer,
-  participantProjectUpdateReducer,
-  participantProjectsListReducer,
-} from './features/participantProjects/participantProjectsSlice';
-import {
-  participantCreateReducer,
-  participantDeleteReducer,
-  participantListReducer,
-  participantReducer,
-  participantUpdateReducer,
-} from './features/participants/participantsSlice';
-import {
-  plantingsReducer,
-  updatePlantingCompletedReducer,
-  updatePlantingsCompletedReducer,
-} from './features/plantings/plantingsSlice';
-import { scoreListReducer, scoresUpdateReducer } from './features/scores/scoresSlice';
-import { snackbarReducer } from './features/snackbar/snackbarSlice';
-import { speciesReducer } from './features/species/speciesSlice';
-import { subLocationsReducer } from './features/subLocations/subLocationsSlice';
-import {
-  monitoringPlotsReducer,
-  plantingSitesSearchResultsReducer,
-  sitePopulationReducer,
-  siteReportedPlantsReducer,
-  trackingReducer,
-} from './features/tracking/trackingSlice';
-import { userAnalyticsReducer } from './features/user/userAnalyticsSlice';
-import { usersByEmailReducer, usersReducer } from './features/user/usersSlice';
-import { votesReducer, votesRequestsReducer } from './features/votes/votesSlice';
+import messageReducers from './features/message/messageSlice';
+import moduleReducers from './features/modules/modulesSlice';
+import observationsReducers from './features/observations/observationsSlice';
+import participantProjectsReducers from './features/participantProjects/participantProjectsSlice';
+import participantsReducers from './features/participants/participantsSlice';
+import plantingsReducers from './features/plantings/plantingsSlice';
+import scoresReducers from './features/scores/scoresSlice';
+import snackbarReducers from './features/snackbar/snackbarSlice';
+import subLocationsReducers from './features/subLocations/subLocationsSlice';
+import trackingReducers from './features/tracking/trackingSlice';
+import userAnalyticsReducers from './features/user/userAnalyticsSlice';
+import usersReducers from './features/user/usersSlice';
+import votesReducers from './features/votes/votesSlice';
 
 // assembly of app reducers
 export const reducers = {
-  acceleratorOrgs: acceleratorOrgsReducer,
-  accessions: accessionsReducer,
-  appVersion: appVersionReducer,
-  batches: batchesReducer,
-  batchesRequests: batchesRequestsReducer,
-  cohorts: cohortsReducer,
-  cohortsRequests: cohortsRequestsReducer,
-  deliverablesEdit: deliverablesEditReducer,
-  deliverablesSearch: deliverablesSearchReducer,
-  deliverables: deliverablesReducer,
+  ...acceleratorReducers,
+  ...accessionsReducers,
+  ...appVersionReducers,
+  ...batchesReducers,
+  ...cohortsReducers,
+  ...deliverablesReducers,
   ...documentProducerReducers,
-  draftPlantingSiteCreate: draftPlantingSiteCreateReducer,
-  draftPlantingSiteEdit: draftPlantingSiteEditReducer,
-  draftPlantingSiteGet: draftPlantingSiteGetReducer,
-  draftPlantingSiteSearch: draftPlantingSiteSearchReducer,
-  globalRolesUsersList: globalRolesUsersListReducer,
-  globalRolesUsersRemove: globalRolesUsersRemoveReducer,
-  globalRolesUserUpdate: globalRolesUserUpdateReducer,
-  message: messageReducer,
-  module: moduleReducer,
-  moduleEvent: moduleEventReducer,
-  moduleList: moduleListReducer,
-  monitoringPlots: monitoringPlotsReducer,
-  observations: observationsReducer,
-  observationsResults: observationsResultsReducer,
-  participantCreate: participantCreateReducer,
-  participantDelete: participantDeleteReducer,
-  participant: participantReducer,
-  participantProject: participantProjectReducer,
-  participantProjectsList: participantProjectsListReducer,
-  participantProjectUpdate: participantProjectUpdateReducer,
-  participantList: participantListReducer,
-  participantUpdate: participantUpdateReducer,
-  plantingSiteObservationsResults: plantingSiteObservationsResultsReducer,
-  plantingSitesSearchResults: plantingSitesSearchResultsReducer,
-  plantings: plantingsReducer,
-  projects: projectsReducer,
-  projectsRequests: projectsRequestsReducer,
-  replaceObservationPlot: replaceObservationPlotReducer,
-  reportsSettings: reportsSettingsReducer,
-  rescheduleObservation: rescheduleObservationReducer,
-  scheduleObservation: scheduleObservationReducer,
-  scoreList: scoreListReducer,
-  scoresUpdate: scoresUpdateReducer,
-  sitePopulation: sitePopulationReducer,
-  siteReportedPlantsResults: siteReportedPlantsReducer,
-  snackbar: snackbarReducer,
-  species: speciesReducer,
-  speciesProjects: speciesProjectsReducer,
-  subLocations: subLocationsReducer,
-  tracking: trackingReducer,
-  updatePlantingCompleted: updatePlantingCompletedReducer,
-  updatePlantingsCompleted: updatePlantingsCompletedReducer,
-  userAnalytics: userAnalyticsReducer,
-  users: usersReducer,
-  usersByEmail: usersByEmailReducer,
-  votes: votesReducer,
-  votesRequests: votesRequestsReducer,
+  ...draftPlantingSiteReducers,
+  ...globalRolesReducers,
+  ...messageReducers,
+  ...moduleReducers,
+  ...observationsReducers,
+  ...participantsReducers,
+  ...participantProjectsReducers,
+  ...plantingsReducers,
+  ...projectsReducers,
+  ...reportsSettingsReducers,
+  ...scoresReducers,
+  ...snackbarReducers,
+  ...speciesReducers,
+  ...subLocationsReducers,
+  ...trackingReducers,
+  ...userAnalyticsReducers,
+  ...usersReducers,
+  ...votesReducers,
 };
 const combinedReducers = combineReducers(reducers);
 


### PR DESCRIPTION
- export reducers from the xyzSlice files
- xyzSlice files will now own semantics of redux store key names
- rootReducer will simply import and spread the reducers, no context of redux store key names
- typescript will handle key errors so we are good there