### PR TITLE
SW-5579 Link to a Project's Deliverables from Project Profile page

### DIFF
--- a/src/components/common/SearchFiltersWrapperV2/FeaturedFilters.tsx
+++ b/src/components/common/SearchFiltersWrapperV2/FeaturedFilters.tsx
@@ -16,12 +16,13 @@ interface FeaturedFiltersProps {
 
 type MultiSelectFilters = Record<string, (string | number | null)[]>;
 
-const defaultSearchNodeCreator = (field: string, values: (number | string | null)[]) => ({
-  field,
-  operation: 'field',
-  type: 'Exact',
-  values: values.map((value: number | string | null): string | null => (value === null ? value : `${value}`)),
-});
+export const defaultSearchNodeCreator = (field: string, values: (number | string | null)[]) =>
+  ({
+    field,
+    operation: 'field',
+    type: 'Exact',
+    values: values.map((value: number | string | null): string | null => (value === null ? value : `${value}`)),
+  }) as SearchNodePayload;
 
 const defaultRenderOption = (status: string | number) => `${status}`;
 

--- a/src/components/common/SearchFiltersWrapperV2/index.tsx
+++ b/src/components/common/SearchFiltersWrapperV2/index.tsx
@@ -30,6 +30,10 @@ export type FilterConfig = {
   type?: FilterField['type'];
 };
 
+export type FilterConfigWithValues = FilterConfig & {
+  values?: (string | number | null)[];
+};
+
 export type SearchProps = SearchInputProps & {
   iconFilters?: FilterConfig[];
   featuredFilters?: FilterConfig[];

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/SingleView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/SingleView.tsx
@@ -12,6 +12,7 @@ import ProjectFieldTextAreaDisplay from 'src/components/ProjectField/TextAreaDis
 import VotingDecisionCard from 'src/components/ProjectField/VotingDecisionCard';
 import Card from 'src/components/common/Card';
 import ExportCsvModal from 'src/components/common/ExportCsvModal';
+import Link from 'src/components/common/Link';
 import OptionsMenu from 'src/components/common/OptionsMenu';
 import PageWithModuleTimeline from 'src/components/common/PageWithModuleTimeline';
 import TextTruncated from 'src/components/common/TextTruncated';
@@ -105,9 +106,17 @@ const SingleView = () => {
     }
   }, [activeLocale]);
 
+  const projectViewTitle = (
+    <Box paddingLeft={3}>
+      <Typography fontSize={'24px'} fontWeight={600}>
+        {participant?.name || ''} / {project?.name || ''}
+      </Typography>
+    </Box>
+  );
+
   return (
     <PageWithModuleTimeline
-      title={`${participant?.name || ''} / ${project?.name || ''}`}
+      title={projectViewTitle}
       crumbs={crumbs}
       hierarchicalCrumbs={false}
       rightComponent={rightComponent}
@@ -116,6 +125,11 @@ const SingleView = () => {
 
       {project && (
         <>
+          <Box paddingLeft={3} marginBottom={4}>
+            <Link to={`${APP_PATHS.ACCELERATOR_DELIVERABLES}?projectId=${project.id}`} style={{ fontWeight: 400 }}>
+              {strings.VIEW_ALL_DELIVERABLES}
+            </Link>
+          </Box>
           <Card
             style={{
               display: 'flex',

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -1785,6 +1785,7 @@ VIABILITY_TESTING_EMPTY_MESSAGE,"Viability Testing helps you track seed quality.
 VIABILITY_TESTS,Viability Tests,
 VIEW,View,
 VIEW_APPLICATION,View Application,
+VIEW_ALL_DELIVERABLES,View All Deliverables,
 VIEW_LESS,View Less,
 VIEW_MORE,View More,
 VIEW_PRESCREEN_SUBMISSION,View Pre-screen Submission,


### PR DESCRIPTION
- Modified the TableWithSearchFilters component to allow having a filter applied from the creation of the table.
- Added the projectName filter to the DeliverablesTable, when coming from the link in the Participant Project page