### PR TITLE
Fix doc producer document variables tab crashes terraware sometimes

### DIFF
--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
@@ -139,7 +139,7 @@ const DocumentVariablesTab = ({ document: doc, setSelectedTab }: DocumentVariabl
       ) {
         newAcc.push(currentVal.parentSectionNumber);
       }
-      currentVal.children.forEach((childSection) => {
+      currentVal.children?.forEach((childSection) => {
         const childContainingSections = containingSections(variableId)([], childSection as SectionVariableWithValues);
         newAcc.push(...childContainingSections);
       });


### PR DESCRIPTION
This PR includes a fix for an issue that results in Terraware crashing sometimes when viewing the Variables tab of a Document in the Doc Producer.

## Screenshots

![localhost_3000_accelerator_documents_1_tab=variables](https://github.com/user-attachments/assets/29e189c3-dba1-40d8-ae25-ee92ce566aef)
