### PR TITLE
Migrate to Docker Compose v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ For the moment, we're not asking for code contributions from the community. (Che
 
 You may see references to some private repositories in the documentation. We're working toward opening more of our code, but not everything is ready yet.
 
+## Requirements
+
+- Docker Desktop version `4.32.0` or later
+
 ## How to Run the App in Development Mode
 
 1. Configure the `.env` file using the sample file `.env.sample` located at the root directory of this repo.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ yarn docker:stop    # don't forget to stop the server when you're done
 If you want to examine or change the database that's used for your local testing, you can run the PostgreSQL interactive command-line client. This will only work after you've run `scripts/resetdb.sh` or `yarn docker:start`.
 
 ```shell
-docker-compose exec postgres psql -U postgres terraware
+docker compose exec postgres psql -U postgres terraware
 ```
 
 To exit the PostgreSQL client, type `\quit` or hit control-D.

--- a/dump/README.md
+++ b/dump/README.md
@@ -42,5 +42,5 @@ pg_dump -O -x -f dump.sql terraware
 OR
 
 ```shell
-docker-compose exec postgres pg_dump -O -x -U postgres terraware > dump.sql
+docker compose exec postgres pg_dump -O -x -U postgres terraware > dump.sql
 ```

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ts": "tsc --project ./tsconfig.json",
     "format": "prettier --write .",
     "docker:start": "./scripts/launch_server.sh",
-    "docker:stop": "docker-compose -f docker-compose.yml kill",
+    "docker:stop": "docker compose -f docker-compose.yml kill",
     "wait-be": "wait-on -t 120000 http://localhost:8080/swagger-ui/index.html",
     "server:prepare": "./scripts/preparedb.sh",
     "server:reset": "./scripts/resetdb.sh",

--- a/remote-backend/README.md
+++ b/remote-backend/README.md
@@ -27,7 +27,7 @@ openssl req \
 3. Set `REACT_APP_TERRAWARE_API` to that URL in the `.env` file in the repo root directory.
 4. Start (or restart) the Node dev server, e.g., by running `yarn start:dev` in the repo
    root directory.
-5. In this directory, run `docker-compose up -d`.
+5. In this directory, run `docker compose up -d`.
 6. Point your browser at `https://localhost/` (HTTPS and no port number).
 7. Accept the self-signed certificate. In Chrome, you'd click the "Advanced" button on the
    warning message, then click the "Proceed" link. You should only need to do this once;
@@ -35,7 +35,7 @@ openssl req \
 
 Now you should be able to log in and use the web app.
 
-When you're done, you can run `docker-compose down` in this directory to shut down the HTTPS
+When you're done, you can run `docker compose down` in this directory to shut down the HTTPS
 proxy.
 
 You don't need to run the HTTPS proxy if you're testing with a local terraware-server instance;

--- a/scripts/launch_server.sh
+++ b/scripts/launch_server.sh
@@ -1,3 +1,3 @@
 mkdir -p photo-data
-docker-compose pull
-docker-compose up -d
+docker compose pull
+docker compose up -d

--- a/scripts/preparedb.sh
+++ b/scripts/preparedb.sh
@@ -34,7 +34,7 @@ if [ -z "$speciesId1" ]; then
     echo
     echo Failed to make request to server
     echo
-    docker-compose logs terraware-server
+    docker compose logs terraware-server
     exit 1
 fi
 

--- a/scripts/resetdb.sh
+++ b/scripts/resetdb.sh
@@ -2,7 +2,7 @@
 set -e
 
 restore_dump() {
-    if docker-compose exec -T postgres psql -d terraware -U postgres < "$1"; then
+    if docker compose exec -T postgres psql -d terraware -U postgres < "$1"; then
         :
     else
         echo
@@ -13,8 +13,8 @@ restore_dump() {
 }
 
 rm -rf $HOME/docker/volumes/postgres/data
-docker-compose down --volumes
-docker-compose up -d postgres
+docker compose down --volumes
+docker compose up -d postgres
 
 # Need to wait for the PostgreSQL server to start up and for the database to be
 # initialized; it's not enough to just wait for the server to accept connections
@@ -22,7 +22,7 @@ docker-compose up -d postgres
 
 attempts_remaining=45
 while [ $attempts_remaining -gt 0 ]; do
-    if docker-compose logs postgres | grep -q "PostgreSQL init process complete"; then
+    if docker compose logs postgres | grep -q "PostgreSQL init process complete"; then
         break
     fi
 
@@ -35,7 +35,7 @@ if [ $attempts_remaining = 0 ]; then
     echo "No response from PostgreSQL."
     echo
 
-    docker-compose logs postgres
+    docker compose logs postgres
     exit 1
 fi
 
@@ -45,7 +45,7 @@ yarn docker:start
 if yarn wait-be; then
     :
 else
-    docker-compose logs terraware-server
+    docker compose logs terraware-server
     exit 1
 fi
 


### PR DESCRIPTION
This PR migrates the repo to Docker Compose v2 for compatibility with the latest version of Docker Desktop `4.32.0`:

- Replace `docker-compose` with `docker compose`

**Background:**

After upgrading to the latest version of Docker Desktop `4.32.0` (`157355`) today, when I attempted to run `docker-compose up -d` I ran into the following error: `zsh: command not found: docker-compose`.

Dropping the dash from `docker-compose` resolves the issue.