### PR TITLE
SW-5976: Optional question preventing questionnaire saving

### DIFF
--- a/src/hooks/useProjectVariablesUpdate/util.ts
+++ b/src/hooks/useProjectVariablesUpdate/util.ts
@@ -184,7 +184,7 @@ export const makeVariableValueOperations = ({
           value: nV,
           existingValueId: pendingValues[index].id,
         });
-      } else {
+      } else if (nV.textValue) {
         operations.push({ operation: 'Append', variableId: variable.id, value: nV });
       }
     });


### PR DESCRIPTION
This PR includes a fix for a `400` error that occurs when a user enters text and then deletes it before pressing save, for a text variable question with no previous value within a questionnaire deliverable.