### PR TITLE
Make yarn docker:stop remove containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ts": "tsc --project ./tsconfig.json",
     "format": "prettier --write .",
     "docker:start": "./scripts/launch_server.sh",
-    "docker:stop": "docker compose -f docker-compose.yml kill",
+    "docker:stop": "docker compose down",
     "wait-be": "wait-on -t 120000 http://localhost:8080/swagger-ui/index.html",
     "server:prepare": "./scripts/preparedb.sh",
     "server:reset": "./scripts/resetdb.sh",


### PR DESCRIPTION
Use a different Docker Compose command that removes the containers from the
filesystem, which should cause the server to use the most recently pulled image
when it is restarted.