### PR TITLE
SW-5829: Visual bugs for Prescreen module details page & rejected page

### DIFF
--- a/src/scenes/ApplicationRouter/portal/ApplicationPage.tsx
+++ b/src/scenes/ApplicationRouter/portal/ApplicationPage.tsx
@@ -13,9 +13,10 @@ type Props = {
   crumbs?: Crumb[];
   hierarchicalCrumbs?: boolean;
   rightComponent?: ReactNode;
+  showFeedback?: boolean;
 };
 
-const ApplicationPage = ({ children, crumbs, hierarchicalCrumbs, rightComponent }: Props) => {
+const ApplicationPage = ({ children, crumbs, hierarchicalCrumbs, rightComponent, showFeedback = true }: Props) => {
   const { allApplications, selectedApplication, setSelectedApplication } = useApplicationData();
 
   const pathParams = useParams<{ applicationId: string }>();
@@ -36,7 +37,7 @@ const ApplicationPage = ({ children, crumbs, hierarchicalCrumbs, rightComponent 
       title={strings.formatString(strings.APPLICATION_FOR_PROJECT, selectedApplication?.projectName ?? '')}
       titleStyle={{ marginTop: '24px' }}
     >
-      {selectedApplication?.status === 'Failed Pre-screen' && (
+      {showFeedback && selectedApplication?.status === 'Failed Pre-screen' && (
         <FeedbackMessage feedback={selectedApplication.feedback} />
       )}
       {children}

--- a/src/scenes/ApplicationRouter/portal/Prescreen/FeedbackMessage.tsx
+++ b/src/scenes/ApplicationRouter/portal/Prescreen/FeedbackMessage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { Message } from '@terraware/web-components';
 
 import strings from 'src/strings';
@@ -11,21 +11,23 @@ type FeedbackMessageProps = {
 
 const FeedbackMessage = ({ feedback }: FeedbackMessageProps) => {
   return (
-    <Message
-      type='page'
-      priority='critical'
-      title={strings.PRESCREEN_FAILED}
-      body={
-        <>
-          <Typography sx={{ margin: 0 }}>{strings.APPLICATION_PRESCREEN_FAILURE_SUBTITLE}</Typography>
-          {feedback && (
-            <Typography sx={{ margin: 0 }} whiteSpace={'pre-line'}>
-              {feedback}
-            </Typography>
-          )}
-        </>
-      }
-    />
+    <Box sx={{ marginBottom: '24px', width: '100%' }}>
+      <Message
+        type='page'
+        priority='critical'
+        title={strings.PRESCREEN_FAILED}
+        body={
+          <>
+            <Typography sx={{ margin: 0 }}>{strings.APPLICATION_PRESCREEN_FAILURE_SUBTITLE}</Typography>
+            {feedback && (
+              <Typography sx={{ margin: 0 }} whiteSpace={'pre-line'}>
+                {feedback}
+              </Typography>
+            )}
+          </>
+        }
+      />
+    </Box>
   );
 };
 

--- a/src/scenes/ApplicationRouter/portal/PrescreenResult/index.tsx
+++ b/src/scenes/ApplicationRouter/portal/PrescreenResult/index.tsx
@@ -155,7 +155,7 @@ const PrescreenResultViewWrapper = () => {
   );
 
   return (
-    <ApplicationPage crumbs={crumbs}>
+    <ApplicationPage crumbs={crumbs} showFeedback={false}>
       <PrescreenResultView
         feedback={selectedApplication?.feedback}
         isFailure={!!selectedApplication && selectedApplication.status === 'Failed Pre-screen'}

--- a/src/scenes/ApplicationRouter/portal/PrescreenResult/index.tsx
+++ b/src/scenes/ApplicationRouter/portal/PrescreenResult/index.tsx
@@ -130,7 +130,7 @@ const PrescreenResultView = ({ isFailure, feedback }: ResultViewProp) => {
           onClick={() => goToApplicationPrescreen(selectedApplication.id)}
           style={{ display: 'block', textAlign: 'center' }}
         >
-          {`${strings.VIEW} ${strings.VIEW_PRESCREEN_SUBMISSION}`}
+          {strings.VIEW_PRESCREEN_SUBMISSION}
         </Link>
       </Card>
     </>


### PR DESCRIPTION
This PR includes several fixes for visual issues:

- Increase vertical spacing between rejected message and content card
- Remove redundant "View" from "View View Pre-screen Submission" copy
- Don't show redundant feedback message on pre-screen result page