### PR TITLE
SW-5978: Saving an unchanged questionnaire deliverable should return the user to the view display mode

### DIFF
--- a/src/components/DeliverableView/QuestionsDeliverableEditForm.tsx
+++ b/src/components/DeliverableView/QuestionsDeliverableEditForm.tsx
@@ -219,7 +219,6 @@ const QuestionsDeliverableEditForm = (props: QuestionsDeliverableEditViewProps):
       }
     } else {
       setValidateFields(true);
-      return;
     }
 
     update();

--- a/src/hooks/useProjectVariablesUpdate/index.ts
+++ b/src/hooks/useProjectVariablesUpdate/index.ts
@@ -206,6 +206,7 @@ export const useProjectVariablesUpdate = (
     pendingNewImages,
     pendingVariableValues,
     projectId,
+    removedVariableValues,
     variablesWithValues,
   ]);
 

--- a/src/hooks/useProjectVariablesUpdate/index.ts
+++ b/src/hooks/useProjectVariablesUpdate/index.ts
@@ -82,20 +82,6 @@ export const useProjectVariablesUpdate = (
   };
 
   const update = useCallback(() => {
-    const hasPendingChanges =
-      pendingCellValues.size > 0 ||
-      pendingImages.size > 0 ||
-      pendingDeletedImages.size > 0 ||
-      pendingNewImages.size > 0 ||
-      pendingVariableValues.size > 0 ||
-      removedVariableValues.size > 0;
-
-    // if there are no pending changes, set flag to true to fake success & exit
-    if (!hasPendingChanges) {
-      setNoOp(true);
-      return;
-    }
-
     let operations: Operation[] = [];
 
     pendingVariableValues.forEach((pendingValues, variableId) => {
@@ -198,6 +184,9 @@ export const useProjectVariablesUpdate = (
       );
 
       setUpdateVariableRequestId(request.requestId);
+    } else {
+      // if there are no pending changes, set flag to true to fake success & exit
+      setNoOp(true);
     }
   }, [
     pendingCellValues,

--- a/src/hooks/useProjectVariablesUpdate/index.ts
+++ b/src/hooks/useProjectVariablesUpdate/index.ts
@@ -55,6 +55,8 @@ export const useProjectVariablesUpdate = (
   const updateResult = useAppSelector(selectUpdateVariableValues(updateVariableRequestId));
   const uploadResult = useAppSelector(selectUploadImageValue(uploadRequestId));
 
+  const [noOp, setNoOp] = useState(false);
+
   const setValues = (variableId: number, values: VariableValueValue[]) => {
     setPendingVariableValues(new Map(pendingVariableValues).set(variableId, values));
   };
@@ -80,6 +82,20 @@ export const useProjectVariablesUpdate = (
   };
 
   const update = useCallback(() => {
+    const hasPendingChanges =
+      pendingCellValues.size > 0 ||
+      pendingImages.size > 0 ||
+      pendingDeletedImages.size > 0 ||
+      pendingNewImages.size > 0 ||
+      pendingVariableValues.size > 0 ||
+      removedVariableValues.size > 0;
+
+    // if there are no pending changes, set flag to true to fake success & exit
+    if (!hasPendingChanges) {
+      setNoOp(true);
+      return;
+    }
+
     let operations: Operation[] = [];
 
     pendingVariableValues.forEach((pendingValues, variableId) => {
@@ -209,7 +225,7 @@ export const useProjectVariablesUpdate = (
     setNewImages,
     setRemovedValue,
     setValues,
-    updateSuccess: updateResult?.status === 'success',
+    updateSuccess: noOp || updateResult?.status === 'success',
     uploadSuccess: Object.keys(pendingNewImages).length === 0 ? true : uploadResult?.status === 'success',
     update,
   };


### PR DESCRIPTION
This PR includes:

- A fix for an issue that was preventing saving questionnaire deliverables (modified or not)
- A fix to return to display mode when pressing save with no pending changes in questionnaire deliverables