### PR TITLE
SW-5913: "Edited By" column in document history table is not populated (Follow-up #1)

### DIFF
--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentHistoryTab.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentHistoryTab.tsx
@@ -10,6 +10,7 @@ import CellRenderer from 'src/components/common/table/TableCellRenderer';
 import { useDocumentProducerData } from 'src/providers/DocumentProducer/Context';
 import { searchHistory } from 'src/redux/features/documentProducer/documents/documentsSelector';
 import { requestListHistory } from 'src/redux/features/documentProducer/documents/documentsThunks';
+import { requestGetUser } from 'src/redux/features/user/usersAsyncThunks';
 import { useSelectorProcessor } from 'src/redux/hooks/useSelectorProcessor';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
@@ -75,6 +76,20 @@ const DocumentHistoryTab = (): JSX.Element => {
   // select history data
   const history = useAppSelector((state) => searchHistory(state, documentId, searchValue));
   useSelectorProcessor(history, setTableRows);
+
+  const [userIdsRequested, setUserIdsRequested] = useState<number[]>([]);
+
+  useEffect(() => {
+    const newUserIdsRequested: number[] = [];
+    const userIds = tableRows.map((row) => row.createdBy);
+    userIds.forEach((userId) => {
+      if (!userIdsRequested.includes(userId) && !newUserIdsRequested.includes(userId)) {
+        dispatch(requestGetUser(userId));
+        newUserIdsRequested.push(userId);
+      }
+    });
+    setUserIdsRequested((prev) => [...prev, ...newUserIdsRequested]);
+  }, [tableRows]);
 
   useEffect(() => {
     // TODO should these be admin users? TF accelerator users?


### PR DESCRIPTION
This PR includes a follow-up change to request user data for all users listed in the "Edited By" column.

## Screenshots

### Before

![localhost_3000_accelerator_documents_9_tab=history](https://github.com/user-attachments/assets/ade88733-edfc-43f3-b370-428269700aa4)

### After

![localhost_3000_accelerator_documents_9_tab=history (1)](https://github.com/user-attachments/assets/6edb4b11-d285-45ce-b4db-e64d1132702a)
