### PR TITLE
SW-5704 Use large primary button for event action

### DIFF
--- a/src/scenes/ModulesRouter/ModuleEventSessionView.tsx
+++ b/src/scenes/ModulesRouter/ModuleEventSessionView.tsx
@@ -100,6 +100,8 @@ const ModuleEventSessionView = () => {
 
                 <Button
                   label={buttonLabel}
+                  priority='primary'
+                  size='large'
                   onClick={() => {
                     openExternalURL(buttonUrl);
                   }}


### PR DESCRIPTION
Make the action button on the event session page larger and give it primary
priority.