### PR TITLE
SW-6162 Fix document upgrade modal visibility

### DIFF
--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/index.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/index.tsx
@@ -44,7 +44,7 @@ export default function DocumentView(): JSX.Element {
     } else if (currentManifestId === latestManifestId) {
       setShowUpgradeModal(false);
     }
-  }, [document?.variableManifestId, latestManifestId]);
+  }, [currentManifestId, latestManifestId]);
 
   const onUpgradeManifest = useCallback(async () => {
     if (documentId && latestManifestId) {

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/index.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/index.tsx
@@ -44,7 +44,7 @@ export default function DocumentView(): JSX.Element {
       await dispatch(
         requestUpgradeManifest({ id: `${documentId}`, payload: { variableManifestId: latestManifestId } })
       );
-      reload();
+      window.location.reload();
     }
     setShowUpgradeModal(false);
   }, [dispatch, documentId, latestManifestId, reload]);

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/index.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/index.tsx
@@ -31,21 +31,29 @@ export default function DocumentView(): JSX.Element {
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
   const [outlinePanelOpen, setOutlinePanelOpen] = useState(true);
 
-  const latestManifestId = useMemo(() => documentTemplate?.variableManifestId ?? -1, [documentTemplate]);
+  const currentManifestId = document?.variableManifestId;
+  const latestManifestId = documentTemplate?.variableManifestId;
 
   useEffect(() => {
-    if (document?.variableManifestId && document.variableManifestId < latestManifestId) {
-      setShowUpgradeModal(true);
+    if (!currentManifestId || !latestManifestId) {
+      return;
     }
-  }, [document, documentTemplate, latestManifestId]);
+
+    if (currentManifestId < latestManifestId) {
+      setShowUpgradeModal(true);
+    } else if (currentManifestId === latestManifestId) {
+      setShowUpgradeModal(false);
+    }
+  }, [document?.variableManifestId, latestManifestId]);
 
   const onUpgradeManifest = useCallback(async () => {
     if (documentId && latestManifestId) {
       await dispatch(
         requestUpgradeManifest({ id: `${documentId}`, payload: { variableManifestId: latestManifestId } })
       );
-      window.location.reload();
+      reload();
     }
+
     setShowUpgradeModal(false);
   }, [dispatch, documentId, latestManifestId, reload]);
 


### PR DESCRIPTION
This PR fixes the component state and some checks to make sure that the upgrade modal is only visible when a yet-to-be-completed upgrade is available for the current document.

Although this can be deployed on its own, [this](https://github.com/terraware/terraware-server/pull/2612) PR needs to be merged to QA the ticket.