### PR TITLE
SW-5973: Remove extraneous asterisk

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@mui/styled-engine-sc": "^5.14.12",
     "@mui/styles": "^5.15.15",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^3.3.2",
+    "@terraware/web-components": "^3.3.4",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.3.0",
     "@testing-library/user-event": "^14.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3980,10 +3980,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.3.2.tgz#4fc3b234082c83a08e8efe505861a028c33cc115"
-  integrity sha512-j1ei74vGAw7zMMFDOtBRnz28DcdxaJHVRNcYQDH5dQ4OmQyXi+An4gg+dRkDNtRiyBRix/dFQWchvmyEAiNlCQ==
+"@terraware/web-components@^3.3.4":
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.3.4.tgz#e510889c9eed032dca49b525d2a51027793b272d"
+  integrity sha512-rD3Bu6RasE7yJ0ESIj1liXCt1tdxpm5/WNbaJP7pqNWJ1HwM8eC8BPN+YgtI/dOiC0AX6kfsutiD0LkSOqEYfg==
   dependencies:
     "@date-io/luxon" "^3.0.0"
     "@dnd-kit/core" "^6.0.7"


### PR DESCRIPTION
This PR includes a change to bump `web-components` to the latest version (`3.3.4`) to pickup a fix for an issue that results in an extraneous asterisk on required fields with no label defined.