### PR TITLE
SW-5759: When Min/Max Carbon Accumulation is not filled out, put N/A to match other fields

### DIFF
--- a/src/scenes/AcceleratorRouter/ParticipantProjects/SingleView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/SingleView.tsx
@@ -242,7 +242,7 @@ const SingleView = () => {
                 value={
                   participantProject?.minCarbonAccumulation && participantProject?.maxCarbonAccumulation
                     ? `${participantProject.minCarbonAccumulation}-${participantProject.maxCarbonAccumulation}`
-                    : false
+                    : undefined
                 }
               />
               <ProjectFieldDisplay label={strings.CARBON_CAPACITY_TC02_HA} value={participantProject?.carbonCapacity} />


### PR DESCRIPTION
Use `undefined` rather `false` as fallback value so `ProjectField` will display N/A when there's no value.

## Screenshots

### Before

![localhost_3000_accelerator_projects_34 (2)](https://github.com/user-attachments/assets/a2f85b64-3a83-4c3d-b175-6fab9a5a9d98)

### After

![localhost_3000_accelerator_projects_34](https://github.com/user-attachments/assets/cc8e924e-3a15-495f-8e1f-579af39ab131)
