### PR TITLE
SW-5744 Add module stepper to cohort detail view

### DIFF
--- a/src/hooks/useCohorts.ts
+++ b/src/hooks/useCohorts.ts
@@ -39,7 +39,7 @@ export const useCohorts = (cohortId?: number): Response => {
   }, [result, snackbar]);
 
   const fetch = useCallback(() => {
-    dispatch(requestCohorts({ locale: activeLocale }));
+    dispatch(requestCohorts({ locale: activeLocale, moduleDepth: 'Module' }));
   }, [activeLocale, dispatch]);
 
   useEffect(() => {

--- a/src/redux/features/cohorts/cohortsAsyncThunks.ts
+++ b/src/redux/features/cohorts/cohortsAsyncThunks.ts
@@ -5,6 +5,7 @@ import CohortService, {
   CreateCohortResponsePayload,
   DeleteCohortResponsePayload,
   ListCohortsRequestDepth,
+  ListCohortsRequestModuleDepth,
   UpdateCohortResponsePayload,
 } from 'src/services/CohortService';
 import { Response2 } from 'src/services/HttpService';
@@ -18,14 +19,15 @@ export const requestCohorts = createAsyncThunk(
     request: {
       locale: string | null;
       depth?: ListCohortsRequestDepth;
+      moduleDepth?: ListCohortsRequestModuleDepth;
       search?: SearchNodePayload;
       searchSortOrder?: SearchSortOrder;
     },
     { dispatch, rejectWithValue }
   ) => {
-    const { depth, locale, search, searchSortOrder } = request;
+    const { depth, locale, search, searchSortOrder, moduleDepth } = request;
 
-    const response = await CohortService.listCohorts(locale, search, searchSortOrder, depth);
+    const response = await CohortService.listCohorts(locale, search, searchSortOrder, depth, moduleDepth);
 
     if (response !== null && response.requestSucceeded && response?.cohorts !== undefined) {
       dispatch(setCohortsAction({ error: response.error, cohorts: response.cohorts }));
@@ -38,8 +40,12 @@ export const requestCohorts = createAsyncThunk(
 
 export const requestCohort = createAsyncThunk(
   'cohorts/get',
-  async (request: { cohortId: number }, { dispatch, rejectWithValue }) => {
-    const response: Response2<Cohort> = await CohortService.getCohort(request.cohortId);
+  async (
+    request: { cohortId: number; depth?: ListCohortsRequestDepth; moduleDepth?: ListCohortsRequestModuleDepth },
+    { dispatch, rejectWithValue }
+  ) => {
+    const { depth, moduleDepth } = request;
+    const response: Response2<Cohort> = await CohortService.getCohort(request.cohortId, depth, moduleDepth);
 
     if (response !== null && response.requestSucceeded && response.data !== undefined) {
       dispatch(setCohortAction({ error: response.error, cohorts: [response.data] }));

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortView.tsx
@@ -30,7 +30,7 @@ const CohortView = () => {
   const cohort = useAppSelector(selectCohort(cohortId));
 
   useEffect(() => {
-    void dispatch(requestCohort({ cohortId }));
+    void dispatch(requestCohort({ cohortId, moduleDepth: 'Module' }));
   }, [cohortId, dispatch]);
 
   const goToEditCohort = useCallback(() => {


### PR DESCRIPTION
Allow cohort view to show the modules stepper. Since the name of the modules come from the project (and there is no project in this view) this is how the stepper looks:

<img width="1320" alt="Screenshot 2024-08-07 at 5 05 57 PM" src="https://github.com/user-attachments/assets/f54acdde-c0f7-4e2c-8ad0-c727243b1c56">

