### PR TITLE
SW-5902: Full application questionnaire deliverables inputs missing

### DIFF
--- a/src/components/DocumentProducer/DeliverableVariableDetailsInput/index.tsx
+++ b/src/components/DocumentProducer/DeliverableVariableDetailsInput/index.tsx
@@ -262,7 +262,7 @@ const DeliverableVariableDetailsInput = ({
 
       {variable.type === 'Text' && (
         <>
-          {(values as VariableValueTextValue[])
+          {(values.length ? (values as VariableValueTextValue[]) : [{ textValue: '' }])
             ?.map((tv) => tv.textValue)
             .map((iValue, index) => (
               <Box key={index} display='flex' alignItems='center' sx={{ position: 'relative' }}>


### PR DESCRIPTION
This PR fixes a regression from my [previous PR for SW-5825](https://github.com/terraware/terraware-web/pull/3064), where I missed adding an empty fallback value for text variables without pre-existing values. This update corrects that oversight.