### PR TITLE
SW-5761 Automatically check boxes for subzones that have plants

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -3483,6 +3483,8 @@ export interface components {
       /** Format: int64 */
       plantingSiteId: number;
       plantingSiteName: string;
+      /** @description If specific subzones were requested for this observation, their IDs. */
+      requestedSubzoneIds?: number[];
       /**
        * Format: date
        * @description Date this observation started.
@@ -3813,6 +3815,12 @@ export interface components {
        */
       plantingCompletedTime?: string;
     };
+    PlantingSubzoneReportedPlantsPayload: {
+      /** Format: int64 */
+      id: number;
+      /** Format: int32 */
+      totalPlants: number;
+    };
     PlantingSubzoneSpeciesPayload: {
       commonName?: string;
       /** Format: int64 */
@@ -3832,6 +3840,7 @@ export interface components {
     PlantingZoneReportedPlantsPayload: {
       /** Format: int64 */
       id: number;
+      plantingSubzones: components["schemas"]["PlantingSubzoneReportedPlantsPayload"][];
       /** Format: int32 */
       plantsSinceLastObservation: number;
       /** Format: int32 */
@@ -4130,7 +4139,7 @@ export interface components {
     ScheduleObservationRequestPayload: {
       /**
        * Format: date
-       * @description The end date for this observation, should be limited to 2 months from the start date .
+       * @description The end date for this observation, should be limited to 2 months from the start date.
        */
       endDate: string;
       /**

--- a/src/scenes/ObservationsRouter/schedule/ObservationSubzoneSelector.tsx
+++ b/src/scenes/ObservationsRouter/schedule/ObservationSubzoneSelector.tsx
@@ -1,13 +1,14 @@
 import React, { useEffect, useState } from 'react';
 
 import { Box, Grid, useTheme } from '@mui/material';
-import { Checkbox } from '@terraware/web-components';
+import { Checkbox, Icon } from '@terraware/web-components';
 
-import { PlantingSite, PlantingZone } from 'src/types/Tracking';
+import strings from 'src/strings';
+import { PlantingSiteWithReportedPlants, PlantingZone } from 'src/types/Tracking';
 
 interface ObservationSubzoneSelectorProps {
   onChangeSelectedSubzones: (requestedSubzoneIds: number[]) => void;
-  plantingSite: PlantingSite;
+  plantingSite: PlantingSiteWithReportedPlants;
 }
 
 const ObservationSubzoneSelector = ({ onChangeSelectedSubzones, plantingSite }: ObservationSubzoneSelectorProps) => {
@@ -16,11 +17,12 @@ const ObservationSubzoneSelector = ({ onChangeSelectedSubzones, plantingSite }: 
   const [selectedSubzones, setSelectedSubzones] = useState(new Map<number, boolean>());
 
   useEffect(() => {
-    // TODO determine which subzones have plants
-    // Initialize all subzone selections with subzoneId -> false
+    // Initialize all subzone selections with subzoneId -> false unless they have totalPlants > 0
     setSelectedSubzones(
       new Map(
-        plantingSite.plantingZones?.flatMap((zone) => zone.plantingSubzones.map((subzone) => [subzone.id, false]))
+        plantingSite.plantingZones?.flatMap((zone) =>
+          zone.plantingSubzones.map((subzone) => [subzone.id, (subzone.totalPlants || 0) > 0])
+        )
       )
     );
   }, [plantingSite]);
@@ -78,7 +80,16 @@ const ObservationSubzoneSelector = ({ onChangeSelectedSubzones, plantingSite }: 
               <Box sx={{ display: 'inline-block' }} key={_index}>
                 <Checkbox
                   id={`observation-subzone-${zone.id}`}
-                  label={subzone.name}
+                  label={
+                    subzone.totalPlants ? (
+                      subzone.name
+                    ) : (
+                      <Box>
+                        <Icon name='warning' style={{ margin: '4px 4px 4px 0', verticalAlign: 'bottom' }} />
+                        {subzone.name}
+                      </Box>
+                    )
+                  }
                   name='Limit Observation to Subzone'
                   onChange={(value) => onChangeSubzoneCheckbox(subzone.id, value)}
                   value={selectedSubzones.get(subzone.id)}
@@ -88,6 +99,11 @@ const ObservationSubzoneSelector = ({ onChangeSelectedSubzones, plantingSite }: 
           </Box>
         </Grid>
       ))}
+      <Grid item xs={12}>
+        <Box>
+          <Icon name='warning' style={{ margin: '4px 0', verticalAlign: 'bottom' }} />: {strings.NO_PLANTS}
+        </Box>
+      </Grid>
     </Grid>
   );
 };

--- a/src/scenes/ObservationsRouter/schedule/ScheduleObservationForm.tsx
+++ b/src/scenes/ObservationsRouter/schedule/ScheduleObservationForm.tsx
@@ -11,7 +11,7 @@ import PageForm from 'src/components/common/PageForm';
 import TfMain from 'src/components/common/TfMain';
 import { Statuses } from 'src/redux/features/asyncUtils';
 import strings from 'src/strings';
-import { PlantingSite } from 'src/types/Tracking';
+import { PlantingSite, PlantingSiteWithReportedPlants } from 'src/types/Tracking';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 
 import ObservationSubzoneSelector from './ObservationSubzoneSelector';
@@ -30,6 +30,7 @@ export type ScheduleObservationFormProps = {
   plantingSiteId?: number;
   plantingSites: PlantingSite[];
   saveID: string;
+  selectedPlantingSite?: PlantingSiteWithReportedPlants;
   startDate?: string;
   status?: Statuses;
   validate?: boolean;
@@ -49,6 +50,7 @@ export default function ScheduleObservationForm({
   onSave,
   onStartDate,
   saveID,
+  selectedPlantingSite,
   startDate,
   status,
   validate,
@@ -103,11 +105,6 @@ export default function ScheduleObservationForm({
         value: site.id.toString(),
       })),
     [plantingSites]
-  );
-
-  const selectedPlantingSite = useMemo(
-    () => plantingSites.find((plantingSite) => plantingSite.id === plantingSiteId),
-    [plantingSites, plantingSiteId]
   );
 
   return (

--- a/src/types/Tracking.ts
+++ b/src/types/Tracking.ts
@@ -32,6 +32,20 @@ export type Planting = components['schemas']['PlantingPayload'];
 
 // reported plants
 export type PlantingSiteReportedPlants = components['schemas']['PlantingSiteReportedPlantsPayload'];
+export type PlantingSiteReportedZonePlants = components['schemas']['PlantingZoneReportedPlantsPayload'];
+export type PlantingSiteReportedSubzonePlants = components['schemas']['PlantingSubzoneReportedPlantsPayload'];
+
+// Planting site with select data from reports merged in
+export type PlantingSiteWithReportedPlants = Omit<PlantingSite, 'plantingZones'> & {
+  plantingZones: PlantingSiteZoneWithReportedPlants[];
+};
+export type PlantingSiteZoneWithReportedPlants = Omit<PlantingZone, 'plantingSubzones'> & {
+  plantingSubzones: PlantingSiteSubzoneWithReportedPlants[];
+};
+export type PlantingSiteSubzoneWithReportedPlants = PlantingSubzone &
+  Omit<PlantingSiteReportedSubzonePlants, 'totalPlants'> & {
+    totalPlants?: number;
+  };
 
 // monitoring plots
 export type MonitoringPlotSearchResult = {


### PR DESCRIPTION
- Create new selector that merges the plant reporting data into the planting sites used in the schedule observation form
- Auto select subzones that have plants
- Render warning icon for subzones that have no plants

**The warning icon will change when we get a new one added to zeroheight**

![SCR-20240809-mwhk.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/a6a3953e-e84c-4754-8ef0-27ada77521a2.png)

