### PR TITLE
SW-5280 Sync with BE that has other new species fields

### DIFF
--- a/playwright/e2e/suites/species.spec.ts
+++ b/playwright/e2e/suites/species.spec.ts
@@ -41,12 +41,10 @@ export default function SpeciesTests() {
       .locator('li')
       .filter({ hasText: /^Orthodox$/ })
       .click();
-    await page
-      .locator('div')
-      .filter({ hasText: /^Select\.\.\.$/ })
-      .nth(1)
-      .click();
-    await page.getByText('Tropical and subtropical dry').click();
+
+    await page.locator('#ecosystemTypes').getByText('Select...').click();
+    await page.locator('li').getByText('Tropical and subtropical dry').click();
+
     await page.getByRole('button', { name: 'Save' }).click();
 
     await expect(page.getByRole('main')).toContainText(`Scientific Name${newSpeciesName}`);

--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -3611,7 +3611,6 @@ export interface components {
       type: "Name Misspelled" | "Name Not Found" | "Name Is Synonym";
     };
     SpeciesRequestPayload: {
-      /** Format: double */
       averageWoodDensity?: number;
       commonName?: string;
       /**
@@ -3620,14 +3619,12 @@ export interface components {
        */
       conservationCategory?: "CR" | "DD" | "EN" | "EW" | "EX" | "LC" | "NE" | "NT" | "VU";
       dbhSource?: string;
-      /** Format: double */
       dbhValue?: number;
       ecologicalRoleKnown?: string;
       ecosystemTypes?: ("Boreal forests/Taiga" | "Deserts and xeric shrublands" | "Flooded grasslands and savannas" | "Mangroves" | "Mediterranean forests, woodlands and scrubs" | "Montane grasslands and shrublands" | "Temperate broad leaf and mixed forests" | "Temperate coniferous forest" | "Temperate grasslands, savannas and shrublands" | "Tropical and subtropical coniferous forests" | "Tropical and subtropical dry broad leaf forests" | "Tropical and subtropical grasslands, savannas and shrublands" | "Tropical and subtropical moist broad leaf forests" | "Tundra")[];
       familyName?: string;
       growthForms?: ("Tree" | "Shrub" | "Forb" | "Graminoid" | "Fern" | "Fungus" | "Lichen" | "Moss" | "Vine" | "Liana" | "Shrub/Tree" | "Subshrub" | "Multiple Forms" | "Mangrove")[];
       heightAtMaturitySource?: string;
-      /** Format: double */
       heightAtMaturityValue?: number;
       localUsesKnown?: string;
       nativeEcosystem?: string;
@@ -3644,10 +3641,9 @@ export interface components {
       seedStorageBehavior?: "Orthodox" | "Recalcitrant" | "Intermediate" | "Unknown" | "Likely Orthodox" | "Likely Recalcitrant" | "Likely Intermediate";
       successionalGroups?: ("Pioneer" | "Early secondary" | "Late secondary" | "Mature")[];
       /** @enum {string} */
-      woodDensityLevel?: "Species level" | "Genus level" | "Family level";
+      woodDensityLevel?: "Species" | "Genus" | "Family";
     };
     SpeciesResponseElement: {
-      /** Format: double */
       averageWoodDensity?: number;
       commonName?: string;
       /**
@@ -3656,14 +3652,12 @@ export interface components {
        */
       conservationCategory?: "CR" | "DD" | "EN" | "EW" | "EX" | "LC" | "NE" | "NT" | "VU";
       dbhSource?: string;
-      /** Format: double */
       dbhValue?: number;
       ecologicalRoleKnown?: string;
       ecosystemTypes?: ("Boreal forests/Taiga" | "Deserts and xeric shrublands" | "Flooded grasslands and savannas" | "Mangroves" | "Mediterranean forests, woodlands and scrubs" | "Montane grasslands and shrublands" | "Temperate broad leaf and mixed forests" | "Temperate coniferous forest" | "Temperate grasslands, savannas and shrublands" | "Tropical and subtropical coniferous forests" | "Tropical and subtropical dry broad leaf forests" | "Tropical and subtropical grasslands, savannas and shrublands" | "Tropical and subtropical moist broad leaf forests" | "Tundra")[];
       familyName?: string;
       growthForms?: ("Tree" | "Shrub" | "Forb" | "Graminoid" | "Fern" | "Fungus" | "Lichen" | "Moss" | "Vine" | "Liana" | "Shrub/Tree" | "Subshrub" | "Multiple Forms" | "Mangrove")[];
       heightAtMaturitySource?: string;
-      /** Format: double */
       heightAtMaturityValue?: number;
       /** Format: int64 */
       id: number;
@@ -3678,7 +3672,7 @@ export interface components {
       seedStorageBehavior?: "Orthodox" | "Recalcitrant" | "Intermediate" | "Unknown" | "Likely Orthodox" | "Likely Recalcitrant" | "Likely Intermediate";
       successionalGroups?: ("Pioneer" | "Early secondary" | "Late secondary" | "Mature")[];
       /** @enum {string} */
-      woodDensityLevel?: "Species level" | "Genus level" | "Family level";
+      woodDensityLevel?: "Species" | "Genus" | "Family";
     };
     SpeciesSummaryNurseryPayload: {
       /** Format: int64 */

--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -3611,39 +3611,65 @@ export interface components {
       type: "Name Misspelled" | "Name Not Found" | "Name Is Synonym";
     };
     SpeciesRequestPayload: {
+      /** Format: double */
+      averageWoodDensity?: number;
       commonName?: string;
       /**
        * @description IUCN Red List conservation category code.
        * @enum {string}
        */
       conservationCategory?: "CR" | "DD" | "EN" | "EW" | "EX" | "LC" | "NE" | "NT" | "VU";
+      dbhSource?: string;
+      /** Format: double */
+      dbhValue?: number;
+      ecologicalRoleKnown?: string;
       ecosystemTypes?: ("Boreal forests/Taiga" | "Deserts and xeric shrublands" | "Flooded grasslands and savannas" | "Mangroves" | "Mediterranean forests, woodlands and scrubs" | "Montane grasslands and shrublands" | "Temperate broad leaf and mixed forests" | "Temperate coniferous forest" | "Temperate grasslands, savannas and shrublands" | "Tropical and subtropical coniferous forests" | "Tropical and subtropical dry broad leaf forests" | "Tropical and subtropical grasslands, savannas and shrublands" | "Tropical and subtropical moist broad leaf forests" | "Tundra")[];
       familyName?: string;
       growthForms?: ("Tree" | "Shrub" | "Forb" | "Graminoid" | "Fern" | "Fungus" | "Lichen" | "Moss" | "Vine" | "Liana" | "Shrub/Tree" | "Subshrub" | "Multiple Forms" | "Mangrove")[];
+      heightAtMaturitySource?: string;
+      /** Format: double */
+      heightAtMaturityValue?: number;
+      localUsesKnown?: string;
+      nativeEcosystem?: string;
       /**
        * Format: int64
        * @description Which organization's species list to update.
        */
       organizationId: number;
+      otherFacts?: string;
       plantMaterialSourcingMethods?: (("Seed collection & germination") | ("Seed purchase & germination") | "Mangrove propagules" | "Vegetative propagation" | "Wildling harvest" | "Seedling purchase" | "Other")[];
       rare?: boolean;
       scientificName: string;
       /** @enum {string} */
       seedStorageBehavior?: "Orthodox" | "Recalcitrant" | "Intermediate" | "Unknown" | "Likely Orthodox" | "Likely Recalcitrant" | "Likely Intermediate";
       successionalGroups?: ("Pioneer" | "Early secondary" | "Late secondary" | "Mature")[];
+      /** @enum {string} */
+      woodDensityLevel?: "Species level" | "Genus level" | "Family level";
     };
     SpeciesResponseElement: {
+      /** Format: double */
+      averageWoodDensity?: number;
       commonName?: string;
       /**
        * @description IUCN Red List conservation category code.
        * @enum {string}
        */
       conservationCategory?: "CR" | "DD" | "EN" | "EW" | "EX" | "LC" | "NE" | "NT" | "VU";
+      dbhSource?: string;
+      /** Format: double */
+      dbhValue?: number;
+      ecologicalRoleKnown?: string;
       ecosystemTypes?: ("Boreal forests/Taiga" | "Deserts and xeric shrublands" | "Flooded grasslands and savannas" | "Mangroves" | "Mediterranean forests, woodlands and scrubs" | "Montane grasslands and shrublands" | "Temperate broad leaf and mixed forests" | "Temperate coniferous forest" | "Temperate grasslands, savannas and shrublands" | "Tropical and subtropical coniferous forests" | "Tropical and subtropical dry broad leaf forests" | "Tropical and subtropical grasslands, savannas and shrublands" | "Tropical and subtropical moist broad leaf forests" | "Tundra")[];
       familyName?: string;
       growthForms?: ("Tree" | "Shrub" | "Forb" | "Graminoid" | "Fern" | "Fungus" | "Lichen" | "Moss" | "Vine" | "Liana" | "Shrub/Tree" | "Subshrub" | "Multiple Forms" | "Mangrove")[];
+      heightAtMaturitySource?: string;
+      /** Format: double */
+      heightAtMaturityValue?: number;
       /** Format: int64 */
       id: number;
+      localUsesKnown?: string;
+      nativeEcosystem?: string;
+      otherFacts?: string;
       plantMaterialSourcingMethods?: (("Seed collection & germination") | ("Seed purchase & germination") | "Mangrove propagules" | "Vegetative propagation" | "Wildling harvest" | "Seedling purchase" | "Other")[];
       problems?: components["schemas"]["SpeciesProblemElement"][];
       rare?: boolean;
@@ -3651,6 +3677,8 @@ export interface components {
       /** @enum {string} */
       seedStorageBehavior?: "Orthodox" | "Recalcitrant" | "Intermediate" | "Unknown" | "Likely Orthodox" | "Likely Recalcitrant" | "Likely Intermediate";
       successionalGroups?: ("Pioneer" | "Early secondary" | "Late secondary" | "Mature")[];
+      /** @enum {string} */
+      woodDensityLevel?: "Species level" | "Genus level" | "Family level";
     };
     SpeciesSummaryNurseryPayload: {
       /** Format: int64 */

--- a/src/features.ts
+++ b/src/features.ts
@@ -6,7 +6,8 @@ export type FeatureName =
   | 'User Detailed Sites'
   | 'Console'
   | 'Participant Experience'
-  | 'Document Producer';
+  | 'Document Producer'
+  | 'Mocked Species';
 
 export type Feature = {
   name: FeatureName;
@@ -65,6 +66,15 @@ export const OPT_IN_FEATURES: Feature[] = [
     enabled: false,
     allowInternalProduction: false,
     description: ['Terraware Accelerator Console access to the document producer tool'],
+    disclosure: ['This is WIP'],
+  },
+  {
+    name: 'Mocked Species',
+    preferenceName: 'enableMockedSpecies',
+    active: true,
+    enabled: false,
+    allowInternalProduction: false,
+    description: ['Appends mocked data for new fields to species'],
     disclosure: ['This is WIP'],
   },
 ];

--- a/src/features.ts
+++ b/src/features.ts
@@ -6,8 +6,7 @@ export type FeatureName =
   | 'User Detailed Sites'
   | 'Console'
   | 'Participant Experience'
-  | 'Document Producer'
-  | 'Mocked Species';
+  | 'Document Producer';
 
 export type Feature = {
   name: FeatureName;
@@ -66,15 +65,6 @@ export const OPT_IN_FEATURES: Feature[] = [
     enabled: false,
     allowInternalProduction: false,
     description: ['Terraware Accelerator Console access to the document producer tool'],
-    disclosure: ['This is WIP'],
-  },
-  {
-    name: 'Mocked Species',
-    preferenceName: 'enableMockedSpecies',
-    active: true,
-    enabled: false,
-    allowInternalProduction: false,
-    description: ['Appends mocked data for new fields to species'],
     disclosure: ['This is WIP'],
   },
 ];

--- a/src/scenes/Species/SpeciesAddView.tsx
+++ b/src/scenes/Species/SpeciesAddView.tsx
@@ -76,7 +76,7 @@ export default function SpeciesAddView({ reloadData }: SpeciesAddViewProps): JSX
           sx={{
             display: 'flex',
             margin: '0 auto',
-            width: isMobile ? '100%' : '700px',
+            width: '100%',
             paddingLeft: theme.spacing(isMobile ? 0 : 4),
             paddingRight: theme.spacing(isMobile ? 0 : 4),
             paddingTop: theme.spacing(5),
@@ -84,7 +84,7 @@ export default function SpeciesAddView({ reloadData }: SpeciesAddViewProps): JSX
         >
           <Grid
             container
-            width={isMobile ? '100%' : '700px'}
+            width={'100%'}
             sx={{
               backgroundColor: theme.palette.TwClrBg,
               borderRadius: theme.spacing(4),

--- a/src/scenes/Species/SpeciesAddView.tsx
+++ b/src/scenes/Species/SpeciesAddView.tsx
@@ -76,7 +76,7 @@ export default function SpeciesAddView({ reloadData }: SpeciesAddViewProps): JSX
           sx={{
             display: 'flex',
             margin: '0 auto',
-            width: '100%',
+            width: isMobile ? '100%' : '700px',
             paddingLeft: theme.spacing(isMobile ? 0 : 4),
             paddingRight: theme.spacing(isMobile ? 0 : 4),
             paddingTop: theme.spacing(5),
@@ -84,7 +84,7 @@ export default function SpeciesAddView({ reloadData }: SpeciesAddViewProps): JSX
         >
           <Grid
             container
-            width={'100%'}
+            width={isMobile ? '100%' : '700px'}
             sx={{
               backgroundColor: theme.palette.TwClrBg,
               borderRadius: theme.spacing(4),

--- a/src/scenes/Species/SpeciesAddView.tsx
+++ b/src/scenes/Species/SpeciesAddView.tsx
@@ -4,8 +4,9 @@ import { useNavigate } from 'react-router-dom';
 import { Container, Grid, Typography, useTheme } from '@mui/material';
 import { BusySpinner } from '@terraware/web-components';
 
+import PageForm from 'src/components/common/PageForm';
+import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
-import isEnabled from 'src/features';
 import { useOrganization } from 'src/providers/hooks';
 import SpeciesDetailsForm from 'src/scenes/Species/SpeciesDetailsForm';
 import { SpeciesService } from 'src/services';
@@ -13,9 +14,6 @@ import strings from 'src/strings';
 import { Species, SpeciesRequestError } from 'src/types/Species';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import useForm from 'src/utils/useForm';
-
-import PageForm from '../../components/common/PageForm';
-import TfMain from '../../components/common/TfMain';
 
 function initSpecies(species?: Species): Species {
   return (
@@ -38,7 +36,6 @@ export default function SpeciesAddView({ reloadData }: SpeciesAddViewProps): JSX
   const navigate = useNavigate();
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
-  const featureFlagMockedSpecies: boolean = isEnabled('Mocked Species');
 
   const newGridSize = isMobile ? 12 : 4;
 
@@ -79,7 +76,7 @@ export default function SpeciesAddView({ reloadData }: SpeciesAddViewProps): JSX
           sx={{
             display: 'flex',
             margin: '0 auto',
-            width: isMobile || featureFlagMockedSpecies ? '100%' : '700px',
+            width: '100%',
             paddingLeft: theme.spacing(isMobile ? 0 : 4),
             paddingRight: theme.spacing(isMobile ? 0 : 4),
             paddingTop: theme.spacing(5),
@@ -87,7 +84,7 @@ export default function SpeciesAddView({ reloadData }: SpeciesAddViewProps): JSX
         >
           <Grid
             container
-            width={isMobile || featureFlagMockedSpecies ? '100%' : '700px'}
+            width={'100%'}
             sx={{
               backgroundColor: theme.palette.TwClrBg,
               borderRadius: theme.spacing(4),
@@ -95,7 +92,7 @@ export default function SpeciesAddView({ reloadData }: SpeciesAddViewProps): JSX
             }}
           >
             <SpeciesDetailsForm
-              gridSize={featureFlagMockedSpecies ? newGridSize : 12}
+              gridSize={newGridSize}
               record={record}
               onChange={onChange}
               setRecord={setRecord}

--- a/src/scenes/Species/SpeciesDetailView.tsx
+++ b/src/scenes/Species/SpeciesDetailView.tsx
@@ -11,7 +11,6 @@ import BackToLink from 'src/components/common/BackToLink';
 import Checkbox from 'src/components/common/Checkbox';
 import OptionsMenu from 'src/components/common/OptionsMenu';
 import { APP_PATHS } from 'src/constants';
-import isEnabled from 'src/features';
 import { useOrganization } from 'src/providers/hooks';
 import { SpeciesService } from 'src/services';
 import strings from 'src/strings';
@@ -53,7 +52,6 @@ export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps
   const [deleteSpeciesModalOpen, setDeleteSpeciesModalOpen] = useState(false);
   const [isBusy, setIsBusy] = useState<boolean>(false);
   const snackbar = useSnackbar();
-  const featureFlagMockedSpecies: boolean = isEnabled('Mocked Species');
 
   const gridSize = () => {
     if (isMobile) {
@@ -197,9 +195,8 @@ export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps
               className={classes.blockCheckbox}
             />
           </Grid>
-          {featureFlagMockedSpecies ? (
-            <>
-              <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
+          {/* TODO this will eventually come from the participant project species, not the org species */}
+          {/* <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
                 <TextField
                   id={'nativeStatus'}
                   label={strings.NATIVE_NON_NATIVE}
@@ -208,116 +205,93 @@ export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps
                   display={true}
                   required
                 />
-              </Grid>
-              <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
-                <TextField
-                  id={'nativeEcosistem'}
-                  label={strings.NATIVE_ECOSYSTEM}
-                  value={species?.nativeEcosystem}
-                  type='text'
-                  display={true}
-                />
-              </Grid>
-              <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
-                <TextField
-                  id={'successionalGroup'}
-                  label={strings.SUCCESSIONAL_GROUP}
-                  value={species?.successionalGroup?.join(', ')}
-                  type='text'
-                  display={true}
-                />
-              </Grid>
-              <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
-                <TextField
-                  id={'ecosystemType'}
-                  label={strings.ECOSYSTEM_TYPE}
-                  value={species?.ecosystemTypes?.join(', ')}
-                  type='text'
-                  display={true}
-                />
-              </Grid>
-              <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
-                <TextField
-                  id={'ecologicalRoleKnown'}
-                  label={strings.ECOLOGICAL_ROLE_KNOWN}
-                  value={species?.ecologicalRoleKnown}
-                  type='text'
-                  display={true}
-                  tooltipTitle={strings.ECOLOGICAL_ROLE_KNOWN_TOOLTIP}
-                />
-              </Grid>
-              <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
-                <TextField
-                  id={'localUsesKnown'}
-                  label={strings.LOCAL_USES_KNOWN}
-                  value={species?.localUsesKnown}
-                  type='text'
-                  display={true}
-                  tooltipTitle={strings.LOCAL_USES_KNOWN_TOOLTIP}
-                />
-              </Grid>
-              <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
-                <TextField
-                  id={'seedStorageBehavior'}
-                  label={strings.SEED_STORAGE_BEHAVIOR}
-                  value={species?.seedStorageBehavior}
-                  type='text'
-                  display={true}
-                />
-              </Grid>
-              <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
-                <TextField
-                  id={'plantMaterialSourcingMethod'}
-                  label={strings.PLANT_MATERIAL_SOURCING_METHOD}
-                  value={species?.plantMaterialSourcingMethod?.join(', ')}
-                  type='text'
-                  display={true}
-                  tooltipTitle={
-                    <>
-                      <ul style={{ paddingLeft: '16px' }}>
-                        <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_SEED_COLLECTION_AND_GERMINATION}</li>
-                        <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_SEED_PURCHASE_AND_GERMINATION}</li>
-                        <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_MANGROVE_PROPAGULES}</li>
-                        <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_VEGETATIVE_PROPAGATION}</li>
-                        <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_WILDLING_HARVEST}</li>
-                        <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_SEEDLING_PURCHASE}</li>
-                      </ul>
-                    </>
-                  }
-                />
-              </Grid>
-              <Grid item xs={isMobile ? 12 : 8}>
-                <TextField
-                  id={'otherFacts'}
-                  label={strings.OTHER_FACTS}
-                  value={species?.otherFacts}
-                  type='textarea'
-                  display={true}
-                />
-              </Grid>
-            </>
-          ) : (
-            <>
-              <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
-                <TextField
-                  id={'seedStorageBehavior'}
-                  label={strings.SEED_STORAGE_BEHAVIOR}
-                  value={species?.seedStorageBehavior}
-                  type='text'
-                  display={true}
-                />
-              </Grid>
-              <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
-                <TextField
-                  id={'ecosystemType'}
-                  label={strings.ECOSYSTEM_TYPE}
-                  type='text'
-                  display={true}
-                  value={species?.ecosystemTypes?.join(', ')}
-                />
-              </Grid>
-            </>
-          )}
+              </Grid> */}
+          <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
+            <TextField
+              id={'nativeEcosistem'}
+              label={strings.NATIVE_ECOSYSTEM}
+              value={species?.nativeEcosystem}
+              type='text'
+              display={true}
+            />
+          </Grid>
+          <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
+            <TextField
+              id={'successionalGroup'}
+              label={strings.SUCCESSIONAL_GROUP}
+              value={species?.successionalGroups?.join(', ')}
+              type='text'
+              display={true}
+            />
+          </Grid>
+          <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
+            <TextField
+              id={'ecosystemType'}
+              label={strings.ECOSYSTEM_TYPE}
+              value={species?.ecosystemTypes?.join(', ')}
+              type='text'
+              display={true}
+            />
+          </Grid>
+          <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
+            <TextField
+              id={'ecologicalRoleKnown'}
+              label={strings.ECOLOGICAL_ROLE_KNOWN}
+              value={species?.ecologicalRoleKnown}
+              type='text'
+              display={true}
+              tooltipTitle={strings.ECOLOGICAL_ROLE_KNOWN_TOOLTIP}
+            />
+          </Grid>
+          <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
+            <TextField
+              id={'localUsesKnown'}
+              label={strings.LOCAL_USES_KNOWN}
+              value={species?.localUsesKnown}
+              type='text'
+              display={true}
+              tooltipTitle={strings.LOCAL_USES_KNOWN_TOOLTIP}
+            />
+          </Grid>
+          <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
+            <TextField
+              id={'seedStorageBehavior'}
+              label={strings.SEED_STORAGE_BEHAVIOR}
+              value={species?.seedStorageBehavior}
+              type='text'
+              display={true}
+            />
+          </Grid>
+          <Grid item xs={gridSize()} paddingBottom={theme.spacing(2)}>
+            <TextField
+              id={'plantMaterialSourcingMethod'}
+              label={strings.PLANT_MATERIAL_SOURCING_METHOD}
+              value={species?.plantMaterialSourcingMethods?.join(', ')}
+              type='text'
+              display={true}
+              tooltipTitle={
+                <>
+                  <ul style={{ paddingLeft: '16px' }}>
+                    <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_SEED_COLLECTION_AND_GERMINATION}</li>
+                    <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_SEED_PURCHASE_AND_GERMINATION}</li>
+                    <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_MANGROVE_PROPAGULES}</li>
+                    <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_VEGETATIVE_PROPAGATION}</li>
+                    <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_WILDLING_HARVEST}</li>
+                    <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_SEEDLING_PURCHASE}</li>
+                  </ul>
+                </>
+              }
+            />
+          </Grid>
+          <Grid item xs={isMobile ? 12 : 8}>
+            <TextField
+              id={'otherFacts'}
+              label={strings.OTHER_FACTS}
+              value={species?.otherFacts}
+              type='textarea'
+              display={true}
+            />
+          </Grid>
         </Grid>
       </Grid>
       {species && (

--- a/src/scenes/Species/SpeciesDetailsForm.tsx
+++ b/src/scenes/Species/SpeciesDetailsForm.tsx
@@ -14,7 +14,6 @@ import TooltipLearnMoreModal, {
 import Checkbox from 'src/components/common/Checkbox';
 import Select from 'src/components/common/Select/Select';
 import TextField from 'src/components/common/Textfield/Textfield';
-import isEnabled from 'src/features';
 import { useLocalization } from 'src/providers/hooks';
 import { SpeciesService } from 'src/services';
 import strings from 'src/strings';
@@ -26,7 +25,6 @@ import {
   conservationCategories,
   ecosystemTypes,
   growthForms,
-  nativeStatuses,
   plantMaterialSourcingMethods,
   storageBehaviors,
   successionalGroups,
@@ -70,7 +68,6 @@ export default function SpeciesDetailsForm({
     undefined
   );
   const { isMobile } = useDeviceInfo();
-  const featureFlagMockedSpecies: boolean = isEnabled('Mocked Species');
 
   const openTooltipLearnMoreModal = (data: TooltipLearnMoreModalData) => {
     setTooltipLearnMoreModalData(data);
@@ -263,9 +260,8 @@ export default function SpeciesDetailsForm({
             className={classes.blockCheckbox}
           />
         </Grid>
-        {featureFlagMockedSpecies ? (
-          <>
-            <Grid item xs={gridSize}>
+        {/* TODO this will eventually come from the participant project species, not the org species */}
+        {/* <Grid item xs={gridSize}>
               <Dropdown
                 id='nativeStatus'
                 selectedValue={record.nativeStatus}
@@ -278,208 +274,144 @@ export default function SpeciesDetailsForm({
                 fixedMenu
                 required
               />
-            </Grid>
-            <Grid item xs={gridSize}>
-              <TextField
-                id={'nativeEcosystem'}
-                label={strings.NATIVE_ECOSYSTEM}
-                onChange={(value) => onChange('nativeEcosystem', value)}
-                value={record.familyName}
-                type='text'
-              />
-            </Grid>
-            <Grid item xs={gridSize}>
-              <MultiSelect
-                label={strings.SUCCESSIONAL_GROUP}
-                fullWidth={true}
-                onAdd={(successionalGroup: SuccessionalGroup) => {
-                  const selectedSuccessionalGroups = record.successionalGroup ?? [];
-                  selectedSuccessionalGroups.push(successionalGroup);
-                  onChange('successionalGroup', selectedSuccessionalGroups);
-                }}
-                onRemove={(successionalGroup: SuccessionalGroup) => {
-                  onChange(
-                    'successionalGroup',
-                    record.successionalGroup?.filter((sg) => sg !== successionalGroup) ?? []
-                  );
-                }}
-                options={new Map(successionalGroups().map((sg) => [sg.value, sg.label]))}
-                valueRenderer={(sgVal: string) => sgVal}
-                selectedOptions={record.successionalGroup ?? []}
-                placeHolder={strings.SELECT}
-              />
-            </Grid>
-            <Grid item xs={gridSize}>
-              <MultiSelect
-                fullWidth={true}
-                label={strings.ECOSYSTEM_TYPE}
-                tooltipTitle={
-                  <>
-                    {`${strings.TOOLTIP_ECOSYSTEM_TYPE} `}
-                    <a
-                      target='_blank'
-                      rel='noopener noreferrer'
-                      href='https://www.worldwildlife.org/publications/terrestrial-ecoregions-of-the-world'
-                    >
-                      {strings.LEARN_MORE}
-                    </a>
-                  </>
-                }
-                onAdd={(type: EcosystemType) => {
-                  const selectedTypes = record.ecosystemTypes ?? [];
-                  selectedTypes.push(type);
-                  onChange('ecosystemTypes', selectedTypes);
-                }}
-                onRemove={(type: EcosystemType) => {
-                  onChange('ecosystemTypes', record.ecosystemTypes?.filter((et) => et !== type) ?? []);
-                }}
-                options={new Map(ecosystemTypes().map((type) => [type.value, type.label]))}
-                valueRenderer={(typeVal: string) => typeVal}
-                selectedOptions={record.ecosystemTypes ?? []}
-                placeHolder={strings.SELECT}
-              />
-            </Grid>
-            <Grid item xs={gridSize}>
-              <TextField
-                id={'ecologicalRoleKnown'}
-                label={strings.ECOLOGICAL_ROLE_KNOWN}
-                onChange={(value) => onChange('ecologicalRoleKnown', value)}
-                value={record.ecologicalRoleKnown}
-                type='text'
-                tooltipTitle={strings.ECOLOGICAL_ROLE_KNOWN_TOOLTIP}
-              />
-            </Grid>
-            <Grid item xs={gridSize}>
-              <TextField
-                id={'localUsesKnown'}
-                label={strings.LOCAL_USES_KNOWN}
-                onChange={(value) => onChange('localUsesKnown', value)}
-                value={record.localUsesKnown}
-                type='text'
-                tooltipTitle={strings.LOCAL_USES_KNOWN_TOOLTIP}
-              />
-            </Grid>
-            <Grid item xs={gridSize}>
-              <Dropdown
-                id='seedStorageBehavior'
-                selectedValue={record.seedStorageBehavior}
-                onChange={(value) => onChange('seedStorageBehavior', value)}
-                options={storageBehaviors()}
-                label={strings.SEED_STORAGE_BEHAVIOR}
-                aria-label={strings.SEED_STORAGE_BEHAVIOR}
-                placeholder={strings.SELECT}
-                fullWidth={true}
-                fixedMenu
-                tooltipTitle={
-                  <>
-                    {strings.TOOLTIP_SPECIES_SEED_STORAGE_BEHAVIOR}
-                    <LearnMoreLink
-                      onClick={() =>
-                        openTooltipLearnMoreModal({
-                          title: strings.SEED_STORAGE_BEHAVIOR,
-                          content: <LearnMoreModalContentSeedStorageBehavior />,
-                        })
-                      }
-                    />
-                  </>
-                }
-              />
-            </Grid>
-            <Grid item xs={gridSize}>
-              <Dropdown
-                id='plantMaterialSourcingMethod'
-                selectedValue={record.plantMaterialSourcingMethod}
-                onChange={(value) => onChange('plantMaterialSourcingMethod', value)}
-                options={plantMaterialSourcingMethods()}
-                label={strings.PLANT_MATERIAL_SOURCING_METHOD}
-                aria-label={strings.PLANT_MATERIAL_SOURCING_METHOD}
-                placeholder={strings.SELECT}
-                fullWidth={true}
-                fixedMenu
-                tooltipTitle={
-                  <>
-                    <ul style={{ paddingLeft: '16px' }}>
-                      <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_SEED_COLLECTION_AND_GERMINATION}</li>
-                      <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_SEED_PURCHASE_AND_GERMINATION}</li>
-                      <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_MANGROVE_PROPAGULES}</li>
-                      <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_VEGETATIVE_PROPAGATION}</li>
-                      <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_WILDLING_HARVEST}</li>
-                      <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_SEEDLING_PURCHASE}</li>
-                    </ul>
-                  </>
-                }
-              />
-            </Grid>
-            <Grid item xs={isMobile ? 12 : 8}>
-              <TextField
-                id={'otherFacts'}
-                label={strings.OTHER_FACTS}
-                onChange={(value) => onChange('otherFacts', value)}
-                value={record.otherFacts}
-                type='textarea'
-              />
-            </Grid>
-          </>
-        ) : (
-          <>
-            <Grid item xs={gridSize}>
-              <Dropdown
-                id='seedStorageBehavior'
-                selectedValue={record.seedStorageBehavior}
-                onChange={(value) => onChange('seedStorageBehavior', value)}
-                options={storageBehaviors()}
-                label={strings.SEED_STORAGE_BEHAVIOR}
-                aria-label={strings.SEED_STORAGE_BEHAVIOR}
-                placeholder={strings.SELECT}
-                fullWidth={true}
-                fixedMenu
-                tooltipTitle={
-                  <>
-                    {strings.TOOLTIP_SPECIES_SEED_STORAGE_BEHAVIOR}
-                    <LearnMoreLink
-                      onClick={() =>
-                        openTooltipLearnMoreModal({
-                          title: strings.SEED_STORAGE_BEHAVIOR,
-                          content: <LearnMoreModalContentSeedStorageBehavior />,
-                        })
-                      }
-                    />
-                  </>
-                }
-              />
-            </Grid>
-            <Grid item xs={gridSize}>
-              <MultiSelect
-                fullWidth={true}
-                label={strings.ECOSYSTEM_TYPE}
-                tooltipTitle={
-                  <>
-                    {`${strings.TOOLTIP_ECOSYSTEM_TYPE} `}
-                    <a
-                      target='_blank'
-                      rel='noopener noreferrer'
-                      href='https://www.worldwildlife.org/publications/terrestrial-ecoregions-of-the-world'
-                    >
-                      {strings.LEARN_MORE}
-                    </a>
-                  </>
-                }
-                onAdd={(type: EcosystemType) => {
-                  const selectedTypes = record.ecosystemTypes ?? [];
-                  selectedTypes.push(type);
-                  onChange('ecosystemTypes', selectedTypes);
-                }}
-                onRemove={(type: EcosystemType) => {
-                  onChange('ecosystemTypes', record.ecosystemTypes?.filter((et) => et !== type) ?? []);
-                }}
-                options={new Map(ecosystemTypes().map((type) => [type.value, type.label]))}
-                valueRenderer={(typeVal: string) => typeVal}
-                selectedOptions={record.ecosystemTypes ?? []}
-                placeHolder={strings.SELECT}
-              />
-            </Grid>
-          </>
-        )}
+            </Grid> */}
+        <Grid item xs={gridSize}>
+          <TextField
+            id={'nativeEcosystem'}
+            label={strings.NATIVE_ECOSYSTEM}
+            onChange={(value) => onChange('nativeEcosystem', value)}
+            value={record.familyName}
+            type='text'
+          />
+        </Grid>
+        <Grid item xs={gridSize}>
+          <MultiSelect
+            label={strings.SUCCESSIONAL_GROUP}
+            fullWidth={true}
+            onAdd={(successionalGroup: SuccessionalGroup) => {
+              const selectedSuccessionalGroups = record.successionalGroups ?? [];
+              selectedSuccessionalGroups.push(successionalGroup);
+              onChange('successionalGroup', selectedSuccessionalGroups);
+            }}
+            onRemove={(successionalGroup: SuccessionalGroup) => {
+              onChange('successionalGroup', record.successionalGroups?.filter((sg) => sg !== successionalGroup) ?? []);
+            }}
+            options={new Map(successionalGroups().map((sg) => [sg.value, sg.label]))}
+            valueRenderer={(sgVal: string) => sgVal}
+            selectedOptions={record.successionalGroups ?? []}
+            placeHolder={strings.SELECT}
+          />
+        </Grid>
+        <Grid item xs={gridSize}>
+          <MultiSelect
+            fullWidth={true}
+            label={strings.ECOSYSTEM_TYPE}
+            tooltipTitle={
+              <>
+                {`${strings.TOOLTIP_ECOSYSTEM_TYPE} `}
+                <a
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  href='https://www.worldwildlife.org/publications/terrestrial-ecoregions-of-the-world'
+                >
+                  {strings.LEARN_MORE}
+                </a>
+              </>
+            }
+            onAdd={(type: EcosystemType) => {
+              const selectedTypes = record.ecosystemTypes ?? [];
+              selectedTypes.push(type);
+              onChange('ecosystemTypes', selectedTypes);
+            }}
+            onRemove={(type: EcosystemType) => {
+              onChange('ecosystemTypes', record.ecosystemTypes?.filter((et) => et !== type) ?? []);
+            }}
+            options={new Map(ecosystemTypes().map((type) => [type.value, type.label]))}
+            valueRenderer={(typeVal: string) => typeVal}
+            selectedOptions={record.ecosystemTypes ?? []}
+            placeHolder={strings.SELECT}
+          />
+        </Grid>
+        <Grid item xs={gridSize}>
+          <TextField
+            id={'ecologicalRoleKnown'}
+            label={strings.ECOLOGICAL_ROLE_KNOWN}
+            onChange={(value) => onChange('ecologicalRoleKnown', value)}
+            value={record.ecologicalRoleKnown}
+            type='text'
+            tooltipTitle={strings.ECOLOGICAL_ROLE_KNOWN_TOOLTIP}
+          />
+        </Grid>
+        <Grid item xs={gridSize}>
+          <TextField
+            id={'localUsesKnown'}
+            label={strings.LOCAL_USES_KNOWN}
+            onChange={(value) => onChange('localUsesKnown', value)}
+            value={record.localUsesKnown}
+            type='text'
+            tooltipTitle={strings.LOCAL_USES_KNOWN_TOOLTIP}
+          />
+        </Grid>
+        <Grid item xs={gridSize}>
+          <Dropdown
+            id='seedStorageBehavior'
+            selectedValue={record.seedStorageBehavior}
+            onChange={(value) => onChange('seedStorageBehavior', value)}
+            options={storageBehaviors()}
+            label={strings.SEED_STORAGE_BEHAVIOR}
+            aria-label={strings.SEED_STORAGE_BEHAVIOR}
+            placeholder={strings.SELECT}
+            fullWidth={true}
+            fixedMenu
+            tooltipTitle={
+              <>
+                {strings.TOOLTIP_SPECIES_SEED_STORAGE_BEHAVIOR}
+                <LearnMoreLink
+                  onClick={() =>
+                    openTooltipLearnMoreModal({
+                      title: strings.SEED_STORAGE_BEHAVIOR,
+                      content: <LearnMoreModalContentSeedStorageBehavior />,
+                    })
+                  }
+                />
+              </>
+            }
+          />
+        </Grid>
+        <Grid item xs={gridSize}>
+          <Dropdown
+            id='plantMaterialSourcingMethod'
+            selectedValue={record.plantMaterialSourcingMethods}
+            onChange={(value) => onChange('plantMaterialSourcingMethod', value)}
+            options={plantMaterialSourcingMethods()}
+            label={strings.PLANT_MATERIAL_SOURCING_METHOD}
+            aria-label={strings.PLANT_MATERIAL_SOURCING_METHOD}
+            placeholder={strings.SELECT}
+            fullWidth={true}
+            fixedMenu
+            tooltipTitle={
+              <>
+                <ul style={{ paddingLeft: '16px' }}>
+                  <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_SEED_COLLECTION_AND_GERMINATION}</li>
+                  <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_SEED_PURCHASE_AND_GERMINATION}</li>
+                  <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_MANGROVE_PROPAGULES}</li>
+                  <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_VEGETATIVE_PROPAGATION}</li>
+                  <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_WILDLING_HARVEST}</li>
+                  <li>{strings.PLANT_MATERIAL_SOURCING_METHOD_TOOLTIP_SEEDLING_PURCHASE}</li>
+                </ul>
+              </>
+            }
+          />
+        </Grid>
+        <Grid item xs={isMobile ? 12 : 8}>
+          <TextField
+            id={'otherFacts'}
+            label={strings.OTHER_FACTS}
+            onChange={(value) => onChange('otherFacts', value)}
+            value={record.otherFacts}
+            type='textarea'
+          />
+        </Grid>
       </Grid>
     </>
   );

--- a/src/scenes/Species/SpeciesDetailsForm.tsx
+++ b/src/scenes/Species/SpeciesDetailsForm.tsx
@@ -286,6 +286,7 @@ export default function SpeciesDetailsForm({
         </Grid>
         <Grid item xs={gridSize}>
           <MultiSelect
+            id='successionalGroups'
             label={strings.SUCCESSIONAL_GROUP}
             fullWidth={true}
             onAdd={(successionalGroup: SuccessionalGroup) => {
@@ -304,6 +305,7 @@ export default function SpeciesDetailsForm({
         </Grid>
         <Grid item xs={gridSize}>
           <MultiSelect
+            id='ecosystemTypes'
             fullWidth={true}
             label={strings.ECOSYSTEM_TYPE}
             tooltipTitle={

--- a/src/services/SpeciesService.ts
+++ b/src/services/SpeciesService.ts
@@ -1,8 +1,7 @@
 import { paths } from 'src/api/types/generated-schema';
-import isEnabled from 'src/features';
 import { GetUploadStatusResponsePayload, UploadFileResponse } from 'src/types/File';
 import { FieldNodePayload, SearchRequestPayload, SearchResponseElement } from 'src/types/Search';
-import { Species, SpeciesDetails, SuggestedSpecies, mockSpeciesNewFieldsData } from 'src/types/Species';
+import { Species, SpeciesDetails, SuggestedSpecies } from 'src/types/Species';
 import { parseSearchTerm } from 'src/utils/search';
 
 import HttpService, { Response, ServerData } from './HttpService';
@@ -106,7 +105,6 @@ const createSpecies = async (species: Omit<Species, 'id'>, organizationId: numbe
  */
 const getSpecies = async (speciesId: number, organizationId: number): Promise<SpeciesIdResponse> => {
   const params = { organizationId: organizationId.toString() };
-  const featureFlagMockedSpecies = isEnabled('Mocked Species');
   const response: SpeciesIdResponse = await httpSpeciesId.get<SpeciesIdResponsePayload, SpeciesIdData>(
     {
       params,
@@ -118,9 +116,7 @@ const getSpecies = async (speciesId: number, organizationId: number): Promise<Sp
       }
 
       const speciesData: SpeciesIdData = {
-        species: (featureFlagMockedSpecies
-          ? { ...data.species, ...mockSpeciesNewFieldsData }
-          : data.species) as Species, // TODO remove this casting when we remove the mock data
+        species: data.species,
       };
 
       return speciesData;
@@ -174,7 +170,6 @@ const deleteSpecies = async (speciesId: number, organizationId: number): Promise
  */
 const getAllSpecies = async (organizationId: number, inUse?: boolean): Promise<AllSpeciesResponse> => {
   const params: any = { organizationId: organizationId.toString() };
-  const featureFlagMockedSpecies = isEnabled('Mocked Species');
 
   if (inUse) {
     params.inUse = inUse.toString();
@@ -183,10 +178,7 @@ const getAllSpecies = async (organizationId: number, inUse?: boolean): Promise<A
   const response: AllSpeciesResponse = await httpSpecies.get<SpeciesResponsePayload, AllSpeciesData>(
     { params },
     (data) => ({
-      species:
-        featureFlagMockedSpecies && data?.species
-          ? (data?.species.map((species) => ({ ...species, ...mockSpeciesNewFieldsData })) as Species[]) // TODO remove this casting when we remove the mock data
-          : (data?.species as Species[]), // TODO remove this casting when we remove the mock data
+      species: data?.species,
     })
   );
 

--- a/src/types/Species.ts
+++ b/src/types/Species.ts
@@ -3,70 +3,21 @@ import strings from 'src/strings';
 
 import { ArrayDeref, NonUndefined } from './utils';
 
-export type Species = {
-  id: number;
-  commonName?: string;
-  conservationCategory?: 'CR' | 'DD' | 'EN' | 'EW' | 'EX' | 'LC' | 'NE' | 'NT' | 'VU';
-  familyName?: string;
-  growthForms?: GrowthForm[];
-  scientificName: string;
-  rare?: boolean;
-  seedStorageBehavior?: SeedStorageBehavior;
-  problems?: SpeciesProblemElement[];
-  ecosystemTypes?: EcosystemType[];
-  nativeStatus?: NativeStatus;
-  nativeEcosystem?: string;
-  successionalGroup?: SuccessionalGroup[];
-  ecologicalRoleKnown?: string;
-  localUsesKnown?: string;
-  plantMaterialSourcingMethod?: PlantMaterialSourcingMethod[];
-  heightAtMaturity?: number;
-  heightAtMaturitySource?: string;
-  dbhDiameterAtMaturity?: number;
-  dbhSource?: string;
-  averageWoodDensity?: number;
-  woodDensityLevel?: WoodDensityLevel;
-  otherFacts?: string;
-};
+export type Species = components['schemas']['GetSpeciesResponsePayload']['species'];
 
-// TODO: remove this mock data when the actual data is available
-export const mockSpeciesNewFieldsData: Partial<Species> = {
-  nativeStatus: 'Native',
-  nativeEcosystem: 'Tropical and subtropical moist broad leaf forests',
-  ecologicalRoleKnown: 'Yes',
-  localUsesKnown: 'Yes',
-  heightAtMaturity: 10,
-  heightAtMaturitySource: 'Source',
-  dbhDiameterAtMaturity: 10,
-  dbhSource: 'Source',
-  averageWoodDensity: 10,
-  woodDensityLevel: 'Species',
-  otherFacts: 'Other facts',
-};
+export type WoodDensityLevel = NonUndefined<Species['woodDensityLevel']>;
 
-export type WoodDensityLevel = 'Species' | 'Genus' | 'Family';
+export type PlantMaterialSourcingMethod = ArrayDeref<NonUndefined<Species['plantMaterialSourcingMethods']>>;
 
-export type PlantMaterialSourcingMethod = ArrayDeref<
-  NonUndefined<components['schemas']['GetSpeciesResponsePayload']['species']['plantMaterialSourcingMethods']>
->;
-
-export type SuccessionalGroup = ArrayDeref<
-  NonUndefined<components['schemas']['GetSpeciesResponsePayload']['species']['successionalGroups']>
->;
+export type SuccessionalGroup = ArrayDeref<NonUndefined<Species['successionalGroups']>>;
 
 export type NativeStatus = 'Native' | 'Non-Native';
 
-export type EcosystemType = ArrayDeref<
-  NonUndefined<components['schemas']['GetSpeciesResponsePayload']['species']['ecosystemTypes']>
->;
+export type EcosystemType = ArrayDeref<NonUndefined<Species['ecosystemTypes']>>;
 
-export type GrowthForm = ArrayDeref<
-  NonUndefined<components['schemas']['GetSpeciesResponsePayload']['species']['growthForms']>
->;
+export type GrowthForm = ArrayDeref<NonUndefined<Species['growthForms']>>;
 
-export type SeedStorageBehavior = NonUndefined<
-  components['schemas']['GetSpeciesResponsePayload']['species']['seedStorageBehavior']
->;
+export type SeedStorageBehavior = NonUndefined<Species['seedStorageBehavior']>;
 
 export type SpeciesProblemElement = {
   id: number;


### PR DESCRIPTION
- Sync with backend types that have the new fields that were mocked
- ~Remove opt-in flag for mocked data~ leaving this for now since we are using the flag to show mocked deliverable data

Depends on `terraware-server` PR  https://github.com/terraware/terraware-server/pull/1893