### PR TITLE
SW-5688: Have to refresh to see status update in Console (and feedback when applicable)

### DIFF
--- a/src/scenes/AcceleratorRouter/Deliverables/QuestionsDeliverableView.tsx
+++ b/src/scenes/AcceleratorRouter/Deliverables/QuestionsDeliverableView.tsx
@@ -103,14 +103,14 @@ const QuestionBox = ({
   }, [updateVariableValueSuccess]);
 
   useEffect(() => {
-    if (approveWorkflowDetailsResponse) {
+    if (approveWorkflowDetailsResponse?.status === 'success') {
       reload();
       snackbar.toastSuccess(strings.ANSWER_APPROVED);
     }
   }, [approveWorkflowDetailsResponse]);
 
   useEffect(() => {
-    if (rejectWorkflowDetailsResponse) {
+    if (rejectWorkflowDetailsResponse?.status === 'success') {
       reload();
       snackbar.toastSuccess(strings.ANSWER_REJECTED);
     }


### PR DESCRIPTION
This PR includes a fix for an issue that caused Questionnaire Deliverable question status updates to require a manual page refresh to reflect the updated status.