### PR TITLE
SW-5931: Existing Project not recognized when Starting New Application

### DIFF
--- a/src/scenes/ApplicationRouter/NewApplicationModal.tsx
+++ b/src/scenes/ApplicationRouter/NewApplicationModal.tsx
@@ -75,7 +75,7 @@ const NewApplicationModal = ({ open, onClose }: NewApplicationModalProps): JSX.E
 
     setProjectOptions(nextProjectOptions);
 
-    if (newApplication.projectType === 'New' && nextProjectOptions.length) {
+    if (!newApplication.projectId && newApplication.projectType === 'New' && nextProjectOptions.length) {
       setNewApplication({
         projectType: 'Existing',
         projectId: nextProjectOptions[0]?.value,


### PR DESCRIPTION
This PR includes a fix for a regression caused by [my previous PR for this ticket](https://github.com/terraware/terraware-web/pull/3136) that results in being unable to select the "Create New Project" option in the Start New Application modal.