### PR TITLE
SW-5989 Questionnaire deliverable not marked as complete when all required questions are filled out

### DIFF
--- a/src/utils/documentProducer/variables.ts
+++ b/src/utils/documentProducer/variables.ts
@@ -89,7 +89,13 @@ export const missingRequiredFields = (variablesWithValues: VariableWithValues[])
   const missingRequiredFields = allRequiredVariables.some((variable) => {
     let hasEmptyValue = false;
     const values = variable.values;
-    if (!values || values.length === 0 || getRawValue(variable) === undefined || getRawValue(variable) === '') {
+    console.log('varible', variable);
+    if (
+      !values ||
+      values.length === 0 ||
+      ((variable.type === 'Text' || variable.type === 'Number' || variable.type === 'Select') &&
+        (getRawValue(variable) === undefined || getRawValue(variable) === ''))
+    ) {
       hasEmptyValue = true;
     }
     return hasEmptyValue;

--- a/src/utils/documentProducer/variables.ts
+++ b/src/utils/documentProducer/variables.ts
@@ -89,7 +89,6 @@ export const missingRequiredFields = (variablesWithValues: VariableWithValues[])
   const missingRequiredFields = allRequiredVariables.some((variable) => {
     let hasEmptyValue = false;
     const values = variable.values;
-    console.log('varible', variable);
     if (
       !values ||
       values.length === 0 ||


### PR DESCRIPTION
Some required questions were marked as incomplete because of the condition: getRawValue(variable) === undefined || getRawValue(variable) === ''

Only use that condition for text, number and select variables. Other varaibles types return undefined for getRawValue()