### PR TITLE
SW-4682 Use exact-or-fuzzy search for batch numbers

### DIFF
--- a/src/services/NurseryBatchService.ts
+++ b/src/services/NurseryBatchService.ts
@@ -309,7 +309,7 @@ const getAllBatches = async (
   }
 
   if (query) {
-    const { type, values } = parseSearchTerm(query);
+    const { type, values } = parseSearchTerm(query, 'ExactOrFuzzy');
     const searchValueChildren: FieldNodePayload[] = [];
     searchValueChildren.push({
       operation: 'field',

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -8,13 +8,18 @@ function escapeRegExp(input: string) {
 }
 
 /**
- * Parse the text search term and return the query and the type of search, Fuzzy or PhraseMatch.
+ * Parse the text search term and return the query and the type of search. If the query is
+ * surrounded by double quotes, the type is PhraseMatch. Otherwise it is the value of defaultType,
+ * which is Fuzzy by default.
  */
-const parseSearchTerm = (searchTerm: string): { type: SearchType; values: string[] } => {
+const parseSearchTerm = (
+  searchTerm: string,
+  defaultType: SearchType = 'Fuzzy'
+): { type: SearchType; values: string[] } => {
   const phraseMatchQuery = removeDoubleQuotes(searchTerm);
 
   return {
-    type: phraseMatchQuery ? 'PhraseMatch' : 'Fuzzy',
+    type: phraseMatchQuery ? 'PhraseMatch' : defaultType,
     values: [phraseMatchQuery || searchTerm],
   };
 };

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -9,17 +9,14 @@ function escapeRegExp(input: string) {
 
 /**
  * Parse the text search term and return the query and the type of search. If the query is
- * surrounded by double quotes, the type is PhraseMatch. Otherwise it is the value of defaultType,
- * which is Fuzzy by default.
+ * surrounded by double quotes, the type is PhraseMatch (and the search term will have the quotes
+ * stripped). Otherwise the type is the value of the "type" parameter, which is Fuzzy by default.
  */
-const parseSearchTerm = (
-  searchTerm: string,
-  defaultType: SearchType = 'Fuzzy'
-): { type: SearchType; values: string[] } => {
+const parseSearchTerm = (searchTerm: string, type: SearchType = 'Fuzzy'): { type: SearchType; values: string[] } => {
   const phraseMatchQuery = removeDoubleQuotes(searchTerm);
 
   return {
-    type: phraseMatchQuery ? 'PhraseMatch' : defaultType,
+    type: phraseMatchQuery ? 'PhraseMatch' : type,
     values: [phraseMatchQuery || searchTerm],
   };
 };


### PR DESCRIPTION
If the user enters an exact batch number or species name in the nursery inventory
batches view, only show the batch with that exact number, the same way we do with
accession numbers on the accessions page.