### PR TITLE
SW-5672 Add messages to add to species dialog depending on active/recent deliverables 

### DIFF
--- a/src/components/SpeciesDeliverableTable/AddSpeciesModal.tsx
+++ b/src/components/SpeciesDeliverableTable/AddSpeciesModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { Grid, useTheme } from '@mui/material';
-import { Dropdown, SelectT } from '@terraware/web-components';
+import { Dropdown, Message, SelectT } from '@terraware/web-components';
 
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import TextField from 'src/components/common/Textfield/Textfield';
@@ -21,6 +21,8 @@ import useForm from 'src/utils/useForm';
 import useSnackbar from 'src/utils/useSnackbar';
 
 export interface AddSpeciesModalProps {
+  hasActiveDeliverable: boolean;
+  hasRecentDeliverable: boolean;
   onClose: () => void;
   participantProjectSpecies: SpeciesForParticipantProject[];
   projectId: number;
@@ -28,7 +30,7 @@ export interface AddSpeciesModalProps {
 }
 
 export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Element {
-  const { onClose, participantProjectSpecies, reload, projectId } = props;
+  const { hasActiveDeliverable, hasRecentDeliverable, onClose, participantProjectSpecies, reload, projectId } = props;
 
   const dispatch = useAppDispatch();
   const snackbar = useSnackbar();
@@ -107,6 +109,12 @@ export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Elemen
     }));
   };
 
+  const message = hasActiveDeliverable
+    ? strings.SPECIES_LIST_DELIVERABLE_ADD_SPECIES_ACTIVE_DELIVERABLE_INFO
+    : hasRecentDeliverable
+      ? strings.SPECIES_LIST_DELIVERABLE_ADD_SPECIES_RECENT_DELIVERABLE_INFO
+      : false;
+
   return (
     <DialogBox
       onClose={onClose}
@@ -126,6 +134,12 @@ export default function AddSpeciesModal(props: AddSpeciesModalProps): JSX.Elemen
       ]}
     >
       <Grid container textAlign={'left'}>
+        {message && (
+          <Grid item xs={12} sx={{ marginBottom: theme.spacing(2) }}>
+            <Message body={message} priority='info' type='page' />
+          </Grid>
+        )}
+
         <Grid item xs={12}>
           <TextField
             id='project-name'

--- a/src/components/SpeciesDeliverableTable/index.tsx
+++ b/src/components/SpeciesDeliverableTable/index.tsx
@@ -8,11 +8,14 @@ import Table from 'src/components/common/table';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import useNavigateTo from 'src/hooks/useNavigateTo';
 import { useLocalization } from 'src/providers';
+import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
+import { requestListModuleDeliverables } from 'src/redux/features/modules/modulesAsyncThunks';
+import { selectModuleDeliverables } from 'src/redux/features/modules/modulesSelectors';
 import { requestListParticipantProjectSpecies } from 'src/redux/features/participantProjectSpecies/participantProjectSpeciesAsyncThunks';
 import { selectParticipantProjectSpeciesListRequest } from 'src/redux/features/participantProjectSpecies/participantProjectSpeciesSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
-import { Deliverable } from 'src/types/Deliverables';
+import { Deliverable, DeliverableTypeType } from 'src/types/Deliverables';
 
 import AddSpeciesModal from './AddSpeciesModal';
 import RemoveSpeciesDialog from './RemoveSpeciesDialog';
@@ -42,12 +45,49 @@ const SpeciesDeliverableTable = ({ deliverable }: SpeciesDeliverableTableProps):
   const theme = useTheme();
   const { isAcceleratorRoute } = useAcceleratorConsole();
   const { goToParticipantProjectSpecies } = useNavigateTo();
+  const { currentDeliverables, currentParticipantProject, modules } = useParticipantData();
 
   const participantProjectSpecies = useAppSelector(selectParticipantProjectSpeciesListRequest(deliverable.projectId));
+  const [deliverableSearchRequestId, setDeliverableSearchRequestId] = useState('');
+  const deliverableSearchRequest = useAppSelector(selectModuleDeliverables(deliverableSearchRequestId));
 
   const [selectedRows, setSelectedRows] = useState<TableRowType[]>([]);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [openedAddSpeciesModal, setOpenedAddSpeciesModal] = useState(false);
+
+  useEffect(() => {
+    if (!modules || modules.length === 0 || !currentParticipantProject) {
+      return;
+    }
+
+    if (currentDeliverables.length === 0) {
+      const deliverableRequest = dispatch(
+        requestListModuleDeliverables({
+          projectId: currentParticipantProject.id,
+          moduleIds: modules?.map((module) => module.id),
+          searchChildren: [
+            {
+              operation: 'field',
+              field: 'type(raw)',
+              type: 'Exact',
+              values: ['Species' as DeliverableTypeType],
+            },
+          ],
+        })
+      );
+      setDeliverableSearchRequestId(deliverableRequest.requestId);
+    }
+  }, [currentDeliverables, currentParticipantProject, modules]);
+
+  const hasActiveDeliverable = useMemo(
+    () => !!currentDeliverables.find((deliverable) => deliverable.type === 'Species'),
+    [currentDeliverables]
+  );
+
+  const hasRecentDeliverable = useMemo(
+    () => deliverableSearchRequest?.status === 'success' && (deliverableSearchRequest?.data || []).length > 0,
+    [deliverableSearchRequest]
+  );
 
   const rows = useMemo(() => {
     return (participantProjectSpecies?.data || []).map((value) => ({
@@ -95,6 +135,8 @@ const SpeciesDeliverableTable = ({ deliverable }: SpeciesDeliverableTableProps):
               participantProjectSpecies={participantProjectSpecies?.data || []}
               reload={reload}
               projectId={deliverable.projectId}
+              hasActiveDeliverable={hasActiveDeliverable}
+              hasRecentDeliverable={hasRecentDeliverable}
             />
           )}
 

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -1520,6 +1520,8 @@ SPECIES_DESCRIPTION,"Manage your organization’s species list for planning, ope
 SPECIES_EMPTY_MSG_BODY,Enter species that you collect or plant now to simplify your experience when you’re out in the field.,
 SPECIES_IMPORT_COMPLETE,Species data import complete!,
 SPECIES_LIST,Species List,
+SPECIES_LIST_DELIVERABLE_ADD_SPECIES_ACTIVE_DELIVERABLE_INFO,Adding this species to this project will reset the status of your active species deliverable. You will need to resubmit the deliverable for approval.,
+SPECIES_LIST_DELIVERABLE_ADD_SPECIES_RECENT_DELIVERABLE_INFO,Adding this species to this project will reset the status of your most recent species deliverable. You will need to resubmit the deliverable for approval.,
 SPECIES_NAME,Species Name,
 SPECIES_NOT_ACCEPTED,Species Not Accepted,
 SPECIES_OBSERVED,Species Observed,


### PR DESCRIPTION
- Pass `hasActiveDeliverable` and `hasRecentDeliverable` flags into Species deliverable Add Species modal with specific messages for each.

Here's what it looks like when there is no active species list deliverable but there is a "recent" one.

![SCR-20240808-mgeb.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/9e4aac83-0370-4cf8-a9ef-83c96e767cc5.png)

Here's what it looks like when there is an active deliverable:

![SCR-20240808-mhcm.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/26ad5254-27ec-4b8d-ae00-bd2c7f29edcc.png)

