### PR TITLE
TSW-6237 Terraware Server Error: No Permission to read cohorts

### DIFF
--- a/src/hooks/useListModules.ts
+++ b/src/hooks/useListModules.ts
@@ -36,10 +36,6 @@ const useListModules = () => {
   }, [dispatch, setDeliverablesRequestId]);
 
   useEffect(() => {
-    listModules();
-  }, [dispatch]);
-
-  useEffect(() => {
     if (allDeliverablesResponse && allDeliverablesResponse.status === 'success') {
       const deliverables = allDeliverablesResponse.data;
       const _deliverablesByModuleId: Record<number, ListDeliverablesElementWithOverdue[]> = {};


### PR DESCRIPTION
The useListModules hooks was executing the listModules function **always**, but this is not necessary, because the listModules is a function exported in the hook, then it can be called when it is required.

For example in the home page it is called explicitly in the [ParticipantProvider](https://github.com/terraware/terraware-web/blob/main/src/providers/Participant/ParticipantProvider.tsx#L85)