### PR TITLE
Fix remove recently added projects

### DIFF
--- a/src/scenes/Species/SpeciesProjectsTable.tsx
+++ b/src/scenes/Species/SpeciesProjectsTable.tsx
@@ -108,7 +108,7 @@ export default function SpeciesProjectsTable({
     if (addedProjectsIds) {
       const newProjects = addedProjectsIds?.map((id) => {
         return {
-          participantProjectSpeciesId: -1,
+          participantProjectSpeciesId: id,
           participantProjectSpeciesSubmissionStatus: 'Not Submitted',
           projectId: id,
           projectName: allProjects?.find((proj) => proj.id === id)?.name,


### PR DESCRIPTION
When adding a new project to the species projects table and then removing that same project, we were not removing it correctly.

The removedIdsList includes participantProjectSpeciesIds, and the addedIdsList uses projectsIds. So for new added projects entrances we need to use the projectId as participantProjectSpeciesIds, so if they get removed we can find them in the added projects ids list