### PR TITLE
SW-5761 Add subzone selection for observation scheduling

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@mui/styled-engine-sc": "^5.14.12",
     "@mui/styles": "^5.15.15",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^3.1.2-rc.0",
+    "@terraware/web-components": "^3.1.2-rc.1",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.3.0",
     "@testing-library/user-event": "^14.4.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@mui/styled-engine-sc": "^5.14.12",
     "@mui/styles": "^5.15.15",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^3.1.2-rc.1",
+    "@terraware/web-components": "^3.2.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.3.0",
     "@testing-library/user-event": "^14.4.3",

--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -4138,6 +4138,8 @@ export interface components {
        * @description Which planting site this observation needs to be scheduled for.
        */
       plantingSiteId: number;
+      /** @description If this observation should only cover specific parts of the planting site, the IDs of the subzones it should include. */
+      requestedSubzoneIds?: number[];
       /**
        * Format: date
        * @description The start date for this observation, can be up to a year from the date this schedule request occurs on.

--- a/src/scenes/ObservationsRouter/schedule/ObservationSubzoneSelector.tsx
+++ b/src/scenes/ObservationsRouter/schedule/ObservationSubzoneSelector.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react';
+
+import { Box, Grid, useTheme } from '@mui/material';
+import { Checkbox } from '@terraware/web-components';
+
+import { PlantingSite, PlantingZone } from 'src/types/Tracking';
+
+interface ObservationSubzoneSelectorProps {
+  onChangeSelectedSubzones: (requestedSubzoneIds: number[]) => void;
+  plantingSite: PlantingSite;
+}
+
+const ObservationSubzoneSelector = ({ onChangeSelectedSubzones, plantingSite }: ObservationSubzoneSelectorProps) => {
+  const theme = useTheme();
+
+  const [selectedSubzones, setSelectedSubzones] = useState(new Map<number, boolean>());
+
+  useEffect(() => {
+    // TODO determine which subzones have plants
+    // Initialize all subzone selections with subzoneId -> false
+    setSelectedSubzones(
+      new Map(
+        plantingSite.plantingZones?.flatMap((zone) => zone.plantingSubzones.map((subzone) => [subzone.id, false]))
+      )
+    );
+  }, [plantingSite]);
+
+  const handleOnChangeSelectedSubzones = (nextSelectedSubzones: Map<number, boolean>) => {
+    setSelectedSubzones(nextSelectedSubzones);
+
+    // If we were using es2015 or above, this entire function can go away
+    // We could call onChangeSelectedSubzones with a one liner array creation from the map
+    const selectedSubzoneIds: number[] = [];
+    nextSelectedSubzones.forEach((value: boolean, subzoneId: number) => {
+      if (value) {
+        selectedSubzoneIds.push(subzoneId);
+      }
+    });
+    onChangeSelectedSubzones(selectedSubzoneIds);
+  };
+
+  const onChangeSubzoneCheckbox = (subzoneId: number, value: boolean) => {
+    // Consider using es2015 or above so we can spread iterators and interact with Map a bit better
+    const nextSelectedSubzones = new Map(selectedSubzones).set(subzoneId, value);
+    handleOnChangeSelectedSubzones(nextSelectedSubzones);
+  };
+
+  const onChangeZoneCheckbox = (zone: PlantingZone, value: boolean) => {
+    const nextSelectedSubzones = new Map(selectedSubzones);
+    zone.plantingSubzones.forEach((subzone) => {
+      nextSelectedSubzones.set(subzone.id, value);
+    });
+
+    handleOnChangeSelectedSubzones(nextSelectedSubzones);
+  };
+
+  const isZoneFullySelected = (zone: PlantingZone) =>
+    zone.plantingSubzones.every((subzone) => selectedSubzones.get(subzone.id));
+
+  const isZonePartiallySelected = (zone: PlantingZone) =>
+    !isZoneFullySelected(zone) && zone.plantingSubzones.some((subzone) => selectedSubzones.get(subzone.id));
+
+  return (
+    <Grid container spacing={3}>
+      {plantingSite.plantingZones?.map((zone, index) => (
+        <Grid item xs={12} key={index}>
+          <Checkbox
+            id={`observation-zone-${zone.id}`}
+            indeterminate={isZonePartiallySelected(zone)}
+            label={zone.name}
+            name='Limit Observation to Zone'
+            onChange={(value) => onChangeZoneCheckbox(zone, value)}
+            value={isZoneFullySelected(zone)}
+          />
+
+          <Box sx={{ columnCount: 2, columnGap: theme.spacing(3), paddingLeft: `${theme.spacing(4)}` }}>
+            {zone.plantingSubzones.map((subzone, _index) => (
+              <Box sx={{ display: 'inline-block' }} key={_index}>
+                <Checkbox
+                  id={`observation-subzone-${zone.id}`}
+                  label={subzone.name}
+                  name='Limit Observation to Subzone'
+                  onChange={(value) => onChangeSubzoneCheckbox(subzone.id, value)}
+                  value={selectedSubzones.get(subzone.id)}
+                />
+              </Box>
+            ))}
+          </Box>
+        </Grid>
+      ))}
+    </Grid>
+  );
+};
+
+export default ObservationSubzoneSelector;

--- a/src/scenes/ObservationsRouter/schedule/ScheduleObservation.tsx
+++ b/src/scenes/ObservationsRouter/schedule/ScheduleObservation.tsx
@@ -19,12 +19,14 @@ export default function ScheduleObservation(): JSX.Element {
   const snackbar = useSnackbar();
   const dispatch = useAppDispatch();
   const { selectedOrganization } = useOrganization();
+
   const [validate, setValidate] = useState(false);
   const [plantingSiteId, setPlantingSiteId] = useState<number>();
   const [startDate, setStartDate] = useState<string>();
   const [endDate, setEndDate] = useState<string>();
   const [hasErrors, setHasErrors] = useState<boolean>(false);
   const [requestId, setRequestId] = useState<string>('');
+  const [selectedSubzones, setSelectedSubzones] = useState<number[]>([]);
 
   const plantingSites = useAppSelector(selectObservationSchedulableSites) ?? [];
   const result = useAppSelector((state) => selectScheduleObservation(state, requestId));
@@ -32,7 +34,9 @@ export default function ScheduleObservation(): JSX.Element {
   const scheduleObservation = async () => {
     setValidate(true);
     if (!hasErrors && plantingSiteId && startDate && endDate) {
-      const dispatched = dispatch(requestScheduleObservation({ plantingSiteId, startDate, endDate }));
+      const dispatched = dispatch(
+        requestScheduleObservation({ endDate, plantingSiteId, requestedSubzoneIds: selectedSubzones, startDate })
+      );
       setRequestId(dispatched.requestId);
     }
     return Promise.resolve(true);
@@ -60,21 +64,22 @@ export default function ScheduleObservation(): JSX.Element {
 
   return (
     <ScheduleObservationForm
-      title={strings.SCHEDULE_OBSERVATION}
-      plantingSites={plantingSites}
-      plantingSiteId={plantingSiteId}
-      onPlantingSiteId={(id) => setPlantingSiteId(id)}
-      startDate={startDate}
-      onStartDate={(date) => setStartDate(date)}
-      endDate={endDate}
-      onEndDate={(date) => setEndDate(date)}
-      validate={validate}
-      onErrors={onErrors}
       cancelID='cancelScheduleObservation'
-      saveID='scheduleObservation'
+      endDate={endDate}
+      title={strings.SCHEDULE_OBSERVATION}
+      plantingSiteId={plantingSiteId}
+      plantingSites={plantingSites}
       onCancel={() => goToObservations()}
+      onChangeSelectedSubzones={setSelectedSubzones}
+      onEndDate={(date) => setEndDate(date)}
+      onErrors={onErrors}
+      onPlantingSiteId={(id) => setPlantingSiteId(id)}
       onSave={scheduleObservation}
+      onStartDate={(date) => setStartDate(date)}
+      saveID='scheduleObservation'
+      startDate={startDate}
       status={result?.status}
+      validate={validate}
     />
   );
 }

--- a/src/scenes/ObservationsRouter/schedule/ScheduleObservationForm.tsx
+++ b/src/scenes/ObservationsRouter/schedule/ScheduleObservationForm.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 
-import { Box, Grid, Typography, useTheme } from '@mui/material';
-import { BusySpinner, Dropdown } from '@terraware/web-components';
+import { Box, Divider, Grid, Typography, useTheme } from '@mui/material';
+import { BusySpinner, Checkbox, Dropdown } from '@terraware/web-components';
 import { DateTime } from 'luxon';
 
 import PageSnackbar from 'src/components/PageSnackbar';
@@ -14,45 +14,51 @@ import strings from 'src/strings';
 import { PlantingSite } from 'src/types/Tracking';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 
+import ObservationSubzoneSelector from './ObservationSubzoneSelector';
+
 export type ScheduleObservationFormProps = {
-  title: string;
-  plantingSites: PlantingSite[];
-  onPlantingSiteId: (siteId: number) => void;
-  onStartDate: (value: string) => void;
-  onEndDate: (value: string) => void;
-  plantingSiteId?: number;
-  startDate?: string;
-  endDate?: string;
-  validate?: boolean;
-  onErrors: (hasErrors: boolean) => void;
-  status?: Statuses;
-  onCancel: () => void;
-  onSave: () => void;
-  saveID: string;
   cancelID: string;
+  endDate?: string;
+  title: string;
+  onCancel: () => void;
+  onChangeSelectedSubzones?: (requestedSubzoneIds: number[]) => void;
+  onEndDate: (value: string) => void;
+  onErrors: (hasErrors: boolean) => void;
+  onPlantingSiteId: (siteId: number) => void;
+  onSave: () => void;
+  onStartDate: (value: string) => void;
+  plantingSiteId?: number;
+  plantingSites: PlantingSite[];
+  saveID: string;
+  startDate?: string;
+  status?: Statuses;
+  validate?: boolean;
 };
 
 export default function ScheduleObservationForm({
-  title,
-  plantingSites,
-  onPlantingSiteId,
-  onStartDate,
-  onEndDate,
-  plantingSiteId,
-  startDate,
-  endDate,
-  validate,
-  onErrors,
-  status,
-  onCancel,
-  onSave,
-  saveID,
   cancelID,
+  endDate,
+  title,
+  plantingSiteId,
+  plantingSites,
+  onCancel,
+  onChangeSelectedSubzones,
+  onEndDate,
+  onErrors,
+  onPlantingSiteId,
+  onSave,
+  onStartDate,
+  saveID,
+  startDate,
+  status,
+  validate,
 }: ScheduleObservationFormProps): JSX.Element {
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
+
   const [startDateError, setStartDateError] = useState<string>();
   const [endDateError, setEndDateError] = useState<string>();
+  const [limitObservation, setLimitObservation] = useState(false);
 
   const gridSize = () => {
     if (isMobile) {
@@ -99,6 +105,11 @@ export default function ScheduleObservationForm({
     [plantingSites]
   );
 
+  const selectedPlantingSite = useMemo(
+    () => plantingSites.find((plantingSite) => plantingSite.id === plantingSiteId),
+    [plantingSites, plantingSiteId]
+  );
+
   return (
     <TfMain>
       {status === 'pending' && <BusySpinner withSkrim={true} />}
@@ -109,6 +120,7 @@ export default function ScheduleObservationForm({
           </Typography>
           <PageSnackbar />
         </Box>
+
         <Card style={{ maxWidth: '568px', margin: 'auto' }}>
           <Grid container spacing={3}>
             <Grid item xs={12}>
@@ -122,6 +134,30 @@ export default function ScheduleObservationForm({
                 fullWidth
               />
             </Grid>
+
+            <Grid item xs={12}>
+              <Checkbox
+                id='limitObservation'
+                name='Limit Observation'
+                label={strings.LIMIT_OBSERVATION_LABEL}
+                value={limitObservation}
+                onChange={(value) => setLimitObservation(value)}
+              />
+            </Grid>
+
+            {limitObservation && selectedPlantingSite && onChangeSelectedSubzones && (
+              <Grid item xs={12}>
+                <ObservationSubzoneSelector
+                  onChangeSelectedSubzones={onChangeSelectedSubzones}
+                  plantingSite={selectedPlantingSite}
+                />
+              </Grid>
+            )}
+
+            <Grid item xs={12}>
+              <Divider />
+            </Grid>
+
             <Grid item xs={gridSize()}>
               <DatePicker
                 id='startDate'
@@ -136,6 +172,7 @@ export default function ScheduleObservationForm({
                 errorText={validate ? startDateError : ''}
               />
             </Grid>
+
             <Grid item xs={gridSize()}>
               <DatePicker
                 id='endDate'
@@ -150,6 +187,7 @@ export default function ScheduleObservationForm({
                 errorText={validate ? endDateError : ''}
               />
             </Grid>
+
             <Typography
               fontSize='14px'
               fontWeight={400}

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -734,6 +734,7 @@ LIGHT,Light,
 LIKELY_INTERMEDIATE,Likely Intermediate,Option to indicate that a species' seed storage behavior has not been scientifically confirmed but is believed to be Intermediate.
 LIKELY_ORTHODOX,Likely Orthodox,Option to indicate that a species' seed storage behavior has not been scientifically confirmed but is believed to be Orthodox.
 LIKELY_RECALCITRANT,Likely Recalcitrant,Option to indicate that a species' seed storage behavior has not been scientifically confirmed but is believed to be Recalcitrant.
+LIMIT_OBSERVATION_LABEL,Limit observation to selected subzones,
 LINK,Link,
 LIST,List,
 LIVE,Live,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3980,10 +3980,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^3.1.2-rc.1":
-  version "3.1.2-rc.1"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.1.2-rc.1.tgz#1077ea14b8f3fd7332260edbb90a866b85f90207"
-  integrity sha512-s6pSDaaA8U+KHgPSLrW3CILoTO0cAh+NAvUoc377OcD3ysTC9b5mgAC9VEanMFyqWs/F/XIfn9+aScMvwAFDyA==
+"@terraware/web-components@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.2.0.tgz#a0846c97fa92dfbf17dfbcdf2f062a0f9c2e26ba"
+  integrity sha512-cr1z2NhqV1KiX9JB+Eb/vp5OVyMeKZ/W/TmMpctHWAmtm2N6zVALyXiIKQW3ZUrfIFOP4oNPcDX3JRINxg2BgQ==
   dependencies:
     "@date-io/luxon" "^3.0.0"
     "@dnd-kit/core" "^6.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3980,10 +3980,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^3.1.2-rc.0":
-  version "3.1.2-rc.0"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.1.2-rc.0.tgz#95f65baaa855f5fec637652dc7c7d8edce5b68d8"
-  integrity sha512-d6q+uZPxsyRe0rowkkJTOG+Ho1ucMnm6qSRbg6Cit9yGulgKoZQQxFtpkuziv01/LGIXL9X/tDrw7jjV0NIL5Q==
+"@terraware/web-components@^3.1.2-rc.1":
+  version "3.1.2-rc.1"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.1.2-rc.1.tgz#1077ea14b8f3fd7332260edbb90a866b85f90207"
+  integrity sha512-s6pSDaaA8U+KHgPSLrW3CILoTO0cAh+NAvUoc377OcD3ysTC9b5mgAC9VEanMFyqWs/F/XIfn9+aScMvwAFDyA==
   dependencies:
     "@date-io/luxon" "^3.0.0"
     "@dnd-kit/core" "^6.0.7"


### PR DESCRIPTION
- Implement new version of web-components with indeterminate checkbox
- Create `ScheduleObservationForm` with zone and subzone rendering and selection

Subsequent PRs:
- Auto check for subzones that have plants
- No plants icon

Depends on https://github.com/terraware/web-components/pull/628

![2024-08-09 13.12.10.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/085e4af0-3e2d-4c62-9b8e-ad8d0caba7eb.gif)

