### PR TITLE
SW-5874 Remove rounding helper text

### DIFF
--- a/src/components/DocumentProducer/DeliverableVariableDetailsInput/index.tsx
+++ b/src/components/DocumentProducer/DeliverableVariableDetailsInput/index.tsx
@@ -321,7 +321,6 @@ const DeliverableVariableDetailsInput = ({
           type={variable.type === 'Number' ? 'number' : 'text'}
           onChange={(newValue: any) => onChangeValueHandler(newValue, 'value')}
           value={value?.toString()}
-          helperText={variable.type === 'Number' ? strings.ROUNDED_INFO : ''}
           sx={[formElementStyles, textFieldLabelStyles]}
         />
       )}

--- a/src/components/DocumentProducer/VariableDetailsInput/index.tsx
+++ b/src/components/DocumentProducer/VariableDetailsInput/index.tsx
@@ -353,7 +353,6 @@ const VariableDetailsInput = ({
           onChange={(newValue: any) => onChangeValueHandler(newValue, 'value')}
           value={value?.toString()}
           errorText={validate ? valueError() : ''}
-          helperText={variable?.type === 'Number' ? strings.ROUNDED_INFO : ''}
           sx={formElementStyles}
         />
       )}


### PR DESCRIPTION
Remove the "rounded to the nearest thousandth" message from number
variable inputs. Not only does it add visual noise, but it's usually not
correct since we ask for a lot of integer values.