### PR TITLE
Add cached selector for fetching deliverable-specific variables and values for a given project

### DIFF
--- a/src/redux/features/documentProducer/values/valuesSlice.ts
+++ b/src/redux/features/documentProducer/values/valuesSlice.ts
@@ -3,7 +3,13 @@ import { ActionReducerMapBuilder, createSlice } from '@reduxjs/toolkit';
 import { StatusT, buildReducers } from 'src/redux/features/asyncUtils';
 import { VariableValue } from 'src/types/documentProducer/VariableValue';
 
-import { requestListVariablesValues, requestUpdateVariableValues, requestUploadImageValue } from './valuesThunks';
+import { deliverableCompositeKeyFn } from '../../deliverables/deliverablesSlice';
+import {
+  requestListDeliverableVariablesValues,
+  requestListVariablesValues,
+  requestUpdateVariableValues,
+  requestUploadImageValue,
+} from './valuesThunks';
 
 /**
  * Variable Values List
@@ -18,6 +24,15 @@ const variableValuesListSlice = createSlice({
   reducers: {},
   extraReducers: (builder: ActionReducerMapBuilder<VariableValuesListState>) => {
     buildReducers(requestListVariablesValues, true)(builder);
+  },
+});
+
+const deliverableVariableValuesListSlice = createSlice({
+  name: 'deliverableVariableValuesListSlice',
+  initialState: initialVariableValuesListState,
+  reducers: {},
+  extraReducers: (builder: ActionReducerMapBuilder<VariableValuesListState>) => {
+    buildReducers(requestListDeliverableVariablesValues, true, deliverableCompositeKeyFn)(builder);
   },
 });
 
@@ -54,6 +69,7 @@ const variableValuesImageUploadSlice = createSlice({
 });
 
 export const documentProducerVariableValuesReducers = {
+  documentProducerDeliverableVariableValues: deliverableVariableValuesListSlice.reducer,
   documentProducerVariableValuesImageUpload: variableValuesImageUploadSlice.reducer,
   documentProducerVariableValuesList: variableValuesListSlice.reducer,
   documentProducerVariableValuesUpdate: variableValuesUpdateSlice.reducer,

--- a/src/redux/features/documentProducer/values/valuesThunks.ts
+++ b/src/redux/features/documentProducer/values/valuesThunks.ts
@@ -10,6 +10,18 @@ import {
   VariableValuesListResponse,
 } from 'src/types/documentProducer/VariableValue';
 
+export const requestListDeliverableVariablesValues = createAsyncThunk(
+  'listDeliverableVariablesValues',
+  async (params: { deliverableId: number; projectId: number }, { rejectWithValue }) => {
+    const response: Response2<VariableValuesListResponse> = await ValueService.getDeliverableValues(params);
+    if (response.requestSucceeded && response.data?.values) {
+      return response.data.values;
+    }
+
+    return rejectWithValue(response.error || strings.GENERIC_ERROR);
+  }
+);
+
 export const requestListVariablesValues = createAsyncThunk(
   'listVariablesValues',
   async (projectId: number, { rejectWithValue }) => {

--- a/src/redux/features/documentProducer/variables/variablesSlice.ts
+++ b/src/redux/features/documentProducer/variables/variablesSlice.ts
@@ -3,7 +3,7 @@ import { ActionReducerMapBuilder, createSlice } from '@reduxjs/toolkit';
 import { StatusT, buildReducers } from 'src/redux/features/asyncUtils';
 import { Variable } from 'src/types/documentProducer/Variable';
 
-import { requestListVariables } from './variablesThunks';
+import { requestListDeliverableVariables, requestListVariables } from './variablesThunks';
 
 type VariablesState = Record<string, StatusT<Variable[]>>;
 
@@ -18,6 +18,16 @@ const variablesSlice = createSlice({
   },
 });
 
+const deliverableVariablesSlice = createSlice({
+  name: 'deliverableVariablesSlice',
+  initialState: initialVariablesState,
+  reducers: {},
+  extraReducers: (builder: ActionReducerMapBuilder<VariablesState>) => {
+    buildReducers(requestListDeliverableVariables, true)(builder);
+  },
+});
+
 export const documentProducerVariablesReducers = {
   documentProducerVariables: variablesSlice.reducer,
+  documentProducerDeliverableVariables: deliverableVariablesSlice.reducer,
 };

--- a/src/redux/features/documentProducer/variables/variablesThunks.ts
+++ b/src/redux/features/documentProducer/variables/variablesThunks.ts
@@ -16,3 +16,15 @@ export const requestListVariables = createAsyncThunk(
     return rejectWithValue(response.error || strings.GENERIC_ERROR);
   }
 );
+
+export const requestListDeliverableVariables = createAsyncThunk(
+  'listDeliverableVariables',
+  async (deliverableId: number, { rejectWithValue }) => {
+    const response: Response2<VariableListResponse> = await VariableService.getDeliverableVariables(deliverableId);
+    if (response && response.requestSucceeded && response.data) {
+      return response.data.variables;
+    }
+
+    return rejectWithValue(response.error || strings.GENERIC_ERROR);
+  }
+);

--- a/src/services/documentProducer/ValueService.ts
+++ b/src/services/documentProducer/ValueService.ts
@@ -8,22 +8,29 @@ import {
 const VALUES_ENDPOINT = '/api/v1/document-producer/projects/{projectId}/values';
 const IMAGES_ENDPOINT = '/api/v1/document-producer/projects/{projectId}/images';
 
-const getValues = async (projectId: number): Promise<Response2<VariableValuesListResponse>> =>
-  await HttpService.root(VALUES_ENDPOINT.replace('{projectId}', projectId.toString())).get2({});
+const getDeliverableValues = (params: {
+  deliverableId: number;
+  projectId: number;
+}): Promise<Response2<VariableValuesListResponse>> =>
+  HttpService.root(VALUES_ENDPOINT.replace('{projectId}', `${params.projectId}`)).get2({
+    params: {
+      deliverableId: `${params.deliverableId}`,
+    },
+  });
 
-const updateValue = async (
-  projectId: number,
-  operations: Operation[]
-): Promise<Response2<VariableValuesListResponse>> => {
+const getValues = (projectId: number): Promise<Response2<VariableValuesListResponse>> =>
+  HttpService.root(VALUES_ENDPOINT.replace('{projectId}', projectId.toString())).get2({});
+
+const updateValue = (projectId: number, operations: Operation[]): Promise<Response2<VariableValuesListResponse>> => {
   const entity: UpdateVariableValuesRequestPayload = {
     operations,
   };
-  return await HttpService.root(VALUES_ENDPOINT.replace('{projectId}', projectId.toString())).post({
+  return HttpService.root(VALUES_ENDPOINT.replace('{projectId}', projectId.toString())).post({
     entity,
   });
 };
 
-const uploadImageValue = async (
+const uploadImageValue = (
   projectId: number,
   variableId: number,
   file: File,
@@ -31,13 +38,14 @@ const uploadImageValue = async (
   caption?: string
 ): Promise<Response2<VariableValuesListResponse>> => {
   const headers = { 'content-type': 'multipart/form-data' };
-  return await HttpService.root(IMAGES_ENDPOINT.replace('{projectId}', projectId.toString())).post({
+  return HttpService.root(IMAGES_ENDPOINT.replace('{projectId}', projectId.toString())).post({
     entity: { file, caption, citation, variableId },
     headers,
   });
 };
 
 const VariableService = {
+  getDeliverableValues,
   getValues,
   updateValue,
   uploadImageValue,

--- a/src/services/documentProducer/VariableService.ts
+++ b/src/services/documentProducer/VariableService.ts
@@ -1,14 +1,20 @@
 import HttpService, { Response2 } from 'src/services/HttpService';
 import { VariableListResponse } from 'src/types/documentProducer/Variable';
 
-const VARIABLES_ENDPOINT = '/api/v1/variables';
+const VARIABLES_ENDPOINT = '/api/v1/document-producer/variables';
 
-const getVariables = async (manifestId: number): Promise<Response2<VariableListResponse>> =>
-  await HttpService.root(VARIABLES_ENDPOINT).get2({
+const getDeliverableVariables = (deliverableId: number): Promise<Response2<VariableListResponse>> =>
+  HttpService.root(VARIABLES_ENDPOINT).get2({
+    params: { deliverableId: `${deliverableId}` },
+  });
+
+const getVariables = (manifestId: number): Promise<Response2<VariableListResponse>> =>
+  HttpService.root(VARIABLES_ENDPOINT).get2({
     params: { manifestId: manifestId.toString() },
   });
 
 const VariableService = {
+  getDeliverableVariables,
   getVariables,
 };
 

--- a/src/types/documentProducer/Variable.ts
+++ b/src/types/documentProducer/Variable.ts
@@ -12,6 +12,10 @@ export type VariableType = components['schemas']['ExistingValuePayload']['type']
 
 export type Column = components['schemas']['TableColumnPayload'];
 
+export type LinkVariable = components['schemas']['LinkVariablePayload'];
+
+export type SectionVariable = components['schemas']['SectionVariablePayload'];
+
 export type DateVariable = components['schemas']['DateVariablePayload'];
 
 export type TextVariable = components['schemas']['TextVariablePayload'];
@@ -36,7 +40,9 @@ export type VariableUnion =
   | TableVariable
   | NumberVariable
   | SelectVariable
-  | DateVariable;
+  | DateVariable
+  | LinkVariable
+  | SectionVariable;
 
 export type Section = components['schemas']['SectionVariablePayload'];
 


### PR DESCRIPTION
- I plumbed it into the `QuestionsDeliverableView`
- The two requests are dispatched separately and are stitched together with a cached selector. This is generally how we should be selecting this stuff since there are some functions that combine the two, which (I believe) all the components that consume this data are expecting.