### PR TITLE
SW-5533: Can't add Species to Project (from Species page) even when Deliverable is active

### DIFF
--- a/src/scenes/Species/SpeciesProjectsTable.tsx
+++ b/src/scenes/Species/SpeciesProjectsTable.tsx
@@ -108,7 +108,7 @@ export default function SpeciesProjectsTable({
       );
     });
     setSelectableProjects(pendingProjects || []);
-  }, [allProjects, filteredResults, currentDeliverables]);
+  }, [allProjects, currentDeliverables, filteredResults]);
 
   useEffect(() => {
     let updatedResults = searchResults ?? [];

--- a/src/scenes/Species/SpeciesProjectsTable.tsx
+++ b/src/scenes/Species/SpeciesProjectsTable.tsx
@@ -99,10 +99,16 @@ export default function SpeciesProjectsTable({
   useEffect(() => {
     const assignedProjectsIds = filteredResults?.map((fr) => Number(fr.projectId));
     const pendingProjects = allProjects?.filter((project) => {
-      return !assignedProjectsIds?.includes(project.id);
+      // only show projects that are not already assigned to the species and have a species deliverable
+      return (
+        !assignedProjectsIds?.includes(project.id) &&
+        currentDeliverables?.find(
+          (deliverable) => deliverable.type === 'Species' && deliverable.projectId === project.id
+        )
+      );
     });
     setSelectableProjects(pendingProjects || []);
-  }, [filteredResults, allProjects]);
+  }, [allProjects, filteredResults, currentDeliverables]);
 
   useEffect(() => {
     let updatedResults = searchResults ?? [];


### PR DESCRIPTION
This PR includes changes to resolve an issue that was preventing adding a species to a project from the species detail view.

Context: The previously available projects included projects without a species deliverable, but that is a requirement from the API when adding a species to a project.