### PR TITLE
SW-5732 Allow hashmarks in exported CSVs

### DIFF
--- a/src/components/common/ExportCsvModal.tsx
+++ b/src/components/common/ExportCsvModal.tsx
@@ -26,8 +26,7 @@ export default function ExportCsvModal(props: ExportCsvModalProps): JSX.Element 
     const apiResponse = await onExport();
 
     if (apiResponse !== null) {
-      const csvContent = 'data:text/csv;charset=utf-8,' + apiResponse;
-      const encodedUri = encodeURI(csvContent);
+      const encodedUri = 'data:text/csv;charset=utf-8,' + encodeURIComponent(apiResponse);
       const link = document.createElement('a');
       link.setAttribute('href', encodedUri);
       link.setAttribute('download', `${name}.csv`);


### PR DESCRIPTION
If an exported CSV contained a `#` character, the file would be cut off because it
was treated as the anchor part of the generated `data:` URL.