### PR TITLE
SW-5193 crossed off undone withdrawals

### DIFF
--- a/src/scenes/NurseryRouter/WithdrawalLogRenderer.tsx
+++ b/src/scenes/NurseryRouter/WithdrawalLogRenderer.tsx
@@ -50,7 +50,7 @@ export default function WithdrawalLogRenderer(props: RendererProps<TableRowType>
     return (
       <Link
         to={nurseryWithdrawalDetailLocation}
-        className={`${classes.link} ${row.undoesWithdrawalId ? classes.undone : ''}`}
+        className={`${classes.link} ${row.undoneByWithdrawalId ? classes.undone : ''}`}
       >
         {iValue as React.ReactNode}
       </Link>


### PR DESCRIPTION
In withdrawal log, undone withdrawals need to be crossed off, instead of withdrawals with purpose "undo"