### PR TITLE
SW-6186 Calculate observed hectares from plot sizes

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -1443,6 +1443,11 @@ export interface components {
       /** Format: int64 */
       plotId: number;
       plotName: string;
+      /**
+       * Format: int32
+       * @description Length of each edge of the monitoring plot in meters.
+       */
+      sizeMeters: number;
     };
     AutomationPayload: {
       /** @description Human-readable description of this automation. */
@@ -3713,6 +3718,11 @@ export interface components {
        * @description Number of live plants per hectare.
        */
       plantingDensity: number;
+      /**
+       * Format: int32
+       * @description Length of each edge of the monitoring plot in meters.
+       */
+      sizeMeters: number;
       species: components["schemas"]["ObservationSpeciesResultsPayload"][];
       /** @enum {string} */
       status: "Outstanding" | "InProgress" | "Completed";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,8 @@ export const API_PULL_INTERVAL = 60000;
 export const ONE_MINUTE_INTERVAL_MS = 60 * 1000;
 export const FIFTEEN_MINUTE_INTERVAL_MS = 15 * 60 * 1000;
 
+export const SQ_M_TO_HECTARES = 1 / 10000;
+
 export const TERRAWARE_MOBILE_APP_IOS_APP_STORE_LINK = 'https://apps.apple.com/us/app/terraware/id1568369900';
 export const TERRAWARE_MOBILE_APP_ANDROID_GOOGLE_PLAY_LINK =
   'https://play.google.com/store/apps/details?id=com.terraformation.seedcollector';

--- a/src/scenes/ApplicationRouter/portal/MapUpdate/index.tsx
+++ b/src/scenes/ApplicationRouter/portal/MapUpdate/index.tsx
@@ -10,7 +10,7 @@ import EditableMap from 'src/components/Map/EditableMapV2';
 import MapIcon from 'src/components/Map/MapIcon';
 import useRenderAttributes from 'src/components/Map/useRenderAttributes';
 import { toFeature, unionMultiPolygons } from 'src/components/Map/utils';
-import { APP_PATHS } from 'src/constants';
+import { APP_PATHS, SQ_M_TO_HECTARES } from 'src/constants';
 import useNavigateTo from 'src/hooks/useNavigateTo';
 import useUndoRedoState from 'src/hooks/useUndoRedoState';
 import { useLocalization } from 'src/providers';
@@ -21,7 +21,6 @@ import { requestGetCountryBoundary } from 'src/redux/features/location/locationA
 import { selectCountryBoundary } from 'src/redux/features/location/locationSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import StepTitleDescription, { Description } from 'src/scenes/PlantingSitesRouter/edit/editor/StepTitleDescription';
-import { SQ_M_TO_HECTARES } from 'src/scenes/PlantingSitesRouter/edit/editor/utils';
 import strings from 'src/strings';
 import { RenderableReadOnlyBoundary } from 'src/types/Map';
 import { MultiPolygon } from 'src/types/Tracking';

--- a/src/scenes/PlantingSitesRouter/edit/editor/utils.ts
+++ b/src/scenes/PlantingSitesRouter/edit/editor/utils.ts
@@ -4,12 +4,11 @@ import bboxPolygon from '@turf/bbox-polygon';
 import { Feature, FeatureCollection, MultiPolygon, Polygon, Position } from 'geojson';
 
 import { overlayAndSubtract, toFeature } from 'src/components/Map/utils';
+import { SQ_M_TO_HECTARES } from 'src/constants';
 import strings from 'src/strings';
 import { GeometryFeature } from 'src/types/Map';
 import { DraftPlantingSite } from 'src/types/PlantingSite';
 import { MinimalPlantingSubzone, MinimalPlantingZone } from 'src/types/Tracking';
-
-export const SQ_M_TO_HECTARES = 1 / 10000;
 
 export type DefaultZonePayload = Omit<MinimalPlantingZone, 'plantingSubzones'>;
 

--- a/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
+++ b/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
@@ -245,12 +245,14 @@ export default function PlantsDashboardView(): JSX.Element {
     !!plantingSiteResult && !!plantingSiteResult.plantingZones && plantingSiteResult.plantingZones.length > 0;
 
   const getObservationHectares = () => {
-    const numMonitoringPlots =
-      latestObservation?.plantingZones.flatMap((pz) => pz.plantingSubzones.flatMap((psz) => psz.monitoringPlots))
-        ?.length ?? 0;
-    const monitoringPlotHa = 0.0625;
-    const totalHa = numMonitoringPlots * monitoringPlotHa;
-    return totalHa;
+    const totalSquareMeters =
+      latestObservation?.plantingZones
+        .flatMap((pz) =>
+          pz.plantingSubzones.flatMap((psz) => psz.monitoringPlots.map((mp) => mp.sizeMeters * mp.sizeMeters))
+        )
+        .reduce((acc, area) => acc + area, 0) ?? 0;
+
+    return totalSquareMeters / 10000;
   };
 
   const getDashboardSubhead = () => {

--- a/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
+++ b/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
@@ -5,7 +5,7 @@ import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { useDeviceInfo } from '@terraware/web-components/utils';
 
 import PlantsPrimaryPage from 'src/components/PlantsPrimaryPage';
-import { APP_PATHS } from 'src/constants';
+import { APP_PATHS, SQ_M_TO_HECTARES } from 'src/constants';
 import { useLocalization, useOrganization } from 'src/providers';
 import { selectLatestObservation } from 'src/redux/features/observations/observationsSelectors';
 import { requestObservations, requestObservationsResults } from 'src/redux/features/observations/observationsThunks';
@@ -252,7 +252,7 @@ export default function PlantsDashboardView(): JSX.Element {
         )
         .reduce((acc, area) => acc + area, 0) ?? 0;
 
-    return totalSquareMeters / 10000;
+    return totalSquareMeters * SQ_M_TO_HECTARES;
   };
 
   const getDashboardSubhead = () => {


### PR DESCRIPTION
The plants dashboard shows the number of hectares covered by the most recent
observation. Use the actual sizes of the monitoring plots as returned by the
server so that the total will be correct once we start supporting variable
plot sizes.