### PR TITLE
SW-6184 Make table with search filters wait and get overridden by sticky filters if applicable

### DIFF
--- a/src/components/TableWithSearchFilters/index.tsx
+++ b/src/components/TableWithSearchFilters/index.tsx
@@ -150,7 +150,7 @@ const TableWithSearchFilters = (props: TableWithSearchFiltersProps) => {
     });
   }, [extraTableFilters]);
 
-  // set current filters if any featuredFilters has initial value, but not if we have sticky fitlers
+  // set current filters if any featuredFilters has initial value, but not if we have sticky filters
   useEffect(() => {
     if (!sessionFilters) {
       // Wait for session filters to finish loading

--- a/src/components/common/SearchFiltersWrapperV2/index.tsx
+++ b/src/components/common/SearchFiltersWrapperV2/index.tsx
@@ -112,7 +112,12 @@ export default function SearchFiltersWrapperV2({
   );
 
   useEffect(() => {
-    if (stickyFilters && Object.keys(sessionFilters).length > 0 && Object.keys(currentFilters).length === 0) {
+    if (
+      stickyFilters &&
+      sessionFilters &&
+      Object.keys(sessionFilters).length > 0 &&
+      Object.keys(currentFilters).length === 0
+    ) {
       const sessionFiltersToApply: Record<string, SearchNodePayload> = {};
       const existingKeys = Object.keys(sessionFilters);
       existingKeys?.forEach((key) => {
@@ -146,7 +151,7 @@ export default function SearchFiltersWrapperV2({
         ...incomingFilters,
       });
 
-      if (incomingFilters && stickyFilters) {
+      if (incomingFilters && stickyFilters && sessionFilters) {
         const existingKeys = Object.keys(sessionFilters);
         const allFilters = { ...currentFilters, ...incomingFilters };
         let sessionFiltersCopy = { ...sessionFilters };

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -435,7 +435,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
   }, [activeLocale, setSearchCriteria]);
 
   useEffect(() => {
-    if (Object.keys(sessionFilters).length === 0) {
+    if (!sessionFilters || Object.keys(sessionFilters).length === 0) {
       return;
     }
 

--- a/src/scenes/AcceleratorRouter/Applications/ApplicationsList.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationsList.tsx
@@ -10,12 +10,7 @@ import { requestListApplications } from 'src/redux/features/application/applicat
 import { selectApplicationList } from 'src/redux/features/application/applicationSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
-import {
-  Application,
-  ApplicationReviewStatuses,
-  ApplicationStatus,
-  ApplicationStatusOrder,
-} from 'src/types/Application';
+import { Application, ApplicationStatus, ApplicationStatusOrder } from 'src/types/Application';
 import { SearchNodePayload, SearchSortOrder } from 'src/types/Search';
 import { getCountryByCode } from 'src/utils/country';
 import { SearchAndSortFn, SearchOrderConfig, searchAndSort as genericSearchAndSort } from 'src/utils/searchAndSort';
@@ -83,6 +78,35 @@ const ApplicationList = () => {
       return [];
     }
 
+    const allFilterValues: ApplicationStatus[] = [
+      'Failed Pre-screen',
+      'Passed Pre-screen',
+      'Accepted',
+      'Carbon Eligible',
+      'Issue Active',
+      'Issue Pending',
+      'Issue Resolved',
+      'Needs Follow-up',
+      'Not Accepted',
+      'PL Review',
+      'Pre-check',
+      'Ready for Review',
+      'Submitted',
+    ];
+
+    const defaultFilterValues: ApplicationStatus[] = [
+      'Accepted',
+      'Carbon Eligible',
+      'Issue Active',
+      'Issue Pending',
+      'Issue Resolved',
+      'Needs Follow-up',
+      'PL Review',
+      'Pre-check',
+      'Ready for Review',
+      'Submitted',
+    ];
+
     const filters: FilterConfigWithValues[] = [
       {
         field: 'countryCode',
@@ -94,11 +118,9 @@ const ApplicationList = () => {
       },
       {
         field: 'status',
-        options: ApplicationReviewStatuses.sort(
-          (left, right) => ApplicationStatusOrder[left] - ApplicationStatusOrder[right]
-        ),
+        options: allFilterValues,
         label: strings.STATUS,
-        values: [...ApplicationReviewStatuses],
+        values: defaultFilterValues,
       },
     ];
 

--- a/src/scenes/InventoryRouter/InventoryTable.tsx
+++ b/src/scenes/InventoryRouter/InventoryTable.tsx
@@ -54,6 +54,11 @@ export default function InventoryTable(props: InventoryTableProps): JSX.Element 
 
   // Sync query filters into view
   useEffect(() => {
+    if (!sessionFilters) {
+      // Wait for session filters to finish loading
+      return;
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { showEmptyBatches: filterShowEmptyBatches, ...restFilters } = filters;
     const { showEmptyBatches: sessionFilterShowEmptyBatches, ...restSessionFilters } = sessionFilters;

--- a/src/utils/filterHooks/useSessionFilters.ts
+++ b/src/utils/filterHooks/useSessionFilters.ts
@@ -17,7 +17,7 @@ export const useSessionFilters = (viewIdentifier?: string) => {
   const navigate = useNavigate();
   const query = useQuery();
 
-  const [localFilters, setLocalFilters] = useState<FiltersType>({});
+  const [localFilters, setLocalFilters] = useState<FiltersType>();
   const [isInitialized, setIsInitialized] = useState<boolean>(false);
 
   // Sync filters to query and session, this happens when filters are changed within the consumer


### PR DESCRIPTION
If default filters and sticky filters are both provided. Make sticky filters take priority.
Session filters are set to be nullable to distinguish loading states.