### PR TITLE
SW-5419 Mobile UX improvements for Module lists

### DIFF
--- a/src/scenes/Home/ParticipantHomeView/ToDoCta.tsx
+++ b/src/scenes/Home/ParticipantHomeView/ToDoCta.tsx
@@ -29,7 +29,14 @@ const ToDoCta = ({ toDo }: ToDoCtaProps) => {
     }
   }, [goToDeliverable, goToModuleEventSession, toDo]);
 
-  return <Button style={isMobile ? { width: '100%' } : {}} label={strings.VIEW} onClick={handleOnClick} />;
+  return (
+    <Button
+      priority={'secondary'}
+      style={isMobile ? { width: '100%' } : {}}
+      label={strings.VIEW}
+      onClick={handleOnClick}
+    />
+  );
 };
 
 export default ToDoCta;

--- a/src/scenes/ModulesRouter/CurrentTimeline.tsx
+++ b/src/scenes/ModulesRouter/CurrentTimeline.tsx
@@ -1,4 +1,5 @@
 import React, { Box, Grid, Typography, useTheme } from '@mui/material';
+import { useDeviceInfo } from '@terraware/web-components/utils';
 
 import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 import strings from 'src/strings';
@@ -7,6 +8,7 @@ const CurrentTimeline = (): JSX.Element => {
   const theme = useTheme();
 
   const { currentParticipant } = useParticipantData();
+  const { isDesktop } = useDeviceInfo();
 
   // TODO these will probably come from the BE, not sure if they will be attached to the project, or cohort, or some
   // other data model, so for now they are hard coded.
@@ -55,7 +57,12 @@ const CurrentTimeline = (): JSX.Element => {
           <Typography fontWeight={600}>{strings.CURRENT_TIMELINE}</Typography>
         </Grid>
         <Grid item>
-          <Grid display={'flex'} flexDirection={'row'} justifyContent={'space-between'} alignItems={'center'}>
+          <Grid
+            display={'flex'}
+            flexDirection={isDesktop ? 'row' : 'column'}
+            justifyContent={'space-between'}
+            alignItems={'center'}
+          >
             {displayPhases.map((phase, index) => {
               const isActivePhase = phase.phaseEnum === currentParticipant?.cohortPhase;
 
@@ -65,33 +72,44 @@ const CurrentTimeline = (): JSX.Element => {
                     <Grid item key={index + 0.5}>
                       <Box
                         borderBottom={`1px solid ${theme.palette.TwClrBgTertiary}`}
-                        width={'45px'}
+                        borderLeft={`1px solid ${theme.palette.TwClrBgTertiary}`}
+                        height={isDesktop ? undefined : '40px'}
+                        width={isDesktop ? '40px' : undefined}
                         marginX={theme.spacing(2)}
-                        marginTop={theme.spacing(3)}
+                        marginY={isDesktop ? undefined : theme.spacing(3)}
                       />
                     </Grid>
                   ) : null}
-                  <Grid item key={index} color={theme.palette.TwClrBaseBlack} alignSelf={'start'}>
-                    <Box
-                      bgcolor={isActivePhase ? theme.palette.TwClrBgBrand : ''}
-                      width={'100%'}
-                      marginBottom={theme.spacing(1)}
-                      borderRadius={theme.spacing(0.5)}
-                      padding={theme.spacing(0.5)}
-                      minHeight={theme.spacing(3)}
-                    >
-                      {isActivePhase ? (
-                        <Typography
-                          color={theme.palette.TwClrBaseWhite}
-                          fontWeight={600}
-                          fontSize={'12px'}
-                          lineHeight={'16px'}
-                          textAlign={'center'}
-                        >
-                          {strings.YOU_ARE_HERE}
-                        </Typography>
-                      ) : null}
-                    </Box>
+                  <Grid
+                    item
+                    key={index}
+                    color={theme.palette.TwClrBaseBlack}
+                    alignSelf={'start'}
+                    xs={isDesktop ? undefined : 12}
+                  >
+                    {(isDesktop || isActivePhase) && (
+                      <Box
+                        bgcolor={isActivePhase ? theme.palette.TwClrBgBrand : ''}
+                        width={'100%'}
+                        marginBottom={theme.spacing(1)}
+                        borderRadius={theme.spacing(0.5)}
+                        padding={theme.spacing(0.5)}
+                        minHeight={theme.spacing(3)}
+                      >
+                        {isActivePhase && (
+                          <Typography
+                            color={theme.palette.TwClrBaseWhite}
+                            fontWeight={600}
+                            fontSize={'12px'}
+                            lineHeight={'16px'}
+                            textAlign={'center'}
+                          >
+                            {strings.YOU_ARE_HERE}
+                          </Typography>
+                        )}
+                      </Box>
+                    )}
+
                     <Typography fontWeight={600} marginBottom={theme.spacing(1)}>
                       {phase.phase}
                     </Typography>

--- a/src/scenes/ModulesRouter/ListModulesContent.tsx
+++ b/src/scenes/ModulesRouter/ListModulesContent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box } from '@mui/material';
+import { Box, useTheme } from '@mui/material';
 
 import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 
@@ -8,8 +8,9 @@ import ModuleEntry from './ModuleEntry';
 
 export default function ListModulesContent(): JSX.Element {
   const { currentParticipantProject, modules } = useParticipantData();
+  const theme = useTheme();
   return (
-    <Box>
+    <Box paddingX={theme.spacing(2)}>
       {currentParticipantProject &&
         modules?.map((module, index) => (
           <ModuleEntry index={index} key={index} module={module} projectId={currentParticipantProject?.id} />

--- a/src/scenes/ModulesRouter/ModuleEntry.tsx
+++ b/src/scenes/ModulesRouter/ModuleEntry.tsx
@@ -1,4 +1,5 @@
 import React, { Box, Grid, Typography, useTheme } from '@mui/material';
+import { useDeviceInfo } from '@terraware/web-components/utils';
 
 import Button from 'src/components/common/button/Button';
 import useNavigateTo from 'src/hooks/useNavigateTo';
@@ -15,6 +16,7 @@ interface ModuleEntryProps {
 const ModuleEntry = ({ module, projectId }: ModuleEntryProps) => {
   const theme = useTheme();
   const { goToModule } = useNavigateTo();
+  const { isDesktop, isMobile } = useDeviceInfo();
 
   return (
     <Box
@@ -23,24 +25,34 @@ const ModuleEntry = ({ module, projectId }: ModuleEntryProps) => {
       sx={{ '&:last-child': { border: 'none' } }}
     >
       <Grid container display={'flex'} justifyContent={'space-between'} marginBottom={theme.spacing(1)}>
-        <Grid item>
+        <Grid item xs={isDesktop ? undefined : 12}>
           <Typography
             component={'span'}
             fontSize={'20px'}
             fontWeight={600}
             lineHeight={'28px'}
             marginRight={theme.spacing(3)}
+            whiteSpace={'nowrap'}
           >
             {module.title}
           </Typography>
 
+          {isMobile && <br />}
+
           {module?.startDate && module?.endDate && (
-            <Typography component={'span'}>{getDateRangeString(module?.startDate, module?.endDate)}</Typography>
+            <Typography component={'span'} fontSize={'16px'} fontWeight={400} lineHeight={'24px'} whiteSpace={'nowrap'}>
+              {getDateRangeString(module?.startDate, module?.endDate)}
+            </Typography>
           )}
         </Grid>
 
-        <Grid item>
-          <Button onClick={() => goToModule(projectId, module.id)} label={strings.VIEW} priority={'secondary'} />
+        <Grid item xs={isDesktop ? undefined : 12}>
+          <Button
+            onClick={() => goToModule(projectId, module.id)}
+            label={strings.VIEW}
+            priority={'secondary'}
+            style={isMobile ? { width: '100%' } : {}}
+          />
         </Grid>
       </Grid>
 


### PR DESCRIPTION
Changes:
1) Use secondary button color

![Screenshot 2024-05-31 at 2.45.53 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NOxkRPuhAfT4F7nmdXtG/87d2ef9a-5ff9-4eaf-a502-3af45d8dfcae.png)

2) Module Timeline mobile + tablet breakpoints: 

![Screenshot 2024-05-31 at 2.46.49 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NOxkRPuhAfT4F7nmdXtG/5a439681-524b-4cdb-9586-45dbd29fecd3.png)

![Screenshot 2024-05-31 at 2.46.24 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NOxkRPuhAfT4F7nmdXtG/7500af05-a6ff-4a84-9d95-259f78c9dc19.png)

3) Module list view breakpoints 

![Screenshot 2024-05-31 at 2.46.57 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NOxkRPuhAfT4F7nmdXtG/10c653e6-327c-45c3-8c4e-79967cf9913f.png)


![Screenshot 2024-05-31 at 2.46.31 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NOxkRPuhAfT4F7nmdXtG/f0bcc79a-122f-46a4-b6ba-a449f23a0cfa.png)
