### PR TITLE
SW-5931: Existing Project not recognized when Starting New Application

### DIFF
--- a/src/scenes/ApplicationRouter/NewApplicationModal.tsx
+++ b/src/scenes/ApplicationRouter/NewApplicationModal.tsx
@@ -65,7 +65,7 @@ const NewApplicationModal = ({ open, onClose }: NewApplicationModalProps): JSX.E
 
   // Init the options and auto select the first project option if there is a project without an application
   useEffect(() => {
-    if (!allApplications || allApplications.length === 0) {
+    if (!allApplications) {
       return;
     }
 


### PR DESCRIPTION
This PR includes a fix for an issue that caused new projects to not be recognized/available as an option when starting a new application.

## Screenshots

### Before

![localhost_home_organizationId=181](https://github.com/user-attachments/assets/e329fcec-49a5-4a17-bc51-6b1b1dc371e7)

### After

![localhost_home_organizationId=181 (1)](https://github.com/user-attachments/assets/8b84707a-a701-47a3-9664-79324a2a99a2)
