### PR TITLE
Bump web-components to pickup style changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@mui/styled-engine-sc": "^5.14.12",
     "@mui/styles": "^5.15.15",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^3.0.3",
+    "@terraware/web-components": "^3.0.6",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.3.0",
     "@testing-library/user-event": "^14.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3956,10 +3956,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.0.3.tgz#f98799157fd301c1c8148c32f591ddcd751e312f"
-  integrity sha512-HcutwfZfyIR6TdqYN3cnw4qkJeCF2g4D46yQ/mrPj40QWdSbahDnf3KgaBG8O1frw0NlUod2R+MAIODxPJ+j0w==
+"@terraware/web-components@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.0.6.tgz#08722ea484b26dd2d4927fde864554dd7607b13d"
+  integrity sha512-sZZ3rFkMv9FvMUeq2JB5Msuvb4UmmkJ4JyWKbZVzd9bOPjMyUFK2mVpfIoDAJnJe/ORYNDk0XFGgzqoYSv/GUw==
   dependencies:
     "@date-io/luxon" "^3.0.0"
     "@dnd-kit/core" "^6.0.7"


### PR DESCRIPTION
This is a quick PR to bump the version of `web-components` to pickup recent style changes.