### PR TITLE
SW-5992: Show asterisks for required fields in Detail Views

### DIFF
--- a/src/components/AcceleratorDeliverableView/QuestionsDeliverableCard.tsx
+++ b/src/components/AcceleratorDeliverableView/QuestionsDeliverableCard.tsx
@@ -266,7 +266,9 @@ const QuestionBox = ({
               width: '100%',
             }}
           >
-            <Typography sx={{ fontWeight: '600' }}>{variable.deliverableQuestion ?? variable.name}</Typography>
+            <Typography
+              sx={{ fontWeight: '600' }}
+            >{`${variable.deliverableQuestion ?? variable.name} ${variable.isRequired ? '*' : ''}`}</Typography>
 
             <Box
               sx={{

--- a/src/components/DeliverableView/QuestionsDeliverableCard.tsx
+++ b/src/components/DeliverableView/QuestionsDeliverableCard.tsx
@@ -47,7 +47,7 @@ const QuestionBox = ({
       </Box>
       <Typography sx={{ fontWeight: '600', marginBottom: '16px' }}>
         {/* Defaults to deliverable question, then variable name */}
-        {variable.deliverableQuestion ?? variable.name}
+        {`${variable.deliverableQuestion ?? variable.name} ${variable.isRequired ? '*' : ''}`}
       </Typography>
       {!!variable.description && (
         <Typography


### PR DESCRIPTION
This PR includes changes to support showing an asterisk (`*`) beside field labels in display views, rather than just edit views.

## Screenshots

### Before

![localhost_3000_deliverables_295_submissions_32_organizationId=141 (1)](https://github.com/user-attachments/assets/678a1b6e-409f-49d9-8208-63d228d4397b)

### After

![localhost_3000_deliverables_295_submissions_32_organizationId=141](https://github.com/user-attachments/assets/1bf3eea1-9eec-48f0-9dd0-8ae620bdebc1)
