### PR TITLE
Update the citations display in the document producer preview

### DIFF
--- a/public/preview.css
+++ b/public/preview.css
@@ -19,11 +19,10 @@
     }
 
     @footnote {
-        border-width: 1px;
-        border-style: solid;
-        border-image: linear-gradient(to right, black 0 33%, transparent 33% 100%) 100% 0 0 0;
-        padding-top: 10px;
-        margin-top: 14px;
+        border-top: 1px solid #B2AB93;
+        padding-top: 0.125in;
+        margin-top: 0.25in;
+        margin-bottom: 0.25in;
     }
 }
 
@@ -76,8 +75,12 @@
 }
 
 /* Main Content */
+:root {
+    --pagedjs-padding-top: 0.5in;
+}
+
 body {
-    font-family: "Inter";
+    font-family: "Arial";
 }
 
 h1,
@@ -87,6 +90,7 @@ h4,
 h5,
 h6 {
     color: #2C8658;
+    margin: 0 0 0.25in 0;
 }
 
 h1 {
@@ -113,6 +117,10 @@ h3 {
 .section-body {
     width: 100%;
     white-space: pre-wrap;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 20px;
+    text-align: left;
 }
 
 p {
@@ -126,13 +134,25 @@ p {
 
 .footnote {
     float: footnote;
-    footnote-style-position: inside;
-    font-size: 9pt;
-    font-style: italic;
+    list-style-position: outside;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 16px;
+    text-align: left;
+    margin-left: 15px;
+}
+
+.footnote::marker {
+    vertical-align: super;
+    font-variant-position: super;
 }
 
 .footnote::after {
     vertical-align: super;
+    font-variant-position: super;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 16px;
 }
 
 .image-container {
@@ -251,15 +271,15 @@ td {
 }
 
 #table-of-contents .toc-major {
-    margin-top: 12pt;
-    font-size: 12pt;
-    font-weight: 600;
-    font-variant: small-caps;
+    font-size: 14px;
+    line-height: 20px;
+    font-weight: 400;
 }
 
 #table-of-contents .toc-minor {
-    margin-top: 6pt;
-    font-size: 12pt;
+    font-size: 14px;
+    line-height: 20px;
+    font-weight: 400;
     padding-left: 0.25in;
 }
 

--- a/public/preview.html
+++ b/public/preview.html
@@ -14,10 +14,6 @@
     <link rel="manifest" href="manifest.json" />
     <title>Preview</title>
 
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
-
     <link rel="stylesheet" href="preview.css" />
   </head>
   <body>

--- a/src/scenes/AcceleratorRouter/Documents/PreviewView/PreviewSection.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/PreviewView/PreviewSection.tsx
@@ -62,7 +62,7 @@ const PreviewSection = ({
     <>
       {isTopLevel && (
         <h1 className='toc-major'>
-          <span className='section-number'>{sectionVariableWithRelevantVariables.sectionNumber}</span>
+          <span className='section-number'>{sectionVariableWithRelevantVariables.sectionNumber}.</span>
           <span> {sectionVariableWithRelevantVariables.name}</span>
         </h1>
       )}


### PR DESCRIPTION
I was unable to get the citation number to be superscript within the footnotes. This seems to be because of the fact that PagedJS renders these using the `::marker` pseudo element, which does not allow for properties such as `vertical-align: super;` or
`font-variant-position: super;` because it is displayed with `display: static` and can not be overridden. 

I also tried to see if there was a way to wrap the actual marker with a `<sup>` tag, but this also seems to be impossible since the content of the element is populated within the CSS, which does not allow for HTML tags.

Hopefully this is good enough for now and we can attempt to style it differently if we need in the future.

![SCR-20240729-ovbw.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/e8cae39e-dd43-436c-b23b-664fcf16a68f.png)

