### PR TITLE
SW-5881: [Visual] Document Producer - Add Document form not centered

### DIFF
--- a/src/scenes/AcceleratorRouter/Documents/DocumentsAddView/index.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentsAddView/index.tsx
@@ -61,6 +61,7 @@ const DocumentsAddView = (): JSX.Element => {
         saveID='save'
         saveButtonText={strings.SAVE}
         cancelButtonText={strings.CANCEL}
+        style={{ width: '100%' }}
       >
         <PageContent styles={{ width: '568px', margin: 'auto' }}>
           <DocumentMetadataEdit


### PR DESCRIPTION
This PR centers the Add Document form.

## Screenshots

### Before

![localhost_3000_accelerator_documents_new (1)](https://github.com/user-attachments/assets/c5818804-9016-4668-b415-7de507c5bd2d)

### After

![localhost_3000_accelerator_documents_new](https://github.com/user-attachments/assets/6b8b5920-9ba0-421c-8dcd-a5be49ac49a0)
