### PR TITLE
SW-5539: Native/Non-Native is marked required but adding a species without a value is allowed (follow-up)

### DIFF
--- a/src/components/SpeciesDeliverableTable/EditSpeciesModal.tsx
+++ b/src/components/SpeciesDeliverableTable/EditSpeciesModal.tsx
@@ -50,8 +50,8 @@ export default function EditSpeciesModal(props: EditSpeciesModalProps): JSX.Elem
   }, [result, snackbar]);
 
   const save = () => {
-    if (!record.participantProjectSpecies.rationale) {
-      setError(strings.GENERIC_ERROR);
+    if (!record.participantProjectSpecies.rationale || !record?.participantProjectSpecies.speciesNativeCategory) {
+      setError(strings.REQUIRED_FIELD);
       return;
     }
 
@@ -127,6 +127,7 @@ export default function EditSpeciesModal(props: EditSpeciesModalProps): JSX.Elem
             fixedMenu
             required
             fullWidth={true}
+            errorText={error && !record?.participantProjectSpecies.speciesNativeCategory ? error : ''}
           />
         </Grid>
         <Grid item xs={12} sx={{ marginTop: theme.spacing(2) }}>
@@ -137,7 +138,7 @@ export default function EditSpeciesModal(props: EditSpeciesModalProps): JSX.Elem
             type='textarea'
             value={record?.participantProjectSpecies.rationale}
             onChange={onChangeRationale}
-            errorText={error && !record?.participantProjectSpecies.rationale ? strings.REQUIRED_FIELD : ''}
+            errorText={error && !record?.participantProjectSpecies.rationale ? error : ''}
           />
         </Grid>
       </Grid>

--- a/src/scenes/Species/AddToProjectModal.tsx
+++ b/src/scenes/Species/AddToProjectModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Box, Grid, useTheme } from '@mui/material';
 import { Dropdown, SelectT } from '@terraware/web-components';
@@ -27,9 +27,15 @@ export default function AddToProjectModal(props: AddToProjectModalProps): JSX.El
   const theme = useTheme();
 
   const [projectsSpeciesAdded, setProjectsSpeciesAdded] = useForm<ProjectSpecies[]>([{ project: projects[0] }]);
+  const [error, setError] = useState('');
 
   const save = () => {
     if (projectsSpeciesAdded.length > 0) {
+      if (!projectsSpeciesAdded.every((ps) => ps.nativeCategory)) {
+        setError(strings.REQUIRED_FIELD);
+        return;
+      }
+
       onSubmit(projectsSpeciesAdded);
       onClose();
     }
@@ -108,6 +114,7 @@ export default function AddToProjectModal(props: AddToProjectModalProps): JSX.El
                   fixedMenu
                   required
                   fullWidth={true}
+                  errorText={error && !ps.nativeCategory ? error : ''}
                 />
               </Grid>
             </Box>

--- a/src/scenes/Species/AddToProjectModal.tsx
+++ b/src/scenes/Species/AddToProjectModal.tsx
@@ -83,7 +83,12 @@ export default function AddToProjectModal(props: AddToProjectModalProps): JSX.El
         {projectsSpeciesAdded.map((ps, index) => {
           return (
             <Box
-              sx={{ borderBottom: `1px solid ${theme.palette.TwClrBaseGray300}`, paddingBottom: 2, marginBottom: 2 }}
+              sx={{
+                borderBottom:
+                  projectsSpeciesAdded.length > 1 ? `1px solid ${theme.palette.TwClrBaseGray300}` : undefined,
+                paddingBottom: 2,
+                marginBottom: 2,
+              }}
               key={`project-${index}`}
             >
               <Grid item xs={12} sx={{ marginTop: theme.spacing(2) }}>


### PR DESCRIPTION
I missed a couple of instances in my initial PR to resolve this issue, this PR includes changes to cover those additional instances.

There's one additional change included to only display the bottom border separator when there's more than one entry.

## Screenshots

![localhost_3000_species_6875_edit_organizationId=141](https://github.com/terraware/terraware-web/assets/1474361/d3a6ab38-704d-40d9-8f24-06bb2aa50870)

### Bottom border before

![localhost_3000_accelerator_deliverables](https://github.com/terraware/terraware-web/assets/1474361/5b330bd0-a8bf-40ec-8f52-434ec6b18756)

### Bottom border after

![localhost_3000_accelerator_deliverables (1)](https://github.com/terraware/terraware-web/assets/1474361/35615f69-3af5-4237-85cf-556806c339d3)
