### PR TITLE
Revert "SW-5533: Can't add Species to Project (from Species page) even when Deliverable is active"

### DIFF
--- a/src/scenes/Species/SpeciesProjectsTable.tsx
+++ b/src/scenes/Species/SpeciesProjectsTable.tsx
@@ -99,16 +99,10 @@ export default function SpeciesProjectsTable({
   useEffect(() => {
     const assignedProjectsIds = filteredResults?.map((fr) => Number(fr.projectId));
     const pendingProjects = allProjects?.filter((project) => {
-      // only show projects that are not already assigned to the species and have a species deliverable
-      return (
-        !assignedProjectsIds?.includes(project.id) &&
-        currentDeliverables?.find(
-          (deliverable) => deliverable.type === 'Species' && deliverable.projectId === project.id
-        )
-      );
+      return !assignedProjectsIds?.includes(project.id);
     });
     setSelectableProjects(pendingProjects || []);
-  }, [allProjects, currentDeliverables, filteredResults]);
+  }, [filteredResults, allProjects]);
 
   useEffect(() => {
     let updatedResults = searchResults ?? [];


### PR DESCRIPTION
Reverts terraware/terraware-web#2757. The referenced PR seems to have reduced the list of projects available in the projects filter dropdown to a subset that is missing options.