### PR TITLE
SW-5239: Withdrawals: List View is titled "Withdrawal History" but breadcrumb says "Withdrawal Log"

### DIFF
--- a/playwright/e2e/suites/inventory.spec.ts
+++ b/playwright/e2e/suites/inventory.spec.ts
@@ -164,7 +164,7 @@ export default function InventoryTests() {
     await expect(page.locator('#row1-notReady')).toContainText('10');
     await expect(page.locator('#row1-ready')).toContainText('0');
     await expect(page.locator('#row1-total')).toContainText('15');
-    await page.getByRole('link', { name: 'Withdrawal Log' }).click();
+    await page.getByRole('link', { name: 'Withdrawal History' }).click();
     await expect(page.locator('#row1-speciesScientificNames')).toContainText('Coconut');
     await expect(page.getByRole('cell', { name: '15', exact: true })).toBeVisible();
   });

--- a/src/scenes/NurseryRouter/NurseryReassignmentView.tsx
+++ b/src/scenes/NurseryRouter/NurseryReassignmentView.tsx
@@ -233,7 +233,7 @@ export default function NurseryReassignmentView(): JSX.Element {
             id='back'
             to={`${APP_PATHS.NURSERY_WITHDRAWALS}?tab=withdrawal_history`}
             className={classes.backToWithdrawals}
-            name={strings.WITHDRAWAL_LOG}
+            name={strings.WITHDRAWAL_HISTORY}
           />
         </Box>
         <Box marginTop={theme.spacing(3)}>

--- a/src/scenes/NurseryRouter/NurseryWithdrawals.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawals.tsx
@@ -22,7 +22,7 @@ export default function NurseryWithdrawals(): JSX.Element {
             <Grid container spacing={3} sx={{ paddingLeft: theme.spacing(3), paddingBottom: theme.spacing(4) }}>
               <Grid item xs={8}>
                 <Typography sx={{ marginTop: 0, marginBottom: 0, fontSize: '24px', fontWeight: 600 }}>
-                  {strings.WITHDRAWAL_LOG}
+                  {strings.WITHDRAWAL_HISTORY}
                 </Typography>
               </Grid>
             </Grid>

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
@@ -185,7 +185,7 @@ export default function NurseryWithdrawalsDetailsView({
               id='back'
               to={`${APP_PATHS.NURSERY_WITHDRAWALS}?tab=withdrawal_history`}
               className={classes.backToWithdrawals}
-              name={strings.WITHDRAWAL_LOG}
+              name={strings.WITHDRAWAL_HISTORY}
             />
           </Box>
           <Box

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -1852,7 +1852,6 @@ WITHDRAWAL_BATCHES_MISSING_QUANTITY_ERROR,Enter a quantity in at least one seedl
 WITHDRAWAL_DESCRIPTION,All the details about withdrawal of the seeds.,
 WITHDRAWAL_DETAILS,Withdrawal Details,
 WITHDRAWAL_HISTORY,Withdrawal History,
-WITHDRAWAL_LOG,Withdrawal Log,
 WITHDRAWAL_UNDONE,Withdrawal Undone,
 WITHDRAWAL_UNDONE_DESCRIPTION,Withdraw was undone and the quantities were restored to the original batch.,
 WITHDRAWALS,Withdrawals,

--- a/src/strings/csv/es.csv
+++ b/src/strings/csv/es.csv
@@ -1845,7 +1845,6 @@ WITHDRAWAL_BATCHES_MISSING_QUANTITY_ERROR,Ingresar una cantidad en al menos una 
 WITHDRAWAL_DESCRIPTION,Todos los detalles acerca de la extracción de las semillas.,
 WITHDRAWAL_DETAILS,Detalles de extracción,
 WITHDRAWAL_HISTORY,Historial de retiros,
-WITHDRAWAL_LOG,Registro de extracción,
 WITHDRAWAL_UNDONE,Retiro deshecho,
 WITHDRAWAL_UNDONE_DESCRIPTION,Se deshizo el retiro y las cantidades se devolvieron al lote original.,
 WITHDRAWALS,Retiros,


### PR DESCRIPTION
This PR includes a quick fix to update "Withdrawal Log" to "Withdrawal History".

## Screenshots

### After

![localhost_nursery_withdrawals_tab=withdrawal_history organizationId=28](https://github.com/terraware/terraware-web/assets/1474361/a10b9032-54ec-4f28-9d86-87ed8c0473b1)
