### PR TITLE
SW-5074: Accessions: Collection Site dropdown menu

### DIFF
--- a/playwright/e2e/suites/accession.spec.ts
+++ b/playwright/e2e/suites/accession.spec.ts
@@ -25,8 +25,8 @@ export default function AccessionTests() {
     await page.getByLabel('Close').click();
     await page.getByPlaceholder('Collectors').click();
     await page.getByPlaceholder('Collectors').fill('Alex');
-    await page.locator('#collectionSiteName').getByRole('textbox').click();
-    await page.locator('#collectionSiteName').getByRole('textbox').fill("Alex's Mansion");
+    await page.locator('#collectionSiteName').click();
+    await page.locator('#collectionSiteName').fill("Alex's Mansion");
     await page.locator('#collectionSiteLandowner').getByRole('textbox').click();
     await page.locator('#collectionSiteLandowner').getByRole('textbox').fill('Ashtyn');
     await page.getByRole('button', { name: 'Add GPS Coordinates' }).click();

--- a/src/scenes/AccessionsRouter/Accession2CreateView.tsx
+++ b/src/scenes/AccessionsRouter/Accession2CreateView.tsx
@@ -31,6 +31,7 @@ import {
   Collectors2,
   SeedBank2Selector,
 } from './properties';
+import CollectionSiteName from './properties/CollectionSiteName';
 
 const SubTitleStyle = {
   fontSize: '20px',
@@ -202,14 +203,7 @@ export default function CreateAccession(): JSX.Element {
               justifyContent='space-between'
             >
               <Grid item xs={gridSize()} sx={{ ...marginTop, marginRight: isMobile ? 0 : theme.spacing(2) }}>
-                <Textfield
-                  id='collectionSiteName'
-                  value={record.collectionSiteName}
-                  onChange={(value) => onChange('collectionSiteName', value)}
-                  type='text'
-                  label={strings.COLLECTION_SITE}
-                  tooltipTitle={strings.TOOLTIP_ACCESSIONS_ADD_COLLECTING_SITE}
-                />
+                <CollectionSiteName onChange={onChange} collectionSiteName={record?.collectionSiteName} />
               </Grid>
               <Grid item xs={gridSize()} sx={marginTop}>
                 <Textfield

--- a/src/scenes/AccessionsRouter/edit/Accession2EditModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/Accession2EditModal.tsx
@@ -20,6 +20,7 @@ import {
   CollectedReceivedDate2,
   Collectors2,
 } from '../properties';
+import CollectionSiteName from '../properties/CollectionSiteName';
 
 export interface Accession2EditModalProps {
   open: boolean;
@@ -134,14 +135,7 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
           <Typography>{strings.SITE_DETAIL} </Typography>
         </Grid>
         <Grid item xs={12}>
-          <Textfield
-            id='collectionSiteName'
-            type='text'
-            label={strings.COLLECTION_SITE}
-            value={record?.collectionSiteName}
-            onChange={(value) => onChange('collectionSiteName', value)}
-            tooltipTitle={strings.TOOLTIP_ACCESSIONS_ADD_COLLECTING_SITE}
-          />
+          <CollectionSiteName onChange={onChange} collectionSiteName={record?.collectionSiteName} />
         </Grid>
 
         <Grid item xs={12}>

--- a/src/scenes/AccessionsRouter/properties/CollectionSiteName.tsx
+++ b/src/scenes/AccessionsRouter/properties/CollectionSiteName.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+
+import { Box } from '@mui/material';
+
+import Autocomplete from 'src/components/common/Autocomplete';
+import { useLocalization, useOrganization } from 'src/providers/hooks';
+import { SeedBankService } from 'src/services';
+import strings from 'src/strings';
+
+interface Props {
+  collectionSiteName?: string;
+  onChange: (id: string, value: string) => void;
+}
+
+export default function CollectionSiteName({ collectionSiteName = '', onChange }: Props): JSX.Element | null {
+  const { activeLocale } = useLocalization();
+  const { selectedOrganization } = useOrganization();
+  const [options, setOptions] = useState<string[]>();
+
+  useEffect(() => {
+    const populateCollectionSiteNames = async () => {
+      setOptions(await SeedBankService.getCollectionSiteNames(selectedOrganization.id));
+    };
+    populateCollectionSiteNames();
+  }, [selectedOrganization]);
+
+  return !activeLocale ? null : (
+    <Box mb={2} display='flex' alignItems='center' sx={{ display: 'block', position: 'relative' }}>
+      <Autocomplete
+        freeSolo={true}
+        id='collectionSiteName'
+        label={strings.COLLECTION_SITE}
+        onChange={(value) => onChange('collectionSiteName', value as string)}
+        options={options || []}
+        selected={collectionSiteName}
+        tooltipTitle={strings.TOOLTIP_ACCESSIONS_ADD_COLLECTING_SITE}
+      />
+    </Box>
+  );
+}

--- a/src/services/SeedBankService.ts
+++ b/src/services/SeedBankService.ts
@@ -172,6 +172,19 @@ const getCollectors = async (organizationId: number): Promise<string[] | undefin
 };
 
 /**
+ * Returns all the CollectionSiteName values associated with an organization id, or undefined if the API request failed.
+ */
+const getCollectionSiteNames = async (organizationId: number): Promise<string[] | undefined> => {
+  try {
+    const collectionSiteNames =
+      (await searchFieldValues(['collectionSiteName'], {}, organizationId))?.collectionSiteName?.values || [];
+    return collectionSiteNames.filter((collectionSiteName) => collectionSiteName !== null) as string[];
+  } catch {
+    return undefined;
+  }
+};
+
+/**
  * Get accessions awaiting check-in
  */
 const getPendingAccessions = async (organizationId: number): Promise<SearchResponseElementWithId[] | null> => {
@@ -296,6 +309,7 @@ const SeedBankService = {
   searchAccessions,
   searchFieldValues,
   getCollectors,
+  getCollectionSiteNames,
   getPendingAccessions,
   downloadAccessionsTemplate,
   uploadAccessions,


### PR DESCRIPTION
This PR changes the Collection Site Name field for Accessions, from a standard textfield to a textfield with a dropdown of previously entered values.

## Screenshots

<img width="2032" alt="Screenshot 2024-05-23 at 9 35 51 AM" src="https://github.com/terraware/terraware-web/assets/1474361/f3282b51-81be-4658-8d87-76a2a9af1807">

