### PR TITLE
SW-5694: Display required * for Feedback when rejecting a variable

### DIFF
--- a/src/scenes/AcceleratorRouter/Deliverables/RejectDialog.tsx
+++ b/src/scenes/AcceleratorRouter/Deliverables/RejectDialog.tsx
@@ -57,6 +57,7 @@ export default function RejectDialog({ onClose, onSubmit }: RejectDialogProps): 
           label={strings.FEEDBACK}
           id='feedback'
           onChange={(value) => setFeedback(value as string)}
+          required
           type='textarea'
           value={feedback}
         />


### PR DESCRIPTION
This PR includes a change to make the feedback text field required in the dialog when rejecting a variable.