### PR TITLE
SW-5502: FE - Create utility to check users consent status

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -770,10 +770,6 @@ export interface paths {
     /** Creates a new planting site. */
     post: operations["createPlantingSite"];
   };
-  "/api/v1/tracking/sites/validate": {
-    /** Validates the definition of a new planting site. */
-    post: operations["validatePlantingSite"];
-  };
   "/api/v1/tracking/sites/{id}": {
     /**
      * Gets information about a specific planting site.
@@ -2814,13 +2810,11 @@ export interface components {
     };
     NewPlantingSubzonePayload: {
       boundary: components["schemas"]["MultiPolygon"] | components["schemas"]["Polygon"];
-      /** @description Name of this planting subzone. Two subzones in the same planting zone may not have the same name, but using the same subzone name in different planting zones is valid. */
       name: string;
     };
     /** @description List of planting zones to create. If present and not empty, "boundary" must also be specified. */
     NewPlantingZonePayload: {
       boundary: components["schemas"]["MultiPolygon"] | components["schemas"]["Polygon"];
-      /** @description Name of this planting zone. Two zones in the same planting site may not have the same name. */
       name: string;
       plantingSubzones?: components["schemas"]["NewPlantingSubzonePayload"][];
       targetPlantingDensity?: number;
@@ -3300,16 +3294,6 @@ export interface components {
       progressPercent?: number;
       /** Format: int32 */
       totalPlants: number;
-    };
-    PlantingSiteValidationProblemPayload: {
-      /** @description If the problem is a conflict between two planting zones or two subzones, the list of the conflicting zone or subzone names. */
-      conflictsWith?: string[];
-      /** @description If the problem relates to a particular subzone, its name. If this is present, plantingZone will also be present and will be the name of the zone that contains this subzone. */
-      plantingSubzone?: string;
-      /** @description If the problem relates to a particular planting zone, its name. */
-      plantingZone?: string;
-      /** @enum {string} */
-      problemType: "CannotRemovePlantedSubzone" | "CannotSplitSubzone" | "CannotSplitZone" | "DuplicateSubzoneName" | "DuplicateZoneName" | "ExclusionWithoutBoundary" | "SiteTooLarge" | "SubzoneBoundaryChanged" | "SubzoneBoundaryOverlaps" | "SubzoneInExclusionArea" | "SubzoneNotInZone" | "ZoneBoundaryChanged" | "ZoneBoundaryOverlaps" | "ZoneHasNoSubzones" | "ZoneNotInSite" | "ZoneTooSmall" | "ZonesWithoutSiteBoundary";
     };
     PlantingSubzonePayload: {
       /** @description Area of planting subzone in hectares. */
@@ -4566,13 +4550,6 @@ export interface components {
       /** Format: int64 */
       id: number;
       lastName?: string;
-    };
-    ValidatePlantingSiteResponsePayload: {
-      /** @description True if the request was valid. */
-      isValid: boolean;
-      /** @description List of validation problems found, if any. Empty if the request is valid. */
-      problems: components["schemas"]["PlantingSiteValidationProblemPayload"][];
-      status: components["schemas"]["SuccessOrError"];
     };
     VersionsEntryPayload: {
       appName: string;
@@ -8068,18 +8045,6 @@ export interface operations {
           "application/json": components["schemas"]["UploadAttachmentResponsePayload"];
         };
       };
-      /** @description The request was too large. */
-      413: {
-        content: {
-          "application/json": components["schemas"]["SimpleErrorResponsePayload"];
-        };
-      };
-      /** @description The media type is not supported. */
-      415: {
-        content: {
-          "application/json": components["schemas"]["SimpleErrorResponsePayload"];
-        };
-      };
     };
   };
   /** Lists the timeseries for one or more devices. */
@@ -8648,22 +8613,6 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["CreatePlantingSiteResponsePayload"];
-        };
-      };
-    };
-  };
-  /** Validates the definition of a new planting site. */
-  validatePlantingSite: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreatePlantingSiteRequestPayload"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          "application/json": components["schemas"]["ValidatePlantingSiteResponsePayload"];
         };
       };
     };

--- a/src/redux/features/user/usersAsyncThunks.ts
+++ b/src/redux/features/user/usersAsyncThunks.ts
@@ -1,6 +1,11 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
-import { UserService } from 'src/services';
+import { PreferencesService, UserService } from 'src/services';
+import { Response2 } from 'src/services/HttpService';
+import {
+  UpdateUserCookieConsentRequestPayload,
+  UpdateUserCookieConsentResponsePayload,
+} from 'src/services/PreferencesService';
 import { UserResponse } from 'src/services/UserService';
 import strings from 'src/strings';
 
