### PR TITLE
SW-6010 Add Mixpanel events for accelerator nav

### DIFF
--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -19,6 +19,7 @@ import OrganizationsDropdown from '../OrganizationsDropdown';
 import SmallDeviceUserMenu from '../SmallDeviceUserMenu';
 import UserMenu from '../UserMenu';
 import Icon from '../common/icon/Icon';
+import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 
 type TopBarProps = {
   setShowNavBar: React.Dispatch<React.SetStateAction<boolean>>;
@@ -65,7 +66,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
   };
 
   const handleTopBarClick = () => {
-    mixpanel?.track('TopBarHome');
+    mixpanel?.track(MIXPANEL_EVENTS.TOP_BAR_HOME);
     navigate(APP_PATHS.HOME);
   };
 

--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -10,6 +10,7 @@ import Link from 'src/components/common/Link';
 import { APP_PATHS } from 'src/constants';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import useApplicationPortal from 'src/hooks/useApplicationPortal';
+import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useOrganization, useUser } from 'src/providers/hooks';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 
@@ -19,7 +20,6 @@ import OrganizationsDropdown from '../OrganizationsDropdown';
 import SmallDeviceUserMenu from '../SmallDeviceUserMenu';
 import UserMenu from '../UserMenu';
 import Icon from '../common/icon/Icon';
