### PR TITLE
Show status badges on the participant side of questionnaire deliverables

### DIFF
--- a/src/components/DocumentProducer/DeliverableVariableDetailsInput/index.tsx
+++ b/src/components/DocumentProducer/DeliverableVariableDetailsInput/index.tsx
@@ -329,6 +329,7 @@ const DeliverableVariableDetailsInput = ({
           options={getOptions()}
           selectedValue={value}
           fullWidth={true}
+          sx={[formElementStyles, { paddingBottom: theme.spacing(1) }]}
         />
       )}
 

--- a/src/scenes/DeliverablesRouter/QuestionsDeliverableEditView.tsx
+++ b/src/scenes/DeliverablesRouter/QuestionsDeliverableEditView.tsx
@@ -16,9 +16,11 @@ import { requestListDeliverableVariablesValues } from 'src/redux/features/docume
 import { selectDeliverableVariablesWithValues } from 'src/redux/features/documentProducer/variables/variablesSelector';
 import { requestListDeliverableVariables } from 'src/redux/features/documentProducer/variables/variablesThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
-import { VariableWithValues } from 'src/types/documentProducer/Variable';
-import { VariableValueImageValue, VariableValueValue } from 'src/types/documentProducer/VariableValue';
+import { VariableStatusType, VariableWithValues } from 'src/types/documentProducer/Variable';
+import { VariableValue, VariableValueImageValue, VariableValueValue } from 'src/types/documentProducer/VariableValue';
 import useQuery from 'src/utils/useQuery';
+
+import VariableStatusBadge from '../AcceleratorRouter/Deliverables/VariableStatusBadge';
 
 type QuestionBoxProps = {
   addRemovedValue: (value: VariableValueValue) => void;
@@ -50,24 +52,29 @@ const QuestionBox = ({
     [pendingVariableValues, variable.id]
   );
 
+  const firstVariableValue: VariableValue | undefined = (variable?.variableValues || [])[0];
+  const firstVariableValueStatus: VariableStatusType | undefined = firstVariableValue?.status;
+
   return (
     <Box key={index} data-variable-id={variable.id}>
-      {/* <Box sx={{ float: 'right', marginBottom: '16px', marginLeft: '16px' }}>
-        <DeliverableStatusBadge status={variable.status} />
-      </Box> */}
       <Grid container spacing={3} sx={{ padding: 0 }} textAlign='left'>
         <Grid item xs={12}>
-          <DeliverableVariableDetailsInput
-            values={pendingValues || variable.values}
-            setCellValues={setCellValues}
-            setDeletedImages={setDeletedImages}
-            setImages={setImages}
-            setNewImages={setNewImages}
-            setValues={setValues}
-            variable={variable}
-            addRemovedValue={addRemovedValue}
-            projectId={projectId}
-          />
+          <Box>
+            <Box sx={{ float: 'right', marginBottom: '16px', marginLeft: '16px' }}>
+              <VariableStatusBadge status={firstVariableValueStatus} />
+            </Box>
+            <DeliverableVariableDetailsInput
+              values={pendingValues || variable.values}
+              setCellValues={setCellValues}
+              setDeletedImages={setDeletedImages}
+              setImages={setImages}
+              setNewImages={setNewImages}
+              setValues={setValues}
+              variable={variable}
+              addRemovedValue={addRemovedValue}
+              projectId={projectId}
+            />
+          </Box>
         </Grid>
       </Grid>
     </Box>

--- a/src/scenes/DeliverablesRouter/QuestionsDeliverableView.tsx
+++ b/src/scenes/DeliverablesRouter/QuestionsDeliverableView.tsx
@@ -22,13 +22,13 @@ import { requestListDeliverableVariablesValues } from 'src/redux/features/docume
 import { selectDeliverableVariablesWithValues } from 'src/redux/features/documentProducer/variables/variablesSelector';
 import { requestListDeliverableVariables } from 'src/redux/features/documentProducer/variables/variablesThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import VariableStatusBadge from 'src/scenes/AcceleratorRouter/Deliverables/VariableStatusBadge';
 import strings from 'src/strings';
 import { VariableStatusType, VariableWithValues } from 'src/types/documentProducer/Variable';
 import { VariableValue } from 'src/types/documentProducer/VariableValue';
 import { variableDependencyMet } from 'src/utils/documentProducer/variables';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 
-import VariableStatusBadge from '../AcceleratorRouter/Deliverables/VariableStatusBadge';
 import QuestionsDeliverableStatusMessage from './QuestionsDeliverableStatusMessage';
 import SubmitDeliverableDialog from './SubmitDeliverableDialog';
 

--- a/src/scenes/DeliverablesRouter/QuestionsDeliverableView.tsx
+++ b/src/scenes/DeliverablesRouter/QuestionsDeliverableView.tsx
@@ -23,11 +23,12 @@ import { selectDeliverableVariablesWithValues } from 'src/redux/features/documen
 import { requestListDeliverableVariables } from 'src/redux/features/documentProducer/variables/variablesThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
-import { VariableWithValues } from 'src/types/documentProducer/Variable';
+import { VariableStatusType, VariableWithValues } from 'src/types/documentProducer/Variable';
 import { VariableValue } from 'src/types/documentProducer/VariableValue';
 import { variableDependencyMet } from 'src/utils/documentProducer/variables';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 
+import VariableStatusBadge from '../AcceleratorRouter/Deliverables/VariableStatusBadge';
 import QuestionsDeliverableStatusMessage from './QuestionsDeliverableStatusMessage';
 import SubmitDeliverableDialog from './SubmitDeliverableDialog';
 
@@ -41,6 +42,7 @@ const QuestionBox = ({ projectId, variable }: { projectId: number; variable: Var
   const visible = useIsVisible(containerRef);
 
   const firstVariableValue: VariableValue | undefined = (variable?.variableValues || [])[0];
+  const firstVariableValueStatus: VariableStatusType | undefined = firstVariableValue?.status;
 
   return (
     <Box
@@ -50,7 +52,7 @@ const QuestionBox = ({ projectId, variable }: { projectId: number; variable: Var
       sx={{ marginBottom: theme.spacing(4) }}
     >
       <Box sx={{ float: 'right', marginBottom: '16px', marginLeft: '16px' }}>
-        {/* <DeliverableStatusBadge status={variableWithValues.status} /> */}
+        <VariableStatusBadge status={firstVariableValueStatus} />
       </Box>
       <Typography sx={{ fontWeight: '600', marginBottom: '16px' }}>{variable.name}</Typography>
       {!!variable.description && (


### PR DESCRIPTION
This PR includes changes to show status badges on the participant side of questionnaire deliverables.

## Screenshots

### BEFORE

![staging terraware io_deliverables_123_submissions_32_edit_organizationId=141](https://github.com/user-attachments/assets/40bf169c-b3f4-4917-b470-d0ea170c87db)

![staging terraware io_deliverables_123_submissions_32_edit_organizationId=141 (1)](https://github.com/user-attachments/assets/463aeed9-0158-4c66-a5d6-e1d575ad5d17)

### AFTER

![localhost_3000_deliverables_123_submissions_32_organizationId=141](https://github.com/user-attachments/assets/9ee64a84-2a36-4702-ad69-697969591b9d)

![localhost_3000_deliverables_123_submissions_32_organizationId=141 (1)](https://github.com/user-attachments/assets/3982dd58-205d-4f60-b078-7b7178ffa8b0)

