### PR TITLE
SW-5437 Add accession GPS coordinates to table view

### DIFF
--- a/src/components/seeds/database/EditColumns.tsx
+++ b/src/components/seeds/database/EditColumns.tsx
@@ -204,6 +204,7 @@ function sections(system?: string): Section[] {
           columns.collectionSiteName,
           columns.collectionSiteLandowner,
           columns.collectionSiteNotes,
+          columns['geolocations.coordinates'],
         ],
         [columns.ageYears, columns.ageMonths],
       ],

--- a/src/components/seeds/database/TableCellRenderer.tsx
+++ b/src/components/seeds/database/TableCellRenderer.tsx
@@ -84,5 +84,10 @@ export default function SearchCellRenderer(props: RendererProps<SearchResponseEl
     return <CellRenderer index={index} column={column} value={`${value}%`} row={row} />;
   }
 
+  if (column.key === 'geolocations.coordinates') {
+    const coordinatesValue = ((row.geolocations || []) as any[]).map((gl) => gl.coordinates).join('; ');
+    return <CellRenderer index={index} column={column} value={coordinatesValue} row={row} />;
+  }
+
   return <CellRenderer {...props} />;
 }

--- a/src/components/seeds/database/TableCellRenderer.tsx
+++ b/src/components/seeds/database/TableCellRenderer.tsx
@@ -4,9 +4,11 @@ import { FiberManualRecord } from '@mui/icons-material';
 import { Box, TableCell, Typography, useTheme } from '@mui/material';
 
 import Link from 'src/components/common/Link';
+import TextTruncated from 'src/components/common/TextTruncated';
 import CellRenderer from 'src/components/common/table/TableCellRenderer';
 import { RendererProps } from 'src/components/common/table/types';
 import { APP_PATHS } from 'src/constants';
+import strings from 'src/strings';
 import { SearchResponseElement } from 'src/types/Search';
 
 export default function SearchCellRenderer(props: RendererProps<SearchResponseElement>): JSX.Element {
@@ -85,8 +87,15 @@ export default function SearchCellRenderer(props: RendererProps<SearchResponseEl
   }
 
   if (column.key === 'geolocations.coordinates') {
-    const coordinatesValue = ((row.geolocations || []) as any[]).map((gl) => gl.coordinates).join('; ');
-    return <CellRenderer index={index} column={column} value={coordinatesValue} row={row} />;
+    const coordinatesValues = ((row.geolocations || []) as any[]).map((gl) => gl.coordinates);
+    return (
+      <CellRenderer
+        index={index}
+        column={column}
+        row={row}
+        value={<TextTruncated stringList={coordinatesValues} listSeparator={strings.LIST_SEPARATOR_SECONDARY} />}
+      />
+    );
   }
 
   return <CellRenderer {...props} />;

--- a/src/components/seeds/database/columns.ts
+++ b/src/components/seeds/database/columns.ts
@@ -163,6 +163,12 @@ function columns(): DatabaseColumn[] {
       type: 'number',
       filter: { type: 'number_range' },
     },
+    {
+      key: 'geolocations.coordinates',
+      name: strings.LATITUDE_LONGITUDE,
+      type: 'string',
+      filter: { type: 'search' },
+    },
   ];
 }
 

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -368,26 +368,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
         });
 
         if (requestId === getRequestId('accessions_search')) {
-          const processedResults = apiResponse?.map((result: SearchResponseElementWithId) => {
-            // The "geolocations" value, if present, is a list of child objects each of which has
-            // a "coordinates" field which is a string with comma-separated latitude and longitude.
-            // For display in the table view, we need to turn it into a single string.
-            let coordinatesList = '';
-            (result.geolocations as any[])?.forEach((gl, index) => {
-              if (index === 0) {
-                coordinatesList = gl.coordinates;
-              } else {
-                coordinatesList += `\r${gl.coordinates}`;
-              }
-            });
-
-            return {
-              ...result,
-              'geolocations.coordinates': coordinatesList,
-            };
-          });
-
-          setSearchResults(processedResults);
+          setSearchResults(apiResponse);
         }
       };
 

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -368,7 +368,26 @@ export default function Database(props: DatabaseProps): JSX.Element {
         });
 
         if (requestId === getRequestId('accessions_search')) {
-          setSearchResults(apiResponse);
+          const processedResults = apiResponse?.map((result: SearchResponseElementWithId) => {
+            // The "geolocations" value, if present, is a list of child objects each of which has
+            // a "coordinates" field which is a string with comma-separated latitude and longitude.
+            // For display in the table view, we need to turn it into a single string.
+            let coordinatesList = '';
+            (result.geolocations as any[])?.forEach((gl, index) => {
+              if (index === 0) {
+                coordinatesList = gl.coordinates;
+              } else {
+                coordinatesList += `\r${gl.coordinates}`;
+              }
+            });
+
+            return {
+              ...result,
+              'geolocations.coordinates': coordinatesList,
+            };
+          });
+
+          setSearchResults(processedResults);
         }
       };
 


### PR DESCRIPTION
Allow users to add a "Latitude, Longitude" column to the accessions table to show
the list of GPS coordinates from the seed collection. This column will appear in
exported CSV files, with newline-separated values in the case of multiple
coordinates for an accession.