### PR TITLE
SW-5545 Document deliverable approve button should be disabled immediately after approving

### DIFF
--- a/src/scenes/AcceleratorRouter/Deliverables/DocumentDeliverableView.tsx
+++ b/src/scenes/AcceleratorRouter/Deliverables/DocumentDeliverableView.tsx
@@ -51,7 +51,7 @@ const DocumentDeliverableView = (props: Props): JSX.Element => {
         {props.optionsMenu}
       </Box>
     ),
-    []
+    [props.callToAction, props.optionsMenu]
   );
 
   if (isMobile) {


### PR DESCRIPTION
The deliverable was refreshed correctly, but actions where inside useMemo without the correct dependency array 