@@ -18,6 +23,20 @@ export const requestSearchUserByEmail = createAsyncThunk(
   'users/by-email',
   async (email: string, { rejectWithValue }) => {
     const response: UserResponse = await UserService.getUserByEmail(email);
+
+    if (response.requestSucceeded) {
+      return response;
+    }
+
+    return rejectWithValue(strings.GENERIC_ERROR);
+  }
+);
+
+export const requestUserCookieConsentUpdate = createAsyncThunk(
+  'users/cookie-consent/update',
+  async (payload: UpdateUserCookieConsentRequestPayload, { rejectWithValue }) => {
+    const response: Response2<UpdateUserCookieConsentResponsePayload> =
+      await PreferencesService.updateUserCookieConsentPreferences(payload);
 
     if (response.requestSucceeded) {
       return response;

--- a/src/services/PreferencesService.ts
+++ b/src/services/PreferencesService.ts
@@ -1,4 +1,4 @@
-import { paths } from 'src/api/types/generated-schema';
+import { components, paths } from 'src/api/types/generated-schema';
 
 import CachedUserService from './CachedUserService';
 import HttpService, { Response } from './HttpService';
@@ -30,6 +30,7 @@ export type UpdateResponse = Response & {
 };
 
 // end point
+const COOKIE_CONSENT_ENDPOINT = '/api/v1/users/me/cookies';
 const PREFERENCES_ENDPOINT = '/api/v1/users/me/preferences';
 
 type PreferencesServerResponse =
@@ -37,8 +38,13 @@ type PreferencesServerResponse =
 type UpdatePreferencesPayloadType =
   paths[typeof PREFERENCES_ENDPOINT]['put']['requestBody']['content']['application/json'];
 
-// http service
+type UpdateUserCookieConsentRequestPayload =
+  paths[typeof COOKIE_CONSENT_ENDPOINT]['put']['requestBody']['content']['application/json'];
+type UpdateUserCookieConsentResponsePayload = components['schemas']['SimpleSuccessResponsePayload'];
+
+// http services
 const httpPreferences = HttpService.root(PREFERENCES_ENDPOINT);
+const httpCookieConsent = HttpService.root(COOKIE_CONSENT_ENDPOINT);
 
 // primary get preferences code with optional org
 const getPreferences = async (organizationId: string = ''): Promise<UserPreferencesResponse> => {
@@ -104,6 +110,10 @@ const updateUserPreferences = async (toUpdate: Preferences): Promise<UpdateRespo
   return response;
 };
 
+// set user cookie preferences
+const updateUserCookieConsentPreferences = async (payload: UpdateUserCookieConsentRequestPayload) =>
+  httpCookieConsent.put2<UpdateUserCookieConsentResponsePayload>({ entity: payload });
+
 // set org preferences
 const updateUserOrgPreferences = async (organizationId: number, toUpdate: Preferences): Promise<UpdateResponse> => {
   const response: UpdateResponse = await updatePreferences(toUpdate, organizationId);
@@ -123,6 +133,7 @@ const PreferencesService = {
   getUserPreferences,
   getUserOrgPreferences,
   updateUserPreferences,
+  updateUserCookieConsentPreferences,
   updateUserOrgPreferences,
 };
 

--- a/src/services/PreferencesService.ts
+++ b/src/services/PreferencesService.ts
@@ -38,9 +38,9 @@ type PreferencesServerResponse =
 type UpdatePreferencesPayloadType =
   paths[typeof PREFERENCES_ENDPOINT]['put']['requestBody']['content']['application/json'];
 
-type UpdateUserCookieConsentRequestPayload =
+export type UpdateUserCookieConsentRequestPayload =
   paths[typeof COOKIE_CONSENT_ENDPOINT]['put']['requestBody']['content']['application/json'];
-type UpdateUserCookieConsentResponsePayload = components['schemas']['SimpleSuccessResponsePayload'];
+export type UpdateUserCookieConsentResponsePayload = components['schemas']['SimpleSuccessResponsePayload'];
 
 // http services
 const httpPreferences = HttpService.root(PREFERENCES_ENDPOINT);
@@ -111,7 +111,7 @@ const updateUserPreferences = async (toUpdate: Preferences): Promise<UpdateRespo
 };
 
 // set user cookie preferences
-const updateUserCookieConsentPreferences = async (payload: UpdateUserCookieConsentRequestPayload) =>
+const updateUserCookieConsentPreferences = (payload: UpdateUserCookieConsentRequestPayload) =>
   httpCookieConsent.put2<UpdateUserCookieConsentResponsePayload>({ entity: payload });
 
 // set org preferences

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -116,17 +116,15 @@ const updateUser = async (user: User, options: UpdateOptions = {}): Promise<Resp
   }
 
   const response: Response = await httpCurrentUser.put({ entity });
+  if (response.requestSucceeded && typeof user.cookiesConsented === 'boolean') {
+    await PreferencesService.updateUserCookieConsentPreferences({ cookiesConsented: user.cookiesConsented });
+  }
 
   getUser();
 
   if (user.timeZone && !options.skipAcknowledgeTimeZone) {
     await PreferencesService.updateUserPreferences({ timeZoneAcknowledgedOnMs: Date.now() });
   }
-  if (typeof user.cookiesConsented === 'boolean') {
-    await PreferencesService.updateUserCookieConsentPreferences({ cookiesConsented: user.cookiesConsented });
-  }
-
-  getUser();
 
   return response;
 };


### PR DESCRIPTION
This PR includes changes to support getting/setting the current user's cookie consent preferences.

**NOTE:** Cookie consent preference is returned as properties of the user object, so all that was required to get the user's cookie consent preference was to update the `getUser` method to include the new properties. We also need a way to set the user's cookie consent preference, so changes are included to support that.