### PR TITLE
SW-5692: Edit mode in Console should stay open even if the user removes the hover

### DIFF
--- a/src/scenes/AcceleratorRouter/Deliverables/QuestionsDeliverableView.tsx
+++ b/src/scenes/AcceleratorRouter/Deliverables/QuestionsDeliverableView.tsx
@@ -235,7 +235,7 @@ const QuestionBox = ({
           </Grid>
         </DialogBox>
       )}
-      <Box key={`question-${index}`} onMouseLeave={() => setEditing(false)}>
+      <Box key={`question-${index}`}>
         {showRejectDialog && <RejectDialog onClose={() => setShowRejectDialog(false)} onSubmit={rejectItem} />}
         <Box
           sx={{


### PR DESCRIPTION
This PR fixes an issue where edit mode would become disabled when the mouse is not hovering over the question.