### PR TITLE
SW-5871 Remove communities from project profile

### DIFF
--- a/src/scenes/AcceleratorRouter/ParticipantProjects/EditView/index.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/EditView/index.tsx
@@ -249,13 +249,6 @@ const EditView = () => {
               value={participantProjectRecord?.perHectareBudget}
             />
             <ProjectFieldTextfield
-              id={'numCommunities'}
-              label={strings.NUMBER_OF_COMMUNITIES_WITHIN_PROJECT_AREA}
-              onChange={onChangeParticipantProject}
-              type={'number'}
-              value={participantProjectRecord?.numCommunities}
-            />
-            <ProjectFieldTextfield
               id={'hubSpotUrl'}
               label={strings.HUBSPOT_LINK}
               onChange={onChangeParticipantProject}

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/SingleView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/SingleView.tsx
@@ -213,11 +213,6 @@ const SingleView = () => {
                 value={participantProject?.perHectareBudget}
               />
               <ProjectFieldDisplay
-                label={strings.NUMBER_OF_COMMUNITIES_WITHIN_PROJECT_AREA}
-                value={participantProject?.numCommunities}
-                rightBorder={!isMobile}
-              />
-              <ProjectFieldDisplay
                 label={strings.HUBSPOT_LINK}
                 value={
                   participantProject?.hubSpotUrl ? (


### PR DESCRIPTION
Remove the "number of communities within project area" field from the project
profile in the accelerator console.