### PR TITLE
SW-5535: Feedback for Rejected species does not display

### DIFF
--- a/src/scenes/DeliverablesRouter/SpeciesDeliverableStatusMessage.tsx
+++ b/src/scenes/DeliverablesRouter/SpeciesDeliverableStatusMessage.tsx
@@ -48,7 +48,12 @@ const SpeciesDeliverableStatusMessage = ({ deliverable, species }: Props): JSX.E
             body={
               <ul>
                 {rejectedSpecies.map((species, index) => (
-                  <li key={index}>{species.species.scientificName}</li>
+                  <li key={index}>
+                    {species.species.scientificName}
+                    {species.participantProjectSpecies.feedback
+                      ? `: ${species.participantProjectSpecies.feedback}`
+                      : ''}
+                  </li>
                 ))}
               </ul>
             }


### PR DESCRIPTION
This PR includes a change to display feedback for rejected species within a species deliverable list, when available.

## Screenshots

![localhost_3000_deliverables_453_submissions_38_organizationId=141](https://github.com/terraware/terraware-web/assets/1474361/ede78b6a-1af5-4f1f-9af8-b25d774b8d0a)
