### PR TITLE
SW-5477 Fixed scroll bounce on Support Forms

### DIFF
--- a/src/scenes/ContactUsRouter/AttachmentRow.tsx
+++ b/src/scenes/ContactUsRouter/AttachmentRow.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 
 import { Grid, Typography, useTheme } from '@mui/material';
+import { useDeviceInfo } from '@terraware/web-components/utils';
 
 import Button from 'src/components/common/button/Button';
 import { selectSupportUploadAttachmentRequest } from 'src/redux/features/support/supportSelectors';
@@ -18,7 +19,9 @@ type AttachmentRowProps = {
 
 const AttachmentRow = ({ attachment, onChange, onRemove }: AttachmentRowProps) => {
   const theme = useTheme();
+  const { isDesktop } = useDeviceInfo();
 
+  const { filename, requestId } = attachment;
   const attachmentRequest = useAppSelector(selectSupportUploadAttachmentRequest(attachment.requestId));
 
   useEffect(() => {
@@ -27,11 +30,16 @@ const AttachmentRow = ({ attachment, onChange, onRemove }: AttachmentRowProps) =
         ? attachmentRequest.data[0].temporaryAttachmentId
         : undefined;
 
-    const newAttachment = { ...attachment, status: attachmentRequest.status, temporaryAttachmentId };
-    if (newAttachment !== attachment && onChange) {
+    const newAttachment: AttachmentRequest = {
+      filename,
+      requestId,
+      status: attachmentRequest.status,
+      temporaryAttachmentId,
+    };
+    if (newAttachment.status !== attachment.status && onChange) {
       onChange(newAttachment);
     }
-  }, [attachment, attachmentRequest, onChange]);
+  }, [attachmentRequest, onChange]);
 
   return (
     <Grid
@@ -61,7 +69,7 @@ const AttachmentRow = ({ attachment, onChange, onRemove }: AttachmentRowProps) =
         <Button
           priority={'secondary'}
           icon={'iconTrashCan'}
-          label={strings.REMOVE}
+          label={isDesktop ? strings.REMOVE : undefined}
           onClick={() => {
             onRemove && onRemove(attachment);
           }}


### PR DESCRIPTION
<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/NOxkRPuhAfT4F7nmdXtG/1960ff05-bb8c-479e-9b47-fc3103165ad0.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/NOxkRPuhAfT4F7nmdXtG/1960ff05-bb8c-479e-9b47-fc3103165ad0.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NOxkRPuhAfT4F7nmdXtG/1960ff05-bb8c-479e-9b47-fc3103165ad0.mov">Screen Recording 2024-06-04 at 1.54.38 PM.mov</video>



Issue was previously caused by useEffect and onChange causing an infinite re-render loop, since onChange will modify the attachment status, and useEffect gets called in an AttachmentRow.


Also fixed an issue on small screen, where an attachment button is taking up all the space.

