### PR TITLE
SW-5877 Filtering for "Accepted" Applications also pulls up "Not Accepted"

### DIFF
--- a/src/utils/searchAndSort.test.ts
+++ b/src/utils/searchAndSort.test.ts
@@ -329,7 +329,7 @@ describe('searchAndSort', () => {
       },
     ];
 
-    const searchValue = 'corpot';
+    const searchValue = 'corpotrees';
 
     const search: SearchNodePayload = {
       operation: 'or',

--- a/src/utils/searchAndSort.ts
+++ b/src/utils/searchAndSort.ts
@@ -84,7 +84,7 @@ const searchConditionMet = <T extends Record<string, unknown>>(result: T, condit
     }
 
     if (condition.type === 'Exact') {
-      return searchValues.some((value) => resultValue.includes(value));
+      return searchValues.some((value) => resultValue === value);
     } else if (condition.type === 'Fuzzy') {
       return searchValues.some((searchValue) => {
         // Trigrams don't work with single letter searches


### PR DESCRIPTION
The Exact search condition in the front-end was executing an includes (not exact condition) instead of an equals