### PR TITLE
SW-5670 Use trigram word similarity for fuzzy match in document producer variables tab

### DIFF
--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
@@ -32,6 +32,7 @@ import {
   VariableValueSelectValue,
   VariableValueTextValue,
 } from 'src/types/documentProducer/VariableValue';
+import { fuzzyMatch } from 'src/utils/searchAndSort';
 
 const tableColumns: TableColumnType[] = [
   { key: 'name', name: strings.NAME, type: 'string' },
@@ -96,7 +97,7 @@ export type DocumentVariablesProps = {
 const filterSearch =
   (searchValue: string) =>
   (variable: VariableWithValues): boolean =>
-    searchValue ? variable.name.toLowerCase().includes(searchValue) : true;
+    searchValue ? fuzzyMatch(searchValue, variable.name.toLowerCase()) : true;
 
 const DocumentVariablesTab = ({ document: doc, setSelectedTab }: DocumentVariablesProps): JSX.Element => {
   const dispatch = useAppDispatch();

--- a/src/utils/searchAndSort.ts
+++ b/src/utils/searchAndSort.ts
@@ -59,6 +59,8 @@ export const trigramWordSimilarity = (a: string, b: string) => {
   return similarity;
 };
 
+export const fuzzyMatch = (a: string, b: string) => trigramWordSimilarity(a, b) > TRIGRAM_SIMILARITY_THRESHOLD;
+
 const searchConditionMet = <T extends Record<string, unknown>>(result: T, condition: SearchNodePayload): boolean => {
   // `as SearchNodePayload` casts below are because the SearchNodePayload in the generated types only has `operation`
   // The the union type from our types has the correct properties
@@ -89,7 +91,7 @@ const searchConditionMet = <T extends Record<string, unknown>>(result: T, condit
         if (searchValue.length === 1) {
           return resultValue.includes(searchValue);
         }
-        return trigramWordSimilarity(searchValue, resultValue) > TRIGRAM_SIMILARITY_THRESHOLD;
+        return fuzzyMatch(searchValue, resultValue);
       });
     }
   }


### PR DESCRIPTION
The trigram word similarity is how we do fuzzy matching for in-runtime filtering of search results.

![SCR-20240731-lzki.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/22c858e4-3946-44cd-82f1-2ce9a42a2b4f.png)

