### PR TITLE
SW-5798: Limit status options for review application in console

### DIFF
--- a/src/scenes/AcceleratorRouter/Applications/ApplicationReview.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationReview.tsx
@@ -50,7 +50,7 @@ const ApplicationReview = ({ application }: ApplicationReviewProps) => {
   const { goToParticipantProject } = useNavigateTo();
   const { isAllowed } = useUser();
 
-  const canCreateInternalComments = isAllowed('UPDATE_APPLICATION_INTERNAL_COMMENTS');
+  const canUpdateInternalComments = isAllowed('UPDATE_APPLICATION_INTERNAL_COMMENTS');
   const color = getApplicationStatusColor(application.status, theme);
 
   const { reload } = useApplicationData();
@@ -104,7 +104,7 @@ const ApplicationReview = ({ application }: ApplicationReviewProps) => {
           </Typography>
           <Button
             disabled={
-              !canCreateInternalComments &&
+              !canUpdateInternalComments &&
               (application.status === 'Failed Pre-screen' || application.status === 'Not Submitted')
             }
             label={strings.REVIEW_APPLICATION}

--- a/src/scenes/AcceleratorRouter/Applications/ApplicationReview.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationReview.tsx
@@ -104,8 +104,8 @@ const ApplicationReview = ({ application }: ApplicationReviewProps) => {
           </Typography>
           <Button
             disabled={
-              !canUpdateInternalComments &&
-              (application.status === 'Failed Pre-screen' || application.status === 'Not Submitted')
+              (application.status === 'Failed Pre-screen' || application.status === 'Not Submitted') &&
+              !canUpdateInternalComments
             }
             label={strings.REVIEW_APPLICATION}
             onClick={() => {

--- a/src/scenes/AcceleratorRouter/Applications/ApplicationReview.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationReview.tsx
@@ -7,6 +7,7 @@ import { Property } from 'csstype';
 
 import ProjectFieldTextAreaDisplay from 'src/components/ProjectField/TextAreaDisplay';
 import useNavigateTo from 'src/hooks/useNavigateTo';
+import { useUser } from 'src/providers';
 import { useApplicationData } from 'src/providers/Application/Context';
 import strings from 'src/strings';
 import { Application, ApplicationStatus } from 'src/types/Application';
@@ -47,12 +48,16 @@ type ApplicationReviewProps = {
 const ApplicationReview = ({ application }: ApplicationReviewProps) => {
   const theme = useTheme();
   const { goToParticipantProject } = useNavigateTo();
+  const { isAllowed } = useUser();
 
+  const canCreateInternalComments = isAllowed('CREATE_APPLICATION_INTERNAL_COMMENTS');
   const color = getApplicationStatusColor(application.status, theme);
 
   const { reload } = useApplicationData();
   const navigate = useNavigate();
+
   const [isReviewModalOpen, setIsReviewModalOpen] = useState<boolean>(false);
+
   const onReviewSubmitted = useCallback(() => {
     reload(() => navigate(0));
   }, [application, reload]);
@@ -98,6 +103,10 @@ const ApplicationReview = ({ application }: ApplicationReviewProps) => {
             {application.status}
           </Typography>
           <Button
+            disabled={
+              !canCreateInternalComments &&
+              (application.status === 'Failed Pre-screen' || application.status === 'Not Submitted')
+            }
             label={strings.REVIEW_APPLICATION}
             onClick={() => {
               setIsReviewModalOpen(true);

--- a/src/scenes/AcceleratorRouter/Applications/ApplicationReview.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationReview.tsx
@@ -50,7 +50,7 @@ const ApplicationReview = ({ application }: ApplicationReviewProps) => {
   const { goToParticipantProject } = useNavigateTo();
   const { isAllowed } = useUser();
 
-  const canCreateInternalComments = isAllowed('CREATE_APPLICATION_INTERNAL_COMMENTS');
+  const canCreateInternalComments = isAllowed('UPDATE_APPLICATION_INTERNAL_COMMENTS');
   const color = getApplicationStatusColor(application.status, theme);
 
   const { reload } = useApplicationData();

--- a/src/scenes/AcceleratorRouter/Applications/ApplicationReviewModal.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationReviewModal.tsx
@@ -11,10 +11,10 @@ import { selectApplicationReview } from 'src/redux/features/application/applicat
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 import {
-  ApplicaitonReviewStatuses,
   Application,
   ApplicationReview,
   ApplicationReviewStatus,
+  ApplicationReviewStatuses,
   ApplicationStatus,
 } from 'src/types/Application';
 import useForm from 'src/utils/useForm';
@@ -39,7 +39,7 @@ const ApplicationReviewModal = ({
   const [requestId, setRequestId] = useState<string>('');
   const result = useAppSelector(selectApplicationReview(requestId));
 
-  const dropdownOptions: DropdownItem[] = ApplicaitonReviewStatuses.map((status) => ({
+  const dropdownOptions: DropdownItem[] = ApplicationReviewStatuses.map((status) => ({
     label: status,
     value: status,
   }));
@@ -62,7 +62,9 @@ const ApplicationReviewModal = ({
   });
 
   const canUpdateStatus = useMemo(
-    () => ApplicaitonReviewStatuses.find((status) => status === application.status) !== undefined,
+    () =>
+      ApplicationReviewStatuses.find((status) => status === application.status) !== undefined &&
+      !(application.status === 'Failed Pre-screen' || application.status === 'Not Submitted'),
     [application.status]
   );
 

--- a/src/types/Application.ts
+++ b/src/types/Application.ts
@@ -8,7 +8,7 @@ export type ApplicationDeliverable = components['schemas']['ApplicationDeliverab
 export type ApplicationReview = components['schemas']['ReviewApplicationRequestPayload'];
 export type ApplicationReviewStatus = ApplicationReview['status'];
 
-export const ApplicaitonReviewStatuses: ApplicationReviewStatus[] = [
+export const ApplicationReviewStatuses: ApplicationReviewStatus[] = [
   'Accepted',
   'Carbon Eligible',
   'Issue Active',

--- a/src/utils/acl.ts
+++ b/src/utils/acl.ts
@@ -21,7 +21,7 @@ import { isManagerOrHigher, isMember } from './organization';
 /**
  * We split the permissions up loosely by the entity that the user is being authorized to interact with or view
  */
-type PermissionApplication = 'READ_ALL_APPLICATIONS';
+type PermissionApplication = 'READ_ALL_APPLICATIONS' | 'CREATE_APPLICATION_INTERNAL_COMMENTS';
 type PermissionCohort = 'CREATE_COHORTS' | 'READ_COHORTS' | 'UPDATE_COHORTS' | 'DELETE_COHORTS';
 type PermissionConsole = 'VIEW_CONSOLE';
 type PermissionDeliverable =
@@ -134,6 +134,7 @@ const ACL: Record<GlobalRolePermission, UserGlobalRoles | PermissionCheckFn> = {
   ASSIGN_PARTICIPANT_TO_COHORT: TFExpertPlus,
   ASSIGN_PROJECT_TO_PARTICIPANT: TFExpertPlus,
   ASSIGN_SOME_GLOBAL_ROLES: isAllowedAssignSomeGlobalRoles,
+  CREATE_APPLICATION_INTERNAL_COMMENTS: AcceleratorAdminPlus,
   CREATE_COHORTS: AcceleratorAdminPlus,
   CREATE_PARTICIPANTS: AcceleratorAdminPlus,
   CREATE_SUBMISSION: isAllowedCreateSubmission,

--- a/src/utils/acl.ts
+++ b/src/utils/acl.ts
@@ -21,7 +21,7 @@ import { isManagerOrHigher, isMember } from './organization';
 /**
  * We split the permissions up loosely by the entity that the user is being authorized to interact with or view
  */
-type PermissionApplication = 'READ_ALL_APPLICATIONS' | 'CREATE_APPLICATION_INTERNAL_COMMENTS';
+type PermissionApplication = 'READ_ALL_APPLICATIONS' | 'UPDATE_APPLICATION_INTERNAL_COMMENTS';
 type PermissionCohort = 'CREATE_COHORTS' | 'READ_COHORTS' | 'UPDATE_COHORTS' | 'DELETE_COHORTS';
 type PermissionConsole = 'VIEW_CONSOLE';
 type PermissionDeliverable =
@@ -134,7 +134,6 @@ const ACL: Record<GlobalRolePermission, UserGlobalRoles | PermissionCheckFn> = {
   ASSIGN_PARTICIPANT_TO_COHORT: TFExpertPlus,
   ASSIGN_PROJECT_TO_PARTICIPANT: TFExpertPlus,
   ASSIGN_SOME_GLOBAL_ROLES: isAllowedAssignSomeGlobalRoles,
-  CREATE_APPLICATION_INTERNAL_COMMENTS: AcceleratorAdminPlus,
   CREATE_COHORTS: AcceleratorAdminPlus,
   CREATE_PARTICIPANTS: AcceleratorAdminPlus,
   CREATE_SUBMISSION: isAllowedCreateSubmission,
@@ -149,6 +148,7 @@ const ACL: Record<GlobalRolePermission, UserGlobalRoles | PermissionCheckFn> = {
   READ_PARTICIPANTS: TFExpertPlus,
   READ_PARTICIPANT_PROJECT: ReadOnlyPlus,
   READ_SUBMISSION_DOCUMENT: ReadOnlyPlus,
+  UPDATE_APPLICATION_INTERNAL_COMMENTS: AcceleratorAdminPlus,
   UPDATE_COHORTS: AcceleratorAdminPlus,
   UPDATE_PARTICIPANTS: TFExpertPlus,
   UPDATE_PARTICIPANT_PROJECT_SCORING_VOTING: TFExpertPlus,


### PR DESCRIPTION
This PR includes changes to limit app application review for two application statuses, aside from an exception to allow admins to create/update internal comments only.

## Screenshots

### Before

![localhost_3000_accelerator_applications_12 (3)](https://github.com/user-attachments/assets/d66a2c63-df1f-4b03-a367-1b10597aa403)

### After

![localhost_3000_accelerator_applications_12 (2)](https://github.com/user-attachments/assets/6f590abd-a27e-4afb-b877-8d1cb7843f0c)
