### PR TITLE
SW-5901 Used pending values to determine dependencies on edit view

### DIFF
--- a/src/components/DeliverableView/QuestionsDeliverableEditForm.tsx
+++ b/src/components/DeliverableView/QuestionsDeliverableEditForm.tsx
@@ -153,6 +153,17 @@ const QuestionsDeliverableEditForm = (props: QuestionsDeliverableEditViewProps):
     uploadSuccess,
   } = useProjectVariablesUpdate(deliverable.projectId, variablesWithValues);
 
+  const stagedVariableWithValues: VariableWithValues[] = useMemo(() => {
+    return variablesWithValues.map((variableWithValues) => {
+      const pendingValues = pendingVariableValues.get(variableWithValues.id);
+      if (pendingValues !== undefined) {
+        return { ...variableWithValues, values: pendingValues };
+      } else {
+        return variableWithValues;
+      }
+    });
+  }, [pendingVariableValues, variablesWithValues]);
+
   useEffect(() => {
     if (!deliverable) {
       return;
@@ -201,7 +212,7 @@ const QuestionsDeliverableEditForm = (props: QuestionsDeliverableEditViewProps):
             }}
           >
             {variablesWithValues.map((variableWithValues: VariableWithValues, index: number) =>
-              variableDependencyMet(variableWithValues, variablesWithValues) ? (
+              variableDependencyMet(variableWithValues, stagedVariableWithValues) ? (
                 <QuestionBox
                   addRemovedValue={(removedValue: VariableValueValue) =>
                     setRemovedValue(variableWithValues.id, removedValue)

--- a/src/utils/documentProducer/variables.ts
+++ b/src/utils/documentProducer/variables.ts
@@ -31,7 +31,8 @@ export const variableDependencyMet = (variable: VariableWithValues, allVariables
     case 'eq':
       if (isSelectVariable(dependsOnVariable) && isArrayOfT(rawDependsOnValue, isNumber)) {
         const optionIdOfDependencyValue = dependsOnVariable.options.find(
-          (option) => option.name === variable.dependencyValue
+          // Remove double-quoutes here. But we likely want to update that in the spreadsheet instead.
+          (option) => option.name === variable.dependencyValue?.replace(/"/g, '')
         )?.id;
         if (!optionIdOfDependencyValue) {
           // This means the value listed as the dependency value doesn't exist within the depended on variable


### PR DESCRIPTION
The replace Regex is likely not required, but put in because of a mistake in the spreadsheet.

The behavior in console remains unchanged, since it does not allow editing of multiple inputs at once anyways. 