### PR TITLE
SW-5851 Save modified or deleted table cells

### DIFF
--- a/src/components/AcceleratorDeliverableView/QuestionsDeliverableCard.tsx
+++ b/src/components/AcceleratorDeliverableView/QuestionsDeliverableCard.tsx
@@ -160,10 +160,6 @@ const QuestionBox = ({
   const onSave = () => {
     setEditingId(undefined);
 
-    if (pendingVariableValues.size === 0) {
-      return;
-    }
-
     update();
   };
 

--- a/src/components/DeliverableView/QuestionsDeliverableEditForm.tsx
+++ b/src/components/DeliverableView/QuestionsDeliverableEditForm.tsx
@@ -181,15 +181,6 @@ const QuestionsDeliverableEditForm = (props: QuestionsDeliverableEditViewProps):
     }
   }, [exit, updateSuccess, uploadSuccess]);
 
-  const handleOnSave = () => {
-    if (pendingVariableValues.size === 0) {
-      // If the user clicks save but there are no changes, just navigate them back to the deliverable
-      exit();
-    }
-
-    update();
-  };
-
   if (!deliverable) {
     return null;
   }
@@ -198,7 +189,7 @@ const QuestionsDeliverableEditForm = (props: QuestionsDeliverableEditViewProps):
     <WrappedPageForm
       cancelID={'cancelEditQuestionsDeliverable'}
       onCancel={exit}
-      onSave={handleOnSave}
+      onSave={update}
       saveID={'saveEditQuestionsDeliverable'}
     >
       <Box display='flex' flexDirection='column' flexGrow={1}>

--- a/src/hooks/useProjectVariablesUpdate/util.ts
+++ b/src/hooks/useProjectVariablesUpdate/util.ts
@@ -90,7 +90,7 @@ export const makeVariableValueOperations = ({
     initialCellValues.forEach((row) => {
       const rowId = row[0].rowId;
       if (rowId !== undefined) {
-        const foundRow = cellValues.find((r) => r[0].rowId === rowId);
+        const foundRow = pendingCellValues.find((r) => r[0].rowId === rowId);
         if (foundRow === undefined) {
           // delete operations
           operations.push({


### PR DESCRIPTION
Adding rows to table variable values and editing existing table cells
wasn't working for two reasons:

* There was an optimization that skipped saving the value if it
  looked like the user hadn't changed anything. But that check was
  only looking at changes to simple variables like text and number
  fields, and was ignoring changes to other variable types such as
  tables and images. The code that assembles the server request
  already has logic to skip the request if it would be a no-op,
  so the optimization wasn't needed anyway; it's gone now.

* The code that assembled the server request was comparing the
  initial cell values with themselves and thinking that edited
  cells hadn't changed. Now it compares against the values from
  the edit form.

Also fixes SW-5933.