### PR TITLE
SW-6169 Only reload variables when updating variable within section

### DIFF
--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentTab.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentTab.tsx
@@ -50,7 +50,7 @@ const DocumentTab = (): JSX.Element => {
             projectId={projectId}
             section={section}
             allVariables={allVariables ?? []}
-            onUpdate={reload}
+            onUpdate={reloadVariables}
             onEdit={(editing) => setMetadataDisabled(editing)}
           />
         );
@@ -64,7 +64,7 @@ const DocumentTab = (): JSX.Element => {
       }
       return sectionsToRender;
     },
-    [allVariables, document, reload]
+    [allVariables, document, reload, reloadVariables]
   );
 
   const renderVariable = useCallback(


### PR DESCRIPTION
Within the document producer, when updating a variable within a section, by reloading the document producer provider's variables only, we can avoid losing changes within the editable section.
![2024-11-08 11 33 59](https://github.com/user-attachments/assets/0c82f31d-5d38-49a8-9b69-311e7c644c70)

