### PR TITLE
SW-5276: FE: Setup mock data for new species

### DIFF
--- a/src/features.ts
+++ b/src/features.ts
@@ -6,7 +6,8 @@ export type FeatureName =
   | 'User Detailed Sites'
   | 'Console'
   | 'Participant Experience'
-  | 'Document Producer';
+  | 'Document Producer'
+  | 'Mocked Species';
 
 export type Feature = {
   name: FeatureName;
@@ -65,6 +66,15 @@ export const OPT_IN_FEATURES: Feature[] = [
     enabled: false,
     allowInternalProduction: false,
     description: ['Terraware Accelerator Console access to the document producer tool'],
+    disclosure: ['This is WIP'],
+  },
+  {
+    name: 'Mocked Species',
+    preferenceName: 'enableMockedSpecies',
+    active: true,
+    enabled: false,
+    allowInternalProduction: false,
+    description: ['Appends mocked data for new fields to species'],
     disclosure: ['This is WIP'],
   },
 ];

--- a/src/types/Species.ts
+++ b/src/types/Species.ts
@@ -32,7 +32,6 @@ export type Species = {
 export const mockSpeciesNewFieldsData: Partial<Species> = {
   nativeStatus: 'Native',
   nativeEcosystem: 'Tropical and subtropical moist broad leaf forests',
-  growthForms: ['Tree', 'Shrub'],
   successionalGroup: ['Pioneer', 'Early secondary'],
   ecologicalRoleKnown: 'Yes',
   localUsesKnown: 'Yes',

--- a/src/types/Species.ts
+++ b/src/types/Species.ts
@@ -14,7 +14,7 @@ export type Species = {
   ecosystemTypes?: EcosystemType[];
   nativeStatus?: NativeStatus;
   nativeEcosystem?: string;
-  growthFormNEXT?: GrowthForm[];
+  growthForms?: GrowthForm[];
   successionalGroup?: SuccessionalGroup[];
   ecologicalRoleKnown?: string;
   localUsesKnown?: string;
@@ -32,7 +32,7 @@ export type Species = {
 export const mockSpeciesNewFieldsData: Partial<Species> = {
   nativeStatus: 'Native',
   nativeEcosystem: 'Tropical and subtropical moist broad leaf forests',
-  growthFormNEXT: ['Tree', 'Shrub'],
+  growthForms: ['Tree', 'Shrub'],
   successionalGroup: ['Pioneer', 'Early secondary'],
   ecologicalRoleKnown: 'Yes',
   localUsesKnown: 'Yes',

--- a/src/types/Species.ts
+++ b/src/types/Species.ts
@@ -14,7 +14,6 @@ export type Species = {
   ecosystemTypes?: EcosystemType[];
   nativeStatus?: NativeStatus;
   nativeEcosystem?: string;
-  growthForms?: GrowthForm[];
   successionalGroup?: SuccessionalGroup[];
   ecologicalRoleKnown?: string;
   localUsesKnown?: string;

--- a/src/types/Species.ts
+++ b/src/types/Species.ts
@@ -12,7 +12,54 @@ export type Species = {
   seedStorageBehavior?: SeedStorageBehavior;
   problems?: SpeciesProblemElement[];
   ecosystemTypes?: EcosystemType[];
+  nativeStatus?: NativeStatus;
+  nativeEcosystem?: string;
+  growthFormNEXT?: GrowthForm[];
+  successionalGroup?: SuccessionalGroup[];
+  ecologicalRoleKnown?: string;
+  localUsesKnown?: string;
+  plantMaterialSourcingMethod?: PlantMaterialSourcingMethod[];
+  heightAtMaturity?: number;
+  heightAtMaturitySource?: string;
+  dbhDiameterAtMaturity?: number;
+  dbhSource?: string;
+  averageWoodDensity?: number;
+  woodDensityLevel?: WoodDensityLevel;
+  otherFacts?: string;
 };
+
+// TODO: remove this mock data when the actual data is available
+export const mockSpeciesNewFieldsData: Partial<Species> = {
+  nativeStatus: 'Native',
+  nativeEcosystem: 'Tropical and subtropical moist broad leaf forests',
+  growthFormNEXT: ['Tree', 'Shrub'],
+  successionalGroup: ['Pioneer', 'Early secondary'],
+  ecologicalRoleKnown: 'Yes',
+  localUsesKnown: 'Yes',
+  plantMaterialSourcingMethod: ['Seed collection & germination', 'Seedling purchase'],
+  heightAtMaturity: 10,
+  heightAtMaturitySource: 'Source',
+  dbhDiameterAtMaturity: 10,
+  dbhSource: 'Source',
+  averageWoodDensity: 10,
+  woodDensityLevel: 'Species',
+  otherFacts: 'Other facts',
+};
+
+export type WoodDensityLevel = 'Species' | 'Genus' | 'Family';
+
+export type PlantMaterialSourcingMethod =
+  | 'Seed collection & germination'
+  | 'Seed purchase & germination'
+  | 'Mangrove propagules'
+  | 'Vegetative propagation'
+  | 'Wildling harvest'
+  | 'Seedling purchase'
+  | 'Other';
+
+export type SuccessionalGroup = 'Pioneer' | 'Early secondary' | 'Late secondary' | 'Mature';
+
+export type NativeStatus = 'Native' | 'Non-Native';
 
 export type EcosystemType =
   | 'Boreal forests/Taiga'


### PR DESCRIPTION
This PR adds mocked data to species in the `getSpecies` and `getAllSpecies` methods of the `SpeciesService`. The mocked data includes new additional fields to support species deliverables. The mocked data is only appended when a new "Mocked Species" feature flag is enabled.

I'm sure the new property names added to `Species` aren't quite right, will get these updated as soon as we know what they will be on the BE.