### PR TITLE
SW-5758: Project Details page - Land Use Model Type font weight should be 600

### DIFF
--- a/src/components/common/TextTruncated.tsx
+++ b/src/components/common/TextTruncated.tsx
@@ -10,18 +10,25 @@ const COLUMN_WIDTH = 250;
 export type Props = {
   columnWidth?: number;
   fontSize?: number;
+  fontWeight?: number;
   listSeparator?: string;
   stringList: string[];
 };
 
-export default function TextTruncated({ columnWidth, fontSize, listSeparator, stringList }: Props): JSX.Element {
+export default function TextTruncated({
+  columnWidth,
+  fontSize,
+  fontWeight,
+  listSeparator,
+  stringList,
+}: Props): JSX.Element {
   const theme = useTheme();
 
   return (
     <Truncated
       stringList={stringList}
       maxLengthPx={columnWidth || COLUMN_WIDTH}
-      textStyle={{ fontSize: fontSize || 14 }}
+      textStyle={{ fontSize: fontSize || 14, fontWeight: fontWeight || 400 }}
       showAllStyle={{ padding: theme.spacing(2), fontSize: fontSize || 14 }}
       listSeparator={listSeparator || strings.LIST_SEPARATOR}
       moreSeparator={strings.TRUNCATED_TEXT_MORE_SEPARATOR}

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/SingleView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/SingleView.tsx
@@ -202,7 +202,13 @@ const SingleView = () => {
               <ProjectFieldDisplay label={strings.REGION} value={participantProject?.region} />
               <ProjectFieldDisplay
                 label={strings.LAND_USE_MODEL_TYPE}
-                value={<TextTruncated fontSize={24} stringList={participantProject?.landUseModelTypes || []} />}
+                value={
+                  <TextTruncated
+                    fontSize={24}
+                    fontWeight={600}
+                    stringList={participantProject?.landUseModelTypes || []}
+                  />
+                }
                 rightBorder={!isMobile}
               />
               <ProjectFieldDisplay


### PR DESCRIPTION
This PR includes changes to adjust the font weight for the land use model type field on the project details page.

## Screenshots

### Before

![localhost_3000_accelerator_cohorts_11_edit (3)](https://github.com/user-attachments/assets/6031697a-e226-446b-af23-a6836186c004)

### After

![localhost_3000_accelerator_cohorts_11_edit (4)](https://github.com/user-attachments/assets/7486e086-6477-48c2-b347-a949f5343f9a)
