### PR TITLE
SW-5865 Fix deliverables filters not working

### DIFF
--- a/src/scenes/DeliverablesRouter/DeliverablesList.tsx
+++ b/src/scenes/DeliverablesRouter/DeliverablesList.tsx
@@ -84,9 +84,10 @@ const DeliverablesList = (): JSX.Element => {
       };
 
       const modifiedSearch = modifySearchNode(modifyStatus, search);
+      const firstSort = genericSearchAndSort(results, modifiedSearch, sortOrderConfig);
       if (sortOrderConfig?.sortOrder.field === 'status') {
         const direction = sortOrderConfig?.sortOrder.direction;
-        return results.sort((a, b) => {
+        return firstSort.sort((a, b) => {
           if (a.status !== b.status) {
             if (direction === 'Descending') {
               return statusOrder[b.status] - statusOrder[a.status];
@@ -104,7 +105,7 @@ const DeliverablesList = (): JSX.Element => {
           }
         });
       } else {
-        return genericSearchAndSort(results, modifiedSearch, sortOrderConfig);
+        return firstSort;
       }
     },
     []


### PR DESCRIPTION
When sorting by status (default order), the filters were not being applied on the FE.
Add the generic "search and sort" before applying the custom status order