### PR TITLE
Fix a bug with the columns in the subzone selector

### DIFF
--- a/src/scenes/ObservationsRouter/schedule/ObservationSubzoneSelector.tsx
+++ b/src/scenes/ObservationsRouter/schedule/ObservationSubzoneSelector.tsx
@@ -77,7 +77,7 @@ const ObservationSubzoneSelector = ({ onChangeSelectedSubzones, plantingSite }: 
 
           <Box sx={{ columnCount: 2, columnGap: theme.spacing(3), paddingLeft: `${theme.spacing(4)}` }}>
             {zone.plantingSubzones.map((subzone, _index) => (
-              <Box sx={{ display: 'inline-block' }} key={_index}>
+              <Box sx={{ display: 'inline-block', width: '100%' }} key={_index}>
                 <Checkbox
                   id={`observation-subzone-${zone.id}`}
                   label={


### PR DESCRIPTION
For some reason `column-count: 2` breaks if there are a lot of items in the underlying table. This forces each item to take up 100% of the column, which forces the next item to the next row.

Before

![SCR-20240812-lluq.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/af5b0877-a90f-44c0-a878-a53482b9c33d.png)

After

![SCR-20240812-llst.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/bcd61d80-0547-410a-8915-854d66f7efa7.png)

