### PR TITLE
SW-6168 Fix up types for Slate editor, attempt to fix issue with first line break from hitting enter key not working

### DIFF
--- a/src/components/DocumentProducer/EditableSection/types.ts
+++ b/src/components/DocumentProducer/EditableSection/types.ts
@@ -1,0 +1,48 @@
+import { BaseEditor, Element as SlateElement } from 'slate';
+import { ReactEditor } from 'slate-react';
+
+// Required type definitions for slatejs (https://docs.slatejs.org/concepts/12-typescript):
+export type CustomText = { text: string };
+
+export type VariableElement = {
+  // This is unused, but required by Slate
+  children: CustomText[];
+  docId?: number;
+  reference: boolean;
+  type: 'variable';
+  variableId?: number;
+};
+
+export type TextElement = {
+  children: CustomText[];
+  type: 'text';
+};
+
+export type SectionElement = {
+  children: (VariableElement | TextElement)[];
+  type: 'section';
+};
+
+export type ElementUnion = SectionElement | VariableElement | TextElement;
+
+// For some reason the typeguards in Slate do not actually narrow the type
+export const isVariableElement = (input: unknown): input is VariableElement =>
+  SlateElement.isElementType(input, 'variable');
+export const isTextElement = (input: unknown): input is TextElement => SlateElement.isElementType(input, 'text');
+export const isSectionElement = (input: unknown): input is SectionElement =>
+  SlateElement.isElementType(input, 'section');
+export const isCustomText = (input: unknown): input is CustomText => (input as CustomText).text !== undefined;
+
+// Slate editor will return everything as a Descendant, which is a union of our custom elements and CustomText
+// This is used to disambiguate the two, since most of the operations going from Slate to variable values are in the
+// context of the custom elements (ElementUnion)
+// export const isSlateElementWithChildren = (input: unknown): input is ElementUnion =>
+//   isArray((input as ElementUnion).children);
+
+declare module 'slate' {
+  interface CustomTypes {
+    Editor: BaseEditor & ReactEditor;
+    Element: ElementUnion;
+    Text: CustomText;
+  }
+}

--- a/src/components/DocumentProducer/EditableSection/types.ts
+++ b/src/components/DocumentProducer/EditableSection/types.ts
@@ -1,4 +1,4 @@
-import { BaseEditor, Element as SlateElement } from 'slate';
+import { BaseEditor, Descendant, Element as SlateElement } from 'slate';
 import { ReactEditor } from 'slate-react';
 
 // Required type definitions for slatejs (https://docs.slatejs.org/concepts/12-typescript):
@@ -46,3 +46,28 @@ declare module 'slate' {
     Text: CustomText;
   }
 }
+
+// An "empty" descendant is either a TextElement with no children that have text, or an empty CustomText
+// A VariableElement is never considered "empty"
+export const isEmptyDescendant = (value: Descendant): boolean => {
+  // If https://tc39.es/proposal-pattern-matching/ ever lands, I can stop using this pattern!
+  switch (true) {
+    case isVariableElement(value):
+      return false;
+
+    case isSectionElement(value):
+    case isTextElement(value):
+      if (value.children.length > 1) {
+        return false;
+      }
+
+      const onlyChild = value.children[0];
+      return isEmptyDescendant(onlyChild);
+
+    case isCustomText(value):
+      return value.text === '';
+
+    default:
+      return true;
+  }
+};


### PR DESCRIPTION
This did not end up fixing the issue, but might be an improvement we want. 

Cleans up the types, gets rid of casting. Implements `SectionElement` to contain text and variable elements.

I spent a while on this, the main area where the fix is attempted is [here](https://github.com/terraware/terraware-web/pull/3315/files#diff-f66b3b5e9a35a6d4b929206aadf4d2d5a406efd85b7f4a057f54ea5413cdc786R102), but it still does not seem to work. Even though I can see the values are being fixed (through the console), the Slate editor still does not show the line break. 