### PR TITLE
SW-5745: Add created and edited timestamps to cohort edit view (Follow-up #1)

### DIFF
--- a/src/components/ProjectField/Meta.tsx
+++ b/src/components/ProjectField/Meta.tsx
@@ -58,7 +58,7 @@ const ProjectFieldMeta = ({ date, dateLabel, userId, userName, userLabel }: Proj
             // do name and ID here but if they are spread into the project entity the structure
             // will be different */}
             <Link
-              to={APP_PATHS.PEOPLE_VIEW.replace(':userId', `${userId}`)}
+              to={APP_PATHS.PEOPLE_VIEW.replace(':personId', `${userId}`)}
               fontSize={'16px'}
               fontWeight={400}
               lineHeight={'24px'}

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortForm.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortForm.tsx
@@ -167,7 +167,7 @@ export default function CohortForm<T extends CreateCohortRequestPayload | Update
                     fontSize={'16px'}
                     fontWeight={400}
                     lineHeight={'24px'}
-                    to={APP_PATHS.PEOPLE_VIEW.replace(':userId', `${cohort.createdBy}`)}
+                    to={APP_PATHS.PEOPLE_VIEW.replace(':personId', `${cohort.createdBy}`)}
                   >
                     {getUserDisplayName(createdByUser)}
                   </Link>
@@ -187,7 +187,7 @@ export default function CohortForm<T extends CreateCohortRequestPayload | Update
                     fontSize={'16px'}
                     fontWeight={400}
                     lineHeight={'24px'}
-                    to={APP_PATHS.PEOPLE_VIEW.replace(':userId', `${cohort.modifiedBy}`)}
+                    to={APP_PATHS.PEOPLE_VIEW.replace(':personId', `${cohort.modifiedBy}`)}
                   >
                     {getUserDisplayName(modifiedByUser)}
                   </Link>


### PR DESCRIPTION
This PR includes a quick fix for an oversight in [my previous PR for SW-5745](https://github.com/terraware/terraware-web/pull/3090): the URI placeholder `:userId` should be `:personId`.