### PR TITLE
SW-5687: Spacing in edit view of Questionnaire deliverable is off

### DIFF
--- a/src/scenes/DeliverablesRouter/QuestionsDeliverableEditView.tsx
+++ b/src/scenes/DeliverablesRouter/QuestionsDeliverableEditView.tsx
@@ -117,10 +117,10 @@ const QuestionsDeliverableEditView = (): JSX.Element | null => {
               }}
             >
               {variablesWithValues.map((variableWithValues: VariableWithValues, index: number) => (
-                <Box key={index} sx={{ marginBottom: theme.spacing(4) }} data-variable-id={variableWithValues.id}>
-                  <Box sx={{ float: 'right', marginBottom: '16px', marginLeft: '16px' }}>
-                    {/* <DeliverableStatusBadge status={variableWithValues.status} /> */}
-                  </Box>
+                <Box key={index} data-variable-id={variableWithValues.id}>
+                  {/* <Box sx={{ float: 'right', marginBottom: '16px', marginLeft: '16px' }}>
+                    <DeliverableStatusBadge status={variableWithValues.status} />
+                  </Box> */}
                   <Grid container spacing={3} sx={{ padding: 0 }} textAlign='left'>
                     <Grid item xs={12}>
                       <DeliverableVariableDetailsInput


### PR DESCRIPTION
This PR includes changes to adjust the vertical spacing between questions in the Questions Deliverable Edit View, to align with [designs](https://www.figma.com/design/zmJYSYt317qXCMUNaLvjxW/Deliverable---Questionnaire?node-id=4200-139562&t=raRwXX0Wize9bMJk-0).

## Screenshots

### BEFORE

![localhost_3000_deliverables_123_submissions_32_edit_organizationId=141](https://github.com/user-attachments/assets/fb209a86-09e9-41b6-a545-4c0f42f23180)

### AFTER

![localhost_3000_deliverables_123_submissions_32_edit_organizationId=141 (1)](https://github.com/user-attachments/assets/93d83e9d-875e-47f2-aebf-daa421671b1f)
