### PR TITLE
SW-5267 Fix horizontal alignment of accelerator console link

### DIFF
--- a/src/components/TopBar/AcceleratorBreadcrumbs.tsx
+++ b/src/components/TopBar/AcceleratorBreadcrumbs.tsx
@@ -61,7 +61,7 @@ export default function AcceleratorBreadcrumbs(): JSX.Element | null {
       <div>
         <Grid container>
           <Grid item>
-            <Link fontSize={16} to={APP_PATHS.ACCELERATOR} className={classes.link}>
+            <Link className={classes.link} fontSize={16} lineHeight='32px' to={APP_PATHS.ACCELERATOR}>
               {strings.ACCELERATOR_CONSOLE}
             </Link>
           </Grid>


### PR DESCRIPTION
- adjusted the line height for the link

<img width="357" alt="Terraware App 2024-04-23 15-13-36" src="https://github.com/terraware/terraware-web/assets/1865174/41de806e-f2a2-42ba-a123-deda13a1153e">
