### PR TITLE
SW-5384 Make TextWithLink work with external links

### DIFF
--- a/src/components/common/TextWithLink.tsx
+++ b/src/components/common/TextWithLink.tsx
@@ -53,15 +53,15 @@ export default function TextWithLink({
   return (
     <>
       {handlePrefix ? handlePrefix(prefix) : prefix}
-      <Link
-        className={className}
-        to={isExternal ? { pathname: href } : href}
-        onClick={onClick}
-        fontSize={fontSize ?? '16px'}
-        target={isExternal ? '_blank' : undefined}
-      >
-        {linkText}
-      </Link>
+      {isExternal ? (
+        <Link className={className} onClick={() => window.open(href)} fontSize={fontSize ?? '16px'}>
+          {linkText}
+        </Link>
+      ) : (
+        <Link className={className} to={href} onClick={onClick} fontSize={fontSize ?? '16px'}>
+          {linkText}
+        </Link>
+      )}
       {handleSuffix ? handleSuffix(suffix) : suffix}
     </>
   );

--- a/src/scenes/ContactUs/index.tsx
+++ b/src/scenes/ContactUs/index.tsx
@@ -96,7 +96,7 @@ export default function ContactUsView(): JSX.Element {
               <Typography fontSize='16px'>
                 <TextWithLink
                   href={docLinks.terraformation}
-                  isExternal={false}
+                  isExternal={true}
                   text={strings.TERRAWARE_IS_SOFTWARE}
                   fontSize='16px'
                 />
@@ -106,7 +106,7 @@ export default function ContactUsView(): JSX.Element {
               <Typography fontSize='16px'>
                 <TextWithLink
                   href={docLinks.terraformation_software_solutions}
-                  isExternal={false}
+                  isExternal={true}
                   text={strings.FOR_A_FULL_OVERVIEW}
                   fontSize='16px'
                 />


### PR DESCRIPTION
TextWithLink with external links was broken.  Update it so that it uses MuiLink rather than the React router link in order to properly handle external links