### PR TITLE
SW-5800 Deliverables list for non-accelerator projects

### DIFF
--- a/src/components/DeliverablesTable/index.tsx
+++ b/src/components/DeliverablesTable/index.tsx
@@ -29,7 +29,6 @@ import TableWithSearchFilters from '../TableWithSearchFilters';
 import DeliverableCellRenderer from './DeliverableCellRenderer';
 
 interface DeliverablesTableProps {
-  acceleratorProjects?: AcceleratorOrgProject[];
   extraTableFilters?: SearchNodePayload[];
   filterModifiers?: (filters: FilterConfig[]) => FilterConfig[];
   isAcceleratorRoute?: boolean;
@@ -87,7 +86,6 @@ const defaultSearchOrder: SearchSortOrder = {
 };
 
 const DeliverablesTable = ({
-  acceleratorProjects,
   extraTableFilters,
   filterModifiers,
   isAcceleratorRoute,
@@ -112,10 +110,11 @@ const DeliverablesTable = ({
 
   const projectsFilterOptions = useMemo(
     () =>
-      (acceleratorProjects || []).filter((project) =>
-        deliverables.find((deliverable) => deliverable.projectId === project.id)
-      ),
-    [acceleratorProjects, deliverables]
+      deliverables.map((deliverable) => ({
+        id: deliverable.projectId,
+        name: deliverable.projectName,
+      })),
+    [deliverables]
   );
 
   const isAllowedReadDeliverable = isAllowed('READ_DELIVERABLE', { organization: selectedOrganization });

--- a/src/scenes/AcceleratorRouter/Deliverables/DeliverablesList.tsx
+++ b/src/scenes/AcceleratorRouter/Deliverables/DeliverablesList.tsx
@@ -7,7 +7,6 @@ import DeliverablesTable from 'src/components/DeliverablesTable';
 import PageHeader from 'src/components/PageHeader';
 import ParticipantsDropdown from 'src/components/ParticipantsDropdown';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
-import { useAcceleratorOrgs } from 'src/hooks/useAcceleratorOrgs';
 import { useParticipants } from 'src/hooks/useParticipants';
 import { useLocalization } from 'src/providers';
 import AcceleratorMain from 'src/scenes/AcceleratorRouter/AcceleratorMain';
@@ -18,10 +17,7 @@ import { SearchNodePayload } from 'src/types/Search';
 const DeliverablesList = () => {
   const { activeLocale } = useLocalization();
   const { availableParticipants } = useParticipants();
-  const { acceleratorOrgs } = useAcceleratorOrgs(true);
   const contentRef = useRef(null);
-
-  const acceleratorProjects = useMemo(() => (acceleratorOrgs || [])?.flatMap((org) => org.projects), [acceleratorOrgs]);
 
   const [participantFilter, setParticipantFilter] = useState<{ id?: number }>({ id: undefined });
 
@@ -76,7 +72,6 @@ const DeliverablesList = () => {
 
       {/* -1 for "non-organization scoped search" IE admin search */}
       <DeliverablesTable
-        acceleratorProjects={acceleratorProjects}
         extraTableFilters={extraTableFilters}
         isAcceleratorRoute={true}
         organizationId={-1}


### PR DESCRIPTION
Deliverable documents imported from PDH may belong to projects whose organizations
don't have the Accelerator internal tag. People will still want to be able to
filter for those projects in the deliverables table. Change the filter dropdown
so it includes all the projects whose deliverables are shown.