### PR TITLE
Hide the observation subzone selector for observation rescheduling

### DIFF
--- a/src/scenes/ObservationsRouter/schedule/ObservationSubzoneSelector.tsx
+++ b/src/scenes/ObservationsRouter/schedule/ObservationSubzoneSelector.tsx
@@ -18,13 +18,12 @@ const ObservationSubzoneSelector = ({ onChangeSelectedSubzones, plantingSite }: 
 
   useEffect(() => {
     // Initialize all subzone selections with subzoneId -> false unless they have totalPlants > 0
-    setSelectedSubzones(
-      new Map(
-        plantingSite.plantingZones?.flatMap((zone) =>
-          zone.plantingSubzones.map((subzone) => [subzone.id, (subzone.totalPlants || 0) > 0])
-        )
+    const initialSelectedSubzones = new Map(
+      plantingSite.plantingZones?.flatMap((zone) =>
+        zone.plantingSubzones.map((subzone) => [subzone.id, (subzone.totalPlants || 0) > 0])
       )
     );
+    handleOnChangeSelectedSubzones(initialSelectedSubzones);
   }, [plantingSite]);
 
   const handleOnChangeSelectedSubzones = (nextSelectedSubzones: Map<number, boolean>) => {

--- a/src/scenes/ObservationsRouter/schedule/ScheduleObservationForm.tsx
+++ b/src/scenes/ObservationsRouter/schedule/ScheduleObservationForm.tsx
@@ -132,23 +132,27 @@ export default function ScheduleObservationForm({
               />
             </Grid>
 
-            <Grid item xs={12}>
-              <Checkbox
-                id='limitObservation'
-                name='Limit Observation'
-                label={strings.LIMIT_OBSERVATION_LABEL}
-                value={limitObservation}
-                onChange={(value) => setLimitObservation(value)}
-              />
-            </Grid>
+            {onChangeSelectedSubzones && (
+              <>
+                <Grid item xs={12}>
+                  <Checkbox
+                    id='limitObservation'
+                    name='Limit Observation'
+                    label={strings.LIMIT_OBSERVATION_LABEL}
+                    value={limitObservation}
+                    onChange={(value) => setLimitObservation(value)}
+                  />
+                </Grid>
 
-            {limitObservation && selectedPlantingSite && onChangeSelectedSubzones && (
-              <Grid item xs={12}>
-                <ObservationSubzoneSelector
-                  onChangeSelectedSubzones={onChangeSelectedSubzones}
-                  plantingSite={selectedPlantingSite}
-                />
-              </Grid>
+                {limitObservation && selectedPlantingSite && (
+                  <Grid item xs={12}>
+                    <ObservationSubzoneSelector
+                      onChangeSelectedSubzones={onChangeSelectedSubzones}
+                      plantingSite={selectedPlantingSite}
+                    />
+                  </Grid>
+                )}
+              </>
             )}
 
             <Grid item xs={12}>


### PR DESCRIPTION
- The reschedule payload doesn't allow for requested subzones, so it must be hidden
- Also auto apply the initially selected subzones in the parent container