### PR TITLE
SW-5919 Document outline should navigate through document on click

### DIFF
--- a/src/components/DocumentProducer/EditableSection/Container.tsx
+++ b/src/components/DocumentProducer/EditableSection/Container.tsx
@@ -25,6 +25,7 @@ import Display from './Display';
 import Edit from './Edit';
 
 type EditableSectionProps = {
+  id?: string;
   docId: number;
   projectId: number;
   section: SectionVariableWithValues;
@@ -33,6 +34,7 @@ type EditableSectionProps = {
 };
 
 export default function EditableSectionContainer({
+  id,
   docId,
   projectId,
   section,
@@ -138,6 +140,7 @@ export default function EditableSectionContainer({
 
   return editing ? (
     <Box
+      id={id}
       sx={{
         background: theme.palette.TwClrBgActive,
         padding: theme.spacing(2),
@@ -180,6 +183,7 @@ export default function EditableSectionContainer({
     </Box>
   ) : (
     <Box
+      id={id}
       sx={{
         padding: theme.spacing(2),
         borderRadius: '16px',

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentOutlinePanel.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentOutlinePanel.tsx
@@ -17,17 +17,6 @@ import { useIsVisible } from 'src/hooks/useIsVisible';
 import { useDocumentProducerData } from 'src/providers/DocumentProducer/Context';
 import { SectionVariableWithValues } from 'src/types/documentProducer/Variable';
 
-const isHTMLElementInViewport = (element: HTMLElement): boolean => {
-  const rect = element.getBoundingClientRect();
-
-  return (
-    rect.top >= 0 &&
-    rect.left >= 0 &&
-    rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-    rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-  );
-};
-
 const StyledTooltip = styled(({ className, ...props }: TooltipProps) => (
   <Tooltip {...props} arrow classes={{ popper: className }} />
 ))(({ theme }) => ({
@@ -72,16 +61,21 @@ const SectionItem = ({
     }
 
     // get document heading element
-    const element = document.getElementById(section.sectionNumber);
+    const element = document.getElementById(section.sectionNumber) || document.getElementById(`${section.id}`);
     if (!element) {
       // exit if element not found
       return;
     }
 
-    if (!isHTMLElementInViewport(element)) {
-      // scroll to section heading in the document, if not already in view
-      element.scrollIntoView({ behavior: 'smooth' });
-    }
+    const currentPosition = window.scrollY || document.documentElement.scrollTop || document.body.scrollTop;
+    // get section heading in the document
+    const newPosition = element.getBoundingClientRect();
+
+    // if going up in the view, the header takes more space so more gap space is needed
+    const headerGap = newPosition.top + window.scrollY - 146 < currentPosition ? 146 : 96;
+
+    // scrolls to section heading with the gap
+    window.scrollTo({ left: newPosition.left, top: newPosition.top + window.scrollY - headerGap, behavior: 'smooth' });
   }, [section.id, selectedSectionId, setSelectedSectionId]);
 
   return (

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentTab.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentTab.tsx
@@ -41,6 +41,7 @@ const DocumentTab = (): JSX.Element => {
       } else {
         sectionsToRender.push(
           <EditableSectionContainer
+            id={`${section.id}`}
             key={`component-${section.position}`}
             docId={documentId}
             projectId={projectId}


### PR DESCRIPTION
- Previously, we where checking if the section header was in the viewport to scroll into it or not. Since we always want to center that section, this validation was removed.

- Also, some sections didn't have id, so it was impossible to scroll into them. Added ids to those sections

- Finally, the scroll was not correct because the header of the page was interfering with the position. Added a gap to scroll into the element, taking the header space into account
