### PR TITLE
SW-6031 Stop linking to admin UI's module details

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -138,6 +138,5 @@ export enum APP_PATHS {
   NURSERY_WITHDRAWALS = '/nursery/withdrawals',
   NURSERY_WITHDRAWALS_DETAILS = '/nursery/withdrawals/:withdrawalId',
   NURSERY_REASSIGNMENT = '/nursery/reassignment/:deliveryId',
-  ADMIN_MODULE = '/admin/modules/:moduleId',
   ADMIN_COHORT_DELIVERABLE = '/admin/cohorts/:cohortId/deliverables/:deliverableId',
 }

--- a/src/scenes/AcceleratorRouter/Modules/CohortModulesCellRenderer.tsx
+++ b/src/scenes/AcceleratorRouter/Modules/CohortModulesCellRenderer.tsx
@@ -16,7 +16,11 @@ export default function CohortModulesCellRenderer(props: RendererProps<TableRowT
           index={index}
           column={column}
           value={
-            <Link fontSize='16px' target='_blank' to={APP_PATHS.ADMIN_MODULE.replace(':moduleId', row.id)}>
+            <Link
+              fontSize='16px'
+              target='_blank'
+              to={APP_PATHS.ACCELERATOR_MODULE_CONTENT.replace(':moduleId', row.id)}
+            >
               {value as React.ReactNode}
             </Link>
           }


### PR DESCRIPTION
The accelerator console has a module details page now, so use it instead of the
admin UI when linking to a module from the cohort's modules list.