### PR TITLE
SW-6232 Add mapbox token to session storage with 30 minute expiration

### DIFF
--- a/src/utils/useMapboxToken/storage.test.ts
+++ b/src/utils/useMapboxToken/storage.test.ts
@@ -1,0 +1,76 @@
+import { getTokenFromSession, MAPBOX_SESSION_KEY, MAPBOX_TOKEN_TTL_MS, writeTokenToSession } from "./storage";
+
+describe('getTokenFromSession', () => {
+  afterAll(() => {
+    sessionStorage.setItem(MAPBOX_SESSION_KEY, '');
+  });
+
+  test('returns the token from the session when not expired', () => {
+    sessionStorage.setItem(
+      MAPBOX_SESSION_KEY,
+      JSON.stringify({
+        // Expires in the future
+        expiresAt: Date.now() + 10,
+        token: 'test-token'
+      })
+    );
+
+    expect(getTokenFromSession()).toEqual('test-token');
+  });
+
+  test('does not return the token from the session when it is expired', () => {
+    sessionStorage.setItem(
+      MAPBOX_SESSION_KEY,
+      JSON.stringify({
+        // Already expired
+        expiresAt: Date.now() - 10,
+        token: 'test-token'
+      })
+    );
+
+    expect(getTokenFromSession()).toEqual('');
+  });
+
+  test('does not return the token if the session value is incorrect', () => {
+    sessionStorage.setItem(MAPBOX_SESSION_KEY, 'not-json');
+    expect(getTokenFromSession()).toEqual('');
+
+    sessionStorage.setItem(MAPBOX_SESSION_KEY, '');
+    expect(getTokenFromSession()).toEqual('');
+
+    sessionStorage.setItem(MAPBOX_SESSION_KEY, JSON.stringify({
+      some: 'other',
+      json: 'object'
+    }));
+    expect(getTokenFromSession()).toEqual('');
+
+    sessionStorage.setItem(MAPBOX_SESSION_KEY, JSON.stringify({
+      expiresAt: Date.now() + 10,
+      token: undefined
+    }));
+    expect(getTokenFromSession()).toEqual('');
+
+    sessionStorage.setItem(MAPBOX_SESSION_KEY, JSON.stringify({
+      expiresAt: Date.now() + 10,
+      token: true
+    }));
+    expect(getTokenFromSession()).toEqual('');
+  });
+});
+
+describe('writeTokenToSession', () => {
+  afterAll(() => {
+    sessionStorage.setItem(MAPBOX_SESSION_KEY, '');
+  });
+
+  test('writes the token to session', () => {
+    writeTokenToSession('test-token');
+
+    // Is should be accessible through sessionStorage
+    const sessionToken = JSON.parse(sessionStorage.getItem(MAPBOX_SESSION_KEY) || '{}');
+    expect(sessionToken.token).toEqual('test-token');
+
+    // It should also be accessible through the util function
+    expect(getTokenFromSession()).toEqual('test-token');
+  });
+});

--- a/src/utils/useMapboxToken/storage.ts
+++ b/src/utils/useMapboxToken/storage.ts
@@ -1,0 +1,42 @@
+import { isNumber, isString } from 'lodash';
+
+// The token will last in session storage for 30 minutes
+export const MAPBOX_TOKEN_TTL_MS = 30 * 60 * 1000;
+export const MAPBOX_SESSION_KEY = 'mapbox-token';
+
+type SessionToken = {
+  expiresAt: number;
+  token: string;
+};
+
+const isSessionToken = (input: unknown): input is SessionToken => {
+  const castInput = input as SessionToken;
+  return !!(isNumber(castInput.expiresAt) && isString(castInput.token));
+};
+
+// Get the token from the session, if it has not expired
+export const getTokenFromSession = (): string => {
+  try {
+    const sessionToken = JSON.parse(sessionStorage.getItem(MAPBOX_SESSION_KEY) || '');
+
+    if (!isSessionToken(sessionToken) || Date.now() > sessionToken.expiresAt) {
+      return '';
+    }
+
+    return sessionToken.token;
+  } catch (e) {
+    return '';
+  }
+};
+
+export const writeTokenToSession = (token: string): void => {
+  try {
+    const sessionToken: SessionToken = {
+      expiresAt: Date.now() + MAPBOX_TOKEN_TTL_MS,
+      token,
+    };
+
+    sessionStorage.setItem(MAPBOX_SESSION_KEY, JSON.stringify(sessionToken));
+    // tslint:disable-next-line:no-empty
+  } catch (e) {}
+};


### PR DESCRIPTION
- Move `useMapboxToken` to its own folder
- Add util functions for getting and setting the mapbox token to session storage
- I used 30 minutes for the default expiration time since that is [what is used](https://github.com/terraware/terraware-server/blob/main/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt#L319) on the server side. 

**Before**
Here you can see what happens when the token is not stored in session:
![2024-11-19 13 51 16](https://github.com/user-attachments/assets/1225e8fc-8567-4465-b0c1-7f324e9f677f)
As you can see, a page refresh causes the FE to retrieve another token, which requires the previously cached Mapbox image to be ignored

**After**
Since we are pulling the token from session, we do not get a new token and the Mapbox asset is pulled from browser cache:
![2024-11-19 13 51 50](https://github.com/user-attachments/assets/3f792114-5a3e-4905-b2b3-a3b2cc06e8a0)

