### PR TITLE
SW-5849: Console: Internal Comments should display regardless of variable's status

### DIFF
--- a/src/components/AcceleratorDeliverableView/QuestionsDeliverableCard.tsx
+++ b/src/components/AcceleratorDeliverableView/QuestionsDeliverableCard.tsx
@@ -82,6 +82,8 @@ const QuestionBox = ({
 
   const firstVariableValue: VariableValue | undefined = (variable?.variableValues || [])[0];
   const firstVariableValueStatus: VariableStatusType | undefined = firstVariableValue?.status;
+  const firstVariableValueFeedback: string | undefined = firstVariableValue?.feedback;
+  const firstVariableValueInternalComment: string | undefined = firstVariableValue?.internalComment;
 
   const [modalFeedback, setModalFeedback] = useState(firstVariableValue?.feedback || '');
 
@@ -138,11 +140,11 @@ const QuestionBox = ({
   };
 
   const rejectItem = (feedback: string) => {
-    setStatus('Rejected', feedback);
+    setStatus('Rejected', feedback, firstVariableValueInternalComment);
   };
 
   const approveItem = () => {
-    setStatus('Approved');
+    setStatus('Approved', undefined, firstVariableValueInternalComment);
   };
 
   const onEditItem = () => {
@@ -151,7 +153,7 @@ const QuestionBox = ({
 
   const onUpdateInternalComment = (internalComment: string) => {
     const currentStatus: VariableStatusType = firstVariableValueStatus || 'Not Submitted';
-    setStatus(currentStatus, undefined, internalComment);
+    setStatus(currentStatus, firstVariableValueFeedback, internalComment);
   };
 
   const onSave = () => {
@@ -168,16 +170,16 @@ const QuestionBox = ({
     (optionItem: DropdownItem) => {
       switch (optionItem.value) {
         case 'needs_translation': {
-          setStatus('Needs Translation');
+          setStatus('Needs Translation', undefined, firstVariableValueInternalComment);
           break;
         }
         case 'not_needed': {
-          setStatus('Not Needed');
+          setStatus('Not Needed', undefined, firstVariableValueInternalComment);
           break;
         }
       }
     },
-    [setStatus]
+    [firstVariableValueInternalComment, setStatus]
   );
 
   const optionItems = useMemo(
@@ -219,7 +221,7 @@ const QuestionBox = ({
             <Button
               id='updateFeedback'
               label={strings.SAVE}
-              onClick={() => setStatus('Rejected', modalFeedback)}
+              onClick={() => setStatus('Rejected', modalFeedback, firstVariableValueInternalComment)}
               key='button-2'
             />,
           ]}

--- a/src/components/Variables/VariableInternalComment.tsx
+++ b/src/components/Variables/VariableInternalComment.tsx
@@ -34,6 +34,7 @@ function VariableInternalComment({ variable, update, editing, sx }: VariableInte
 
   const toggleDialog = useCallback(() => {
     setIsDialogOpen((prev) => !prev);
+    setInternalComment(variableValue?.internalComment || '');
   }, []);
 
   const handleUpdate = () => {
@@ -42,7 +43,7 @@ function VariableInternalComment({ variable, update, editing, sx }: VariableInte
   };
 
   return (
-    (editing || internalComment) && (
+    (editing || internalComment || isDialogOpen) && (
       <Box sx={[...(Array.isArray(sx) ? sx : [sx])]}>
         <Box
           display='flex'
@@ -59,7 +60,7 @@ function VariableInternalComment({ variable, update, editing, sx }: VariableInte
             onChange={(value) => setInternalComment(value as string)}
             preserveNewlines
             type='textarea'
-            value={internalComment || strings.NO_COMMENTS_ADDED}
+            value={variableValue?.internalComment || strings.NO_COMMENTS_ADDED}
             sx={{ padding: '0 8px' }}
           />
           <Button


### PR DESCRIPTION
This PR includes changes to fix an issue that caused feedback and/or internal comments values to get wiped erroneously while "updating variable workflow details" (status, feedback, or internal comments).

I also included several changes to improve the UX of the Internal Comments field:

- Internal comments dialog should not close prematurely when a user deletes all of the text in the textarea
- Internal comments should be reset to the original value when the user presses Cancel in the dialog
- Internal comments should not update the value under the dialog until the user presses Save in the dialog