### PR TITLE
SW-5428: Saving while adding Project to species fails with 404

### DIFF
--- a/src/components/SpeciesDeliverableTable/index.tsx
+++ b/src/components/SpeciesDeliverableTable/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { TableColumnType, TableRowType } from '@terraware/web-components';
@@ -8,6 +8,7 @@ import Table from 'src/components/common/table';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import useNavigateTo from 'src/hooks/useNavigateTo';
 import { useLocalization } from 'src/providers';
+import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 import { requestListParticipantProjectSpecies } from 'src/redux/features/participantProjectSpecies/participantProjectSpeciesAsyncThunks';
 import { selectParticipantProjectSpeciesListRequest } from 'src/redux/features/participantProjectSpecies/participantProjectSpeciesSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
@@ -41,12 +42,17 @@ const SpeciesDeliverableTable = ({ deliverable }: SpeciesDeliverableTableProps):
   const theme = useTheme();
   const { isAcceleratorRoute } = useAcceleratorConsole();
   const { goToParticipantProjectSpecies } = useNavigateTo();
+  const { currentDeliverables } = useParticipantData();
 
   const participantProjectSpecies = useAppSelector(selectParticipantProjectSpeciesListRequest(deliverable.projectId));
 
   const [selectedRows, setSelectedRows] = useState<TableRowType[]>([]);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [openedAddSpeciesModal, setOpenedAddSpeciesModal] = useState(false);
+
+  const addSpeciesToProjectButtonIsDisabled = useMemo(() => {
+    return !currentDeliverables?.find((deliverable) => deliverable.id === deliverable.id);
+  }, [currentDeliverables, deliverable]);
 
   useEffect(() => {
     void dispatch(requestListParticipantProjectSpecies(deliverable.projectId));
@@ -100,6 +106,7 @@ const SpeciesDeliverableTable = ({ deliverable }: SpeciesDeliverableTableProps):
 
             {!isAcceleratorRoute && (
               <Button
+                disabled={addSpeciesToProjectButtonIsDisabled}
                 icon='plus'
                 id='add-species-to-project'
                 label='Add Species to Project'


### PR DESCRIPTION
This PR includes a change to disable the "Add Species to Project" button in the `SpeciesDeliverableTable`, if the deliverable is not "current".