### PR TITLE
SW-4594 Display error for duplicate species addition

### DIFF
--- a/src/types/Species.ts
+++ b/src/types/Species.ts
@@ -187,7 +187,7 @@ export type SpeciesWithScientificName = Species & {
 export type SpeciesById = Map<number, SpeciesWithScientificName>;
 
 export enum SpeciesRequestError {
-  PreexistingSpecies = 'SERVER_RETURNED_409_PREEXISTING_SPECIES',
+  PreexistingSpecies = 'A species with that name already exists.',
   // Server returned any other error (3xx, 4xx, 5xxx), or server did not respond, or there was an error
   // setting up the request. In other words, there was a developer error or server outage.
   RequestFailed = 'AN_UNRECOVERABLE_ERROR_OCCURRED',


### PR DESCRIPTION
This was already done, it was not working maybe because the error message changed

<img width="1306" alt="Screenshot 2024-04-24 at 10 33 37 AM" src="https://github.com/terraware/terraware-web/assets/5919083/1e65f954-b267-42a0-a763-bea5c25d6b23">
