### PR TITLE
SW-5532: Can't click out of native/non-native dropdown without selecting an option first

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@mui/styled-engine-sc": "^5.14.12",
     "@mui/styles": "^5.15.15",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^3.0.28",
+    "@terraware/web-components": "^3.0.29",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.3.0",
     "@testing-library/user-event": "^14.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3970,10 +3970,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^3.0.28":
-  version "3.0.28"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.0.28.tgz#3f0962364431f706045ffab5b965fe03c3662ca4"
-  integrity sha512-KpTd4nXt8urj2QFL4oC70Xvyb7xW1fEvHUh52JaYQCnqIRoJ4knCo5Hs5AR//8W2Ts9xa4HvyEMiHkH7PtfDVw==
+"@terraware/web-components@^3.0.29":
+  version "3.0.29"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.0.29.tgz#499a80dafb4ea4216ebe5d1755b6fea51dc74d08"
+  integrity sha512-SKpMiz2gHX0/qsXkf7wyHzA+aBRWf69R4lNbSmFUtlgYW28txEAsmxZjuB2A9cWLo5GQarBrPawkgI3Nf9HVtA==
   dependencies:
     "@date-io/luxon" "^3.0.0"
     "@dnd-kit/core" "^6.0.7"


### PR DESCRIPTION
This PR updates `web-components` to pickup a [fix](https://github.com/terraware/web-components/pull/610) for an issue where the `DialogBox` component was stopping click event propagation which was preventing the `Dropdown` component from functioning correctly when rendering within the `DialogBox` component.
