### PR TITLE
SW-5543: Approve/Reject... buttons states not affected by species status

### DIFF
--- a/src/components/SpeciesDeliverableTable/TableCellRenderer.tsx
+++ b/src/components/SpeciesDeliverableTable/TableCellRenderer.tsx
@@ -129,7 +129,9 @@ export default function SpeciesDeliverableCellRenderer(props: RendererProps<Tabl
               onClick={() => setShowRejectDialog(true)}
               priority='secondary'
               type='destructive'
-              disabled={row.submissionStatus === 'Rejected'}
+              disabled={
+                row.submissionStatus === 'Rejected' || row?.participantProjectSpecies.submissionStatus === 'Rejected'
+              }
             />
           </>
         }
@@ -161,7 +163,9 @@ export default function SpeciesDeliverableCellRenderer(props: RendererProps<Tabl
             label={strings.APPROVE}
             onClick={() => approveHandler()}
             priority='secondary'
-            disabled={row.submissionStatus === 'Approved'}
+            disabled={
+              row.submissionStatus === 'Approved' || row?.participantProjectSpecies.submissionStatus === 'Approved'
+            }
           />
         }
       />


### PR DESCRIPTION
This PR includes a fix to disable Approve/Reject buttons when a species deliverable has already been approved/rejected.