### PR TITLE
SW-5788: Disable submit pre-screen button until sections are complete

### DIFF
--- a/src/scenes/ApplicationRouter/portal/Prescreen/index.tsx
+++ b/src/scenes/ApplicationRouter/portal/Prescreen/index.tsx
@@ -101,7 +101,7 @@ const PrescreenView = () => {
       <SectionView section={prescreenSection} sectionDeliverables={prescreenDeliverables}>
         {selectedApplication.status === 'Not Submitted' && (
           <Button
-            disabled={(!allDeliverablesCompleted || !selectedApplication.boundary || isLoading) && false}
+            disabled={!allDeliverablesCompleted || !selectedApplication.boundary || isLoading}
             label={strings.SUBMIT_PRESCREEN}
             onClick={() => setIsConfirmModalOpen(true)}
             priority='primary'


### PR DESCRIPTION
Removes what appears to be debug logic so the submit pre-screen button is correctly disabled when appropriate.