### PR TITLE
Clean up unused prop

### DIFF
--- a/src/components/DocumentProducer/EditVariable/index.tsx
+++ b/src/components/DocumentProducer/EditVariable/index.tsx
@@ -32,7 +32,6 @@ import {
 
 export type EditVariableProps = {
   onFinish: (edited: boolean) => void;
-  manifestId: number;
   projectId: number;
   variableId: number;
   sectionsUsed?: string[];

--- a/src/components/DocumentProducer/EditableSection/Container.tsx
+++ b/src/components/DocumentProducer/EditableSection/Container.tsx
@@ -30,7 +30,6 @@ type EditableSectionProps = {
   section: SectionVariableWithValues;
   allVariables: VariableWithValues[];
   onUpdate: () => void;
-  manifestId: number;
 };
 
 export default function EditableSectionContainer({
@@ -39,7 +38,6 @@ export default function EditableSectionContainer({
   section,
   allVariables,
   onUpdate,
-  manifestId,
 }: EditableSectionProps): JSX.Element {
   const dispatch = useAppDispatch();
   const snackbar = useSnackbar();
@@ -164,7 +162,6 @@ export default function EditableSectionContainer({
         docId={docId}
         projectId={projectId}
         onUpdate={onUpdate}
-        manifestId={manifestId}
       />
 
       <Grid paddingTop={theme.spacing(2)}>

--- a/src/components/DocumentProducer/EditableSection/Edit.tsx
+++ b/src/components/DocumentProducer/EditableSection/Edit.tsx
@@ -42,7 +42,6 @@ type EditableSectionEditProps = {
   docId: number;
   projectId: number;
   onUpdate: () => void;
-  manifestId: number;
 };
 
 const SectionEdit = ({
@@ -53,7 +52,6 @@ const SectionEdit = ({
   docId,
   projectId,
   onUpdate,
-  manifestId,
 }: EditableSectionEditProps): JSX.Element => {
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
@@ -194,7 +192,6 @@ const SectionEdit = ({
           projectId={projectId}
           onFinish={variableUpdated}
           onCancel={() => setOpenEditVariableModal(false)}
-          manifestId={manifestId}
         />
       )}
       {recommendedVariables && recommendedVariables.length > 0 && (

--- a/src/components/DocumentProducer/EditableSection/EditVariableModal.tsx
+++ b/src/components/DocumentProducer/EditableSection/EditVariableModal.tsx
@@ -14,16 +14,9 @@ type EditVariableModalProps = {
   onFinish: () => void;
   onCancel: () => void;
   projectId: number;
-  manifestId: number;
 };
 
-export default function EditVariableModal({
-  variable,
-  onFinish,
-  onCancel,
-  projectId,
-  manifestId,
-}: EditVariableModalProps) {
+export default function EditVariableModal({ variable, onFinish, onCancel, projectId }: EditVariableModalProps) {
   switch (variable.type) {
     case 'Image':
       return (
@@ -48,9 +41,7 @@ export default function EditVariableModal({
     case 'Select':
     case 'Number':
     case 'Text':
-      return (
-        <EditVariable variableId={variable.id} projectId={projectId} onFinish={onFinish} manifestId={manifestId} />
-      );
+      return <EditVariable variableId={variable.id} projectId={projectId} onFinish={onFinish} />;
     default:
       return null;
   }

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentTab.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentTab.tsx
@@ -93,7 +93,6 @@ const DocumentTab = ({ document }: DocumentProps): JSX.Element => {
             section={section}
             allVariables={allVariables ?? []}
             onUpdate={onUpdate}
-            manifestId={document.variableManifestId}
           />
         );
       }

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
@@ -224,7 +224,6 @@ const DocumentVariablesTab = ({ document: doc, setSelectedTab }: DocumentVariabl
             setOpenEditVariableModal(false);
             onFinish(updated);
           }}
-          manifestId={doc.variableManifestId}
           projectId={doc.projectId}
           variableId={selectedVariableId || -1}
           sectionsUsed={sectionsUsed}


### PR DESCRIPTION
In preparation for fetching variables by document ID rather than manifest ID, remove some prop-drilling for a `manifestId` variable that is unused in the entire tree