### PR TITLE
SW-5870 Reset assign request after error

### DIFF
--- a/src/scenes/AcceleratorRouter/ParticipantProjects/EditView/index.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/EditView/index.tsx
@@ -94,6 +94,7 @@ const EditView = () => {
       redirectToProjectView();
     } else if (assignResponse?.status === 'error') {
       snackbar.toastError();
+      setAssignTfContactRequestId('');
     }
   }, [assignResponse, redirectToProjectView, snackbar]);
 


### PR DESCRIPTION
Because the requestId was not reset after an error, the error snackbar was appearing again when assigning another TFContact