### PR TITLE
Implement "document variables" and DocumentProducerProvider

### DIFF
--- a/src/components/DocumentProducer/EditableSection/Edit.tsx
+++ b/src/components/DocumentProducer/EditableSection/Edit.tsx
@@ -55,12 +55,13 @@ const SectionEdit = ({
 }: EditableSectionEditProps): JSX.Element => {
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
+  const variableDropdownRef = useRef(null);
+
   const [editor] = useState(() => withInlines(withReact(createEditor())));
   const [openEditVariableModal, setOpenEditVariableModal] = useState<boolean>(false);
   const [clickedVariable, setClickedVariable] = useState<VariableWithValues>();
   const [insertOptionsDropdownAnchor, setInsertOptionsDropdownAnchor] = useState<HTMLElement | null>(null);
   const [variableToBeInserted, setVariableToBeInserted] = useState<VariableWithValues>();
-  const variableDropdownRef = useRef(null);
 
   const initialValue: Descendant[] = useMemo(() => {
     const editorValue =

--- a/src/components/DocumentProducer/EditableSection/EditVariableModal.tsx
+++ b/src/components/DocumentProducer/EditableSection/EditVariableModal.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import EditImagesModal from 'src/components/DocumentProducer/EditImagesModal';
 import EditVariable from 'src/components/DocumentProducer/EditVariable';
 import EditableTableEdit from 'src/components/DocumentProducer/EditableTableModal';
+import { useDocumentProducerData } from 'src/providers/DocumentProducer/Context';
 import {
   ImageVariableWithValues,
   TableVariableWithValues,
@@ -17,6 +18,8 @@ type EditVariableModalProps = {
 };
 
 export default function EditVariableModal({ variable, onFinish, onCancel, projectId }: EditVariableModalProps) {
+  const { getUsedSections } = useDocumentProducerData();
+
   switch (variable.type) {
     case 'Image':
       return (
@@ -41,7 +44,14 @@ export default function EditVariableModal({ variable, onFinish, onCancel, projec
     case 'Select':
     case 'Number':
     case 'Text':
-      return <EditVariable variableId={variable.id} projectId={projectId} onFinish={onFinish} />;
+      return (
+        <EditVariable
+          onFinish={onFinish}
+          projectId={projectId}
+          sectionsUsed={getUsedSections(variable.id)}
+          variable={variable}
+        />
+      );
     default:
       return null;
   }

--- a/src/providers/DocumentProducer/Context.ts
+++ b/src/providers/DocumentProducer/Context.ts
@@ -1,0 +1,31 @@
+import { createContext, useContext } from 'react';
+
+import { Document as DocumentType } from 'src/types/documentProducer/Document';
+import { DocumentTemplate } from 'src/types/documentProducer/DocumentTemplate';
+import { SectionVariableWithValues, VariableOwners, VariableWithValues } from 'src/types/documentProducer/Variable';
+
+export type DocumentProducerData = {
+  allVariables?: VariableWithValues[];
+  document?: DocumentType;
+  documentId: number;
+  documentSectionVariables?: SectionVariableWithValues[];
+  documentTemplate?: DocumentTemplate;
+  documentVariables?: VariableWithValues[];
+  getUsedSections: (variableId: number) => string[];
+  isLoading: boolean;
+  projectId: number;
+  reload: () => void;
+  variablesOwners?: VariableOwners[];
+};
+
+// default values pointing to nothing
+export const DocumentProducerContext = createContext<DocumentProducerData>({
+  documentId: -1,
+  getUsedSections: () => [],
+  isLoading: false,
+  projectId: -1,
+  // tslint:disable-next-line:no-empty
+  reload: () => {},
+});
+
+export const useDocumentProducerData = () => useContext(DocumentProducerContext);

--- a/src/providers/DocumentProducer/Provider.tsx
+++ b/src/providers/DocumentProducer/Provider.tsx
@@ -1,0 +1,160 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { BusySpinner } from '@terraware/web-components';
+
+import { selectDocumentTemplate } from 'src/redux/features/documentProducer/documentTemplates/documentTemplatesSelector';
+import { requestListDocumentTemplates } from 'src/redux/features/documentProducer/documentTemplates/documentTemplatesThunks';
+import { selectGetDocument } from 'src/redux/features/documentProducer/documents/documentsSelector';
+import { requestGetDocument } from 'src/redux/features/documentProducer/documents/documentsThunks';
+import { requestListVariablesValues } from 'src/redux/features/documentProducer/values/valuesThunks';
+import {
+  selectAllVariablesWithValues,
+  selectDocumentVariablesWithValues,
+  selectVariablesOwners,
+} from 'src/redux/features/documentProducer/variables/variablesSelector';
+import {
+  requestListAllVariables,
+  requestListDocumentVariables,
+  requestListVariablesOwners,
+} from 'src/redux/features/documentProducer/variables/variablesThunks';
+import { useMultiSelectorProcessor } from 'src/redux/hooks/useMultiSelectorProcessor';
+import { RootState } from 'src/redux/rootReducer';
+import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import { Document as DocumentType } from 'src/types/documentProducer/Document';
+import {
+  SectionVariableWithValues,
+  VariableOwners,
+  VariableWithValues,
+  isSectionVariableWithValues,
+} from 'src/types/documentProducer/Variable';
+
+import { DocumentProducerContext, DocumentProducerData } from './Context';
+import { getContainingSections } from './util';
+
+export type Props = {
+  children: React.ReactNode;
+};
+
+const DocumentProducerProvider = ({ children }: Props) => {
+  const dispatch = useAppDispatch();
+  const pathParams = useParams<{ documentId: string }>();
+  const documentId = Number(pathParams.documentId || -1);
+
+  const [document, setDocument] = useState<DocumentType>();
+
+  const projectId = document?.projectId ?? -1;
+  const documentTemplateId = document?.documentTemplateId ?? -1;
+  const documentTemplate = useAppSelector((state) => selectDocumentTemplate(state, documentTemplateId));
+
+  const { status, data } = useMultiSelectorProcessor([
+    ['allVariables', (state: RootState) => selectAllVariablesWithValues(state, projectId)],
+    ['document', selectGetDocument(documentId), { onData: setDocument }],
+    ['documentVariables', (state: RootState) => selectDocumentVariablesWithValues(state, documentId, projectId)],
+    ['variablesOwners', (state: RootState) => selectVariablesOwners(state, projectId)],
+  ]);
+
+  const documentVariables = data.documentVariables as VariableWithValues[];
+  const variablesOwners = data.variablesOwners as VariableOwners[];
+
+  // Document variables may contain out-dated variables that are injected into sections within the document
+  // They need to be added into the `allVariables` array so consumers can access out of date variables easily
+  const allVariables = useMemo(
+    () => ((data.allVariables || []) as VariableWithValues[]).concat(documentVariables || []),
+    [data.allVariables, documentVariables]
+  );
+
+  const documentSectionVariables = useMemo(
+    () => (documentVariables || []).filter(isSectionVariableWithValues) as SectionVariableWithValues[],
+    [documentVariables]
+  );
+
+  const isLoading = status === 'pending';
+
+  useEffect(() => {
+    dispatch(requestListDocumentTemplates());
+    dispatch(requestListAllVariables());
+  }, [dispatch]);
+
+  const loadDocument = useCallback(() => {
+    if (documentId !== -1) {
+      dispatch(requestGetDocument(documentId));
+      dispatch(requestListDocumentVariables(documentId));
+    }
+  }, [dispatch, documentId]);
+
+  useEffect(() => {
+    loadDocument();
+  }, [loadDocument]);
+
+  const loadVariables = useCallback(() => {
+    if (projectId !== -1) {
+      dispatch(requestListVariablesOwners(projectId));
+      dispatch(requestListVariablesValues({ projectId }));
+    }
+  }, [dispatch, projectId]);
+
+  useEffect(() => {
+    loadVariables();
+  }, [loadVariables]);
+
+  const reload = useCallback(() => {
+    loadDocument();
+    loadVariables();
+  }, [loadDocument, loadVariables]);
+
+  const getUsedSections = useCallback(
+    (variableId: number) => documentSectionVariables.reduce(getContainingSections(variableId), []),
+    [documentSectionVariables]
+  );
+
+  const [documentProducerData, setDocumentProducerData] = useState<DocumentProducerData>({
+    allVariables,
+    document,
+    documentId,
+    documentTemplate,
+    documentVariables,
+    getUsedSections,
+    isLoading: true,
+    projectId,
+    // tslint:disable-next-line:no-empty
+    reload: () => {},
+    variablesOwners,
+  });
+
+  useEffect(() => {
+    setDocumentProducerData({
+      allVariables,
+      document,
+      documentId,
+      documentSectionVariables,
+      documentTemplate,
+      documentVariables,
+      getUsedSections,
+      isLoading,
+      projectId,
+      reload,
+      variablesOwners,
+    });
+  }, [
+    allVariables,
+    document,
+    documentId,
+    documentSectionVariables,
+    documentTemplate,
+    documentVariables,
+    getUsedSections,
+    isLoading,
+    projectId,
+    reload,
+    variablesOwners,
+  ]);
+
+  if (isLoading) {
+    return <BusySpinner withSkrim />;
+  }
+
+  return <DocumentProducerContext.Provider value={documentProducerData}>{children}</DocumentProducerContext.Provider>;
+};
+
+export default DocumentProducerProvider;

--- a/src/providers/DocumentProducer/util.ts
+++ b/src/providers/DocumentProducer/util.ts
@@ -1,0 +1,21 @@
+import { SectionVariableWithValues } from 'src/types/documentProducer/Variable';
+
+export const getContainingSections =
+  (variableId: number) =>
+  (acc: string[], currentVal: SectionVariableWithValues): string[] => {
+    const newAcc = [...acc];
+
+    if (
+      currentVal.parentSectionNumber &&
+      currentVal?.values?.some((val) => val.type === 'SectionVariable' && val.variableId === variableId)
+    ) {
+      newAcc.push(currentVal.parentSectionNumber);
+    }
+
+    currentVal.children.forEach((childSection) => {
+      const childContainingSections = getContainingSections(variableId)([], childSection as SectionVariableWithValues);
+      newAcc.push(...childContainingSections);
+    });
+
+    return newAcc;
+  };

--- a/src/providers/DocumentProducer/util.ts
+++ b/src/providers/DocumentProducer/util.ts
@@ -7,12 +7,12 @@ export const getContainingSections =
 
     if (
       currentVal.parentSectionNumber &&
-      currentVal?.values?.some((val) => val.type === 'SectionVariable' && val.variableId === variableId)
+      currentVal.values?.some((val) => val.type === 'SectionVariable' && val.variableId === variableId)
     ) {
       newAcc.push(currentVal.parentSectionNumber);
     }
 
-    currentVal.children.forEach((childSection) => {
+    currentVal.children?.forEach((childSection) => {
       const childContainingSections = getContainingSections(variableId)([], childSection as SectionVariableWithValues);
       newAcc.push(...childContainingSections);
     });

--- a/src/redux/features/asyncUtils.ts
+++ b/src/redux/features/asyncUtils.ts
@@ -4,7 +4,9 @@ export type Statuses = 'error' | 'partial-success' | 'pending' | 'success';
 
 export type StatusT<T> = { status: Statuses; data?: T };
 
-export type Status = StatusT<unknown>; // when data is not relevant in the response
+// Type used across all async thunks
+export type AsyncRequest = StatusT<unknown>; // when data is not relevant in the response
+export type AsyncRequestT<T> = StatusT<T>; // This is identical to StatusT, just renamed
 
 export const buildReducers =
   <T>(asyncThunk: AsyncThunk<any, any, any>, useArgAsKey?: boolean, compositeKeyFn?: (args: unknown) => string) =>

--- a/src/redux/features/documentProducer/documentTemplates/documentTemplatesSelector.ts
+++ b/src/redux/features/documentProducer/documentTemplates/documentTemplatesSelector.ts
@@ -10,13 +10,12 @@ export const selectDocumentTemplates = (state: RootState): DocumentTemplatesData
   state.documentProducerDocumentTemplates.listDocumentTemplates;
 
 export const selectDocumentTemplate = createCachedSelector(
-  (state: RootState, documentTemplateId: number) =>
-    state.documentProducerDocumentTemplates.listDocumentTemplates as any,
+  (state: RootState, documentTemplateId: number) => state.documentProducerDocumentTemplates.listDocumentTemplates,
   (state: RootState, documentTemplateId: number) => documentTemplateId,
-  (response, documentTemplateId) => {
+  (response, documentTemplateId): DocumentTemplate | undefined => {
     if (response && response.documentTemplates) {
       return response.documentTemplates.find((m: DocumentTemplate) => m.id === documentTemplateId);
     }
-    return null;
+    return undefined;
   }
 )((state: RootState, documentTemplateId: number) => documentTemplateId);

--- a/src/redux/features/documentProducer/documents/documentsSelector.ts
+++ b/src/redux/features/documentProducer/documents/documentsSelector.ts
@@ -9,12 +9,18 @@ import {
   DocumentHistoryEvent,
   DocumentHistorySavedPayload,
 } from 'src/types/documentProducer/Document';
+import { Document as DocumentType } from 'src/types/documentProducer/Document';
 import { getUserDisplayName } from 'src/utils/user';
+
+import { AsyncRequest, AsyncRequestT } from '../../asyncUtils';
 
 export const selectDocuments = (requestId: string) => (state: RootState) =>
   state.documentProducerDocumentList[requestId];
 
-export const selectGetDocument = (docId: number) => (state: RootState) => state.documentProducerDocument[docId];
+export const selectGetDocument =
+  (docId: number) =>
+  (state: RootState): AsyncRequestT<DocumentType> | undefined =>
+    state.documentProducerDocument[docId];
 
 export const selectListHistory = createCachedSelector(
   (state: RootState, id: number) => state.documentProducerDocumentListHistory[id],

--- a/src/redux/features/documentProducer/documents/documentsThunks.ts
+++ b/src/redux/features/documentProducer/documents/documentsThunks.ts
@@ -11,8 +11,8 @@ import {
   UpgradeManifestPayload,
 } from 'src/types/documentProducer/Document';
 
-export const requestGetDocument = createAsyncThunk('getDocument', async (id: number, { rejectWithValue }) => {
-  const response = await DocumentService.getDocument(id);
+export const requestGetDocument = createAsyncThunk('getDocument', async (documentId: number, { rejectWithValue }) => {
+  const response = await DocumentService.getDocument(documentId);
   if (response.requestSucceeded && response.data?.document) {
     return response.data.document;
   }

--- a/src/redux/features/documentProducer/variables/variablesSelector.ts
+++ b/src/redux/features/documentProducer/variables/variablesSelector.ts
@@ -12,14 +12,15 @@ import {
 } from 'src/types/documentProducer/Variable';
 import { VariableValue } from 'src/types/documentProducer/VariableValue';
 
+import { AsyncRequest, AsyncRequestT, Statuses } from '../../asyncUtils';
 import { deliverableCompositeKeyFn } from '../../deliverables/deliverablesSlice';
 import { variableListCompositeKeyFn } from '../values/valuesSlice';
 
-export const selectVariables = (state: RootState, manifestId: number | string) =>
-  state.documentProducerVariables[manifestId];
+export const selectDocumentVariables = (state: RootState, documentId: number | undefined) =>
+  documentId ? state.documentProducerDocumentVariables[documentId] : undefined;
 
 export const selectSections = createCachedSelector(
-  (state: RootState, manifestId: number) => selectVariables(state, manifestId),
+  (state: RootState, documentId: number | undefined) => selectDocumentVariables(state, documentId),
   (response) => {
     if (response?.data) {
       return {
@@ -30,16 +31,17 @@ export const selectSections = createCachedSelector(
       return response;
     }
   }
-)((state: RootState, id: number) => 'sections');
+)((state: RootState, documentId: number | undefined) => 'sections');
 
 export const searchVariables = createCachedSelector(
-  (state: RootState, manifestId: number, query: string) => selectVariables(state, manifestId),
-  (state: RootState, id: number, query: string) => query,
+  (state: RootState, documentId: number | undefined, query: string) => selectDocumentVariables(state, documentId),
+  (state: RootState, documentId: number | undefined, query: string) => query,
   (response, query) => {
     // filter Section, Image and Table variables because we don't want them in the variables table
-    const dataResponseToReturn = (response.data || []).filter(
+    const dataResponseToReturn = (response?.data || []).filter(
       (variable: Variable) => variable.type !== 'Section' && variable.type !== 'Image' && variable.type !== 'Table'
     );
+
     if (response?.data && query) {
       const regex = new RegExp(query, 'i');
       const fields = ['name', 'type', 'value'];
@@ -53,7 +55,7 @@ export const searchVariables = createCachedSelector(
       return { ...response, data: dataResponseToReturn };
     }
   }
-)((state: RootState, id: number, query: string) => query);
+)((state: RootState, documentId: number | undefined, query: string) => query);
 
 export const selectGetVariable = createCachedSelector(
   (state: RootState, variableId: number) => state.documentProducerAllVariables['all'],
@@ -71,8 +73,8 @@ export const selectGetVariable = createCachedSelector(
   }
 )((state: RootState, variableId: number) => variableId);
 
-const getCombinedProps = (listA: any, listB: any) => {
-  let status = 'pending';
+const getCombinedProps = (listA: any, listB: any): { status: Statuses; error: string | undefined } => {
+  let status: Statuses = 'pending';
   if (listA.status === 'error' || listB.status === 'error') {
     status = 'error';
   }
@@ -162,29 +164,32 @@ const associateValues = (
   };
 };
 
-export const selectVariablesWithValues = createCachedSelector(
-  (state: RootState, manifestId: number | string, projectId: number, maxValueId?: number) =>
-    (state.documentProducerVariables as any)[manifestId],
-  (state: RootState, manifestId: number | string, projectId: number, maxValueId?: number) =>
-    (state.documentProducerVariableValuesList as any)[variableListCompositeKeyFn({ projectId, maxValueId })],
-  (variableList, valueList) => {
-    if (variableList?.data && valueList?.data) {
+export const selectDocumentVariablesWithValues = createCachedSelector(
+  (state: RootState, documentId: number | undefined, projectId: number, maxValueId?: number) =>
+    selectDocumentVariables(state, documentId),
+  (state: RootState, documentId: number | undefined, projectId: number, maxValueId?: number) =>
+    state.documentProducerVariableValuesList[variableListCompositeKeyFn({ projectId, maxValueId })],
+  (variableList, valueList): AsyncRequest | undefined => {
+    const variables = variableList?.data;
+    const values = valueList?.data;
+
+    if (variables && values) {
       let topLevelSectionPosition = 0;
-      const output = variableList.data.map((v: Variable) => {
+      const output = variables.map((v: Variable) => {
         if (v.type === 'Section' && v.renderHeading) {
           topLevelSectionPosition++;
         }
-        return associateValues(v, valueList.data, variableList.data, topLevelSectionPosition);
+        return associateValues(v, values, variables, topLevelSectionPosition);
       });
       return {
         ...getCombinedProps(variableList, valueList),
         data: output,
       };
     } else {
-      return [];
+      return undefined;
     }
   }
-)((state: RootState, manifestId: number | string, projectId: number) => `${projectId}-${manifestId}`);
+)((state: RootState, documentId: number | undefined, projectId: number) => `${projectId}-${documentId}`);
 
 const associateNonSectionVariableValues = (
   variable: Variable,
@@ -226,20 +231,25 @@ const associateNonSectionVariableValues = (
 };
 
 export const selectAllVariablesWithValues = createCachedSelector(
-  (state: RootState, projectId: number, maxValueId?: number) => state.documentProducerAllVariables['all'],
-  (state: RootState, projectId: number, maxValueId?: number) =>
+  (state: RootState, projectId: number | undefined, maxValueId?: number) => state.documentProducerAllVariables['all'],
+  (state: RootState, projectId: number | undefined, maxValueId?: number) =>
     state.documentProducerVariableValuesList[variableListCompositeKeyFn({ projectId, maxValueId })],
-  (variableList, valueList) => {
-    if (variableList?.data && valueList?.data) {
-      const variables = variableList.data;
-      const values = valueList.data;
+  (variableList, valueList): AsyncRequestT<VariableWithValues[]> | undefined => {
+    const variables = variableList?.data;
+    const values = valueList?.data;
 
-      return variableList.data.map((v: Variable) => associateNonSectionVariableValues(v, values, variables));
+    if (variables && values) {
+      return {
+        ...getCombinedProps(variableList, valueList),
+        data: variables.map((v: Variable) => associateNonSectionVariableValues(v, values, variables)),
+      };
     } else {
-      return [];
+      return undefined;
     }
   }
-)((state: RootState, projectId: number, maxValueId?: number) => variableListCompositeKeyFn({ projectId, maxValueId }));
+)((state: RootState, projectId: number | undefined, maxValueId?: number) =>
+  variableListCompositeKeyFn({ projectId, maxValueId })
+);
 
 export const selectDeliverableVariablesWithValues = createCachedSelector(
   (state: RootState, deliverableId: number, projectId: number) =>
@@ -247,11 +257,11 @@ export const selectDeliverableVariablesWithValues = createCachedSelector(
   (state: RootState, deliverableId: number, projectId: number) =>
     state.documentProducerDeliverableVariableValues[deliverableCompositeKeyFn({ deliverableId, projectId })],
   (variableList, valueList) => {
-    if (variableList?.data && valueList?.data) {
-      const variables = variableList.data;
-      const values = valueList.data;
+    const variables = variableList?.data;
+    const values = valueList?.data;
 
-      return variableList.data.map((v: Variable) => associateNonSectionVariableValues(v, values, variables));
+    if (variables && values) {
+      return variables.map((v: Variable) => associateNonSectionVariableValues(v, values, variables));
     } else {
       return [];
     }
@@ -266,4 +276,5 @@ export const selectUpdateVariableWorkflowDetails = (requestId: string) => (state
 export const selectUpdateVariableOwner = (requestId: string) => (state: RootState) =>
   state.variableOwnerUpdate[requestId];
 
-export const selectVariablesOwners = (state: RootState, projectId: number | string) => state.variablesOwners[projectId];
+export const selectVariablesOwners = (state: RootState, projectId: number | undefined) =>
+  projectId ? state.variablesOwners[projectId] : undefined;

--- a/src/redux/features/documentProducer/variables/variablesSlice.ts
+++ b/src/redux/features/documentProducer/variables/variablesSlice.ts
@@ -6,7 +6,7 @@ import { Variable, VariableOwners } from 'src/types/documentProducer/Variable';
 import {
   requestListAllVariables,
   requestListDeliverableVariables,
-  requestListVariables,
+  requestListDocumentVariables,
   requestListVariablesOwners,
   requestUpdateVariableOwner,
   requestUpdateVariableWorkflowDetails,
@@ -34,12 +34,12 @@ const deliverableVariablesSlice = createSlice({
   },
 });
 
-const variablesSlice = createSlice({
-  name: 'variablesSlice',
+const documentVariablesSlice = createSlice({
+  name: 'documentVariablesSlice',
   initialState: initialVariablesState,
   reducers: {},
   extraReducers: (builder: ActionReducerMapBuilder<VariablesState>) => {
-    buildReducers(requestListVariables, true)(builder);
+    buildReducers(requestListDocumentVariables, true)(builder);
   },
 });
 
@@ -91,7 +91,7 @@ const variablesOwnersSlice = createSlice({
 export const documentProducerVariablesReducers = {
   documentProducerAllVariables: allVariablesSlice.reducer,
   documentProducerDeliverableVariables: deliverableVariablesSlice.reducer,
-  documentProducerVariables: variablesSlice.reducer,
+  documentProducerDocumentVariables: documentVariablesSlice.reducer,
   variableWorkflowDetailsUpdate: variableWorkflowDetailsUpdateSlice.reducer,
   variableOwnerUpdate: variableOwnerUpdateSlice.reducer,
   variablesOwners: variablesOwnersSlice.reducer,

--- a/src/redux/features/documentProducer/variables/variablesThunks.ts
+++ b/src/redux/features/documentProducer/variables/variablesThunks.ts
@@ -31,10 +31,10 @@ export const requestListDeliverableVariables = createAsyncThunk(
   }
 );
 
-export const requestListVariables = createAsyncThunk(
-  'listVariables',
-  async (manifestId: number, { rejectWithValue }) => {
-    const response: Response2<VariableListResponse> = await VariableService.getVariables(manifestId);
+export const requestListDocumentVariables = createAsyncThunk(
+  'listDocumentVariables',
+  async (documentId: number, { rejectWithValue }) => {
+    const response: Response2<VariableListResponse> = await VariableService.getDocumentVariables(documentId);
     if (response && response.requestSucceeded && response.data) {
       return response.data.variables;
     }

--- a/src/redux/features/observations/observationsSlice.ts
+++ b/src/redux/features/observations/observationsSlice.ts
@@ -1,6 +1,6 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import { Status, StatusT, buildReducers } from 'src/redux/features/asyncUtils';
+import { AsyncRequest, StatusT, buildReducers } from 'src/redux/features/asyncUtils';
 import { Observation, ObservationResultsPayload, ReplaceObservationPlotResponsePayload } from 'src/types/Observations';
 
 import {
@@ -79,7 +79,7 @@ export const { setPlantingSiteObservationsResultsAction } = plantingSiteObservat
 
 // Schedule/Reschedule observation
 
-type SchedulingState = Record<string, Status>;
+type SchedulingState = Record<string, AsyncRequest>;
 
 const initialSchedulingState: SchedulingState = {};
 

--- a/src/redux/features/plantings/plantingsSlice.ts
+++ b/src/redux/features/plantings/plantingsSlice.ts
@@ -1,6 +1,6 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import { Status, buildReducers } from 'src/redux/features/asyncUtils';
+import { AsyncRequest, buildReducers } from 'src/redux/features/asyncUtils';
 
 import { requestUpdatePlantingCompleted, requestUpdatePlantingsCompleted } from './plantingsAsyncThunks';
 
@@ -39,7 +39,7 @@ export const plantingsSlice = createSlice({
   },
 });
 
-type UpdateData = Record<string, Status>;
+type UpdateData = Record<string, AsyncRequest>;
 
 const initialUpdateState: UpdateData = {};
 

--- a/src/redux/hooks/useMultiSelectorProcessor/index.ts
+++ b/src/redux/hooks/useMultiSelectorProcessor/index.ts
@@ -1,0 +1,119 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { shallowEqual } from 'react-redux';
+
+import { AsyncRequest, Statuses } from 'src/redux/features/asyncUtils';
+import { RootState } from 'src/redux/rootReducer';
+import { useAppSelector } from 'src/redux/store';
+import strings from 'src/strings';
+import useSnackbar from 'src/utils/useSnackbar';
+
+import { createCombinedSelector, getCombinedStatus } from './util';
+
+// selector processor callbacks for easier use
+export type ProcessorCallbacksProps = {
+  handleError?: boolean; // whether to pop up a toast error if the selector has an error
+  dispatched?: boolean; // whether an action has been dispatched for this selector, defaults to true
+  onData?: React.Dispatch<React.SetStateAction<any>>;
+  onError?: (error: string) => void;
+  onPartialSuccess?: (data?: any) => void;
+  onPending?: () => void;
+  onSuccess?: (data?: any) => void;
+};
+
+export type AsyncRequestSelector = (state: RootState) => AsyncRequest | undefined;
+
+export type SelectorIdentifier = string;
+
+export type SelectorConfig = [SelectorIdentifier, AsyncRequestSelector, ProcessorCallbacksProps?];
+
+export type SelectorResultConfig = [SelectorIdentifier, AsyncRequest | undefined, ProcessorCallbacksProps?];
+
+/**
+ * App selector processor that sets data and processes status transition based callbacks
+ */
+export const useMultiSelectorProcessor = (
+  selectors: SelectorConfig[]
+): { status: Statuses; data: Record<SelectorIdentifier, AsyncRequest['data']> } => {
+  const snackbar = useSnackbar();
+
+  const [lastStatus, setLastStatus] = useState<Record<SelectorIdentifier, Statuses>>({});
+  const [lastData, setLastData] = useState<Record<SelectorIdentifier, AsyncRequest['data']>>({});
+
+  const results = useAppSelector(createCombinedSelector(selectors));
+
+  useEffect(() => {
+    const nextLastData = { ...lastData };
+    const nextLastStatus = { ...lastStatus };
+
+    results.forEach(([identifier, selectorResult, config]) => {
+      const {
+        handleError = true,
+        dispatched = true,
+        onData,
+        onError,
+        onPartialSuccess,
+        onPending,
+        onSuccess,
+      } = config || {};
+
+      if (!selectorResult || !dispatched) {
+        return;
+      }
+
+      const { status, data } = selectorResult;
+
+      if (lastStatus[identifier] === status && lastData[identifier] === data) {
+        return;
+      }
+
+      nextLastStatus[identifier] = status;
+      nextLastData[identifier] = data;
+
+      if (status === 'error') {
+        const errorMessage = strings.GENERIC_ERROR;
+        if (handleError) {
+          snackbar.toastError(errorMessage);
+        }
+        // Errors for async thunks are currently stored in the async result's data, eventually we
+        // should implement an `error` property
+        if (onError) {
+          onError(`${data}`);
+        }
+      } else if (status === 'success') {
+        if (onData) {
+          onData(data);
+        }
+        if (onSuccess) {
+          onSuccess(data);
+        }
+      } else if (status === 'partial-success') {
+        if (onData) {
+          onData(data);
+        }
+        if (onPartialSuccess) {
+          onPartialSuccess(data);
+        }
+      } else if (onPending && status === 'pending') {
+        onPending();
+      }
+    });
+
+    if (!shallowEqual(lastStatus, nextLastStatus)) {
+      setLastStatus(nextLastStatus);
+    }
+
+    if (!shallowEqual(lastData, nextLastData)) {
+      setLastData(nextLastData);
+    }
+  }, [lastData, lastStatus, results]);
+
+  console.log({ lastStatus, lastData });
+  return useMemo(() => {
+    const statuses = Object.values(lastStatus);
+
+    return {
+      status: statuses.length === 0 ? 'pending' : getCombinedStatus(statuses),
+      data: lastData,
+    };
+  }, [lastStatus, lastData]);
+};

--- a/src/redux/hooks/useMultiSelectorProcessor/index.ts
+++ b/src/redux/hooks/useMultiSelectorProcessor/index.ts
@@ -107,7 +107,6 @@ export const useMultiSelectorProcessor = (
     }
   }, [lastData, lastStatus, results]);
 
-  console.log({ lastStatus, lastData });
   return useMemo(() => {
     const statuses = Object.values(lastStatus);
 

--- a/src/redux/hooks/useMultiSelectorProcessor/util.spec.ts
+++ b/src/redux/hooks/useMultiSelectorProcessor/util.spec.ts
@@ -1,0 +1,22 @@
+import { getCombinedStatus } from './util';
+
+describe('getCombinedStatus', () => {
+  it('should combine the statuses correctly', () => {
+    // Error overrides all statuses
+    expect(getCombinedStatus(['error', 'success', 'partial-success'])).toEqual('error');
+    expect(getCombinedStatus(['success', 'partial-success', 'error'])).toEqual('error');
+    expect(getCombinedStatus(['pending', 'error'])).toEqual('error');
+    expect(getCombinedStatus(['error', 'pending', 'success', 'partial-success'])).toEqual('error');
+
+    // Partial Success overrides success only
+    expect(getCombinedStatus(['success', 'partial-success'])).toEqual('partial-success');
+    expect(getCombinedStatus(['partial-success', 'success'])).toEqual('partial-success');
+
+    // Pending overrides all statuses except error
+    expect(getCombinedStatus(['pending', 'partial-success'])).toEqual('pending');
+    expect(getCombinedStatus(['partial-success', 'pending'])).toEqual('pending');
+
+    // Success only exists if all statuses are success
+    expect(getCombinedStatus(['success', 'success'])).toEqual('success');
+  });
+});

--- a/src/redux/hooks/useMultiSelectorProcessor/util.ts
+++ b/src/redux/hooks/useMultiSelectorProcessor/util.ts
@@ -1,0 +1,47 @@
+import { createSelector } from '@reduxjs/toolkit';
+
+import { Statuses } from 'src/redux/features/asyncUtils';
+import { RootState } from 'src/redux/store';
+
+import { SelectorConfig, SelectorResultConfig } from '.';
+
+export const createCombinedSelector = (selectors: SelectorConfig[]) =>
+  createSelector(
+    selectors.map(
+      ([identifier, selector, config]) =>
+        (state: RootState): SelectorResultConfig => [identifier, selector(state), config]
+    ),
+    // Extracted values are passed to the result function for recalculation
+    (...results) => results
+  );
+
+export const getCombinedStatus = (statuses: Statuses[]): Statuses =>
+  statuses.reduce((acc: Statuses, curr: Statuses) => {
+    if (curr === 'error') {
+      // Error overrides all statuses
+      return 'error';
+    } else if (curr === 'pending') {
+      // Pending overrides all but error
+      if (['success', 'partial-success'].includes(acc)) {
+        return curr;
+      }
+
+      return acc;
+    } else if (curr === 'success') {
+      // Success does not override any status
+      if (['error', 'partial-success', 'pending'].includes(acc)) {
+        return acc;
+      }
+
+      return curr;
+    } else if (curr === 'partial-success') {
+      // Partial success can override success only
+      if (acc === 'success') {
+        return curr;
+      }
+
+      return acc;
+    }
+
+    return acc;
+  });

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentActions.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentActions.tsx
@@ -56,7 +56,7 @@ const DocumentActions = ({ document, onDocumentUpdate }: DocumentActionsProps): 
           }}
         />
       )}
-      {openPreview && <Preview docId={document.id} close={() => setOpenPreview(false)} />}
+      {openPreview && <Preview close={() => setOpenPreview(false)} />}
       <Box margin={theme.spacing(isMobile ? 2 : 5, isMobile ? 'auto' : 0, 0)}>
         <Button
           id={`preview-document-${document.id}`}

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentHistoryTab.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentHistoryTab.tsx
@@ -7,12 +7,13 @@ import getDateDisplayValue from '@terraware/web-components/utils/date';
 import PageContent from 'src/components/DocumentProducer/PageContent';
 import TableContent from 'src/components/DocumentProducer/TableContent';
 import CellRenderer from 'src/components/common/table/TableCellRenderer';
+import { useDocumentProducerData } from 'src/providers/DocumentProducer/Context';
 import { searchHistory } from 'src/redux/features/documentProducer/documents/documentsSelector';
 import { requestListHistory } from 'src/redux/features/documentProducer/documents/documentsThunks';
 import { useSelectorProcessor } from 'src/redux/hooks/useSelectorProcessor';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
-import { Document, DocumentHistoryEvent } from 'src/types/documentProducer/Document';
+import { DocumentHistoryEvent } from 'src/types/documentProducer/Document';
 
 import DocumentHistoryRowMenu from './DocumentHistoryRowMenu';
 
@@ -63,26 +64,23 @@ const tableCellRenderer = (props: RendererProps<any>): JSX.Element => {
   return <CellRenderer {...props} />;
 };
 
-export type DocumentHistoryProps = {
-  document: Document;
-};
-
-const DocumentHistoryTab = ({ document }: DocumentHistoryProps): JSX.Element => {
+const DocumentHistoryTab = (): JSX.Element => {
   const dispatch = useAppDispatch();
+  const { documentId } = useDocumentProducerData();
+
   const [tableRows, setTableRows] = useState<DocumentHistoryEvent[]>([]);
   const [searchValue, setSearchValue] = useState<string>('');
   const onSearch = (str: string) => setSearchValue(str);
 
   // select history data
-  const history = useAppSelector((state) => searchHistory(state, document.id, searchValue));
-
+  const history = useAppSelector((state) => searchHistory(state, documentId, searchValue));
   useSelectorProcessor(history, setTableRows);
 
   useEffect(() => {
     // TODO should these be admin users? TF accelerator users?
     // dispatch(requestListUsers());
-    dispatch(requestListHistory(document.id));
-  }, [dispatch, document.id]);
+    dispatch(requestListHistory(documentId));
+  }, [dispatch, documentId]);
 
   const props = {
     searchProps: {
@@ -95,7 +93,7 @@ const DocumentHistoryTab = ({ document }: DocumentHistoryProps): JSX.Element => 
       tableOrderBy: 'date',
       tableColumns,
       tableCellRenderer,
-      tableReloadData: () => dispatch(requestListHistory(document.id)),
+      tableReloadData: () => dispatch(requestListHistory(documentId)),
     },
   };
 

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentMetadata.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentMetadata.tsx
@@ -3,25 +3,23 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Box, Typography, useTheme } from '@mui/material';
 
 import { useParticipants } from 'src/hooks/useParticipants';
-import { selectDocumentTemplates } from 'src/redux/features/documentProducer/documentTemplates/documentTemplatesSelector';
-import { requestListDocumentTemplates } from 'src/redux/features/documentProducer/documentTemplates/documentTemplatesThunks';
 import { requestGetUser } from 'src/redux/features/user/usersAsyncThunks';
 import { selectUser } from 'src/redux/features/user/usersSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 import { User } from 'src/types/User';
 import { Document } from 'src/types/documentProducer/Document';
+import { DocumentTemplate } from 'src/types/documentProducer/DocumentTemplate';
 import { getDateTimeDisplayValue } from 'src/utils/dateFormatter';
 import { getUserDisplayName } from 'src/utils/user';
 
-import { getDocumentTemplateName } from '../DocumentsView/helpers';
-
 export type DocumentMetadataProps = {
   document: Document;
+  documentTemplate: DocumentTemplate;
 };
 
-const DocumentMetadata = ({ document }: DocumentMetadataProps): JSX.Element => {
-  const { name, documentTemplateId, ownedBy, modifiedBy, modifiedTime, projectId } = document;
+const DocumentMetadata = ({ document, documentTemplate }: DocumentMetadataProps): JSX.Element => {
+  const { name, ownedBy, modifiedBy, modifiedTime, projectId } = document;
 
   const dispatch = useAppDispatch();
   const theme = useTheme();
@@ -30,15 +28,10 @@ const DocumentMetadata = ({ document }: DocumentMetadataProps): JSX.Element => {
   const [modifiedByUser, setModifiedByUser] = useState<User>();
 
   const modifiedBySelector = useAppSelector(selectUser(modifiedBy));
-  const { documentTemplates } = useAppSelector(selectDocumentTemplates);
 
   useEffect(() => {
     setModifiedByUser(modifiedBySelector);
   }, [modifiedBySelector]);
-
-  useEffect(() => {
-    dispatch(requestListDocumentTemplates());
-  }, [dispatch]);
 
   useEffect(() => {
     dispatch(requestGetUser(ownedBy));
@@ -47,10 +40,6 @@ const DocumentMetadata = ({ document }: DocumentMetadataProps): JSX.Element => {
 
   const modifiedByName = useMemo(() => getUserDisplayName(modifiedByUser), [modifiedByUser]);
   const modifiedTimeDisplay = useMemo(() => getDateTimeDisplayValue(new Date(modifiedTime).getTime()), [modifiedTime]);
-  const documentTemplateName = useMemo(
-    () => getDocumentTemplateName(documentTemplateId, documentTemplates ?? []),
-    [documentTemplates, documentTemplateId]
-  );
 
   const participant = availableParticipants?.find((part) => part.projects.find((proj) => proj.id === projectId));
 
@@ -72,7 +61,7 @@ const DocumentMetadata = ({ document }: DocumentMetadataProps): JSX.Element => {
         color={theme.palette.TwClrTxt}
         margin={theme.spacing(1, 0)}
       >
-        {name} - {documentTemplateName}
+        {name} - {documentTemplate.name}
       </Typography>
       <Typography
         fontWeight={400}
@@ -82,7 +71,7 @@ const DocumentMetadata = ({ document }: DocumentMetadataProps): JSX.Element => {
         component='pre'
         whiteSpace='pre-wrap'
       >
-        {strings.TEMPLATE}: {documentTemplateName}
+        {strings.TEMPLATE}: {documentTemplate.name}
         <br />
         {strings.LAST_EDITED_BY}: {modifiedByName}, {modifiedTimeDisplay}
       </Typography>

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentOutlinePanel.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentOutlinePanel.tsx
@@ -14,13 +14,8 @@ import {
 
 import Icon from 'src/components/common/icon/Icon';
 import { useIsVisible } from 'src/hooks/useIsVisible';
-import { requestListVariablesValues } from 'src/redux/features/documentProducer/values/valuesThunks';
-import { selectVariablesWithValues } from 'src/redux/features/documentProducer/variables/variablesSelector';
-import { requestListVariables } from 'src/redux/features/documentProducer/variables/variablesThunks';
-import { useSelectorProcessor } from 'src/redux/hooks/useSelectorProcessor';
-import { useAppDispatch, useAppSelector } from 'src/redux/store';
-import { Document as DocumentType } from 'src/types/documentProducer/Document';
-import { SectionVariableWithValues, VariableWithValues } from 'src/types/documentProducer/Variable';
+import { useDocumentProducerData } from 'src/providers/DocumentProducer/Context';
+import { SectionVariableWithValues } from 'src/types/documentProducer/Variable';
 
 const isHTMLElementInViewport = (element: HTMLElement): boolean => {
   const rect = element.getBoundingClientRect();
@@ -154,38 +149,27 @@ const SectionItem = ({
 };
 
 type Props = {
-  document: DocumentType;
   open: boolean;
   setOpen: (open: boolean) => void;
 };
 
-const DocumentOutlinePanel = ({ document, open, setOpen }: Props): JSX.Element => {
-  const dispatch = useAppDispatch();
+const DocumentOutlinePanel = ({ open, setOpen }: Props): JSX.Element => {
   const visibilityBoxRef = useRef(null);
   const topIsVisible = useIsVisible(visibilityBoxRef);
+  const { documentVariables } = useDocumentProducerData();
+
   const [selectedSectionId, setSelectedSectionId] = useState<number>();
   const [sections, setSections] = useState<SectionVariableWithValues[]>();
-  const [variables, setVariables] = useState<(VariableWithValues | SectionVariableWithValues)[]>();
-  const result = useAppSelector((state) =>
-    selectVariablesWithValues(state, document.variableManifestId, document.projectId)
-  );
-
-  useSelectorProcessor(result, setVariables);
 
   useEffect(() => {
-    dispatch(requestListVariables(document.variableManifestId));
-    dispatch(requestListVariablesValues({ projectId: document.projectId }));
-  }, [dispatch, document.variableManifestId, document.projectId]);
-
-  useEffect(() => {
-    if (!selectedSectionId && variables) {
-      const sectionVariables = variables.filter((variable) => variable.type === 'Section');
+    if (!selectedSectionId && documentVariables) {
+      const sectionVariables = documentVariables.filter((variable) => variable.type === 'Section');
       setSections(sectionVariables as SectionVariableWithValues[]);
       if (sectionVariables.length) {
         setSelectedSectionId(sectionVariables[0].id);
       }
     }
-  }, [selectedSectionId, variables]);
+  }, [selectedSectionId, documentVariables]);
 
   return (
     <Box width={open ? '200px' : '60px'}>

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
@@ -85,7 +85,6 @@ const filterSearch =
 const DocumentVariablesTab = ({ setSelectedTab }: DocumentVariablesProps): JSX.Element => {
   const { allVariables, documentSectionVariables, getUsedSections, projectId, reload } = useDocumentProducerData();
 
-  console.log({ allVariables });
   const [tableRows, setTableRows] = useState<TableRow[]>([]);
   const [variables, setVariables] = useState<VariableWithValues[]>([]);
   const [searchValue, setSearchValue] = useState<string>('');
@@ -127,7 +126,6 @@ const DocumentVariablesTab = ({ setSelectedTab }: DocumentVariablesProps): JSX.E
       setOpenEditVariableModal(false);
       setSelectedVariable(undefined);
 
-      console.log({ setSelectedTab });
       if (setSelectedTab) {
         setSelectedTab(strings.DOCUMENT);
         setTimeout(() => {

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/SaveVersion.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/SaveVersion.tsx
@@ -15,11 +15,12 @@ export type SaveVersionProps = {
 };
 
 const SaveVersion = ({ docId, onFinish }: SaveVersionProps): JSX.Element => {
+  const dispatch = useAppDispatch();
+  const theme = useTheme();
+
   const [versionName, setVersionName] = useState<string>('');
   const [requestId, setRequestId] = useState<string>('');
   const [errors, setErrors] = useState<Record<string, string>>({});
-  const dispatch = useAppDispatch();
-  const theme = useTheme();
 
   const selector = useAppSelector(selectDocumentRequest(requestId));
 

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/UpdateMetadata.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/UpdateMetadata.tsx
@@ -16,11 +16,12 @@ export type UpdateMetadataProps = {
 };
 
 const UpdateMetadata = ({ doc, onFinish }: UpdateMetadataProps): JSX.Element => {
+  const dispatch = useAppDispatch();
+
   const [documentName, setDocumentName] = useState<string>(doc.name);
   const [documentOwner, setDocumentOwner] = useState<string>(doc.ownedBy.toString());
   const [requestId, setRequestId] = useState<string>('');
   const [formValid, setFormValid] = useState<boolean>();
-  const dispatch = useAppDispatch();
 
   const selector = useAppSelector(selectDocumentRequest(requestId));
 

--- a/src/scenes/AcceleratorRouter/Documents/PreviewView/index.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/PreviewView/index.tsx
@@ -1,49 +1,26 @@
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { useParams } from 'react-router-dom';
 
-import useNavigateTo from 'src/hooks/useNavigateTo';
-import { selectGetDocument } from 'src/redux/features/documentProducer/documents/documentsSelector';
-import { requestGetDocument } from 'src/redux/features/documentProducer/documents/documentsThunks';
+import { useDocumentProducerData } from 'src/providers/DocumentProducer/Context';
 import { selectProject } from 'src/redux/features/projects/projectsSelectors';
 import { requestProject } from 'src/redux/features/projects/projectsThunks';
-import { useSelectorProcessor } from 'src/redux/hooks/useSelectorProcessor';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
-import { Document } from 'src/types/documentProducer/Document';
 
 import PreviewDocument from './PreviewDocument';
 
 export type PreviewProps = {
-  docId?: number;
   close?: () => void;
 };
 
-export default function Preview({ docId, close }: PreviewProps) {
+export default function Preview({ close }: PreviewProps) {
   const dispatch = useAppDispatch();
-  // TODO snackbar had to be removed from the useEffect that creates the window, how do we want to alert if an error occurs creating the document?
-  // const snackbar = useSnackbar();
-  const { goToDocuments } = useNavigateTo();
-  const { documentId: docIdParam } = useParams<{ documentId: string }>();
+  const { document: doc, projectId } = useDocumentProducerData();
 
   const [newWindow, setNewWindow] = useState<Window | null>(null);
   const [containerEl, setContainerEl] = useState<HTMLElement | null>(null);
   const [initialized, setInitialized] = useState(false);
-  const [doc, setDoc] = useState<Document>();
-
-  const id = docId ?? Number(docIdParam);
-  const projectId = doc?.projectId || -1;
 
   const project = useAppSelector(selectProject(projectId));
-
-  const docSelect = useAppSelector(selectGetDocument(id));
-  useSelectorProcessor(docSelect, setDoc, {
-    handleError: true,
-    onError: goToDocuments,
-  });
-
-  useEffect(() => {
-    dispatch(requestGetDocument(id));
-  }, [dispatch, id]);
 
   useEffect(() => {
     if (projectId !== -1) {
@@ -98,5 +75,5 @@ export default function Preview({ docId, close }: PreviewProps) {
     return null;
   }
 
-  return createPortal(<PreviewDocument doc={doc} projectName={project.name} />, containerEl);
+  return createPortal(<PreviewDocument projectName={project.name} />, containerEl);
 }

--- a/src/scenes/AcceleratorRouter/Documents/index.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/index.tsx
@@ -1,5 +1,7 @@
 import React, { Route, Routes } from 'react-router-dom';
 
+import DocumentProducerProvider from 'src/providers/DocumentProducer/Provider';
+
 import DocumentView from './DocumentView';
 import DocumentsAddView from './DocumentsAddView';
 import DocumentsView from './DocumentsView';
@@ -8,8 +10,19 @@ import PreviewView from './PreviewView';
 const DocumentsRouter = (): JSX.Element => {
   return (
     <Routes>
-      <Route path={'/:documentId'} element={<DocumentView />} />
-      <Route path={'/:documentId/preview'} element={<PreviewView />} />
+      <Route
+        path={'/:documentId/*'}
+        element={
+          <DocumentProducerProvider>
+            <Routes>
+              <Route path={'/'} element={<DocumentView />} />
+              <Route path={'/preview'} element={<PreviewView />} />
+            </Routes>
+          </DocumentProducerProvider>
+        }
+      />
+
+      {/* <Route path={'/:documentId/preview'} element={<PreviewView />} /> */}
       <Route path={'/new'} element={<DocumentsAddView />} />
       <Route path={'/*'} element={<DocumentsView />} />
     </Routes>

--- a/src/services/documentProducer/VariableService.ts
+++ b/src/services/documentProducer/VariableService.ts
@@ -18,9 +18,9 @@ const getDeliverableVariables = (deliverableId: number): Promise<Response2<Varia
     params: { deliverableId: `${deliverableId}` },
   });
 
-const getVariables = (manifestId: number): Promise<Response2<VariableListResponse>> =>
+const getDocumentVariables = (documentId: number): Promise<Response2<VariableListResponse>> =>
   HttpService.root(VARIABLES_ENDPOINT).get2({
-    params: { manifestId: manifestId.toString() },
+    params: { documentId: `${documentId}` },
   });
 
 const updateVariableWorkflowDetails = (
@@ -59,7 +59,7 @@ const getVariablesOwners = (projectId: number): Promise<Response2<VariableOwners
 const VariableService = {
   getAllVariables,
   getDeliverableVariables,
-  getVariables,
+  getDocumentVariables,
   updateVariableWorkflowDetails,
   updateVariableOwner,
   getVariablesOwners,


### PR DESCRIPTION
- Implement `DocumentProducerProvider`, which should be used when interacting with documents within the document producer. It bundles all the necessary requests and combines the data in the ways needed for frontend use. 
- Create `useMultiSelectorProcessor`, in the same vain as `useSelectorProcessor`, but keeps track of and combines statuses from multiple `AsyncRequest` s. 
- Within the new provider, extract the document-specific variables and make them available to consumers, this is used to ensure that "outdated" variables are still accessible within the document producer for sections that have outdated variables injected into them.
- Refactor all usages of the variables / document selectors to use the provider.
- Fix issue with document tab variable modal not showing section instances.


TODO
- Write some documentation on how / when to use the multi selector processor