### PR TITLE
SW-5843: Remove "See All Modules" link from Module Overview Card on home page

### DIFF
--- a/src/components/ModuleDetailsCard/index.tsx
+++ b/src/components/ModuleDetailsCard/index.tsx
@@ -6,7 +6,6 @@ import { useDeviceInfo } from '@terraware/web-components/utils';
 import { DateTime } from 'luxon';
 
 import Link from 'src/components/common/Link';
-import { APP_PATHS } from 'src/constants';
 import useNavigateTo from 'src/hooks/useNavigateTo';
 import { useLocalization } from 'src/providers';
 import strings from 'src/strings';
@@ -88,7 +87,6 @@ type ModuleDetailsCardProp = {
   events?: EventDetails[];
   module: ModuleDetails;
   projectId: number;
-  showSeeAllModules?: boolean;
   showSimplifiedStatus?: boolean;
   children?: ReactNode;
 };
@@ -98,7 +96,6 @@ const ModuleDetailsCard = ({
   events,
   module,
   projectId,
-  showSeeAllModules = false,
   showSimplifiedStatus = false,
   children,
 }: ModuleDetailsCardProp) => {
@@ -169,24 +166,9 @@ const ModuleDetailsCard = ({
           <ModuleContentSection>
             <Grid container>
               <Grid item xs={12}>
-                <Grid container justifyContent={'space-between'}>
-                  <Grid item>
-                    <Typography fontSize={'16px'} fontWeight={500} lineHeight={'24px'}>
-                      {module.title}
-                    </Typography>
-                  </Grid>
-                  <Grid item>
-                    {showSeeAllModules && (
-                      <Link
-                        to={APP_PATHS.PROJECT_MODULES.replace(':projectId', `${projectId}`)}
-                        fontSize={16}
-                        fontWeight={500}
-                      >
-                        {strings.SEE_ALL_MODULES}
-                      </Link>
-                    )}
-                  </Grid>
-                </Grid>
+                <Typography fontSize={'16px'} fontWeight={500} lineHeight={'24px'}>
+                  {module.title}
+                </Typography>
               </Grid>
               <Grid item xs={12}>
                 <Typography fontSize={'24px'} lineHeight={'32px'} fontWeight={600}>

--- a/src/scenes/Home/ParticipantHomeView/CurrentModule.tsx
+++ b/src/scenes/Home/ParticipantHomeView/CurrentModule.tsx
@@ -65,7 +65,6 @@ const CurrentModule = () => {
       events={eventDetails}
       module={moduleDetails}
       projectId={currentParticipantProject.id}
-      showSeeAllModules={true}
     />
   );
 };


### PR DESCRIPTION
This PR removes the "See All Modules" link from the Module Overview Card on the home page.

## Screenshots

### Before

![localhost_3000_home_organizationId=141](https://github.com/user-attachments/assets/d39f83fe-54e1-4ba5-ac0f-6be444aab07f)

### After

![localhost_3000_home_organizationId=141 (2)](https://github.com/user-attachments/assets/2d706fb9-108e-49c0-af25-4ad3339e505c)
