### PR TITLE
SW-5807 Add NewApplicationModal to home page and open when the new application card CTA is clicked on

### DIFF
--- a/src/components/common/PageCard.tsx
+++ b/src/components/common/PageCard.tsx
@@ -14,37 +14,45 @@ import { IconName } from './icon/icons';
 export type LinkStyle = 'plain' | 'button-primary' | 'button-secondary';
 
 export interface PageCardProps {
-  name: string;
-  isNameBold?: boolean;
-  icon: IconName;
   description: string;
-  linkText: string;
+  icon: IconName;
+  id?: string;
+  isNameBold?: boolean;
   link: string;
   linkStyle: LinkStyle;
-  id?: string;
+  linkText: string;
+  name: string;
+  onClick?: () => void;
 }
 
+const stopBubblingEvent = (event?: React.MouseEvent) => {
+  if (event) {
+    stopPropagation(event);
+  }
+};
+
 export default function PageCard(props: PageCardProps): JSX.Element {
-  const { name, icon, description, id, linkText, link, linkStyle } = props;
+  const { name, icon, description, id, linkText, link, linkStyle, onClick } = props;
   const theme = useTheme();
   const navigate = useNavigate();
   const { isMobile } = useDeviceInfo();
 
-  const stopBubblingEvent = (event?: React.MouseEvent) => {
-    if (event) {
-      stopPropagation(event);
-    }
+  const goToPage = () => {
+    navigate({ pathname: link });
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const goToPage = (event?: React.MouseEvent) => {
-    navigate({ pathname: link });
+  const handleOnClick = () => {
+    if (onClick) {
+      onClick();
+    } else {
+      goToPage();
+    }
   };
 
   return (
     <Box
       className={isMobile ? '' : 'min-height'}
-      onClick={goToPage}
+      onClick={handleOnClick}
       id={id ?? ''}
       sx={{
         background: theme.palette.TwClrBg,
@@ -107,7 +115,7 @@ export default function PageCard(props: PageCardProps): JSX.Element {
         <Button
           priority={linkStyle === 'button-primary' ? 'primary' : 'secondary'}
           label={linkText}
-          onClick={() => goToPage()}
+          onClick={handleOnClick}
           style={{
             fontSize: '14px',
             lineHeight: '20px',

--- a/src/scenes/ApplicationRouter/ApplicationsList.tsx
+++ b/src/scenes/ApplicationRouter/ApplicationsList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 
 import { Box, Container, Grid } from '@mui/material';
 import { useDeviceInfo } from '@terraware/web-components/utils';
@@ -7,21 +7,15 @@ import { DateTime } from 'luxon';
 import ApplicationCard from 'src/components/Application/ApplicationCard';
 import PageHeader from 'src/components/PageHeader';
 import Button from 'src/components/common/button/Button';
-import useNavigateTo from 'src/hooks/useNavigateTo';
-import { useLocalization } from 'src/providers';
 import strings from 'src/strings';
-import useSnackbar from 'src/utils/useSnackbar';
 
 import { useApplicationData } from '../../providers/Application/Context';
 import NewApplicationModal from './NewApplicationModal';
 
 const ApplicationListView = () => {
-  const { activeLocale } = useLocalization();
   const { isTablet, isMobile } = useDeviceInfo();
-  const { toastSuccess } = useSnackbar();
   const { allApplications } = useApplicationData();
   const [isNewApplicationModalOpen, setIsNewApplicationModalOpen] = useState<boolean>(false);
-  const { goToApplication } = useNavigateTo();
 
   const primaryGridSize = () => {
     if (isMobile) {
@@ -40,16 +34,6 @@ const ApplicationListView = () => {
     return 6;
   };
 
-  const onApplicationCreated = useCallback(
-    (applicationId: number) => {
-      if (activeLocale) {
-        toastSuccess(strings.SUCCESS);
-      }
-      goToApplication(applicationId);
-    },
-    [activeLocale, goToApplication, toastSuccess]
-  );
-
   return (
     <Box
       component='main'
@@ -67,11 +51,7 @@ const ApplicationListView = () => {
           }
         />
         <Container maxWidth={false} sx={{ padding: 0 }}>
-          <NewApplicationModal
-            open={isNewApplicationModalOpen}
-            onClose={() => setIsNewApplicationModalOpen(false)}
-            onApplicationCreated={onApplicationCreated}
-          />
+          <NewApplicationModal open={isNewApplicationModalOpen} onClose={() => setIsNewApplicationModalOpen(false)} />
           <Grid container spacing={3} sx={{ padding: 0 }}>
             {allApplications?.map((application) => (
               <Grid

--- a/src/scenes/ApplicationRouter/NewApplicationModal.tsx
+++ b/src/scenes/ApplicationRouter/NewApplicationModal.tsx
@@ -6,6 +6,7 @@ import { BusySpinner, Dropdown } from '@terraware/web-components';
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import TextField from 'src/components/common/Textfield/Textfield';
 import Button from 'src/components/common/button/Button';
+import useNavigateTo from 'src/hooks/useNavigateTo';
 import { useProjects } from 'src/hooks/useProjects';
 import { useLocalization, useOrganization } from 'src/providers';
 import {
@@ -19,6 +20,7 @@ import {
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 import useForm from 'src/utils/useForm';
+import useSnackbar from 'src/utils/useSnackbar';
 
 import { useApplicationData } from '../../providers/Application/Context';
 
@@ -31,17 +33,17 @@ type NewApplication = {
 export type NewApplicationModalProps = {
   open: boolean;
   onClose: () => void;
-  onApplicationCreated: (applicationId: number) => void;
 };
 
-const NewApplicationModal = ({ open, onClose, onApplicationCreated }: NewApplicationModalProps): JSX.Element => {
+const NewApplicationModal = ({ open, onClose }: NewApplicationModalProps): JSX.Element => {
   const theme = useTheme();
-
   const { activeLocale } = useLocalization();
   const { availableProjects } = useProjects();
   const { selectedOrganization } = useOrganization();
   const { allApplications } = useApplicationData();
   const dispatch = useAppDispatch();
+  const { toastSuccess } = useSnackbar();
+  const { goToApplication } = useNavigateTo();
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
@@ -144,6 +146,16 @@ const NewApplicationModal = ({ open, onClose, onApplicationCreated }: NewApplica
     setCreateProjectApplicationRequestId,
     setIsLoading,
   ]);
+
+  const onApplicationCreated = useCallback(
+    (applicationId: number) => {
+      if (activeLocale) {
+        toastSuccess(strings.SUCCESS);
+      }
+      goToApplication(applicationId);
+    },
+    [activeLocale, goToApplication, toastSuccess]
+  );
 
   useEffect(() => {
     if (createApplicationResult && createApplicationResult.status === 'success' && createApplicationResult.data) {

--- a/src/scenes/Home/TerrawareHomeView.tsx
+++ b/src/scenes/Home/TerrawareHomeView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Box, Container, Grid } from '@mui/material';
 import { useDeviceInfo } from '@terraware/web-components/utils';
@@ -11,10 +11,14 @@ import { useOrganization, useUser } from 'src/providers';
 import strings from 'src/strings';
 import { isAdmin } from 'src/utils/organization';
 
+import NewApplicationModal from '../ApplicationRouter/NewApplicationModal';
+
 const TerrawareHomeView = () => {
   const { user } = useUser();
   const { selectedOrganization } = useOrganization();
   const { isTablet, isMobile } = useDeviceInfo();
+
+  const [isNewApplicationModalOpen, setIsNewApplicationModalOpen] = useState<boolean>(false);
 
   const primaryGridSize = () => {
     if (isMobile) {
@@ -34,86 +38,91 @@ const TerrawareHomeView = () => {
   };
 
   return (
-    <Box
-      component='main'
-      sx={{
-        minHeight: '100vh',
-        display: 'flex',
-        flexDirection: 'column',
-      }}
-    >
-      <Box paddingRight={'24px'} paddingLeft={isMobile ? '24px' : 0}>
-        <PageHeader
-          title={user?.firstName ? strings.formatString(strings.WELCOME_PERSON, user.firstName) : strings.WELCOME}
-          subtitle=''
-        />
-        <Container maxWidth={false} sx={{ padding: 0 }}>
-          <Grid container spacing={3} sx={{ padding: 0 }}>
-            {isAdmin(selectedOrganization) && (
-              <>
-                <Grid item xs={primaryGridSize()}>
-                  <PageCard
-                    id='peopleHomeCard'
-                    name={strings.PEOPLE}
-                    icon='person'
-                    description={strings.PEOPLE_CARD_DESCRIPTION}
-                    link={APP_PATHS.PEOPLE}
-                    linkText={strings.formatString(strings.GO_TO, strings.PEOPLE) as string}
-                    linkStyle={'plain'}
-                  />
-                </Grid>
-                <Grid item xs={primaryGridSize()}>
-                  <PageCard
-                    id='seedbankHomeCard'
-                    name={strings.SEED_BANKS}
-                    icon='seedbankNav'
-                    description={strings.SEED_BANKS_CARD_DESCRIPTION}
-                    link={APP_PATHS.SEED_BANKS}
-                    linkText={strings.formatString(strings.GO_TO, strings.SEED_BANKS) as string}
-                    linkStyle={'plain'}
-                  />
-                </Grid>
-              </>
-            )}
-            <Grid item xs={secondaryGridSize()}>
-              <PageCard
-                id='speciesHomeCard'
-                name={strings.SPECIES}
-                icon='species'
-                description={strings.SPECIES_CARD_DESCRIPTION}
-                link={APP_PATHS.SPECIES}
-                linkText={strings.formatString(strings.GO_TO, strings.SPECIES) as string}
-                linkStyle={'plain'}
-              />
-            </Grid>
-            <Grid item xs={secondaryGridSize()}>
-              <PageCard
-                id='accessionsHomeCard'
-                name={strings.ACCESSIONS}
-                icon='seeds'
-                description={strings.ACCESSIONS_CARD_DESCRIPTION}
-                link={APP_PATHS.ACCESSIONS}
-                linkText={strings.formatString(strings.GO_TO, strings.ACCESSIONS) as string}
-                linkStyle={'plain'}
-              />
-            </Grid>
-            {isEnabled('Accelerator Application') && (
+    <>
+      <NewApplicationModal open={isNewApplicationModalOpen} onClose={() => setIsNewApplicationModalOpen(false)} />
+
+      <Box
+        component='main'
+        sx={{
+          minHeight: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <Box paddingRight={'24px'} paddingLeft={isMobile ? '24px' : 0}>
+          <PageHeader
+            title={user?.firstName ? strings.formatString(strings.WELCOME_PERSON, user.firstName) : strings.WELCOME}
+            subtitle=''
+          />
+          <Container maxWidth={false} sx={{ padding: 0 }}>
+            <Grid container spacing={3} sx={{ padding: 0 }}>
+              {isAdmin(selectedOrganization) && (
+                <>
+                  <Grid item xs={primaryGridSize()}>
+                    <PageCard
+                      id='peopleHomeCard'
+                      name={strings.PEOPLE}
+                      icon='person'
+                      description={strings.PEOPLE_CARD_DESCRIPTION}
+                      link={APP_PATHS.PEOPLE}
+                      linkText={strings.formatString(strings.GO_TO, strings.PEOPLE) as string}
+                      linkStyle={'plain'}
+                    />
+                  </Grid>
+                  <Grid item xs={primaryGridSize()}>
+                    <PageCard
+                      id='seedbankHomeCard'
+                      name={strings.SEED_BANKS}
+                      icon='seedbankNav'
+                      description={strings.SEED_BANKS_CARD_DESCRIPTION}
+                      link={APP_PATHS.SEED_BANKS}
+                      linkText={strings.formatString(strings.GO_TO, strings.SEED_BANKS) as string}
+                      linkStyle={'plain'}
+                    />
+                  </Grid>
+                </>
+              )}
               <Grid item xs={secondaryGridSize()}>
                 <PageCard
-                  id='applicationHomeCard'
-                  name={strings.APPLY_TO_ACCELERATOR}
-                  icon='iconFile'
-                  description={strings.APPLY_TO_ACCELERATOR}
-                  link={APP_PATHS.APPLICATIONS}
-                  linkText={strings.START_NEW_APPLICATION}
-                  linkStyle={'button-primary'}
+                  id='speciesHomeCard'
+                  name={strings.SPECIES}
+                  icon='species'
+                  description={strings.SPECIES_CARD_DESCRIPTION}
+                  link={APP_PATHS.SPECIES}
+                  linkText={strings.formatString(strings.GO_TO, strings.SPECIES) as string}
+                  linkStyle={'plain'}
                 />
               </Grid>
-            )}
-          </Grid>
-        </Container>
+              <Grid item xs={secondaryGridSize()}>
+                <PageCard
+                  id='accessionsHomeCard'
+                  name={strings.ACCESSIONS}
+                  icon='seeds'
+                  description={strings.ACCESSIONS_CARD_DESCRIPTION}
+                  link={APP_PATHS.ACCESSIONS}
+                  linkText={strings.formatString(strings.GO_TO, strings.ACCESSIONS) as string}
+                  linkStyle={'plain'}
+                />
+              </Grid>
+              {isEnabled('Accelerator Application') && (
+                <Grid item xs={secondaryGridSize()}>
+                  <PageCard
+                    id='applicationHomeCard'
+                    name={strings.APPLY_TO_ACCELERATOR}
+                    icon='iconFile'
+                    description={strings.APPLY_TO_ACCELERATOR}
+                    link={APP_PATHS.APPLICATIONS}
+                    linkText={strings.START_NEW_APPLICATION}
+                    linkStyle={'button-primary'}
+                    onClick={() => setIsNewApplicationModalOpen(true)}
+                  />
+                </Grid>
+              )}
+            </Grid>
+          </Container>
+        </Box>
       </Box>
-    </Box>
+    </>
   );
 };
 


### PR DESCRIPTION
- Move the navigate functionality into the dialog since it is also handling all requests, state, etc...
- Add an `onClick` handler override prop to the `PageCard` component so the parent container can handle click state
- Add the `NewApplicationModal` to the home page with the new application card\

![2024-08-14 12.47.01.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/daa028f1-83a5-4dc0-b4c4-ed88859725c7.gif)

