### PR TITLE
Use the search API to get deliverable info about participant project species

### DIFF
--- a/src/services/ParticipantProjectSpeciesService.ts
+++ b/src/services/ParticipantProjectSpeciesService.ts
@@ -188,7 +188,7 @@ const update = (participantProjectSpecies: ParticipantProjectSpecies): Promise<R
 
 const getProjectsForSpecies = async (speciesId: number, organizationId: number): Promise<SpeciesProjectsResult[]> => {
   const todayUTC = DateTime.fromISO(new Date().toISOString()).toFormat('yyyy-MM-dd');
-  console.log('todayUTC', todayUTC);
+
   const searchParams: SearchRequestPayload = {
     prefix: 'projects.projectDeliverables',
     fields: [

--- a/src/services/ParticipantProjectSpeciesService.ts
+++ b/src/services/ParticipantProjectSpeciesService.ts
@@ -210,6 +210,8 @@ const getProjectsForSpecies = async (speciesId: number, organizationId: number):
           operation: 'field',
           field: 'type',
           type: 'Exact',
+          // Since the search API is localized, we need to send the localized values
+          // ** This will not work as expected if the BE and FE localized values do not match
           values: [getDeliverableTypeLabel('Species' as DeliverableTypeType)],
         },
         {
@@ -224,6 +226,7 @@ const getProjectsForSpecies = async (speciesId: number, organizationId: number):
           type: 'Exact',
           values: [speciesId],
         },
+        // We only want to grab deliverables that are part of an active module
         {
           operation: 'field',
           field: 'module.cohortModules.endDate',

--- a/src/services/ParticipantProjectSpeciesService.ts
+++ b/src/services/ParticipantProjectSpeciesService.ts
@@ -1,7 +1,9 @@
+import { DateTime } from 'luxon';
+
 import { components, paths } from 'src/api/types/generated-schema';
+import { DeliverableTypeType, getDeliverableTypeLabel } from 'src/types/Deliverables';
 import { SearchNodePayload, SearchRequestPayload, SearchSortOrder } from 'src/types/Search';
 
-import DeliverablesService from './DeliverablesService';
 import HttpService, { Response2 } from './HttpService';
 import SearchService from './SearchService';
 
@@ -45,7 +47,31 @@ export type SpeciesProjectsResult = {
 };
 
 type SpeciesProjectsSearchResult = {
-  participantProjectSpecies: { id: number; submissionStatus: string; project: { name: string; id: number } }[];
+  // Deliverable ID
+  id: string;
+  module: {
+    cohortModules: {
+      startDate: string;
+      endDate: string;
+    }[];
+  };
+  project: {
+    participantProjectSpecies: {
+      id: string;
+      project: {
+        name: string;
+        id: string;
+      };
+      species: {
+        id: string;
+        organization: {
+          id: string;
+        };
+      };
+      submissionStatus: string;
+    }[];
+  };
+  type: string;
 };
 
 export type SpeciesWithParticipantProjectsSearchResponse = {
@@ -161,70 +187,75 @@ const update = (participantProjectSpecies: ParticipantProjectSpecies): Promise<R
 };
 
 const getProjectsForSpecies = async (speciesId: number, organizationId: number): Promise<SpeciesProjectsResult[]> => {
+  const todayUTC = DateTime.fromISO(new Date().toISOString()).toFormat('yyyy-MM-dd');
+  console.log('todayUTC', todayUTC);
   const searchParams: SearchRequestPayload = {
-    prefix: 'species',
+    prefix: 'projects.projectDeliverables',
     fields: [
-      'participantProjectSpecies.id',
-      'participantProjectSpecies.project.name',
-      'participantProjectSpecies.project.id',
-      'participantProjectSpecies.submissionStatus',
+      'id',
+      'type',
+      'project.participantProjectSpecies.id',
+      'project.participantProjectSpecies.project.name',
+      'project.participantProjectSpecies.project.id',
+      'project.participantProjectSpecies.species.id',
+      'project.participantProjectSpecies.species.organization.id',
+      'project.participantProjectSpecies.submissionStatus',
+      'module.cohortModules.startDate',
+      'module.cohortModules.endDate',
     ],
     search: {
       operation: 'and',
       children: [
         {
           operation: 'field',
-          field: 'organization_id',
+          field: 'type',
+          type: 'Exact',
+          values: [getDeliverableTypeLabel('Species' as DeliverableTypeType)],
+        },
+        {
+          operation: 'field',
+          field: 'project.participantProjectSpecies.species.organization.id',
           type: 'Exact',
           values: [organizationId],
         },
         {
           operation: 'field',
-          field: 'id',
+          field: 'project.participantProjectSpecies.species.id',
           type: 'Exact',
           values: [speciesId],
+        },
+        {
+          operation: 'field',
+          field: 'module.cohortModules.endDate',
+          type: 'Range',
+          values: [todayUTC, null],
+        },
+        {
+          operation: 'field',
+          field: 'module.cohortModules.startDate',
+          type: 'Range',
+          values: [null, todayUTC],
         },
       ],
     },
     count: 1000,
   };
 
-  const apiSearchResults = (await SearchService.search(searchParams)) as SpeciesProjectsSearchResult[];
-  // it will always be one result since we are searching by species id
-  const firstApiResult = apiSearchResults[0];
-  const projects = await Promise.all(
-    firstApiResult?.participantProjectSpecies.map(async (pps) => {
-      //deliverables
-      const response = await DeliverablesService.list(
-        null,
-        {
-          organizationId,
-          projectId: pps.project.id,
-        },
-        {
-          operation: 'and',
-          children: [
-            {
-              operation: 'field',
-              field: 'type',
-              type: 'Exact',
-              values: ['species'],
-            },
-          ],
-        }
-      );
+  const apiSearchResults = await SearchService.search<SpeciesProjectsSearchResult>(searchParams);
 
-      return {
-        submissionStatus: pps.submissionStatus,
-        projectName: pps.project.name,
-        projectId: pps.project.id,
-        id: pps.id,
-        deliverableId: response?.deliverables?.length ? response.deliverables[0].id : undefined,
-      } as SpeciesProjectsResult;
-    })
-  );
-
-  return projects;
+  return apiSearchResults
+    ? apiSearchResults.flatMap((result: SpeciesProjectsSearchResult): SpeciesProjectsResult[] =>
+        result.project.participantProjectSpecies.map(
+          (pps: SpeciesProjectsSearchResult['project']['participantProjectSpecies'][0]): SpeciesProjectsResult => ({
+            submissionStatus: pps.submissionStatus,
+            projectName: pps.project.name,
+            projectId: Number(pps.project.id),
+            id: Number(pps.species.id),
+            deliverableId: Number(result.id),
+          })
+        )
+      )
+    : [];
 };
 
 const ParticipantProjectSpeciesService = {

--- a/src/types/Deliverables.ts
+++ b/src/types/Deliverables.ts
@@ -88,7 +88,7 @@ export const statusLabel = (status: DeliverableStatusType): string => {
   }
 };
 
-export const typeLabel = (status: DeliverableTypeType): string => {
+export const getDeliverableTypeLabel = (status: DeliverableTypeType): string => {
   switch (status) {
     case 'Document':
       return strings.DOCUMENT;


### PR DESCRIPTION
- Use the Search API to get the participant project species through the project deliverables prefix so we can get the deliverable, project, and species data in one call.