### PR TITLE
SW-6318 Fix the CSS that was hiding the TOC contents

### DIFF
--- a/public/js/table-of-contents.js
+++ b/public/js/table-of-contents.js
@@ -98,6 +98,7 @@ const createToc = async (config) => {
       tocElement: '#table-of-contents',
       titleElements: ['.toc-major', '.toc-minor'],
     });
+    debugger;
   } catch (error) {
     console.error(error);
   }

--- a/public/js/table-of-contents.js
+++ b/public/js/table-of-contents.js
@@ -98,7 +98,6 @@ const createToc = async (config) => {
       tocElement: '#table-of-contents',
       titleElements: ['.toc-major', '.toc-minor'],
     });
-    debugger;
   } catch (error) {
     console.error(error);
   }

--- a/public/preview.css
+++ b/public/preview.css
@@ -338,11 +338,6 @@ td {
 }
 
 /** @see https://pagedjs.org/posts/build-a-table-of-contents-from-your-html/ */
-/* hack for leaders */
-#list-toc-generated {
-    overflow-x: hidden;
-}
-
 /* fake leading */
 #list-toc-generated .toc-element::after {
     content: ".............................................."
@@ -356,6 +351,7 @@ td {
 
 #list-toc-generated .toc-element {
     display: flex;
+    overflow-x: hidden;
 }
 
 #list-toc-generated .toc-element a::after {


### PR DESCRIPTION
I am not exactly sure how this stopped working... but the moving the `overflow: hidden` to the element displaying the TOC text (as opposed to the container) solved the issue.

![SCR-20241206-kfka.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/2301b5a3-c245-421c-bc95-ffddf65ed42d.png)

