### PR TITLE
SW-5234 Used cached selector for active modules to not cause infinite renders

### DIFF
--- a/src/providers/Participant/ParticipantProvider.tsx
+++ b/src/providers/Participant/ParticipantProvider.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { useLocalization, useOrganization } from 'src/providers/hooks';
-import { requestGetModule } from 'src/redux/features/modules/modulesAsyncThunks';
 import { selectActiveModules, selectProjectModuleList } from 'src/redux/features/modules/modulesSelectors';
 import { requestGetParticipant } from 'src/redux/features/participants/participantsAsyncThunks';
 import { selectParticipant } from 'src/redux/features/participants/participantsSelectors';
@@ -25,7 +24,7 @@ const ParticipantProvider = ({ children }: Props) => {
   const [participantProjects, setParticipantProjects] = useState<Project[]>([]);
 
   const participant = useAppSelector(selectParticipant(currentParticipantProject?.participantId || -1));
-  const activeModules = useAppSelector(selectActiveModules(currentParticipantProject?.id || -1));
+  const activeModules = useAppSelector((state) => selectActiveModules(state, currentParticipantProject?.id || -1));
   const modules = useAppSelector(selectProjectModuleList(currentParticipantProject?.id || -1));
   const projects = useAppSelector(selectProjects);
 
@@ -41,12 +40,6 @@ const ParticipantProvider = ({ children }: Props) => {
     orgHasParticipants: false,
     setCurrentParticipantProject: _setCurrentParticipantProject,
   });
-
-  useEffect(() => {
-    if (participant?.currentModuleId && currentParticipantProject?.id) {
-      dispatch(requestGetModule({ projectId: currentParticipantProject.id, moduleId: participant.currentModuleId }));
-    }
-  }, [currentParticipantProject, dispatch, participant]);
 
   useEffect(() => {
     const nextParticipantProjects = (projects || []).filter((project) => !!project.participantId);

--- a/src/redux/features/modules/modulesSelectors.ts
+++ b/src/redux/features/modules/modulesSelectors.ts
@@ -2,8 +2,10 @@ import createCachedSelector from 're-reselect';
 
 import { RootState } from 'src/redux/rootReducer';
 
-export const selectActiveModules = (projectId: number) => (state: RootState) =>
-  state.moduleList[projectId]?.data?.filter((module) => module.isActive);
+export const selectActiveModules = createCachedSelector(
+  (state: RootState, projectId: number) => state.moduleList[projectId]?.data?.filter((module) => module.isActive),
+  (data) => data
+)(() => 'activeModules');
 
 export const selectModuleRequest = (requestId: string) => (state: RootState) => state.module[requestId];
 

--- a/src/redux/features/participants/participantsAsyncThunks.ts
+++ b/src/redux/features/participants/participantsAsyncThunks.ts
@@ -1,10 +1,7 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import { Response, Response2 } from 'src/services/HttpService';
-import ParticipantsService, {
-  ParticipantData,
-  ParticipantDataWithCurrentModule,
-} from 'src/services/ParticipantsService';
+import ParticipantsService, { ParticipantData } from 'src/services/ParticipantsService';
 import strings from 'src/strings';
 import { ParticipantCreateRequest, ParticipantSearchResult, ParticipantUpdateRequest } from 'src/types/Participant';
 import { SearchNodePayload, SearchSortOrder } from 'src/types/Search';
@@ -38,7 +35,7 @@ export const requestDeleteParticipant = createAsyncThunk(
 export const requestGetParticipant = createAsyncThunk(
   'participants/get-one',
   async (participantId: number, { rejectWithValue }) => {
-    const response: Response2<ParticipantDataWithCurrentModule> = await ParticipantsService.get(participantId);
+    const response: Response2<ParticipantData> = await ParticipantsService.get(participantId);
 
     if (response && response.requestSucceeded) {
       return response.data?.participant;

--- a/src/redux/features/participants/participantsSlice.ts
+++ b/src/redux/features/participants/participantsSlice.ts
@@ -1,7 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 import { StatusT, buildReducers } from 'src/redux/features/asyncUtils';
-import { ParticipantWithCurrentModule } from 'src/services/ParticipantsService';
 import { Participant, ParticipantSearchResult } from 'src/types/Participant';
 
 import {
@@ -43,7 +42,7 @@ export const participantDeleteSlice = createSlice({
 /**
  * Get Participant
  */
-const initialStateParticipant: { [key: string]: StatusT<ParticipantWithCurrentModule> } = {};
+const initialStateParticipant: { [key: string]: StatusT<Participant> } = {};
 
 export const participantSlice = createSlice({
   name: 'participantSlice',

--- a/src/services/ParticipantsService.ts
+++ b/src/services/ParticipantsService.ts
@@ -48,13 +48,8 @@ const deleteOne = async (participantId: number): Promise<Response> =>
 const download = async (search?: SearchNodePayload, sortOrder?: SearchSortOrder): Promise<string | null> =>
   await SearchService.searchCsv(getSearchParams(search, sortOrder));
 
-// Mocked currentModuleId attached to the participant
-// The location of this data may change in the future when the BE is done
-export type ParticipantWithCurrentModule = Participant & { currentModuleId: number };
-export type ParticipantDataWithCurrentModule = ServerData & { participant: ParticipantWithCurrentModule };
-
-const get = async (participantId: number): Promise<Response2<ParticipantDataWithCurrentModule>> => {
-  const response = await HttpService.root(PARTICIPANT_ENDPOINT).get2<ParticipantDataWithCurrentModule>({
+const get = async (participantId: number): Promise<Response2<ParticipantData>> => {
+  const response = await HttpService.root(PARTICIPANT_ENDPOINT).get2<ParticipantData>({
     urlReplacements: { '{participantId}': `${participantId}` },
   });
 
@@ -65,10 +60,7 @@ const get = async (participantId: number): Promise<Response2<ParticipantDataWith
   return {
     ...response,
     data: {
-      participant: {
-        ...response.data.participant,
-        currentModuleId: 1,
-      },
+      participant: response.data.participant,
     },
   };
 };


### PR DESCRIPTION
Also removed Participant with Current Module since active module ID is not part of participant data and going forward we may need to support multiple active modules. 