### PR TITLE
SW-5918: Doc producer - Missing section display mode variable popover

### DIFF
--- a/src/components/DocumentProducer/EditVariable/index.tsx
+++ b/src/components/DocumentProducer/EditVariable/index.tsx
@@ -70,7 +70,7 @@ const EditVariable = (props: EditVariableProps): JSX.Element => {
 
         newValues = values.reduce((acc: NewTextValuePayload[], nV: VariableValueValue) => {
           if (nV.type === 'Text') {
-            acc.push({ type: 'Text', textValue: nV.textValue });
+            acc.push({ type: 'Text', textValue: nV.textValue, citation: nV.citation });
           }
           return acc;
         }, []);


### PR DESCRIPTION
This PR is a follow-up to fix an issue preventing citation edits from being saved when modifying text variables.