### PR TITLE
Fix invalid DOM nesting warnings in console

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@mui/styled-engine-sc": "^5.14.12",
     "@mui/styles": "^5.15.15",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^3.0.29",
+    "@terraware/web-components": "^3.0.30",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.3.0",
     "@testing-library/user-event": "^14.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3970,10 +3970,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^3.0.29":
-  version "3.0.29"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.0.29.tgz#499a80dafb4ea4216ebe5d1755b6fea51dc74d08"
-  integrity sha512-SKpMiz2gHX0/qsXkf7wyHzA+aBRWf69R4lNbSmFUtlgYW28txEAsmxZjuB2A9cWLo5GQarBrPawkgI3Nf9HVtA==
+"@terraware/web-components@^3.0.30":
+  version "3.0.30"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.0.30.tgz#15e30c64d874b5d5d0f6780d0afac6cf3306e519"
+  integrity sha512-MZBNrolWNG+B/CRp1mh/jbpSBoZ/B1nsbx3h3mtZwskBZtCh+qk5czl62CUDb94u7zPHler7B2RsLc0elM9fuw==
   dependencies:
     "@date-io/luxon" "^3.0.0"
     "@dnd-kit/core" "^6.0.7"


### PR DESCRIPTION
This PR updates `web-components` to pickup changes to the `Badge` component to allow nesting within paragraphs.

Currently in `terraware-web` there are two very large warnings that take up most of the console, these changes will resolve those warnings and clean up the console.

## Screenshots

### Warning 1

<img width="2032" alt="Screenshot 2024-06-28 at 11 47 23 AM" src="https://github.com/terraware/web-components/assets/1474361/52cf88a7-f962-41d3-aae9-8bb0bb3a5494">

### Warning 2

<img width="2032" alt="Screenshot 2024-06-28 at 11 47 16 AM" src="https://github.com/terraware/web-components/assets/1474361/f24418da-19ac-4a5c-a134-f22f76b79a73">
