### PR TITLE
SW-5672 Modify deliverable search request

### DIFF
--- a/src/providers/Participant/ParticipantProvider.tsx
+++ b/src/providers/Participant/ParticipantProvider.tsx
@@ -104,7 +104,10 @@ const ParticipantProvider = ({ children }: Props) => {
 
       if (nextActiveModules.length > 0) {
         const deliverableRequest = dispatch(
-          requestListModuleDeliverables({ moduleId: nextActiveModules[0].id, projectId: currentParticipantProject.id })
+          requestListModuleDeliverables({
+            moduleIds: [nextActiveModules[0].id],
+            projectId: currentParticipantProject.id,
+          })
         );
         setListModuleDeliverablesRequest(deliverableRequest.requestId);
       }

--- a/src/redux/features/modules/modulesAsyncThunks.ts
+++ b/src/redux/features/modules/modulesAsyncThunks.ts
@@ -5,7 +5,7 @@ import { SearchService } from 'src/services';
 import ModuleService from 'src/services/ModuleService';
 import strings from 'src/strings';
 import { ModuleDeliverable, ModuleProjectSearchResult } from 'src/types/Module';
-import { SearchRequestPayload } from 'src/types/Search';
+import { SearchNodePayload, SearchRequestPayload } from 'src/types/Search';
 
 export const requestGetModule = createAsyncThunk(
   'modules/get',
@@ -64,17 +64,29 @@ export const requestListModuleProjects = createAsyncThunk(
 
 export const requestListModuleDeliverables = createAsyncThunk(
   'modules/deliverables',
-  async (request: { moduleId: number; projectId: number }): Promise<ModuleDeliverable[]> => {
-    const deliverableSearchResults = await ModuleService.searchDeliverables(request.projectId, request.moduleId);
+  async (request: {
+    moduleIds: number[];
+    projectId: number;
+    searchChildren?: SearchNodePayload[];
+  }): Promise<ModuleDeliverable[]> => {
+    const searchChildren = request.searchChildren || [];
+
+    const deliverableSearchResults = await ModuleService.searchDeliverables(
+      request.projectId,
+      request.moduleIds,
+      searchChildren
+    );
 
     return deliverableSearchResults
       ? deliverableSearchResults.map((result) => ({
-          id: result.id,
-          moduleId: result.moduleId,
-          projectId: result.projectId,
-          name: result.name,
           category: result.category,
+          id: result.id,
           dueDate: DateTime.fromISO(result.dueDate),
+          moduleEndDate: DateTime.fromISO(result.moduleEndDate),
+          moduleId: result.moduleId,
+          moduleStartDate: DateTime.fromISO(result.moduleStartDate),
+          name: result.name,
+          projectId: result.projectId,
           status: result.status,
           type: result.type,
         }))

--- a/src/scenes/ModulesRouter/Provider/index.tsx
+++ b/src/scenes/ModulesRouter/Provider/index.tsx
@@ -50,7 +50,7 @@ const ModuleProvider = ({ children }: Props) => {
       const request = dispatch(requestGetModule({ projectId, moduleId }));
       setRequestId(request.requestId);
 
-      const deliverableRequest = dispatch(requestListModuleDeliverables({ projectId, moduleId }));
+      const deliverableRequest = dispatch(requestListModuleDeliverables({ projectId, moduleIds: [moduleId] }));
       setDeliverableRequestId(deliverableRequest.requestId);
     }
   }, [dispatch, projectId, moduleId]);

--- a/src/types/Module.ts
+++ b/src/types/Module.ts
@@ -61,12 +61,14 @@ export const getEventStatus = (status: ModuleEventSessionStatus) => {
 };
 
 export type ModuleDeliverable = {
-  id: number;
-  moduleId: number;
-  projectId: number;
-  name: string;
   category: DeliverableCategoryType;
   dueDate: DateTime;
+  id: number;
+  moduleEndDate: DateTime;
+  moduleId: number;
+  moduleStartDate: DateTime;
+  name: string;
+  projectId: number;
   status: DeliverableStatusType;
   type: DeliverableTypeType;
 };


### PR DESCRIPTION
- Change deliverable search request signature to take in an array of module IDs instead of a single module ID. 
- Add `moduleStartDate` and `moduleEndDate` to the deliverable search fields and response hydration. 
- Add ability to pass in specific search field node into deliverable search request.