### PR TITLE
SW-5830: Question Edit View: Allow user to exit Edit mode of question using either "Save" or "Cancel" button when only Internal Comment is added

### DIFF
--- a/src/components/AcceleratorDeliverableView/QuestionsDeliverableCard.tsx
+++ b/src/components/AcceleratorDeliverableView/QuestionsDeliverableCard.tsx
@@ -157,13 +157,13 @@ const QuestionBox = ({
   };
 
   const onSave = () => {
+    setEditingId(undefined);
+
     if (pendingVariableValues.size === 0) {
       return;
     }
 
     update();
-
-    setEditingId(undefined);
   };
 
   const onOptionItemClick = useCallback(


### PR DESCRIPTION
This PR includes a change to always exit edit mode when the Save button is pressed, regardless of whether there are pending changes or not.