### PR TITLE
SW-5275: Move `DeliverableView` to `DocumentDeliverableView`

### DIFF
--- a/src/scenes/DeliverablesRouter/DeliverableViewWrapper.tsx
+++ b/src/scenes/DeliverablesRouter/DeliverableViewWrapper.tsx
@@ -3,7 +3,7 @@ import React, { useParams } from 'react-router-dom';
 import useFetchDeliverable from 'src/components/DeliverableView/useFetchDeliverable';
 import Page from 'src/components/Page';
 
-import DeliverableView from './DeliverableView';
+import DocumentDeliverableView from './DocumentDeliverableView';
 
 const DeliverableViewWrapper = () => {
   const { deliverableId, projectId } = useParams<{ deliverableId: string; projectId: string }>();
@@ -11,7 +11,7 @@ const DeliverableViewWrapper = () => {
   const { deliverable } = useFetchDeliverable({ deliverableId: Number(deliverableId), projectId: Number(projectId) });
 
   if (deliverable) {
-    return <DeliverableView deliverable={deliverable} />;
+    return <DocumentDeliverableView deliverable={deliverable} />;
   } else {
     return <Page isLoading={true} />;
   }

--- a/src/scenes/DeliverablesRouter/DocumentDeliverableView.tsx
+++ b/src/scenes/DeliverablesRouter/DocumentDeliverableView.tsx
@@ -25,7 +25,7 @@ export type Props = EditProps & {
   isBusy?: boolean;
 };
 
-const DeliverableView = (props: Props): JSX.Element => {
+const DocumentDeliverableView = (props: Props): JSX.Element => {
   const { ...viewProps }: ViewProps = props;
   const { isMobile } = useDeviceInfo();
   const { activeLocale } = useLocalization();
@@ -75,4 +75,4 @@ const DeliverableView = (props: Props): JSX.Element => {
   );
 };
 
-export default DeliverableView;
+export default DocumentDeliverableView;


### PR DESCRIPTION
This PR includes changes to move (re-name) `DeliverableView` to `DocumentDeliverableView`.

Hoping I didn't misunderstand the ticket since the change is minimal. Happy to make any adjustments.