### PR TITLE
SW-5822: When the user restarts a prescreen they should end up on the prescreen module details page

### DIFF
--- a/src/scenes/ApplicationRouter/portal/Prescreen/index.tsx
+++ b/src/scenes/ApplicationRouter/portal/Prescreen/index.tsx
@@ -20,7 +20,7 @@ import ApplicationPage from '../ApplicationPage';
 
 const PrescreenView = () => {
   const { selectedApplication, applicationDeliverables, applicationSections, reload } = useApplicationData();
-  const { goToApplication, goToApplicationPrescreen, goToApplicationPrescreenResult } = useNavigateTo();
+  const { goToApplication, goToApplicationPrescreenResult } = useNavigateTo();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const dispatch = useAppDispatch();
 
@@ -63,25 +63,27 @@ const PrescreenView = () => {
     }
   }, [dispatch, selectedApplication, setIsLoading, setRestartRequestId]);
 
-  const onReload = useCallback(() => {
-    if (!selectedApplication) {
-      return;
-    }
-    setIsLoading(false);
-    setIsConfirmModalOpen(false);
-    if (selectedApplication.status === 'Not Submitted') {
-      goToApplicationPrescreenResult(selectedApplication.id);
-    } else {
-      goToApplicationPrescreen(selectedApplication.id);
-    }
-  }, [selectedApplication, goToApplication, goToApplicationPrescreenResult, setIsLoading, setIsConfirmModalOpen]);
+  const onReload = useCallback(
+    (submit: boolean) => {
+      if (!selectedApplication) {
+        return;
+      }
+      setIsLoading(false);
+      setIsConfirmModalOpen(false);
+      if (submit) {
+        setSubmitRequestId('');
+        goToApplicationPrescreenResult(selectedApplication.id);
+      } else {
+        setRestartRequestId('');
+      }
+    },
+    [selectedApplication, goToApplication, goToApplicationPrescreenResult, setIsLoading, setIsConfirmModalOpen]
+  );
 
   useEffect(() => {
-    if (
-      (restartResult && restartResult.status === 'success' && restartResult.data) ||
-      (submitResult && submitResult.status === 'success' && submitResult.data)
-    ) {
-      reload(onReload);
+    const submitResultSuccess = Boolean(submitResult && submitResult.status === 'success' && submitResult.data);
+    if ((restartResult && restartResult.status === 'success' && restartResult.data) || submitResultSuccess) {
+      reload(() => onReload(submitResultSuccess));
     }
   }, [restartResult, submitResult, onReload]);
 


### PR DESCRIPTION
My [first PR](https://github.com/terraware/terraware-web/pull/3010) didn't correctly resolve the issue, this one does.

Changes include:

- Reset request ids on reload
- Remove redundant navigation to the Pre-screen view (this is that view)
- Add `submit` param to `onReload` to be explicit rather than relying on checking application status