### PR TITLE
SW-5513 Don't show empty inventory project dropdown

### DIFF
--- a/src/scenes/InventoryRouter/form/BatchDetailsForm.tsx
+++ b/src/scenes/InventoryRouter/form/BatchDetailsForm.tsx
@@ -330,13 +330,15 @@ export default function BatchDetailsForm(props: BatchDetailsFormProps): JSX.Elem
               </Grid>
             )}
 
-            <Grid item xs={12} padding={dropdownPadding}>
-              <ProjectsDropdown<FormRecord>
-                availableProjects={availableProjects}
-                record={record}
-                setRecord={setRecord}
-              />
-            </Grid>
+            {availableProjects && availableProjects.length > 0 && (
+              <Grid item xs={12} padding={dropdownPadding}>
+                <ProjectsDropdown<FormRecord>
+                  availableProjects={availableProjects}
+                  record={record}
+                  setRecord={setRecord}
+                />
+              </Grid>
+            )}
 
             <Grid item xs={gridSize()} paddingLeft={paddingSeparator}>
               <DatePicker


### PR DESCRIPTION
Only show the "Project" field on the nursery inventory add page if the
organization actually has projects.