### PR TITLE
SW-5014 Fix email search in people dashboard

### DIFF
--- a/src/scenes/PeopleRouter/PeopleListView.tsx
+++ b/src/scenes/PeopleRouter/PeopleListView.tsx
@@ -81,6 +81,12 @@ export default function PeopleListView(): JSX.Element {
                 type,
                 values,
               },
+              {
+                operation: 'field',
+                field: 'user_email',
+                type: 'Exact',
+                values,
+              },
             ],
           }
         : null;


### PR DESCRIPTION
The search was only checking search terms against the user's first and last name, this adds the email. I ended up hard-coding the `type` to `Exact` because otherwise every email with the same domain would show up.

Before

![2024-10-24 10.07.37.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/b13c3bd6-864a-4bb0-885b-2a737fe8ed44.gif)

After

![2024-10-24 10.08.13.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/afbc03a4-e89a-4e18-adf0-4a4cbd4992d2.gif)

