### PR TITLE
SW-5948: Deliverables list view - Projects filter should be an Autocomplete

### DIFF
--- a/src/components/ProjectsDropdown/index.tsx
+++ b/src/components/ProjectsDropdown/index.tsx
@@ -8,6 +8,7 @@ import { Project } from 'src/types/Project';
 
 type ProjectsDropdownProps<T extends { projectId?: number | string } | undefined> = {
   allowUnselect?: boolean;
+  autoComplete?: boolean;
   availableProjects: Project[] | undefined;
   label?: string | undefined;
   record: T;
@@ -18,6 +19,7 @@ type ProjectsDropdownProps<T extends { projectId?: number | string } | undefined
 
 function ProjectsDropdown<T extends { projectId?: number | string } | undefined>({
   allowUnselect,
+  autoComplete,
   availableProjects,
   label,
   record,
@@ -52,6 +54,7 @@ function ProjectsDropdown<T extends { projectId?: number | string } | undefined>
 
   return (
     <Dropdown
+      autocomplete={autoComplete}
       id='projectId'
       label={label === '' ? label : strings.PROJECT}
       selectedValue={record?.projectId}
@@ -66,6 +69,7 @@ function ProjectsDropdown<T extends { projectId?: number | string } | undefined>
       }}
       fullWidth
       required={required}
+      sx={{ backgroundColor: '#fff', minWidth: '240px' }}
     />
   );
 }

--- a/src/providers/Participant/ParticipantProvider.tsx
+++ b/src/providers/Participant/ParticipantProvider.tsx
@@ -110,7 +110,8 @@ const ParticipantProvider = ({ children }: Props) => {
     if (moduleProjectsListRequest && moduleProjectsListRequest.status === 'success' && moduleProjectsListRequest.data) {
       const nextModuleProjects = moduleProjectsListRequest.data
         .map((id) => participantProjects.find((project) => project.id === id))
-        .filter((project): project is Project => !!project);
+        .filter((project): project is Project => !!project)
+        .sort((a, b) => a.name.localeCompare(b.name));
 
       setModuleProjects(nextModuleProjects);
       setOrgHasModules(nextModuleProjects.length > 0);

--- a/src/scenes/DeliverablesRouter/DeliverablesList.tsx
+++ b/src/scenes/DeliverablesRouter/DeliverablesList.tsx
@@ -133,6 +133,7 @@ const DeliverablesList = (): JSX.Element => {
                     </Typography>
                     <ProjectsDropdown
                       allowUnselect
+                      autoComplete
                       availableProjects={moduleProjects}
                       label={''}
                       record={projectFilter}


### PR DESCRIPTION
This PR includes updates to the projects filter in the deliverables list:

- Enable auto-complete functionality
- Sort projects by name

## Screenshots

<img width="2032" alt="Screenshot 2024-09-11 at 10 49 24 AM" src="https://github.com/user-attachments/assets/cec1e16b-95dc-49d5-b1b6-6879cf8d247c">
