### PR TITLE
SW-5470 Don't overflow container if text is too long

### DIFF
--- a/src/components/ProjectField/TextAreaDisplay.tsx
+++ b/src/components/ProjectField/TextAreaDisplay.tsx
@@ -1,15 +1,22 @@
 import React from 'react';
 
-import { Box, Typography, useTheme } from '@mui/material';
+import { Box, Grid, Typography, useTheme } from '@mui/material';
 
 import { ProjectFieldProps } from '.';
-import GridEntryWrapper from './GridEntryWrapper';
 
 const ProjectFieldTextAreaDisplay = ({ label, value }: ProjectFieldProps) => {
   const theme = useTheme();
 
   return (
-    <GridEntryWrapper md={6} height={'144px'}>
+    <Grid
+      item
+      xs={12}
+      md={6}
+      margin={`${theme.spacing(2)} 0`}
+      sx={{
+        minHeight: '144px',
+      }}
+    >
       <Box paddingX={theme.spacing(2)}>
         <Typography fontSize={'16px'} lineHeight={'24px'} fontWeight={600} marginBottom={theme.spacing(1)}>
           {label}
@@ -18,7 +25,7 @@ const ProjectFieldTextAreaDisplay = ({ label, value }: ProjectFieldProps) => {
           {value}
         </Typography>
       </Box>
-    </GridEntryWrapper>
+    </Grid>
   );
 };
 


### PR DESCRIPTION
Grid entry wrapper requires a height.  Use a regular Grid item instead with a minHeight to ensure we can grow vertically with additional text