-import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 
 type TopBarProps = {
   setShowNavBar: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/mixpanelEvents.ts
+++ b/src/mixpanelEvents.ts
@@ -1,0 +1,7 @@
+export enum MIXPANEL_EVENTS {
+  PART_EX_TO_DO_UPCOMING_VIEW_EVENT = 'To-Do/Upcoming View Event',
+  PART_EX_TO_DO_UPCOMING_VIEW_DELIVERABLE = 'To-Do/Upcoming View Deliverable',
+  TOP_BAR_HOME = 'Top Bar Home',
+  PART_EX_LEFT_NAV_DELIVERABLES = 'Participant Deliverables Nav Click',
+  PART_EX_LEFT_NAV_MODULES = 'Participant Modules Nav Click',
+}

--- a/src/scenes/Home/ParticipantHomeView/ToDoCta.tsx
+++ b/src/scenes/Home/ParticipantHomeView/ToDoCta.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { useCallback } from 'react';
+import { useMixpanel } from 'react-mixpanel-browser';
 
 import { Button } from '@terraware/web-components';
 import { useDeviceInfo } from '@terraware/web-components/utils';
 
 import useNavigateTo from 'src/hooks/useNavigateTo';
+import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import strings from 'src/strings';
 import { DeliverableToDoItem, EventToDoItem, ToDoItem } from 'src/types/ProjectToDo';
-import { useMixpanel } from 'react-mixpanel-browser';
-import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 
 interface ToDoCtaProps {
   toDo: ToDoItem;
@@ -27,20 +27,20 @@ const ToDoCta = ({ toDo }: ToDoCtaProps) => {
         const event = toDo as EventToDoItem;
 
         mixpanel?.track(MIXPANEL_EVENTS.PART_EX_TO_DO_UPCOMING_VIEW_EVENT, {
-          'id': event.id,
-          'type': event.type,
-          'status': event.status,
-          'moduleId': event.moduleId,
+          id: event.id,
+          type: event.type,
+          status: event.status,
+          moduleId: event.moduleId,
         });
         return goToModuleEventSession(event.projectId, event.moduleId, event.id);
       case 'Deliverable':
         const deliverable = toDo as DeliverableToDoItem;
         mixpanel?.track(MIXPANEL_EVENTS.PART_EX_TO_DO_UPCOMING_VIEW_DELIVERABLE, {
-          'id': deliverable.id,
-          'type': deliverable.type,
-          'category': deliverable.category,
-          'status': deliverable.status,
-          'moduleId': deliverable.moduleId,
+          id: deliverable.id,
+          type: deliverable.type,
+          category: deliverable.category,
+          status: deliverable.status,
+          moduleId: deliverable.moduleId,
         });
         return goToDeliverable(deliverable.id, deliverable.projectId);
     }

--- a/src/scenes/Home/ParticipantHomeView/ToDoCta.tsx
+++ b/src/scenes/Home/ParticipantHomeView/ToDoCta.tsx
@@ -7,6 +7,8 @@ import { useDeviceInfo } from '@terraware/web-components/utils';
 import useNavigateTo from 'src/hooks/useNavigateTo';
 import strings from 'src/strings';
 import { DeliverableToDoItem, EventToDoItem, ToDoItem } from 'src/types/ProjectToDo';
+import { useMixpanel } from 'react-mixpanel-browser';
+import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 
 interface ToDoCtaProps {
   toDo: ToDoItem;
@@ -15,6 +17,7 @@ interface ToDoCtaProps {
 const ToDoCta = ({ toDo }: ToDoCtaProps) => {
   const { goToDeliverable, goToModuleEventSession } = useNavigateTo();
   const { isMobile } = useDeviceInfo();
+  const mixpanel = useMixpanel();
 
   const handleOnClick = useCallback(() => {
     switch (toDo.getType()) {
@@ -22,9 +25,23 @@ const ToDoCta = ({ toDo }: ToDoCtaProps) => {
       case 'One-on-One Session':
       case 'Live Session':
         const event = toDo as EventToDoItem;
+
+        mixpanel?.track(MIXPANEL_EVENTS.PART_EX_TO_DO_UPCOMING_VIEW_EVENT, {
+          'id': event.id,
+          'type': event.type,
+          'status': event.status,
+          'moduleId': event.moduleId,
+        });
         return goToModuleEventSession(event.projectId, event.moduleId, event.id);
       case 'Deliverable':
         const deliverable = toDo as DeliverableToDoItem;
+        mixpanel?.track(MIXPANEL_EVENTS.PART_EX_TO_DO_UPCOMING_VIEW_DELIVERABLE, {
+          'id': deliverable.id,
+          'type': deliverable.type,
+          'category': deliverable.category,
+          'status': deliverable.status,
+          'moduleId': deliverable.moduleId,
+        });
         return goToDeliverable(deliverable.id, deliverable.projectId);
     }
   }, [goToDeliverable, goToModuleEventSession, toDo]);

--- a/src/scenes/OrgRouter/NavBar.tsx
+++ b/src/scenes/OrgRouter/NavBar.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMixpanel } from 'react-mixpanel-browser';
 import { useMatch, useNavigate } from 'react-router-dom';
 
 import { Box, Typography, useTheme } from '@mui/material';
@@ -13,6 +14,7 @@ import Navbar from 'src/components/common/Navbar/Navbar';
 import NewBadge from 'src/components/common/NewBadge';
 import { APP_PATHS } from 'src/constants';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
+import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useApplicationData } from 'src/providers/Application/Context';
 import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
@@ -22,8 +24,6 @@ import ReportService, { Reports } from 'src/services/ReportService';
 import strings from 'src/strings';
 import { isAdmin, isManagerOrHigher } from 'src/utils/organization';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
-import { useMixpanel } from 'react-mixpanel-browser';
-import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 
 type NavBarProps = {
   backgroundTransparent?: boolean;

--- a/src/scenes/OrgRouter/NavBar.tsx
+++ b/src/scenes/OrgRouter/NavBar.tsx
@@ -22,6 +22,8 @@ import ReportService, { Reports } from 'src/services/ReportService';
 import strings from 'src/strings';
 import { isAdmin, isManagerOrHigher } from 'src/utils/organization';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
+import { useMixpanel } from 'react-mixpanel-browser';
+import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 
 type NavBarProps = {
   backgroundTransparent?: boolean;
@@ -42,6 +44,7 @@ export default function NavBar({
   const [hasDeliverables, setHasDeliverables] = useState<boolean>(false);
   const { isDesktop, isMobile } = useDeviceInfo();
   const navigate = useNavigate();
+  const mixpanel = useMixpanel();
 
   const { isAllowedViewConsole } = useAcceleratorConsole();
   const { activeLocale } = useLocalization();
@@ -179,6 +182,7 @@ export default function NavBar({
           icon='iconSubmit'
           selected={!!isDeliverablesRoute}
           onClick={() => {
+            mixpanel?.track(MIXPANEL_EVENTS.PART_EX_LEFT_NAV_DELIVERABLES);
             closeAndNavigateTo(isDeliverablesRoute && !isDeliverableViewRoute ? '' : APP_PATHS.DELIVERABLES);
           }}
           id='deliverables'
@@ -211,6 +215,7 @@ export default function NavBar({
           label={strings.MODULES}
           selected={!!isProjectModulesRoute}
           onClick={() => {
+            mixpanel?.track(MIXPANEL_EVENTS.PART_EX_LEFT_NAV_MODULES);
             closeAndNavigateTo(
               APP_PATHS.PROJECT_MODULES.replace(':projectId', currentParticipantProject.id.toString())
             );


### PR DESCRIPTION
- Extract list of mixpanel events into a single list. 
- Send events for clicks into the To-Do and Upcoming list of items. 
- Send events for participant clicks on Deliverables & Modules in the left nav.