### PR TITLE
SW-5339: Deliverables: Status - change "Rejected" to "Not Accepted"

### DIFF
--- a/src/components/DeliverableView/DeliverableStatusBadge.tsx
+++ b/src/components/DeliverableView/DeliverableStatusBadge.tsx
@@ -65,7 +65,7 @@ const DeliverableStatusBadge = (props: DeliverableStatusBadgeProps): JSX.Element
           backgroundColor: theme.palette.TwClrBgDangerTertiary,
           borderColor: theme.palette.TwClrBrdrDanger,
           labelColor: theme.palette.TwClrTxtDanger,
-          label: strings.REJECTED,
+          label: strings.NOT_ACCEPTED,
         };
       default:
         return undefined;

--- a/src/scenes/DeliverablesRouter/RejectedDeliverableMessage.tsx
+++ b/src/scenes/DeliverablesRouter/RejectedDeliverableMessage.tsx
@@ -18,7 +18,7 @@ const RejectedDeliverableMessage = ({ deliverable }: ViewProps): JSX.Element => 
           <Message
             body={deliverable?.feedback || ''}
             priority='critical'
-            title={strings.DELIVERABLE_REJECTED}
+            title={strings.DELIVERABLE_NOT_ACCEPTED}
             type='page'
           />
         </Box>

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -339,6 +339,7 @@ DELETED_SPECIES,<deleted species>,
 DELIVERABLE_APPROVED,Deliverable Approved,
 DELIVERABLE_CATEGORY,Category: {0},"Shows the deliverable document's category name, example Category: Legal"
 DELIVERABLE_NAME,Deliverable Name,
+DELIVERABLE_NOT_ACCEPTED,Deliverable Not Accepted,
 DELIVERABLE_PROJECT,Project: {0},"Shows the project name associated with the deliverable document, example Project: Andromeda"
 DELIVERABLE_REJECTED,Deliverable Rejected,
 DELIVERABLE_STATUS_CHANGE_CONFIRMATION_1,Submitting a document after a deliverable has been reviewed will reset the deliverable status.,

--- a/src/types/Deliverables.ts
+++ b/src/types/Deliverables.ts
@@ -76,7 +76,7 @@ export const statusLabel = (status: DeliverableStatusType): string => {
     case 'In Review':
       return strings.IN_REVIEW;
     case 'Rejected':
-      return strings.REJECTED;
+      return strings.NOT_ACCEPTED;
     case 'Approved':
       return strings.APPROVED;
     case 'Not Needed':


### PR DESCRIPTION
This PR includes changes to update the deliverable status label from "Rejected" to "Not Accepted" for participant users.

## Screenshots

![localhost_accelerator_deliverables (1)](https://github.com/terraware/terraware-web/assets/1474361/36aa9a5f-5f45-40e4-a44a-1e14f0b5e598)

![localhost_accelerator_deliverables (2)](https://github.com/terraware/terraware-web/assets/1474361/a646483c-110d-423c-b7a3-bc227bf6ebd0)
