### PR TITLE
SW-5222: Batch detail view should have withdraw button as long as there is a non-zero quantity

### DIFF
--- a/src/scenes/InventoryRouter/InventoryBatchView.tsx
+++ b/src/scenes/InventoryRouter/InventoryBatchView.tsx
@@ -80,7 +80,8 @@ export default function InventoryBatchView({ origin, species }: InventoryBatchPr
   const { selectedOrganization } = useOrganization();
   const { isMobile } = useDeviceInfo();
 
-  const isWithdrawable = Number(batch?.readyQuantity) + Number(batch?.notReadyQuantity) > 0;
+  const isWithdrawable =
+    Number(batch?.readyQuantity) + Number(batch?.notReadyQuantity) + Number(batch?.germinatingQuantity) > 0;
 
   useEffect(() => {
     if (speciesId) {


### PR DESCRIPTION
This PR includes a small change to always show the "Withdraw" button in the Batch detail view as long as there is a non-zero quantity.