### PR TITLE
SW-5834: Application in Console: Application Status field value should be able to be changed for failed pre-screens

### DIFF
--- a/src/scenes/AcceleratorRouter/Applications/ApplicationReview.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationReview.tsx
@@ -103,10 +103,9 @@ const ApplicationReview = ({ application }: ApplicationReviewProps) => {
             {application.status}
           </Typography>
           <Button
-            disabled={
-              (application.status === 'Failed Pre-screen' || application.status === 'Not Submitted') &&
-              !canUpdateInternalComments
-            }
+            // if a user lacks permission to update internal comments,
+            // they also lack permission to review the application or leave feedback
+            disabled={!canUpdateInternalComments}
             label={strings.REVIEW_APPLICATION}
             onClick={() => {
               setIsReviewModalOpen(true);

--- a/src/scenes/AcceleratorRouter/Applications/ApplicationReviewModal.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationReviewModal.tsx
@@ -6,6 +6,7 @@ import { Dropdown, DropdownItem } from '@terraware/web-components';
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import TextField from 'src/components/common/Textfield/Textfield';
 import Button from 'src/components/common/button/Button';
+import { useUser } from 'src/providers';
 import { requestReviewApplication } from 'src/redux/features/application/applicationAsyncThunks';
 import { selectApplicationReview } from 'src/redux/features/application/applicationSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
@@ -33,6 +34,7 @@ const ApplicationReviewModal = ({
   application,
 }: ApplicationReviewModalProps): JSX.Element => {
   const theme = useTheme();
+  const { isAllowed } = useUser();
 
   const dispatch = useAppDispatch();
 
@@ -63,9 +65,10 @@ const ApplicationReviewModal = ({
 
   const canUpdateStatus = useMemo(
     () =>
+      isAllowed('UPDATE_APPLICATION_STATUS') &&
       ApplicationReviewStatuses.find((status) => status === application.status) !== undefined &&
-      !(application.status === 'Failed Pre-screen' || application.status === 'Not Submitted'),
-    [application.status]
+      application.status !== 'Not Submitted',
+    [application.status, isAllowed]
   );
 
   const onCloseWrapper = useCallback(() => {

--- a/src/utils/acl.ts
+++ b/src/utils/acl.ts
@@ -21,7 +21,10 @@ import { isManagerOrHigher, isMember } from './organization';
 /**
  * We split the permissions up loosely by the entity that the user is being authorized to interact with or view
  */
-type PermissionApplication = 'READ_ALL_APPLICATIONS' | 'UPDATE_APPLICATION_INTERNAL_COMMENTS';
+type PermissionApplication =
+  | 'READ_ALL_APPLICATIONS'
+  | 'UPDATE_APPLICATION_INTERNAL_COMMENTS'
+  | 'UPDATE_APPLICATION_STATUS';
 type PermissionCohort = 'CREATE_COHORTS' | 'READ_COHORTS' | 'UPDATE_COHORTS' | 'DELETE_COHORTS';
 type PermissionConsole = 'VIEW_CONSOLE';
 type PermissionDeliverable =
@@ -149,6 +152,7 @@ const ACL: Record<GlobalRolePermission, UserGlobalRoles | PermissionCheckFn> = {
   READ_PARTICIPANT_PROJECT: ReadOnlyPlus,
   READ_SUBMISSION_DOCUMENT: ReadOnlyPlus,
   UPDATE_APPLICATION_INTERNAL_COMMENTS: AcceleratorAdminPlus,
+  UPDATE_APPLICATION_STATUS: TFExpertPlus,
   UPDATE_COHORTS: AcceleratorAdminPlus,
   UPDATE_PARTICIPANTS: TFExpertPlus,
   UPDATE_PARTICIPANT_PROJECT_SCORING_VOTING: TFExpertPlus,


### PR DESCRIPTION
This PR includes some adjustments to the user permission checks before allowing a user to update application status, feedback, and/or internal comments.