### PR TITLE
SW-5831: Projects File Naming field: truncate the value in the filed when the browser shrinks the field size

### DIFF
--- a/src/components/ProjectField/index.tsx
+++ b/src/components/ProjectField/index.tsx
@@ -37,7 +37,7 @@ export const renderFieldValue = (value: DisplayFieldValue): JSX.Element => {
   }
 
   return (
-    <Typography fontSize={'24px'} lineHeight={'32px'} fontWeight={600}>
+    <Typography fontSize='24px' fontWeight={600} lineHeight='32px' overflow='hidden' textOverflow='ellipsis'>
       {([undefined, null] as DisplayFieldValue[]).includes(value) ? 'N/A' : value}
     </Typography>
   );


### PR DESCRIPTION
This PR truncates project display text values when they overflow their parent container.

## Screenshots

### Before

![localhost_3000_accelerator_projects_40](https://github.com/user-attachments/assets/4ba17aa1-3859-41f2-9ef6-56becfaec9b9)

### After

![localhost_3000_accelerator_projects_40 (1)](https://github.com/user-attachments/assets/ab88da7c-405e-410a-bd7e-556308c63627)
