### PR TITLE
WIP Coalesce outdated variable values with current variables for deliverables when the data is selected from state

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -4507,7 +4507,7 @@ export interface components {
       createdTime: string;
       description?: string;
       /** @enum {string} */
-      documentStore: "Dropbox" | "Google";
+      documentStore: "Dropbox" | "Google" | "External";
       /** Format: int64 */
       id: number;
       name: string;
@@ -5293,6 +5293,8 @@ export interface components {
       position?: number;
       /** @description IDs of sections that recommend this variable. */
       recommendedBy?: number[];
+      /** Format: int64 */
+      replacesVariableId?: number;
       stableId: string;
       /** @enum {string} */
       type: "Number" | "Text" | "Date" | "Image" | "Select" | "Table" | "Link" | "Section";
@@ -6929,6 +6931,7 @@ export interface operations {
       query?: {
         deliverableId?: number;
         documentId?: number;
+        projectId?: number;
       };
     };
     responses: {

--- a/src/components/AcceleratorDeliverableView/QuestionsDeliverableCard.tsx
+++ b/src/components/AcceleratorDeliverableView/QuestionsDeliverableCard.tsx
@@ -418,28 +418,26 @@ const QuestionBox = ({
 
 const QuestionsDeliverableCard = (props: EditProps): JSX.Element => {
   const { deliverable, hideStatusBadge }: EditProps = props;
+
   const dispatch = useAppDispatch();
 
   const [editingId, setEditingId] = useState<number | undefined>();
   const [updatePendingId, setUpdatePendingId] = useState<number | undefined>();
 
-  const reload = () => {
-    void dispatch(requestListDeliverableVariables(deliverable.id));
-    void dispatch(
-      requestListDeliverableVariablesValues({ deliverableId: deliverable.id, projectId: deliverable.projectId })
-    );
-  };
+  const deliverableProject = { deliverableId: deliverable.id, projectId: deliverable.projectId };
 
-  useEffect(() => {
+  const reload = useCallback(() => {
     if (!deliverable) {
       return;
     }
 
-    void dispatch(requestListDeliverableVariables(deliverable.id));
-    void dispatch(
-      requestListDeliverableVariablesValues({ deliverableId: deliverable.id, projectId: deliverable.projectId })
-    );
+    void dispatch(requestListDeliverableVariables(deliverableProject));
+    void dispatch(requestListDeliverableVariablesValues(deliverableProject));
   }, [deliverable]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
 
   const variablesWithValues: VariableWithValues[] = useAppSelector((state) =>
     selectDeliverableVariablesWithValues(state, deliverable.id, deliverable.projectId)

--- a/src/components/DeliverableView/QuestionsDeliverableCard.tsx
+++ b/src/components/DeliverableView/QuestionsDeliverableCard.tsx
@@ -74,19 +74,20 @@ const QuestionBox = ({
 };
 
 const QuestionsDeliverableCard = (props: EditProps): JSX.Element | null => {
+  const { deliverable, hideStatusBadge } = props;
+
   const dispatch = useAppDispatch();
   const theme = useTheme();
-  const { deliverable, hideStatusBadge } = props;
+
+  const deliverableProject = { deliverableId: deliverable.id, projectId: deliverable.projectId };
 
   const variablesWithValues: VariableWithValues[] = useAppSelector((state) =>
     selectDeliverableVariablesWithValues(state, deliverable.id, deliverable.projectId)
   );
 
   useEffect(() => {
-    void dispatch(requestListDeliverableVariables(deliverable.id));
-    void dispatch(
-      requestListDeliverableVariablesValues({ deliverableId: deliverable.id, projectId: deliverable.projectId })
-    );
+    void dispatch(requestListDeliverableVariables(deliverableProject));
+    void dispatch(requestListDeliverableVariablesValues(deliverableProject));
   }, [deliverable]);
 
   if (!deliverable) {

--- a/src/components/DeliverableView/QuestionsDeliverableEditForm.tsx
+++ b/src/components/DeliverableView/QuestionsDeliverableEditForm.tsx
@@ -108,11 +108,13 @@ type QuestionsDeliverableEditViewProps = EditProps & {
 };
 
 const QuestionsDeliverableEditForm = (props: QuestionsDeliverableEditViewProps): JSX.Element | null => {
+  const { deliverable, exit, hideStatusBadge } = props;
+
   const dispatch = useAppDispatch();
   const theme = useTheme();
   const query = useQuery();
 
-  const { deliverable, exit, hideStatusBadge } = props;
+  const deliverableProject = { deliverableId: deliverable.id, projectId: deliverable.projectId };
 
   const scrollToVariable = useCallback((variableId: string) => {
     const element = document.querySelector(`[data-variable-id="${variableId}"]`);
@@ -159,10 +161,8 @@ const QuestionsDeliverableEditForm = (props: QuestionsDeliverableEditViewProps):
       return;
     }
 
-    void dispatch(requestListDeliverableVariables(deliverable.id));
-    void dispatch(
-      requestListDeliverableVariablesValues({ deliverableId: deliverable.id, projectId: deliverable.projectId })
-    );
+    void dispatch(requestListDeliverableVariables(deliverableProject));
+    void dispatch(requestListDeliverableVariablesValues(deliverableProject));
   }, [deliverable]);
 
   useEffect(() => {
@@ -201,8 +201,12 @@ const QuestionsDeliverableEditForm = (props: QuestionsDeliverableEditViewProps):
               paddingTop: theme.spacing(3),
             }}
           >
-            {variablesWithValues.map((variableWithValues: VariableWithValues, index: number) =>
-              variableDependencyMet(variableWithValues, variablesWithValues) ? (
+            {variablesWithValues.map((variableWithValues: VariableWithValues, index: number) => {
+              if (variableWithValues.type === 'Table') {
+                console.log({ variableWithValues });
+              }
+
+              return variableDependencyMet(variableWithValues, variablesWithValues) ? (
                 <QuestionBox
                   addRemovedValue={(removedValue: VariableValueValue) =>
                     setRemovedValue(variableWithValues.id, removedValue)
@@ -221,8 +225,8 @@ const QuestionsDeliverableEditForm = (props: QuestionsDeliverableEditViewProps):
                   setValues={(newValues: VariableValueValue[]) => setValues(variableWithValues.id, newValues)}
                   variable={variableWithValues}
                 />
-              ) : null
-            )}
+              ) : null;
+            })}
           </Box>
         </Card>
       </Box>

--- a/src/components/DocumentProducer/DeliverableEditTable/index.tsx
+++ b/src/components/DocumentProducer/DeliverableEditTable/index.tsx
@@ -15,6 +15,7 @@ type DeliverableEditableTableEditProps = {
 };
 
 const DeliverableEditableTableEdit = ({ variable, onChange }: DeliverableEditableTableEditProps) => {
+  console.log({ variable });
   const columns = useMemo<TableColumn[]>(() => variable.columns, [variable]);
   const initialCellValues = useMemo<VariableTableCell[][]>(() => getInitialCellValues(variable), [variable]);
   const [cellValues, setCellValues] = useState<VariableTableCell[][]>(initialCellValues);

--- a/src/components/DocumentProducer/DeliverableVariableDetailsInput/index.tsx
+++ b/src/components/DocumentProducer/DeliverableVariableDetailsInput/index.tsx
@@ -93,7 +93,6 @@ const DeliverableVariableDetailsInput = ({
   }, [variable, values]);
 
   const onChangeValueHandler = (newValue: any, id: string, index: number = 0) => {
-    console.log({ newValue, id, index });
     if (id === 'title') {
       setTitle(newValue);
     } else if (variable.type !== 'Text') {

--- a/src/components/DocumentProducer/EditableTableModal/helpers.ts
+++ b/src/components/DocumentProducer/EditableTableModal/helpers.ts
@@ -71,6 +71,7 @@ export const cellValue = (value: VariableValueValue, placeholder?: string): stri
 };
 
 export const getInitialCellValues = (variable: TableVariableWithValues): VariableTableCell[][] => {
+  debugger;
   return variable.values.map((row) =>
     variable.columns.map((col) => ({
       type: col.variable.type,

--- a/src/redux/features/documentProducer/variables/util.spec.ts
+++ b/src/redux/features/documentProducer/variables/util.spec.ts
@@ -1,0 +1,662 @@
+import { Variable } from 'src/types/documentProducer/Variable';
+import { VariableValue } from 'src/types/documentProducer/VariableValue';
+
+import { mergeVariablesAndValues } from './util';
+
+describe('mergeVariablesAndValues', () => {
+  it('correctly merges table variables with values associated to outdated variables', () => {
+    const tableStableId = '1130';
+    const tableVariableIdCurrent = 250;
+
+    const columnStableIdLocalName = '1131';
+    const columnVariableIdLocalNameCurrent = 251;
+
+    const columnStableIdFamily = '1132';
+    const columnVariableIdFamilyCurrent = 252;
+
+    const row1IdCurrent = 2616;
+    const row2IdCurrent = 2622;
+
+    const variables: Variable[] = [
+      {
+        type: 'Table',
+        columns: [
+          {
+            isHeader: false,
+            variable: {
+              type: 'Text',
+              isRequired: false,
+              position: 0,
+              name: 'Local Name',
+              id: columnVariableIdLocalNameCurrent,
+              stableId: columnStableIdLocalName,
+              isList: false,
+              textType: 'SingleLine',
+            },
+          },
+          {
+            isHeader: false,
+            variable: {
+              type: 'Text',
+              isRequired: false,
+              position: 0,
+              name: 'Family',
+              id: columnVariableIdFamilyCurrent,
+              stableId: columnStableIdFamily,
+              isList: false,
+              textType: 'SingleLine',
+            },
+          },
+        ],
+        isRequired: false,
+        position: 0,
+        name: 'Invasive species to remove',
+        id: tableVariableIdCurrent,
+        stableId: tableStableId,
+        isList: true,
+        deliverableId: 27,
+        deliverableQuestion:
+          'What are the invasive and problematic species that would need to be removed during land preparation?',
+        tableStyle: 'Horizontal',
+      },
+    ];
+
+    const values: VariableValue[] = [
+      {
+        status: 'In Review',
+        variableId: tableVariableIdCurrent,
+        values: [
+          {
+            type: 'Table',
+            id: row1IdCurrent,
+            listPosition: 0,
+          },
+          {
+            type: 'Table',
+            id: row2IdCurrent,
+            listPosition: 1,
+          },
+        ],
+      },
+      {
+        status: 'In Review',
+        variableId: columnVariableIdLocalNameCurrent,
+        rowValueId: row1IdCurrent,
+        values: [
+          {
+            type: 'Text',
+            id: 2517,
+            listPosition: 0,
+            textValue: 'Row 1 local name',
+          },
+        ],
+      },
+      {
+        status: 'In Review',
+        variableId: columnVariableIdLocalNameCurrent,
+        rowValueId: row2IdCurrent,
+        values: [
+          {
+            type: 'Text',
+            id: 2624,
+            listPosition: 0,
+            textValue: 'Row 2 local name',
+          },
+        ],
+      },
+      {
+        status: 'In Review',
+        variableId: columnVariableIdFamilyCurrent,
+        rowValueId: row1IdCurrent,
+        values: [
+          {
+            type: 'Text',
+            id: 2518,
+            listPosition: 0,
+            textValue: 'Row 1 family',
+          },
+        ],
+      },
+      {
+        status: 'In Review',
+        variableId: columnVariableIdFamilyCurrent,
+        rowValueId: row2IdCurrent,
+        values: [
+          {
+            type: 'Text',
+            id: 2625,
+            listPosition: 0,
+            textValue: 'Row 2 family',
+          },
+        ],
+      },
+    ];
+
+    const expected = [
+      {
+        type: 'Table',
+        columns: [
+          {
+            isHeader: false,
+            variable: {
+              type: 'Text',
+              isRequired: false,
+              position: 0,
+              name: 'Local Name',
+              id: columnVariableIdLocalNameCurrent,
+              stableId: columnStableIdLocalName,
+              isList: false,
+              textType: 'SingleLine',
+              values: [
+                {
+                  type: 'Text',
+                  id: 2517,
+                  listPosition: 0,
+                  textValue: 'Row 1 local name',
+                },
+                {
+                  type: 'Text',
+                  id: 2624,
+                  listPosition: 0,
+                  textValue: 'Row 2 local name',
+                },
+              ],
+              variableValues: [
+                {
+                  status: 'In Review',
+                  variableId: columnVariableIdLocalNameCurrent,
+                  rowValueId: row1IdCurrent,
+                  values: [
+                    {
+                      type: 'Text',
+                      id: 2517,
+                      listPosition: 0,
+                      textValue: 'Row 1 local name',
+                    },
+                  ],
+                },
+                {
+                  status: 'In Review',
+                  variableId: columnVariableIdLocalNameCurrent,
+                  rowValueId: row2IdCurrent,
+                  values: [
+                    {
+                      type: 'Text',
+                      id: 2624,
+                      listPosition: 0,
+                      textValue: 'Row 2 local name',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            isHeader: false,
+            variable: {
+              type: 'Text',
+              isRequired: false,
+              position: 0,
+              name: 'Family',
+              id: columnVariableIdFamilyCurrent,
+              stableId: columnStableIdFamily,
+              isList: false,
+              textType: 'SingleLine',
+              values: [
+                {
+                  type: 'Text',
+                  id: 2518,
+                  listPosition: 0,
+                  textValue: 'Row 1 family',
+                },
+                {
+                  type: 'Text',
+                  id: 2625,
+                  listPosition: 0,
+                  textValue: 'Row 2 family',
+                },
+              ],
+              variableValues: [
+                {
+                  status: 'In Review',
+                  variableId: columnVariableIdFamilyCurrent,
+                  rowValueId: row1IdCurrent,
+                  values: [
+                    {
+                      type: 'Text',
+                      id: 2518,
+                      listPosition: 0,
+                      textValue: 'Row 1 family',
+                    },
+                  ],
+                },
+                {
+                  status: 'In Review',
+                  variableId: columnVariableIdFamilyCurrent,
+                  rowValueId: row2IdCurrent,
+                  values: [
+                    {
+                      type: 'Text',
+                      id: 2625,
+                      listPosition: 0,
+                      textValue: 'Row 2 family',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+        isRequired: false,
+        position: 0,
+        name: 'Invasive species to remove',
+        id: tableVariableIdCurrent,
+        stableId: tableStableId,
+        isList: true,
+        deliverableId: 27,
+        deliverableQuestion:
+          'What are the invasive and problematic species that would need to be removed during land preparation?',
+        tableStyle: 'Horizontal',
+        values: [
+          {
+            type: 'Table',
+            id: row1IdCurrent,
+            listPosition: 0,
+          },
+          {
+            type: 'Table',
+            id: row2IdCurrent,
+            listPosition: 1,
+          },
+        ],
+        variableValues: [
+          {
+            status: 'In Review',
+            variableId: tableVariableIdCurrent,
+            values: [
+              {
+                type: 'Table',
+                id: row1IdCurrent,
+                listPosition: 0,
+              },
+              {
+                type: 'Table',
+                id: row2IdCurrent,
+                listPosition: 1,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    expect(mergeVariablesAndValues(variables, values)).toEqual(expected);
+  });
+
+  it('correctly merges table variables with values associated to outdated variables', () => {
+    const tableStableId = '1130';
+    const tableVariableIdCurrent = 250;
+    const tableVariableIdOutdated = 188;
+
+    const columnStableIdLocalName = '1131';
+    const columnVariableIdLocalNameCurrent = 251;
+    const columnVariableIdLocalNameOutdated = 189;
+
+    const columnStableIdFamily = '1132';
+    const columnVariableIdFamilyCurrent = 252;
+    const columnVariableIdFamilyOutdated = 190;
+
+    const row1IdCurrent = 2616;
+    const row1IdOutdated = 2516;
+
+    const row2IdCurrent = 2622;
+    const row2IdOutdated = 2522;
+
+    const variables: Variable[] = [
+      {
+        type: 'Table',
+        columns: [
+          {
+            isHeader: false,
+            variable: {
+              type: 'Text',
+              isRequired: false,
+              position: 0,
+              name: 'Local Name',
+              id: columnVariableIdLocalNameCurrent,
+              stableId: columnStableIdLocalName,
+              isList: false,
+              replacesVariableId: columnVariableIdLocalNameOutdated,
+              textType: 'SingleLine',
+            },
+          },
+          {
+            isHeader: false,
+            variable: {
+              type: 'Text',
+              isRequired: false,
+              position: 0,
+              name: 'Family',
+              id: columnVariableIdFamilyCurrent,
+              stableId: columnStableIdFamily,
+              isList: false,
+              replacesVariableId: columnVariableIdFamilyOutdated,
+              textType: 'SingleLine',
+            },
+          },
+        ],
+        isRequired: false,
+        position: 0,
+        name: 'Invasive species to remove',
+        id: tableVariableIdCurrent,
+        stableId: tableStableId,
+        isList: true,
+        deliverableId: 27,
+        deliverableQuestion:
+          'What are the invasive and problematic species that would need to be removed during land preparation?',
+        replacesVariableId: tableVariableIdOutdated,
+        tableStyle: 'Horizontal',
+      },
+      {
+        type: 'Table',
+        columns: [
+          {
+            isHeader: false,
+            variable: {
+              type: 'Text',
+              isRequired: false,
+              position: 0,
+              name: 'Local Name',
+              id: columnVariableIdLocalNameOutdated,
+              stableId: '1131',
+              isList: false,
+              deliverableId: 27,
+              replacesVariableId: 129,
+              textType: 'SingleLine',
+            },
+          },
+          {
+            isHeader: false,
+            variable: {
+              type: 'Text',
+              isRequired: false,
+              position: 0,
+              description: 'Test description',
+              name: 'Family',
+              id: columnVariableIdFamilyOutdated,
+              stableId: columnStableIdFamily,
+              isList: false,
+              deliverableId: 27,
+              replacesVariableId: 130,
+              textType: 'SingleLine',
+            },
+          },
+        ],
+        isRequired: false,
+        position: 0,
+        name: 'Invasive species to remove',
+        id: tableVariableIdOutdated,
+        stableId: tableStableId,
+        isList: true,
+        deliverableId: 27,
+        deliverableQuestion:
+          'What are the invasive and problematic species that would need to be removed during land preparation?',
+        replacesVariableId: 128,
+        tableStyle: 'Horizontal',
+      },
+    ];
+
+    const values: VariableValue[] = [
+      {
+        status: 'In Review',
+        variableId: tableVariableIdCurrent,
+        values: [
+          {
+            type: 'Table',
+            id: row1IdCurrent,
+            listPosition: 0,
+          },
+          {
+            type: 'Table',
+            id: row2IdCurrent,
+            listPosition: 1,
+          },
+        ],
+      },
+      {
+        status: 'In Review',
+        variableId: tableVariableIdOutdated,
+        values: [
+          {
+            type: 'Table',
+            id: row1IdOutdated,
+            listPosition: 0,
+          },
+          {
+            type: 'Table',
+            id: row2IdOutdated,
+            listPosition: 1,
+          },
+        ],
+      },
+      {
+        status: 'In Review',
+        variableId: columnVariableIdLocalNameOutdated,
+        rowValueId: row1IdOutdated,
+        values: [
+          {
+            type: 'Text',
+            id: 2517,
+            listPosition: 0,
+            textValue: 'Row 1 local name',
+          },
+        ],
+      },
+      {
+        status: 'In Review',
+        variableId: columnVariableIdLocalNameOutdated,
+        rowValueId: row2IdOutdated,
+        values: [
+          {
+            type: 'Text',
+            id: 2624,
+            listPosition: 0,
+            textValue: 'Row 2 local name',
+          },
+        ],
+      },
+      {
+        status: 'In Review',
+        variableId: columnVariableIdFamilyOutdated,
+        rowValueId: row1IdOutdated,
+        values: [
+          {
+            type: 'Text',
+            id: 2518,
+            listPosition: 0,
+            textValue: 'Row 1 family',
+          },
+        ],
+      },
+      {
+        status: 'In Review',
+        variableId: columnVariableIdFamilyOutdated,
+        rowValueId: row2IdOutdated,
+        values: [
+          {
+            type: 'Text',
+            id: 2625,
+            listPosition: 0,
+            textValue: 'Row 2 family',
+          },
+        ],
+      },
+    ];
+
+    const expected = [
+      {
+        type: 'Table',
+        columns: [
+          {
+            isHeader: false,
+            variable: {
+              type: 'Text',
+              isRequired: false,
+              position: 0,
+              name: 'Local Name',
+              id: columnVariableIdLocalNameCurrent,
+              stableId: columnStableIdLocalName,
+              isList: false,
+              replacesVariableId: columnVariableIdLocalNameOutdated,
+              replacementColumnVariableId: columnVariableIdLocalNameCurrent,
+              textType: 'SingleLine',
+              values: [
+                {
+                  type: 'Text',
+                  id: 2517,
+                  listPosition: 0,
+                  textValue: 'Row 1 local name',
+                },
+                {
+                  type: 'Text',
+                  id: 2624,
+                  listPosition: 0,
+                  textValue: 'Row 2 local name',
+                },
+              ],
+              variableValues: [
+                {
+                  status: 'In Review',
+                  variableId: columnVariableIdLocalNameOutdated,
+                  rowValueId: row1IdOutdated,
+                  values: [
+                    {
+                      type: 'Text',
+                      id: 2517,
+                      listPosition: 0,
+                      textValue: 'Row 1 local name',
+                    },
+                  ],
+                },
+                {
+                  status: 'In Review',
+                  variableId: columnVariableIdLocalNameOutdated,
+                  rowValueId: row2IdOutdated,
+                  values: [
+                    {
+                      type: 'Text',
+                      id: 2624,
+                      listPosition: 0,
+                      textValue: 'Row 2 local name',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            isHeader: false,
+            variable: {
+              type: 'Text',
+              isRequired: false,
+              position: 0,
+              name: 'Family',
+              id: columnVariableIdFamilyCurrent,
+              stableId: columnStableIdFamily,
+              isList: false,
+              replacesVariableId: columnVariableIdFamilyOutdated,
+              replacementColumnVariableId: columnVariableIdFamilyCurrent,
+              textType: 'SingleLine',
+              values: [
+                {
+                  type: 'Text',
+                  id: 2518,
+                  listPosition: 0,
+                  textValue: 'Row 1 family',
+                },
+                {
+                  type: 'Text',
+                  id: 2625,
+                  listPosition: 0,
+                  textValue: 'Row 2 family',
+                },
+              ],
+              variableValues: [
+                {
+                  status: 'In Review',
+                  variableId: columnVariableIdFamilyOutdated,
+                  rowValueId: row1IdOutdated,
+                  values: [
+                    {
+                      type: 'Text',
+                      id: 2518,
+                      listPosition: 0,
+                      textValue: 'Row 1 family',
+                    },
+                  ],
+                },
+                {
+                  status: 'In Review',
+                  variableId: columnVariableIdFamilyOutdated,
+                  rowValueId: row2IdOutdated,
+                  values: [
+                    {
+                      type: 'Text',
+                      id: 2625,
+                      listPosition: 0,
+                      textValue: 'Row 2 family',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+        isRequired: false,
+        position: 0,
+        name: 'Invasive species to remove',
+        id: tableVariableIdCurrent,
+        stableId: tableStableId,
+        isList: true,
+        deliverableId: 27,
+        deliverableQuestion:
+          'What are the invasive and problematic species that would need to be removed during land preparation?',
+        replacesVariableId: tableVariableIdOutdated,
+        tableStyle: 'Horizontal',
+        values: [
+          {
+            type: 'Table',
+            id: row1IdOutdated,
+            listPosition: 0,
+          },
+          {
+            type: 'Table',
+            id: row2IdOutdated,
+            listPosition: 1,
+          },
+        ],
+        variableValues: [
+          {
+            status: 'In Review',
+            variableId: tableVariableIdOutdated,
+            replacementVariableId: tableVariableIdCurrent,
+            values: [
+              {
+                type: 'Table',
+                id: row1IdOutdated,
+                listPosition: 0,
+              },
+              {
+                type: 'Table',
+                id: row2IdOutdated,
+                listPosition: 1,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    expect(mergeVariablesAndValues(variables, values)).toEqual(expected);
+  });
+});

--- a/src/redux/features/documentProducer/variables/util.ts
+++ b/src/redux/features/documentProducer/variables/util.ts
@@ -1,0 +1,432 @@
+import {
+  TableColumn,
+  TableColumnWithValues,
+  TableVariable,
+  TableVariableWithValues,
+  Variable,
+  VariableUnion,
+  VariableWithValues,
+  isTableVariable,
+} from 'src/types/documentProducer/Variable';
+import { VariableValue, VariableValueTableValue, VariableValueValue } from 'src/types/documentProducer/VariableValue';
+
+type StableId = string;
+type VariableId = number;
+
+const findOutdatedVariable = (variableList: VariableUnion[], variable: Variable): VariableUnion | undefined =>
+  variableList.find((_variable) => _variable.id === variable.replacesVariableId);
+
+const findOutdatedVariableValues = (
+  variable: Variable,
+  values: VariableValue[],
+  variableList: VariableUnion[],
+  tableVariable?: TableVariable
+): VariableValue[] => {
+  if (!variable.replacesVariableId) {
+    return [];
+  }
+
+  let outdatedVariable: VariableUnion | undefined;
+
+  if (tableVariable) {
+    const outdatedTableVariable = findOutdatedVariable(variableList, tableVariable);
+    if (isTableVariable(outdatedTableVariable)) {
+      outdatedVariable = findOutdatedVariable(
+        outdatedTableVariable?.columns.map((column) => column.variable as Variable),
+        variable
+      );
+    }
+  } else {
+    outdatedVariable = findOutdatedVariable(variableList, variable);
+  }
+
+  if (!outdatedVariable) {
+    return [];
+  }
+
+  const outdatedVariableValues: VariableValue[] = values.filter(
+    (val: VariableValue) => val.variableId === outdatedVariable.id
+  );
+
+  return [
+    ...outdatedVariableValues,
+    ...findOutdatedVariableValues(outdatedVariable, values, variableList, tableVariable),
+  ];
+};
+
+export const associateNonSectionVariableValues = (
+  variable: Variable,
+  values: VariableValue[],
+  variableList: VariableUnion[],
+  stableIdToCurrentVariableId: Map<StableId, VariableId>,
+  tableVariable?: TableVariable
+): VariableWithValues => {
+  const currentValue: VariableValue | undefined = values.find((val: VariableValue) => val.variableId === variable.id);
+
+  // If this variable replaces another one, we should see if there are "old" values
+  // associated to the previous versions of variables
+  let outdatedVariableValues = findOutdatedVariableValues(variable, values, variableList, tableVariable);
+  if (outdatedVariableValues.length) {
+    // console.log({ outdatedVariableValues, values: outdatedVariableValues.flatMap((v) => v.values) });
+  }
+
+  const currentValues = currentValue?.values ?? [];
+  const outdatedValues = outdatedVariableValues.flatMap((v) => v.values);
+  let returnValues: VariableValueValue[] = [];
+
+  // If this is a table, and there are outdated values and no current values, we only want to return the outdated values.
+  // The "values" of a table are actually the rows, and the columns will have values for those rows. We do not want to show
+  // the "empty" rows (rows without values)
+  if (isTableVariable(variable) && outdatedValues.length) {
+    returnValues = outdatedValues;
+  } else {
+    returnValues = [...currentValues, ...outdatedValues];
+  }
+
+  const variablesInVariable: number[] = returnValues
+    .map((value: VariableValueValue) => ('variableId' in value ? value.variableId : false))
+    .filter((variableId: number | false): variableId is number => variableId === 0 || !!variableId);
+
+  const relevantOutdatedVariableValues = outdatedVariableValues.filter((_variableValue) =>
+    returnValues.find((returnValue) => _variableValue.values.find((_value) => _value.id === returnValue.id))
+  );
+
+  // Link up the variable values that are referenced within this variable
+  let variableValues = [];
+  if (isTableVariable(variable) && relevantOutdatedVariableValues.length) {
+    variableValues = relevantOutdatedVariableValues;
+  } else {
+    variableValues = [
+      ...values.filter((val) => val.variableId === variable.id || variablesInVariable.includes(val.variableId)),
+      ...relevantOutdatedVariableValues,
+    ];
+  }
+
+  if (isTableVariable(variable)) {
+    let columns: TableColumnWithValues[] = [];
+    if (variable.columns) {
+      columns = variable.columns.map((col) => {
+        const _variable = associateNonSectionVariableValues(
+          col.variable as Variable,
+          values,
+          variableList,
+          stableIdToCurrentVariableId,
+          variable
+        );
+        return {
+          ...col,
+          variable: _variable,
+        };
+      });
+    }
+
+    return {
+      ...variable,
+      columns,
+      values: returnValues,
+      variableValues,
+    };
+  }
+
+  return {
+    ...variable,
+    values: returnValues,
+    variableValues,
+  };
+};
+
+///////////////////////////////////////////////////////////////////////////
+
+// For each current version of a variable, we need to determine if there are values
+// If there are values, we can return the variable and its values
+// If there are not values, we should see if we have information about outdated versions of this variable, and see if those have values
+// If an outdated variable value is found, we need to embed the ID of the current version of the variable into that value, so we can use the current version to modify it if needed
+
+const findVariable = (variables: VariableUnion[], variableId: VariableId | undefined): VariableUnion | undefined =>
+  variables.find((variable: VariableUnion) => variable.id === variableId);
+
+const findVariableValue = (
+  variableValues: VariableValue[],
+  variableId: VariableId | undefined
+): VariableValue | undefined =>
+  variableValues.find((variableValue: VariableValue) => variableValue.variableId === variableId);
+
+const findVariableValues = (variableValues: VariableValue[], variableId: VariableId | undefined): VariableValue[] =>
+  variableValues.filter((variableValue: VariableValue) => variableValue.variableId === variableId);
+
+const findOutdatedVariableValue = (variables: VariableUnion[], variableValues: VariableValue[], variable: Variable) => {
+  const nextOutdatedVariable = findVariable(variables, variable.replacesVariableId);
+  if (!nextOutdatedVariable) {
+    return undefined;
+  }
+
+  const outdatedVariableValue = findVariableValue(variableValues, nextOutdatedVariable.id);
+  // Keep searching to see if there is an even older variable version with values
+  if (!outdatedVariableValue) {
+    return findOutdatedVariableValue(variables, variableValues, nextOutdatedVariable);
+  }
+
+  return outdatedVariableValue;
+};
+
+// Find the closest outdated table variable that has cell values
+const findOutdatedTableVariableValue = (
+  variables: VariableUnion[],
+  variableValues: VariableValue[],
+  variable: TableVariable
+) => {
+  const nextOutdatedVariable = findVariable(variables, variable.replacesVariableId) as TableVariable;
+  const nextOutdatedVariableValue = findVariableValue(variableValues, nextOutdatedVariable.id);
+  if (!nextOutdatedVariable || !nextOutdatedVariableValue) {
+    return undefined;
+  }
+
+  // If this table doesn't have any cell values, keep looking for another outdated one with values
+  if (!tableHasCellValues(variableValues, nextOutdatedVariable, nextOutdatedVariableValue)) {
+    return findOutdatedTableVariableValue(variables, variableValues, nextOutdatedVariable);
+  }
+
+  return nextOutdatedVariableValue;
+};
+
+const getTableColumnVariables = (tableVariable: TableVariable): VariableUnion[] =>
+  tableVariable.columns.map((column) => column.variable as VariableUnion);
+
+const associateTableColumnVariableValues = (
+  variables: VariableUnion[],
+  variableValues: VariableValue[],
+  replacementVariableIds: Map<VariableId, ReplacementVariableId | undefined>,
+  column: TableColumn,
+  parentTableVariable: TableVariable
+): TableColumnWithValues => {
+  const returnVariable = findVariable(getTableColumnVariables(parentTableVariable), column.variable.id);
+  if (!returnVariable) {
+    return {
+      ...column,
+      variable: {
+        ...(column.variable as VariableUnion),
+        values: [],
+        variableValues: [],
+      },
+    };
+  }
+
+  const returnVariableValues = findVariableValues(variableValues, returnVariable.id);
+
+  const returnValues = returnVariableValues.flatMap((returnVariableValue) => returnVariableValue.values);
+
+  return {
+    ...column,
+    variable: {
+      ...returnVariable,
+      values: returnValues,
+      variableValues: returnVariableValues,
+    },
+  };
+};
+
+const associateOutdatedTableColumnVariableValues = (
+  variables: VariableUnion[],
+  variableValues: VariableValue[],
+  replacementVariableIds: Map<VariableId, ReplacementVariableId | undefined>,
+  currentColumn: TableColumn,
+  outdatedParentTableVariable: TableVariable,
+  outdatedParentTableVariableValue: VariableValue
+): TableColumnWithValues => {
+  const outdatedColumn = findVariable(
+    getTableColumnVariables(outdatedParentTableVariable),
+    currentColumn.variable.replacesVariableId
+  );
+
+  // Since the columns are attached directly to the table version, if we can't find an outdated column, there is nothing to do
+  if (!outdatedColumn) {
+    return {
+      ...currentColumn,
+      variable: {
+        ...(currentColumn.variable as VariableUnion),
+        values: [],
+        variableValues: [],
+      },
+    };
+  }
+
+  // These are the column variable values
+  const returnVariableValues = findVariableValues(variableValues, outdatedColumn.id);
+
+  // These are the cells
+  const returnValues = returnVariableValues.flatMap((returnVariableValue) => returnVariableValue.values);
+
+  return {
+    ...currentColumn,
+    variable: {
+      ...currentColumn.variable,
+      replacementColumnVariableId: replacementVariableIds.get(returnVariableValues[0]?.variableId),
+      values: returnValues,
+      variableValues: returnVariableValues,
+    },
+  };
+};
+
+const findCellVariableValue = (
+  variableValues: VariableValue[],
+  rowId: number,
+  columnId: number
+): VariableValue | undefined =>
+  variableValues.find(
+    (variableValue: VariableValue) => variableValue.rowValueId === rowId && variableValue.variableId === columnId
+  );
+
+const tableHasCellValues = (
+  variableValues: VariableValue[],
+  tableVariable: TableVariable,
+  tableVariableValue: VariableValue
+): boolean => {
+  const rowIds = tableVariableValue.values.map((rowVariableValue) => rowVariableValue.id);
+  const columnIds = tableVariable.columns.map((column) => column.variable.id);
+
+  let cellWithValues: VariableValue | undefined;
+
+  for (const rowId of rowIds) {
+    for (const columnId of columnIds) {
+      cellWithValues = findCellVariableValue(variableValues, rowId, columnId);
+      if (cellWithValues) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+const associateTableVariableValues = (
+  variables: VariableUnion[],
+  variableValues: VariableValue[],
+  replacementVariableIds: Map<VariableId, ReplacementVariableId | undefined>,
+  variable: TableVariable
+): TableVariableWithValues => {
+  let columns: TableColumnWithValues[] = [];
+  let returnValues: VariableValueTableValue[] = [];
+  let returnVariableValues: VariableValue[] = [];
+
+  const currentVariableValue = findVariableValue(variableValues, variable.id);
+
+  if (currentVariableValue && tableHasCellValues(variableValues, variable, currentVariableValue)) {
+    returnVariableValues = [currentVariableValue];
+    returnValues = currentVariableValue.values as VariableValueTableValue[];
+    columns = variable.columns.map((column: TableColumn) => {
+      return associateTableColumnVariableValues(variables, variableValues, replacementVariableIds, column, variable);
+    });
+  } else {
+    // If there are no current values, we need to look for outdated ones
+    const outdatedParentTableVariable = findOutdatedVariable(variables, variable);
+    const outdatedParentTableVariableValue = findOutdatedTableVariableValue(variables, variableValues, variable);
+
+    if (outdatedParentTableVariable && outdatedParentTableVariableValue) {
+      returnVariableValues = [
+        {
+          ...outdatedParentTableVariableValue,
+          replacementVariableId: variable.id,
+        },
+      ];
+      returnValues = outdatedParentTableVariableValue.values as VariableValueTableValue[];
+      columns = variable.columns.map((column: TableColumn) => {
+        return associateOutdatedTableColumnVariableValues(
+          variables,
+          variableValues,
+          replacementVariableIds,
+          column,
+          outdatedParentTableVariable as TableVariable,
+          outdatedParentTableVariableValue
+        );
+      });
+    }
+  }
+
+  if (!variable.columns || variable.columns.length === 0) {
+    // This is a table with no columns, is that possible?
+    return {
+      ...variable,
+      values: returnValues,
+      variableValues: returnVariableValues,
+    };
+  }
+
+  return {
+    ...variable,
+    columns,
+    values: returnValues,
+    variableValues: returnVariableValues,
+  };
+};
+
+export const associateNonSectionVariableValuesV2 = (
+  variables: VariableUnion[],
+  variableValues: VariableValue[],
+  replacementVariableIds: Map<VariableId, ReplacementVariableId | undefined>,
+  variable: Variable
+): VariableWithValues => {
+  if (isTableVariable(variable)) {
+    return associateTableVariableValues(variables, variableValues, replacementVariableIds, variable);
+  }
+};
+
+const getCurrentVariableIds = (variables: Variable[]): Map<StableId, VariableId> => {
+  const stableIdToCurrentVariableId = new Map<StableId, VariableId>();
+
+  variables.forEach((variable: Variable) => {
+    const { stableId, id: variableId } = variable;
+    const current = stableIdToCurrentVariableId.get(stableId) || 0;
+    if (current < variableId) {
+      stableIdToCurrentVariableId.set(stableId, variableId);
+    }
+  });
+
+  return stableIdToCurrentVariableId;
+};
+
+type ReplacementVariableId = VariableId;
+const getReplacementVariableIds = (variables: Variable[]) => {
+  const variableReplacements: [VariableId, ReplacementVariableId | undefined][] = variables.map(
+    (variable): [VariableId, ReplacementVariableId | undefined] => [
+      variable.id,
+      variables.find((_variable) => _variable.replacesVariableId === variable.id)?.id,
+    ]
+  );
+
+  // Table columns are inside of the table, so to find the replacement for the column, we must find the replacement for the table
+  const columnReplacements: [VariableId, ReplacementVariableId | undefined][] = variables
+    .filter(isTableVariable)
+    .flatMap((tableVariable): [VariableId, ReplacementVariableId | undefined][] => {
+      const replacementTableVariable = variables.find(
+        (_variable) => _variable.replacesVariableId === tableVariable.id
+      ) as TableVariable;
+
+      return tableVariable.columns.map((column): [VariableId, ReplacementVariableId | undefined] => [
+        column.variable.id,
+        replacementTableVariable?.columns.find((_column) => _column.variable.replacesVariableId === column.variable.id)
+          ?.variable.id,
+      ]);
+    });
+
+  return new Map<VariableId, ReplacementVariableId | undefined>([...variableReplacements, ...columnReplacements]);
+};
+
+export const mergeVariablesAndValues = (
+  variables: VariableUnion[],
+  variableValues: VariableValue[]
+): VariableWithValues[] => {
+  const stableIdToCurrentVariableId = getCurrentVariableIds(variables);
+  const replacementVariableIds = getReplacementVariableIds(variables);
+
+  return (
+    variables
+      // If the project has values for outdated variables in the deliverable, they will be returned
+      // in the API response and the values for the outdated variables will be merged into the current
+      // version of the variable within `associatedNonSectionVariableValues`.
+      // Filter out any variables that aren't the current version of that variable
+      .filter((variable) => stableIdToCurrentVariableId.get(variable.stableId) === variable.id)
+      .map((variable) =>
+        associateNonSectionVariableValuesV2(variables, variableValues, replacementVariableIds, variable)
+      )
+  );
+};

--- a/src/redux/features/documentProducer/variables/variablesSlice.ts
+++ b/src/redux/features/documentProducer/variables/variablesSlice.ts
@@ -3,6 +3,7 @@ import { ActionReducerMapBuilder, createSlice } from '@reduxjs/toolkit';
 import { StatusT, buildReducers } from 'src/redux/features/asyncUtils';
 import { Variable, VariableOwners } from 'src/types/documentProducer/Variable';
 
+import { deliverableCompositeKeyFn } from '../../deliverables/deliverablesSlice';
 import {
   requestListAllVariables,
   requestListDeliverableVariables,
@@ -30,7 +31,7 @@ const deliverableVariablesSlice = createSlice({
   initialState: initialVariablesState,
   reducers: {},
   extraReducers: (builder: ActionReducerMapBuilder<VariablesState>) => {
-    buildReducers(requestListDeliverableVariables, true)(builder);
+    buildReducers(requestListDeliverableVariables, true, deliverableCompositeKeyFn)(builder);
   },
 });
 

--- a/src/redux/features/documentProducer/variables/variablesThunks.ts
+++ b/src/redux/features/documentProducer/variables/variablesThunks.ts
@@ -21,8 +21,8 @@ export const requestListAllVariables = createAsyncThunk('listAllVariables', asyn
 
 export const requestListDeliverableVariables = createAsyncThunk(
   'listDeliverableVariables',
-  async (deliverableId: number, { rejectWithValue }) => {
-    const response: Response2<VariableListResponse> = await VariableService.getDeliverableVariables(deliverableId);
+  async (request: { deliverableId: number; projectId: number }, { rejectWithValue }) => {
+    const response: Response2<VariableListResponse> = await VariableService.getDeliverableVariables(request);
     if (response && response.requestSucceeded && response.data) {
       return response.data.variables;
     }

--- a/src/services/documentProducer/VariableService.ts
+++ b/src/services/documentProducer/VariableService.ts
@@ -13,9 +13,12 @@ const VARIABLE_OWNERS_ENDPOINT = '/api/v1/document-producer/projects/{projectId}
 
 const getAllVariables = (): Promise<Response2<VariableListResponse>> => HttpService.root(VARIABLES_ENDPOINT).get2({});
 
-const getDeliverableVariables = (deliverableId: number): Promise<Response2<VariableListResponse>> =>
+const getDeliverableVariables = (request: {
+  deliverableId: number;
+  projectId: number;
+}): Promise<Response2<VariableListResponse>> =>
   HttpService.root(VARIABLES_ENDPOINT).get2({
-    params: { deliverableId: `${deliverableId}` },
+    params: { deliverableId: `${request.deliverableId}`, projectId: `${request.projectId}` },
   });
 
 const getDocumentVariables = (documentId: number): Promise<Response2<VariableListResponse>> =>


### PR DESCRIPTION
This depends on https://github.com/terraware/terraware-server/pull/2339

Variables can be updated, which creates a new variable (with `replacesVariableId` pointing to the outdated one) in the system. With the PR above, the backend will return the outdated variables, along with their values, in the event they exist for a deliverable. 

This PR aims to coalesce the outdated variable and values with the current variable, with the ultimate goal of allowing the UI to validate the old values with the new variable, and any changes to the new variable (with the old values) will be saved against the new variable. 

TODO
- [ ] Make the variable combining work for other variable types 
- [ ] Ensure it still works when there are several layers of outdated variables
- [ ] Use the `replacementVariableId` in the UI to ensure that if an outdated value is updated for a current variable, that the new variable ID is passed along
- [ ] Figure out what to do when an old value does not validate against a new variable configuration