### PR TITLE
Hide projects related features for non participants

### DIFF
--- a/src/scenes/Species/SpeciesDetailView.tsx
+++ b/src/scenes/Species/SpeciesDetailView.tsx
@@ -11,6 +11,7 @@ import BackToLink from 'src/components/common/BackToLink';
 import Checkbox from 'src/components/common/Checkbox';
 import OptionsMenu from 'src/components/common/OptionsMenu';
 import { APP_PATHS } from 'src/constants';
+import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 import { useOrganization } from 'src/providers/hooks';
 import { SpeciesService } from 'src/services';
 import strings from 'src/strings';
@@ -53,6 +54,7 @@ export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps
   const [deleteSpeciesModalOpen, setDeleteSpeciesModalOpen] = useState(false);
   const [isBusy, setIsBusy] = useState<boolean>(false);
   const snackbar = useSnackbar();
+  const { orgHasParticipants } = useParticipantData();
 
   const gridSize = () => {
     if (isMobile) {
@@ -293,7 +295,7 @@ export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps
               display={true}
             />
           </Grid>
-          {species && <SpeciesProjectsTable speciesId={species.id} editMode={false} />}
+          {species && orgHasParticipants && <SpeciesProjectsTable speciesId={species.id} editMode={false} />}
         </Grid>
       </Grid>
       {species && (

--- a/src/scenes/Species/SpeciesDetailsForm.tsx
+++ b/src/scenes/Species/SpeciesDetailsForm.tsx
@@ -14,6 +14,7 @@ import TooltipLearnMoreModal, {
 import Checkbox from 'src/components/common/Checkbox';
 import Select from 'src/components/common/Select/Select';
 import TextField from 'src/components/common/Textfield/Textfield';
+import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 import { useLocalization } from 'src/providers/hooks';
 import { SpeciesService } from 'src/services';
 import strings from 'src/strings';
@@ -81,6 +82,7 @@ export default function SpeciesDetailsForm({
     undefined
   );
   const { isMobile } = useDeviceInfo();
+  const { orgHasParticipants } = useParticipantData();
 
   const openTooltipLearnMoreModal = (data: TooltipLearnMoreModalData) => {
     setTooltipLearnMoreModalData(data);
@@ -436,7 +438,7 @@ export default function SpeciesDetailsForm({
             type='textarea'
           />
         </Grid>
-        {
+        {orgHasParticipants && (
           <SpeciesProjectsTable
             speciesId={record.id}
             editMode={true}
@@ -446,7 +448,7 @@ export default function SpeciesDetailsForm({
             addedProjectsIds={addedProjectsIds}
             removedProjectsIds={removedProjectsIds}
           />
-        }
+        )}
       </Grid>
     </>
   );

--- a/src/scenes/Species/SpeciesListView.tsx
+++ b/src/scenes/Species/SpeciesListView.tsx
@@ -25,6 +25,7 @@ import Button from 'src/components/common/button/Button';
 import { OrderPreserveableTable as Table } from 'src/components/common/table';
 import { TableColumnType } from 'src/components/common/table/types';
 import { APP_PATHS } from 'src/constants';
+import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
 import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
 import { useAppSelector } from 'src/redux/store';
@@ -108,6 +109,7 @@ export default function SpeciesListView({ reloadData, species }: SpeciesListProp
   const query = useQuery();
   const navigate = useNavigate();
   const projects = useAppSelector(selectProjects);
+  const { orgHasParticipants } = useParticipantData();
 
   const contentRef = useRef(null);
   const { activeLocale } = useLocalization();
@@ -153,11 +155,15 @@ export default function SpeciesListView({ reloadData, species }: SpeciesListProp
         type: 'string',
         tooltipTitle: strings.TOOLTIP_SPECIES_FAMILY,
       },
-      {
-        key: 'participantProjects',
-        name: strings.PROJECTS,
-        type: 'string',
-      },
+      ...(orgHasParticipants
+        ? ([
+            {
+              key: 'participantProjects',
+              name: strings.PROJECTS,
+              type: 'string',
+            },
+          ] as TableColumnType[])
+        : []),
       {
         key: 'conservationCategory',
         name: strings.CONSERVATION_CATEGORY,
@@ -263,8 +269,8 @@ export default function SpeciesListView({ reloadData, species }: SpeciesListProp
       },
     ];
 
-    return activeLocale ? _filters : [];
-  }, [activeLocale]);
+    return activeLocale && orgHasParticipants ? _filters : [];
+  }, [activeLocale, orgHasParticipants]);
 
   const iconFilters: FilterConfig[] = useMemo(() => {
     const _filters = filterColumns.map((filter) => ({


### PR DESCRIPTION
For non participants, hide projects column and featured filter in species list view, and hide the projects table in the species detail and edit views