### PR TITLE
SW-5265 Fix popup not rendering correctly in plants dashboard map

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -474,6 +474,7 @@ export default function Map(props: MapProps): JSX.Element {
           <MapViewStyleControl mapViewStyle={mapViewStyle} onChangeMapViewStyle={onChangeMapViewStyle} />
           {popupInfo && popupRenderer && renderedPopup && (
             <Popup
+              key={popupInfo.lat + popupInfo.lng}
               anchor={popupRenderer.anchor ?? 'top'}
               longitude={Number(popupInfo.lng)}
               latitude={Number(popupInfo.lat)}


### PR DESCRIPTION
React uses key prop in order to determine if a component should be mounted. Popup info was changing but not the key of the popup, so the new popup was not being mounted again