### PR TITLE
SW-5800 Don't show "undefined" as module title

### DIFF
--- a/src/components/DeliverablesTable/DeliverableCellRenderer.tsx
+++ b/src/components/DeliverablesTable/DeliverableCellRenderer.tsx
@@ -58,7 +58,8 @@ export default function DeliverableCellRenderer(props: RendererProps<TableRowTyp
   }
 
   if (column.key === 'module') {
-    return <CellRenderer index={index} column={column} value={`${row.moduleTitle} - ${row.moduleName}`} row={row} />;
+    const title = row.moduleTitle ? `${row.moduleTitle} - ${row.moduleName}` : row.moduleName;
+    return <CellRenderer index={index} column={column} value={title} row={row} />;
   }
 
   return <CellRenderer {...props} />;


### PR DESCRIPTION
On the deliverables list page in the accelerator console, we show a
column that has the cohort-module-specific module title (which is
usually something like "Module 1") followed by the module name. For
document deliverables whose documents were imported from PDH, there
won't necessarily be a cohort module, and thus there won't be a module
title.

Update the rendering code to show just the module name in that case, so
it doesn't show up like "undefined - GIS".