### PR TITLE
Fix table variable value saving in deliverable view

### DIFF
--- a/src/components/AcceleratorDeliverableView/QuestionsDeliverableCard.tsx
+++ b/src/components/AcceleratorDeliverableView/QuestionsDeliverableCard.tsx
@@ -58,7 +58,8 @@ const QuestionBox = ({
   const theme = useTheme();
   const { activeLocale } = useLocalization();
   const {
-    pendingVariableValues,
+    getPendingValues,
+    hasPendingValues,
     setCellValues,
     setDeletedImages,
     setImages,
@@ -87,11 +88,6 @@ const QuestionBox = ({
   const firstVariableValueInternalComment: string | undefined = firstVariableValue?.internalComment;
 
   const [modalFeedback, setModalFeedback] = useState(firstVariableValue?.feedback || '');
-
-  const pendingValues: VariableValueValue[] | undefined = useMemo(
-    () => pendingVariableValues.get(variable.id),
-    [pendingVariableValues, variable.id]
-  );
 
   const editing = useMemo(() => editingId === variable.id, [editingId, variable.id]);
 
@@ -159,8 +155,7 @@ const QuestionBox = ({
 
   const onSave = () => {
     setEditingId(undefined);
-
-    if (pendingVariableValues.size === 0) {
+    if (!hasPendingValues) {
       return;
     }
 
@@ -354,11 +349,13 @@ const QuestionBox = ({
               <Grid item xs={12}>
                 <DeliverableVariableDetailsInput
                   hideDescription
-                  values={pendingValues || variable.values}
+                  values={(getPendingValues(variable.id) as VariableValueValue[]) || variable.values}
                   setValues={(newValues: VariableValueValue[]) => setValues(variable.id, newValues)}
                   variable={variable}
                   addRemovedValue={(removedValue: VariableValueValue) => setRemovedValue(variable.id, removedValue)}
-                  setCellValues={(newValues: VariableTableCell[][]) => setCellValues(variable.id, newValues)}
+                  setCellValues={(newValues: VariableTableCell[][]) => {
+                    setCellValues(variable.id, newValues);
+                  }}
                   setDeletedImages={(newValues: VariableValueImageValue[]) => setDeletedImages(variable.id, newValues)}
                   setImages={(newValues: VariableValueImageValue[]) => setImages(variable.id, newValues)}
                   setNewImages={(newValues: PhotoWithAttributes[]) => setNewImages(variable.id, newValues)}

--- a/src/components/DeliverableView/QuestionsDeliverableEditForm.tsx
+++ b/src/components/DeliverableView/QuestionsDeliverableEditForm.tsx
@@ -141,6 +141,7 @@ const QuestionsDeliverableEditForm = (props: QuestionsDeliverableEditViewProps):
   }, [variablesWithValues]);
 
   const {
+    hasPendingValues,
     pendingVariableValues,
     setCellValues,
     setDeletedImages,
@@ -171,7 +172,7 @@ const QuestionsDeliverableEditForm = (props: QuestionsDeliverableEditViewProps):
   }, [exit, updateSuccess, uploadSuccess]);
 
   const handleOnSave = () => {
-    if (pendingVariableValues.size === 0) {
+    if (!hasPendingValues) {
       // If the user clicks save but there are no changes, just navigate them back to the deliverable
       exit();
     }

--- a/src/components/DocumentProducer/DeliverableVariableDetailsInput/index.tsx
+++ b/src/components/DocumentProducer/DeliverableVariableDetailsInput/index.tsx
@@ -93,6 +93,7 @@ const DeliverableVariableDetailsInput = ({
   }, [variable, values]);
 
   const onChangeValueHandler = (newValue: any, id: string, index: number = 0) => {
+    console.log({ newValue, id, index });
     if (id === 'title') {
       setTitle(newValue);
     } else if (variable.type !== 'Text') {

--- a/src/hooks/useProjectVariablesUpdate/index.ts
+++ b/src/hooks/useProjectVariablesUpdate/index.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { PhotoWithAttributes } from 'src/components/DocumentProducer/EditImagesModal/PhotoSelector';
 import { VariableTableCell } from 'src/components/DocumentProducer/EditableTableModal/helpers';
@@ -24,6 +24,10 @@ import useSnackbar from 'src/utils/useSnackbar';
 import { makeVariableValueOperations } from './util';
 
 type ProjectVariablesUpdate = {
+  getPendingValues: (
+    variableId: number
+  ) => VariableValueValue[] | VariableTableCell[][] | VariableValueImageValue[] | undefined;
+  hasPendingValues: boolean;
   pendingVariableValues: Map<number, VariableValueValue[]>;
   setCellValues: (variableId: number, values: VariableTableCell[][]) => void;
   setDeletedImages: (variableId: number, values: VariableValueImageValue[]) => void;
@@ -201,7 +205,26 @@ export const useProjectVariablesUpdate = (
     }
   }, [projectId, updateResult]);
 
+  const hasPendingValues = useMemo(
+    () =>
+      pendingVariableValues.size +
+        pendingCellValues.size +
+        pendingImages.size +
+        pendingDeletedImages.size +
+        pendingNewImages.size >
+      0,
+    [pendingVariableValues, pendingCellValues, pendingImages, pendingDeletedImages, pendingNewImages]
+  );
+
+  const getPendingValues = useCallback(
+    (variableId: number) =>
+      pendingVariableValues.get(variableId) || pendingCellValues.get(variableId) || pendingImages.get(variableId),
+    [pendingVariableValues, pendingCellValues, pendingImages, pendingDeletedImages, pendingNewImages]
+  );
+
   return {
+    getPendingValues,
+    hasPendingValues,
     pendingVariableValues,
     setCellValues,
     setDeletedImages,


### PR DESCRIPTION
The variable value update hook was not exposing the pending table variables, so consumers did not know that updates had to occur. This fixes that.