### PR TITLE
SW-5528, SW-5529 Line breaks in profile fields

### DIFF
--- a/src/components/ProjectField/TextAreaDisplay.tsx
+++ b/src/components/ProjectField/TextAreaDisplay.tsx
@@ -6,6 +6,8 @@ import { ProjectFieldProps } from '.';
 
 const ProjectFieldTextAreaDisplay = ({ label, value }: ProjectFieldProps) => {
   const theme = useTheme();
+  const valueLines = value ? `${value}`.split('\n') : null;
+  const valueElements = valueLines?.flatMap((line) => [<br key='break' />, line])?.slice(1);
 
   return (
     <Grid
@@ -21,8 +23,13 @@ const ProjectFieldTextAreaDisplay = ({ label, value }: ProjectFieldProps) => {
         <Typography fontSize={'16px'} lineHeight={'24px'} fontWeight={600} marginBottom={theme.spacing(1)}>
           {label}
         </Typography>
-        <Typography fontSize={'16px'} lineHeight={'24px'} fontWeight={400}>
-          {value}
+        <Typography
+          fontSize={'16px'}
+          lineHeight={'24px'}
+          fontWeight={400}
+          sx={{ wordBreak: 'break-word' }}
+        >
+          {valueElements}
         </Typography>
       </Box>
     </Grid>

--- a/src/components/ProjectField/TextAreaDisplay.tsx
+++ b/src/components/ProjectField/TextAreaDisplay.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
-import TextField from '@terraware/web-components/components/Textfield/Textfield';
 
 import { ProjectFieldProps } from '.';
 
@@ -22,19 +21,15 @@ const ProjectFieldTextAreaDisplay = ({ label, value }: ProjectFieldProps) => {
         <Typography fontSize={'16px'} lineHeight={'24px'} fontWeight={600} marginBottom={theme.spacing(1)}>
           {label}
         </Typography>
-        {typeof value === 'string' && (
-          <Typography fontSize={'16px'} lineHeight={'24px'} fontWeight={400}>
-            <TextField
-              id=''
-              label=''
-              type='textarea'
-              display={true}
-              preserveNewlines={true}
-              value={value}
-              sx={{ wordBreak: 'break-word' }}
-            />
-          </Typography>
-        )}
+        <Typography
+          fontSize={'16px'}
+          lineHeight={'24px'}
+          fontWeight={400}
+          whiteSpace='pre-wrap'
+          sx={{ wordBreak: 'break-word' }}
+        >
+          {value}
+        </Typography>
       </Box>
     </Grid>
   );

--- a/src/components/ProjectField/TextAreaDisplay.tsx
+++ b/src/components/ProjectField/TextAreaDisplay.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
+import TextField from '@terraware/web-components/components/Textfield/Textfield';
 
 import { ProjectFieldProps } from '.';
 
 const ProjectFieldTextAreaDisplay = ({ label, value }: ProjectFieldProps) => {
   const theme = useTheme();
-  const valueLines = value ? `${value}`.split('\n') : null;
-  const valueElements = valueLines?.flatMap((line) => [<br key='break' />, line])?.slice(1);
 
   return (
     <Grid
@@ -23,9 +22,19 @@ const ProjectFieldTextAreaDisplay = ({ label, value }: ProjectFieldProps) => {
         <Typography fontSize={'16px'} lineHeight={'24px'} fontWeight={600} marginBottom={theme.spacing(1)}>
           {label}
         </Typography>
-        <Typography fontSize={'16px'} lineHeight={'24px'} fontWeight={400} sx={{ wordBreak: 'break-word' }}>
-          {valueElements}
-        </Typography>
+        {typeof value === 'string' && (
+          <Typography fontSize={'16px'} lineHeight={'24px'} fontWeight={400}>
+            <TextField
+              id=''
+              label=''
+              type='textarea'
+              display={true}
+              preserveNewlines={true}
+              value={value}
+              sx={{ wordBreak: 'break-word' }}
+            />
+          </Typography>
+        )}
       </Box>
     </Grid>
   );

--- a/src/components/ProjectField/TextAreaDisplay.tsx
+++ b/src/components/ProjectField/TextAreaDisplay.tsx
@@ -23,12 +23,7 @@ const ProjectFieldTextAreaDisplay = ({ label, value }: ProjectFieldProps) => {
         <Typography fontSize={'16px'} lineHeight={'24px'} fontWeight={600} marginBottom={theme.spacing(1)}>
           {label}
         </Typography>
-        <Typography
-          fontSize={'16px'}
-          lineHeight={'24px'}
-          fontWeight={400}
-          sx={{ wordBreak: 'break-word' }}
-        >
+        <Typography fontSize={'16px'} lineHeight={'24px'} fontWeight={400} sx={{ wordBreak: 'break-word' }}>
           {valueElements}
         </Typography>
       </Box>


### PR DESCRIPTION
Display explicit line breaks in participant project profile textarea
fields so multi-paragraph values aren't folded into a single long
paragraph.

Wrap long words (URLs, etc.) to prevent them from overflowing into
other parts of the UI.