### PR TITLE
Fix the collection of variables for tables, modify styling to match designs

### DIFF
--- a/public/preview.css
+++ b/public/preview.css
@@ -77,7 +77,7 @@
 
 /* Main Content */
 body {
-    font-family: "Arial";
+    font-family: "Inter";
 }
 
 h1,
@@ -90,14 +90,15 @@ h6 {
 }
 
 h1 {
-    font-size: 24pt;
-    font-weight: 400;
-    font-variant: small-caps;
+    font-size: 28px;
+    font-weight: 600;
+    line-height: 36px;
 }
 
 h2 {
-    font-size: 13pt;
-    font-weight: 400;
+    font-size: 24px;
+    font-weight: 600;
+    line-height: 32px;
 }
 
 h3 {
@@ -156,20 +157,30 @@ table {
 }
 
 table, th, td {
-    border: 1px solid white;
+    border: 1px solid #B2AB93;
     border-collapse: collapse;
 }
 
+.table-name {
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 16px;
+    text-align: left;
+    margin: 0.25in 0 0.125in 0;
+    padding: 0;
+    color: #2C8658;
+}
+
 th {
-    color: #fff;
-    background-color: #2a3957;
+    color: #333025;
+    background-color: #F1F0EC;
     font-size: 10.5pt;
     padding: 0.1in;
 }
 
 td {
     color: #404040;
-    background-color: #f2f2f2;
+    background-color: #fff;
     font-size: 9.5pt;
     text-align: left;
     padding: 0.1in;

--- a/public/preview.html
+++ b/public/preview.html
@@ -13,6 +13,11 @@
     -->
     <link rel="manifest" href="manifest.json" />
     <title>Preview</title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
+
     <link rel="stylesheet" href="preview.css" />
   </head>
   <body>

--- a/src/scenes/AcceleratorRouter/Documents/PreviewView/PreviewDocument.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/PreviewView/PreviewDocument.tsx
@@ -59,8 +59,8 @@ export default function PreviewDocument({ doc }: PreviewDocumentProps): ReactEle
   }, [documentVariables]);
 
   // TODO remove this, things in state should not be mutated
-  calculateFigures(sectionVariables, documentVariables || [], 'Table');
-  calculateFigures(sectionVariables, documentVariables || [], 'Image');
+  calculateFigures(sectionVariables, allVariables || [], 'Table');
+  calculateFigures(sectionVariables, allVariables || [], 'Image');
 
   if (!(documentVariables && allVariables.length > 0)) {
     return null;

--- a/src/scenes/AcceleratorRouter/Documents/PreviewView/PreviewSection.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/PreviewView/PreviewSection.tsx
@@ -66,6 +66,7 @@ const PreviewSection = ({
           <span> {sectionVariableWithRelevantVariables.name}</span>
         </h1>
       )}
+
       {isMinor && (
         <h2 className='toc-minor'>
           <span className='section-number'>{sectionVariableWithRelevantVariables.sectionNumber}</span>

--- a/src/scenes/AcceleratorRouter/Documents/PreviewView/PreviewTable.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/PreviewView/PreviewTable.tsx
@@ -55,11 +55,13 @@ const PreviewTableHorizontal = ({
       <tbody>
         {rows.map((tableColumn: VariableValue[], index: number) => (
           <tr key={index}>
-            {tableColumn.map((cell: VariableValue, _index: number) => (
-              <td key={_index}>
-                {cell.values.map((value) => getPrintValue(combinedInjectedValue, value, sectionVariable))}
-              </td>
-            ))}
+            {tableColumn.map((cell: VariableValue, _index: number) => {
+              return (
+                <td key={_index}>
+                  {(cell?.values || []).map((value) => getPrintValue(combinedInjectedValue, value, sectionVariable))}
+                </td>
+              );
+            })}
           </tr>
         ))}
       </tbody>
@@ -130,8 +132,8 @@ export const PreviewTable = ({
   return (
     <>
       {!suppressCaptions && (
-        <p>
-          Table {(relevantTableVariable as any).figure}{' '}
+        <p className='table-name'>
+          Table {(relevantTableVariable as any).figure} {relevantTableVariable.name}
           {combinedInjectedValue.citation && <span className='footnote'>{combinedInjectedValue.citation}</span>}
         </p>
       )}


### PR DESCRIPTION
- There is some code that mutates the table and image variables to add the "figure" number, it had to be updated to match the new split variable schema
- Updated some styling in the preview

![SCR-20240726-nkif.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/2de0eeac-bb69-462e-9870-8aeced6505a9.png)

