### PR TITLE
SW-5672 Optimize checking for active and current deliverable

### DIFF
--- a/src/components/SpeciesDeliverableTable/index.tsx
+++ b/src/components/SpeciesDeliverableTable/index.tsx
@@ -55,7 +55,6 @@ const SpeciesDeliverableTable = ({ deliverable }: SpeciesDeliverableTableProps):
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [openedAddSpeciesModal, setOpenedAddSpeciesModal] = useState(false);
 
-  console.log({ isLoading });
   useEffect(() => {
     if (isLoading || !modules || modules.length === 0 || !currentParticipantProject || !currentDeliverables) {
       return;

--- a/src/components/SpeciesDeliverableTable/index.tsx
+++ b/src/components/SpeciesDeliverableTable/index.tsx
@@ -45,7 +45,7 @@ const SpeciesDeliverableTable = ({ deliverable }: SpeciesDeliverableTableProps):
   const theme = useTheme();
   const { isAcceleratorRoute } = useAcceleratorConsole();
   const { goToParticipantProjectSpecies } = useNavigateTo();
-  const { currentDeliverables, currentParticipantProject, modules } = useParticipantData();
+  const { currentDeliverables, currentParticipantProject, isLoading, modules } = useParticipantData();
 
   const participantProjectSpecies = useAppSelector(selectParticipantProjectSpeciesListRequest(deliverable.projectId));
   const [deliverableSearchRequestId, setDeliverableSearchRequestId] = useState('');
@@ -55,8 +55,9 @@ const SpeciesDeliverableTable = ({ deliverable }: SpeciesDeliverableTableProps):
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [openedAddSpeciesModal, setOpenedAddSpeciesModal] = useState(false);
 
+  console.log({ isLoading });
   useEffect(() => {
-    if (!modules || modules.length === 0 || !currentParticipantProject) {
+    if (isLoading || !modules || modules.length === 0 || !currentParticipantProject || !currentDeliverables) {
       return;
     }
 
@@ -77,10 +78,10 @@ const SpeciesDeliverableTable = ({ deliverable }: SpeciesDeliverableTableProps):
       );
       setDeliverableSearchRequestId(deliverableRequest.requestId);
     }
-  }, [currentDeliverables, currentParticipantProject, modules]);
+  }, [currentDeliverables, currentParticipantProject, isLoading, modules]);
 
   const hasActiveDeliverable = useMemo(
-    () => !!currentDeliverables.find((deliverable) => deliverable.type === 'Species'),
+    () => !!(currentDeliverables || []).find((deliverable) => deliverable.type === 'Species'),
     [currentDeliverables]
   );
 

--- a/src/providers/Participant/ParticipantContext.tsx
+++ b/src/providers/Participant/ParticipantContext.tsx
@@ -8,7 +8,8 @@ export type ParticipantData = {
   activeModules?: Module[];
   currentParticipant?: Participant;
   currentParticipantProject?: Project;
-  currentDeliverables: ModuleDeliverable[];
+  currentDeliverables?: ModuleDeliverable[];
+  isLoading: boolean;
   moduleProjects: Project[];
   modules?: Module[];
   participantProjects: Project[];
@@ -20,6 +21,7 @@ export type ParticipantData = {
 // default values pointing to nothing
 export const ParticipantContext = createContext<ParticipantData>({
   currentDeliverables: [],
+  isLoading: true,
   moduleProjects: [],
   participantProjects: [],
   orgHasModules: false,

--- a/src/scenes/Home/ParticipantHomeView/CurrentModule.tsx
+++ b/src/scenes/Home/ParticipantHomeView/CurrentModule.tsx
@@ -20,7 +20,7 @@ const CurrentModule = () => {
   const deliverableDetails = useMemo(
     () =>
       currentParticipantProject
-        ? currentDeliverables.map((deliverable) => ({
+        ? (currentDeliverables || []).map((deliverable) => ({
             ...deliverable,
             onClick: () => goToDeliverable(deliverable.id, currentParticipantProject.id),
           }))


### PR DESCRIPTION
- Add loading state to the `ParticipantProvider`, this is used in `SpeciesDeliverableTable` so we can wait until we know if there is an active deliverable or not before checking for recent deliverables. 
- If there is an active deliverable, no point in checking for a recent one. Also rename a few things in the provider for consistency.
- Change up a few variable names in `ParticipantProvider` for consistency