### PR TITLE
SW-5689: Auto scrolls down when going to edit view from Participant View

### DIFF
--- a/src/scenes/DeliverablesRouter/QuestionsDeliverableEditView.tsx
+++ b/src/scenes/DeliverablesRouter/QuestionsDeliverableEditView.tsx
@@ -30,7 +30,7 @@ const QuestionsDeliverableEditView = (): JSX.Element | null => {
   const scrollToVariable = useCallback((variableId: string) => {
     const element = document.querySelector(`[data-variable-id="${variableId}"]`);
     if (element) {
-      element.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' });
+      element.scrollIntoView({ behavior: 'smooth' });
     }
   }, []);
 

--- a/src/scenes/DeliverablesRouter/QuestionsDeliverableView.tsx
+++ b/src/scenes/DeliverablesRouter/QuestionsDeliverableView.tsx
@@ -139,8 +139,13 @@ const QuestionsDeliverableView = (props: Props): JSX.Element | null => {
           onClick={() => {
             const firstVisibleQuestion = document.querySelector('.question-visible');
             const variableId = firstVisibleQuestion?.getAttribute('data-variable-id');
+            const scrolledBeyondViewport = window.scrollY > window.innerHeight;
 
-            goToDeliverableEdit(deliverableId, projectId, variableId ? Number(variableId) : undefined);
+            goToDeliverableEdit(
+              deliverableId,
+              projectId,
+              Boolean(scrolledBeyondViewport && variableId) ? Number(variableId) : undefined
+            );
           }}
           size='medium'
           priority='secondary'


### PR DESCRIPTION
This PR includes changes to resolve an issue that caused the Questions Deliverable Edit View to always auto-scroll, regardless of how much of the view has been viewed/scrolled.

Changes include:

- Only auto-scroll when the document is scrolled beyond the viewport height
- Remove default option values for `element.scrollIntoView` method (they were previously included unnecessarily)