### PR TITLE
SW-5533: Can't add Species to Project (from Species page) even when Deliverable is active

### DIFF
--- a/src/redux/features/modules/modulesAsyncThunks.ts
+++ b/src/redux/features/modules/modulesAsyncThunks.ts
@@ -99,12 +99,13 @@ export const requestListModuleDeliverables = createAsyncThunk(
     return deliverableSearchResults.map(
       (result) =>
         ({
+          category: result.category,
           moduleId: result.module_id,
           projectId: result.project_id,
-          ...result,
           dueDate: DateTime.fromISO(result.dueDate),
-          module_id: undefined,
-          project_id: undefined,
+          id: result.id,
+          name: result.name,
+          status: result.status,
           type: result['type(raw)'],
         }) as ModuleDeliverable
     );

--- a/src/redux/features/modules/modulesAsyncThunks.ts
+++ b/src/redux/features/modules/modulesAsyncThunks.ts
@@ -67,7 +67,7 @@ export const requestListModuleDeliverables = createAsyncThunk(
   async (request: { moduleId: number; projectId: number }) => {
     const searchParams: SearchRequestPayload = {
       prefix: 'projects.projectDeliverables',
-      fields: ['id', 'module_id', 'project_id', 'name', 'category', 'dueDate', 'status', 'type'],
+      fields: ['id', 'module_id', 'project_id', 'name', 'category', 'dueDate', 'status', 'type', 'type(raw)'],
       search: {
         operation: 'and',
         children: [

--- a/src/redux/features/modules/modulesAsyncThunks.ts
+++ b/src/redux/features/modules/modulesAsyncThunks.ts
@@ -105,6 +105,7 @@ export const requestListModuleDeliverables = createAsyncThunk(
           dueDate: DateTime.fromISO(result.dueDate),
           module_id: undefined,
           project_id: undefined,
+          type: result['type(raw)'],
         }) as ModuleDeliverable
     );
   }

--- a/src/scenes/Species/SpeciesProjectsTable.tsx
+++ b/src/scenes/Species/SpeciesProjectsTable.tsx
@@ -75,7 +75,8 @@ export default function SpeciesProjectsTable({
 
   const addToProjectButtonIsDisabled = useMemo(() => {
     return (
-      selectableProjects?.length < 1 || !currentDeliverables?.find((deliverable) => deliverable.type === 'Species')
+      selectableProjects?.length < 1 ||
+      !currentDeliverables?.find((deliverable) => deliverable['type(raw)'] === 'Species')
     );
   }, [currentDeliverables, selectableProjects]);
 

--- a/src/scenes/Species/SpeciesProjectsTable.tsx
+++ b/src/scenes/Species/SpeciesProjectsTable.tsx
@@ -75,8 +75,7 @@ export default function SpeciesProjectsTable({
 
   const addToProjectButtonIsDisabled = useMemo(() => {
     return (
-      selectableProjects?.length < 1 ||
-      !currentDeliverables?.find((deliverable) => deliverable['type(raw)'] === 'Species')
+      selectableProjects?.length < 1 || !currentDeliverables?.find((deliverable) => deliverable.type === 'Species')
     );
   }, [currentDeliverables, selectableProjects]);
 

--- a/src/types/Module.ts
+++ b/src/types/Module.ts
@@ -78,6 +78,7 @@ export type ModuleDeliverable = {
   dueDate: DateTime;
   status: DeliverableStatusType;
   type: DeliverableTypeType;
+  'type(raw)'?: string;
 };
 
 export type ModuleContentType = keyof Pick<Module, 'additionalResources' | 'preparationMaterials'>;

--- a/src/types/Module.ts
+++ b/src/types/Module.ts
@@ -66,7 +66,8 @@ export type ModuleDeliverableSearchResult = {
   category: DeliverableCategoryType;
   dueDate: string;
   status: DeliverableStatusType;
-  type: DeliverableTypeType;
+  type: string;
+  'type(raw)'?: DeliverableTypeType;
 };
 
 export type ModuleDeliverable = {
@@ -78,7 +79,6 @@ export type ModuleDeliverable = {
   dueDate: DateTime;
   status: DeliverableStatusType;
   type: DeliverableTypeType;
-  'type(raw)'?: string;
 };
 
 export type ModuleContentType = keyof Pick<Module, 'additionalResources' | 'preparationMaterials'>;

--- a/src/types/ProjectToDo.ts
+++ b/src/types/ProjectToDo.ts
@@ -57,7 +57,8 @@ export type DeliverableSearchResultType = {
   name: string;
   position: number;
   status: DeliverableStatusType | null;
-  type: DeliverableTypeType;
+  type: string;
+  'type(raw)': DeliverableTypeType;
 };
 
 export class DeliverableToDoItem implements ToDoItem {
@@ -82,7 +83,7 @@ export class DeliverableToDoItem implements ToDoItem {
     this.position = searchResult.position;
     this.projectId = searchResult.project_id;
     this.status = searchResult.status ?? 'Not Submitted';
-    this.type = searchResult.type;
+    this.type = searchResult['type(raw)'];
   }
 
   isCompleted = (): boolean => this.status == 'Approved' || this.status == 'Not Needed';


### PR DESCRIPTION
This PR includes changes to resolve an issue that was preventing the ability to add a project to a species from the species detail view.