### PR TITLE
SW-5428: Saving while adding Project to species fails with 404 (#2)

### DIFF
--- a/src/scenes/Species/SpeciesProjectsTable.tsx
+++ b/src/scenes/Species/SpeciesProjectsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { Box, Grid, Typography } from '@mui/material';
 import { Button, TableRowType } from '@terraware/web-components';
@@ -6,6 +6,7 @@ import { TableColumnType } from '@terraware/web-components/components/table/type
 
 import Table from 'src/components/common/table';
 import { useOrganization } from 'src/providers';
+import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 import { requestGetProjectsForSpecies } from 'src/redux/features/participantProjectSpecies/participantProjectSpeciesAsyncThunks';
 import { selectProjectsForSpeciesRequest } from 'src/redux/features/participantProjectSpecies/participantProjectSpeciesSelectors';
 import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
@@ -56,6 +57,7 @@ export default function SpeciesProjectsTable({
   const dispatch = useAppDispatch();
   const snackbar = useSnackbar();
   const { selectedOrganization } = useOrganization();
+  const { currentDeliverables } = useParticipantData();
 
   const allProjects = useAppSelector(selectProjects);
 
@@ -69,6 +71,12 @@ export default function SpeciesProjectsTable({
   const [reload, setReload] = useState(false);
   const [openedAddToProjectModal, setOpenedAddToProjectModal] = useState(false);
   const [selectableProjects, setSelectableProjects] = useState<Project[]>([]);
+
+  const addToProjectButtonIsDisabled = useMemo(() => {
+    return (
+      selectableProjects?.length < 1 || !currentDeliverables?.find((deliverable) => deliverable.type === 'Species')
+    );
+  }, [currentDeliverables, selectableProjects]);
 
   useEffect(() => {
     void dispatch(requestProjects(selectedOrganization.id));
@@ -195,13 +203,13 @@ export default function SpeciesProjectsTable({
             </Typography>
             {editMode && (
               <Button
+                disabled={addToProjectButtonIsDisabled}
                 icon='plus'
                 id='add-species-to-project'
-                label='Add to Project'
+                label={strings.ADD_TO_PROJECT}
                 onClick={() => setOpenedAddToProjectModal(true)}
                 priority='secondary'
                 size='medium'
-                disabled={selectableProjects?.length < 1}
               />
             )}
           </Box>


### PR DESCRIPTION
This PR includes changes to disable the "Add to Project" button in the Species Add/Edit views.

## Screenshots

![localhost_3000_species_organizationId=123 (1)](https://github.com/terraware/terraware-web/assets/1474361/23356e28-9c33-44c5-974f-7c894f4524d5)

![localhost_3000_species_organizationId=123](https://github.com/terraware/terraware-web/assets/1474361/dfb70713-484c-4e94-bd0f-697061f14068)
