### PR TITLE
SW-5875: "Questions" type should be "Questionnaire" type for Deliverables table and "Type..." should be "Type"

### DIFF
--- a/src/components/DeliverablesTable/index.tsx
+++ b/src/components/DeliverablesTable/index.tsx
@@ -157,6 +157,10 @@ const DeliverablesTable = ({
         field: 'type',
         options: DeliverableTypes,
         label: strings.TYPE,
+        pillValueRenderer: (values: (string | number | null)[]) =>
+          values.map((value) => (value === 'Questions' ? 'Questionnaire' : value)).join(', '),
+        renderOption: (value: string | number) =>
+          value.toString() === 'Questions' ? 'Questionnaire' : value.toString(),
       },
     ];
 
@@ -212,6 +216,7 @@ const DeliverablesTable = ({
     () =>
       deliverables.map((deliverable) => ({
         ...deliverable,
+        type: deliverable.type === 'Questions' ? 'Questionnaire' : deliverable.type,
         isAllowedRead: isAllowedReadDeliverable,
       })),
     [deliverables, isAllowedReadDeliverable]


### PR DESCRIPTION
This PR includes changes to replace all deliverable type values of "Questions" with "Questionnaire".

This PR approaches this via the shortest path: massaging deliverables data in the FE to update the `type` value. Alternatively, we could approach it more holistically and update the deliverable type value across the BE & FE.

## Screenshots

### Before

![staging terraware io_accelerator_overview_tab=cohorts](https://github.com/user-attachments/assets/be4bf7e9-1ccf-44ee-b46e-b0ca7ec261cf)

![staging terraware io_accelerator_overview_tab=cohorts (1)](https://github.com/user-attachments/assets/c6ed94eb-f3c2-4d1f-a258-fccca8daf491)

### After

![localhost_3000_accelerator_deliverables](https://github.com/user-attachments/assets/29350ab5-c59a-4670-8991-0eb7fc667ea5)


