### PR TITLE
SW-6339 Add email variable type

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -1024,6 +1024,10 @@ export interface paths {
      */
     delete: operations["deletePlantingSite"];
   };
+  "/api/v1/tracking/sites/{id}/history/{historyId}": {
+    /** Gets information about an older version of a planting site. */
+    get: operations["getPlantingSiteHistory"];
+  };
   "/api/v1/tracking/sites/{id}/reportedPlants": {
     /**
      * Gets the total number of plants planted at a planting site and in each planting zone.
@@ -1356,7 +1360,7 @@ export interface components {
        * @description If the variable is a table column and the new value should be appended to an existing row, the existing row's value ID.
        */
       rowValueId?: number;
-      value?: components["schemas"]["NewDateValuePayload"] | components["schemas"]["NewImageValuePayload"] | components["schemas"]["NewLinkValuePayload"] | components["schemas"]["NewNumberValuePayload"] | components["schemas"]["NewSectionTextValuePayload"] | components["schemas"]["NewSectionVariableValuePayload"] | components["schemas"]["NewSelectValuePayload"] | components["schemas"]["NewTableValuePayload"] | components["schemas"]["NewTextValuePayload"];
+      value?: components["schemas"]["NewDateValuePayload"] | components["schemas"]["NewEmailValuePayload"] | components["schemas"]["NewImageValuePayload"] | components["schemas"]["NewLinkValuePayload"] | components["schemas"]["NewNumberValuePayload"] | components["schemas"]["NewSectionTextValuePayload"] | components["schemas"]["NewSectionVariableValuePayload"] | components["schemas"]["NewSelectValuePayload"] | components["schemas"]["NewTableValuePayload"] | components["schemas"]["NewTextValuePayload"];
       /** Format: int64 */
       variableId?: number;
     }), "value" | "variableId">;
@@ -2540,6 +2544,9 @@ export interface components {
        */
       timeZone?: string;
     };
+    EmailVariablePayload: {
+      type: "Email";
+    } & Omit<components["schemas"]["VariablePayload"], "type">;
     ErrorDetails: {
       message: string;
     };
@@ -2553,6 +2560,11 @@ export interface components {
     ExistingDeletedValuePayload: WithRequired<{
       type: "Deleted";
     } & Omit<components["schemas"]["ExistingValuePayload"], "type">, "id" | "listPosition" | "type">;
+    ExistingEmailValuePayload: WithRequired<{
+      type: "Email";
+    } & Omit<components["schemas"]["ExistingValuePayload"], "type"> & {
+      emailValue?: string;
+    }, "emailValue" | "id" | "listPosition" | "type">;
     /** @description Metadata about an image. The actual image data (e.g., the JPEG or PNG file) must be retrieved in a separate request using the value ID in this payload. */
     ExistingImageValuePayload: WithRequired<{
       type: "Image";
@@ -2607,7 +2619,7 @@ export interface components {
       /** Format: int32 */
       listPosition: number;
       /** @enum {string} */
-      type: "Date" | "Deleted" | "Image" | "Link" | "Number" | "SectionText" | "SectionVariable" | "Select" | "Table" | "Text";
+      type: "Date" | "Deleted" | "Email" | "Image" | "Link" | "Number" | "SectionText" | "SectionVariable" | "Select" | "Table" | "Text";
     };
     ExistingVariableValuesPayload: {
       /** @description User-visible feedback from reviewer. Not populated for table cell values. */
@@ -2625,7 +2637,7 @@ export interface components {
        */
       status?: "Not Submitted" | "In Review" | "Needs Translation" | "Approved" | "Rejected" | "Not Needed" | "Incomplete" | "Complete";
       /** @description Values of this variable or this table cell. When getting the full set of values for a document, this will be the complete list of this variable's values in order of list position. When getting incremental changes to a document, this is only the items that have changed, and existing items won't be present. For example, if a variable is a list and has 3 values, and a fourth value is added, the incremental list of values in this payload will have one item and its list position will be 3 (since lists are 0-indexed). */
-      values: (components["schemas"]["ExistingDateValuePayload"] | components["schemas"]["ExistingDeletedValuePayload"] | components["schemas"]["ExistingImageValuePayload"] | components["schemas"]["ExistingLinkValuePayload"] | components["schemas"]["ExistingNumberValuePayload"] | components["schemas"]["ExistingSectionTextValuePayload"] | components["schemas"]["ExistingSectionVariableValuePayload"] | components["schemas"]["ExistingSelectValuePayload"] | components["schemas"]["ExistingTableValuePayload"] | components["schemas"]["ExistingTextValuePayload"])[];
+      values: (components["schemas"]["ExistingDateValuePayload"] | components["schemas"]["ExistingDeletedValuePayload"] | components["schemas"]["ExistingEmailValuePayload"] | components["schemas"]["ExistingImageValuePayload"] | components["schemas"]["ExistingLinkValuePayload"] | components["schemas"]["ExistingNumberValuePayload"] | components["schemas"]["ExistingSectionTextValuePayload"] | components["schemas"]["ExistingSectionVariableValuePayload"] | components["schemas"]["ExistingSelectValuePayload"] | components["schemas"]["ExistingTableValuePayload"] | components["schemas"]["ExistingTextValuePayload"])[];
       /** Format: int64 */
       variableId: number;
     };
@@ -2865,6 +2877,10 @@ export interface components {
       participant: components["schemas"]["ParticipantPayload"];
       status: components["schemas"]["SuccessOrError"];
     };
+    GetPlantingSiteHistoryResponsePayload: {
+      site: components["schemas"]["PlantingSiteHistoryPayload"];
+      status: components["schemas"]["SuccessOrError"];
+    };
     GetPlantingSiteObservationSummariesPayload: {
       status: components["schemas"]["SuccessOrError"];
       /** @description History of rollup summaries of planting site observations in order of observation time, latest first. */
@@ -3062,7 +3078,7 @@ export interface components {
     GetVariableWorkflowHistoryResponsePayload: {
       history: components["schemas"]["VariableWorkflowHistoryElement"][];
       status: components["schemas"]["SuccessOrError"];
-      variable: components["schemas"]["DateVariablePayload"] | components["schemas"]["ImageVariablePayload"] | components["schemas"]["LinkVariablePayload"] | components["schemas"]["NumberVariablePayload"] | components["schemas"]["SectionVariablePayload"] | components["schemas"]["SelectVariablePayload"] | components["schemas"]["TableVariablePayload"] | components["schemas"]["TextVariablePayload"];
+      variable: components["schemas"]["DateVariablePayload"] | components["schemas"]["EmailVariablePayload"] | components["schemas"]["ImageVariablePayload"] | components["schemas"]["LinkVariablePayload"] | components["schemas"]["NumberVariablePayload"] | components["schemas"]["SectionVariablePayload"] | components["schemas"]["SelectVariablePayload"] | components["schemas"]["TableVariablePayload"] | components["schemas"]["TextVariablePayload"];
     };
     GetViabilityTestPayload: {
       /** Format: int64 */
@@ -3457,7 +3473,7 @@ export interface components {
     };
     ListVariablesResponsePayload: {
       status: components["schemas"]["SuccessOrError"];
-      variables: (components["schemas"]["DateVariablePayload"] | components["schemas"]["ImageVariablePayload"] | components["schemas"]["LinkVariablePayload"] | components["schemas"]["NumberVariablePayload"] | components["schemas"]["SectionVariablePayload"] | components["schemas"]["SelectVariablePayload"] | components["schemas"]["TableVariablePayload"] | components["schemas"]["TextVariablePayload"])[];
+      variables: (components["schemas"]["DateVariablePayload"] | components["schemas"]["EmailVariablePayload"] | components["schemas"]["ImageVariablePayload"] | components["schemas"]["LinkVariablePayload"] | components["schemas"]["NumberVariablePayload"] | components["schemas"]["SectionVariablePayload"] | components["schemas"]["SelectVariablePayload"] | components["schemas"]["TableVariablePayload"] | components["schemas"]["TextVariablePayload"])[];
     };
     ListViabilityTestsResponsePayload: {
       status: components["schemas"]["SuccessOrError"];
@@ -3565,6 +3581,12 @@ export interface components {
       /** Format: date */
       dateValue?: string;
     }, "dateValue">;
+    NewEmailValuePayload: WithRequired<{
+      type: "Email";
+    } & Omit<components["schemas"]["NewValuePayload"], "type"> & {
+      citation?: string;
+      emailValue?: string;
+    }, "emailValue">;
     /** @description Updated metadata about an image value. May only be used in Update operations, and cannot be used to replace the actual image data. */
     NewImageValuePayload: {
       type: "Image";
@@ -3833,6 +3855,11 @@ export interface components {
        * @description Total number of monitoring plots that haven't been claimed yet.
        */
       numUnclaimedPlots: number;
+      /**
+       * Format: int64
+       * @description If this observation has already started, the version of the planting site that was used to place its monitoring plots.
+       */
+      plantingSiteHistoryId?: number;
       /** Format: int64 */
       plantingSiteId: number;
       plantingSiteName: string;
@@ -4167,6 +4194,15 @@ export interface components {
       /** Format: date */
       startDate: string;
     };
+    PlantingSiteHistoryPayload: {
+      boundary: components["schemas"]["MultiPolygon"];
+      exclusion?: components["schemas"]["MultiPolygon"];
+      /** Format: int64 */
+      id: number;
+      /** Format: int64 */
+      plantingSiteId: number;
+      plantingZones: components["schemas"]["PlantingZoneHistoryPayload"][];
+    };
     /** @description History of rollup summaries of planting site observations in order of observation time, latest first. */
     PlantingSiteObservationSummaryPayload: {
       /**
@@ -4239,6 +4275,18 @@ export interface components {
       /** @enum {string} */
       problemType: "CannotRemovePlantedSubzone" | "CannotSplitSubzone" | "CannotSplitZone" | "DuplicateSubzoneName" | "DuplicateZoneName" | "ExclusionWithoutBoundary" | "SiteTooLarge" | "SubzoneBoundaryChanged" | "SubzoneBoundaryOverlaps" | "SubzoneInExclusionArea" | "SubzoneNotInZone" | "ZoneBoundaryChanged" | "ZoneBoundaryOverlaps" | "ZoneHasNoSubzones" | "ZoneNotInSite" | "ZoneTooSmall" | "ZonesWithoutSiteBoundary";
     };
+    PlantingSubzoneHistoryPayload: {
+      boundary: components["schemas"]["MultiPolygon"];
+      fullName: string;
+      /** Format: int64 */
+      id: number;
+      name: string;
+      /**
+       * Format: int64
+       * @description ID of planting subzone if it exists in the current version of the site.
+       */
+      plantingSubzoneId?: number;
+    };
     PlantingSubzonePayload: {
       /** @description Area of planting subzone in hectares. */
       areaHa: number;
@@ -4265,6 +4313,18 @@ export interface components {
       /** Format: int64 */
       id: number;
       scientificName: string;
+    };
+    PlantingZoneHistoryPayload: {
+      boundary: components["schemas"]["MultiPolygon"];
+      /** Format: int64 */
+      id: number;
+      name: string;
+      plantingSubzones: components["schemas"]["PlantingSubzoneHistoryPayload"][];
+      /**
+       * Format: int64
+       * @description ID of planting zone if it exists in the current version of the site.
+       */
+      plantingZoneId?: number;
     };
     PlantingZoneObservationSummaryPayload: {
       /** @description Area of this planting zone in hectares. */
@@ -4567,7 +4627,7 @@ export interface components {
        * @description If the variable is a table column, the value ID of the row whose values should be replaced.
        */
       rowValueId?: number;
-      values?: (components["schemas"]["NewDateValuePayload"] | components["schemas"]["NewImageValuePayload"] | components["schemas"]["NewLinkValuePayload"] | components["schemas"]["NewNumberValuePayload"] | components["schemas"]["NewSectionTextValuePayload"] | components["schemas"]["NewSectionVariableValuePayload"] | components["schemas"]["NewSelectValuePayload"] | components["schemas"]["NewTableValuePayload"] | components["schemas"]["NewTextValuePayload"])[];
+      values?: (components["schemas"]["NewDateValuePayload"] | components["schemas"]["NewEmailValuePayload"] | components["schemas"]["NewImageValuePayload"] | components["schemas"]["NewLinkValuePayload"] | components["schemas"]["NewNumberValuePayload"] | components["schemas"]["NewSectionTextValuePayload"] | components["schemas"]["NewSectionVariableValuePayload"] | components["schemas"]["NewSelectValuePayload"] | components["schemas"]["NewTableValuePayload"] | components["schemas"]["NewTextValuePayload"])[];
       /** Format: int64 */
       variableId?: number;
     }), "values" | "variableId">;
@@ -5471,7 +5531,7 @@ export interface components {
     UpdateValueOperationPayload: WithRequired<{
       operation: "Update";
     } & Omit<components["schemas"]["ValueOperationPayload"], "operation"> & ({
-      value?: components["schemas"]["NewDateValuePayload"] | components["schemas"]["NewImageValuePayload"] | components["schemas"]["NewLinkValuePayload"] | components["schemas"]["NewNumberValuePayload"] | components["schemas"]["NewSectionTextValuePayload"] | components["schemas"]["NewSectionVariableValuePayload"] | components["schemas"]["NewSelectValuePayload"] | components["schemas"]["NewTableValuePayload"] | components["schemas"]["NewTextValuePayload"];
+      value?: components["schemas"]["NewDateValuePayload"] | components["schemas"]["NewEmailValuePayload"] | components["schemas"]["NewImageValuePayload"] | components["schemas"]["NewLinkValuePayload"] | components["schemas"]["NewNumberValuePayload"] | components["schemas"]["NewSectionTextValuePayload"] | components["schemas"]["NewSectionVariableValuePayload"] | components["schemas"]["NewSelectValuePayload"] | components["schemas"]["NewTableValuePayload"] | components["schemas"]["NewTextValuePayload"];
       /** Format: int64 */
       valueId?: number;
     }), "existingValueId" | "value" | "valueId">;
@@ -5722,7 +5782,7 @@ export interface components {
       recommendedBy?: number[];
       stableId: string;
       /** @enum {string} */
-      type: "Number" | "Text" | "Date" | "Image" | "Select" | "Table" | "Link" | "Section";
+      type: "Number" | "Text" | "Date" | "Image" | "Select" | "Table" | "Link" | "Section" | "Email";
     };
     VariableWorkflowHistoryElement: {
       /** Format: int64 */
@@ -5739,7 +5799,7 @@ export interface components {
       projectId: number;
       /** @enum {string} */
       status: "Not Submitted" | "In Review" | "Needs Translation" | "Approved" | "Rejected" | "Not Needed" | "Incomplete" | "Complete";
-      variableValues: (components["schemas"]["ExistingDateValuePayload"] | components["schemas"]["ExistingDeletedValuePayload"] | components["schemas"]["ExistingImageValuePayload"] | components["schemas"]["ExistingLinkValuePayload"] | components["schemas"]["ExistingNumberValuePayload"] | components["schemas"]["ExistingSectionTextValuePayload"] | components["schemas"]["ExistingSectionVariableValuePayload"] | components["schemas"]["ExistingSelectValuePayload"] | components["schemas"]["ExistingTableValuePayload"] | components["schemas"]["ExistingTextValuePayload"])[];
+      variableValues: (components["schemas"]["ExistingDateValuePayload"] | components["schemas"]["ExistingDeletedValuePayload"] | components["schemas"]["ExistingEmailValuePayload"] | components["schemas"]["ExistingImageValuePayload"] | components["schemas"]["ExistingLinkValuePayload"] | components["schemas"]["ExistingNumberValuePayload"] | components["schemas"]["ExistingSectionTextValuePayload"] | components["schemas"]["ExistingSectionVariableValuePayload"] | components["schemas"]["ExistingSelectValuePayload"] | components["schemas"]["ExistingTableValuePayload"] | components["schemas"]["ExistingTextValuePayload"])[];
     };
     VersionsEntryPayload: {
       appName: string;
@@ -11023,6 +11083,23 @@ export interface operations {
       409: {
         content: {
           "application/json": components["schemas"]["SimpleErrorResponsePayload"];
+        };
+      };
+    };
+  };
+  /** Gets information about an older version of a planting site. */
+  getPlantingSiteHistory: {
+    parameters: {
+      path: {
+        id: number;
+        historyId: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["GetPlantingSiteHistoryResponsePayload"];
         };
       };
     };

--- a/src/components/DocumentProducer/DeliverableDisplayVariableValue/index.tsx
+++ b/src/components/DocumentProducer/DeliverableDisplayVariableValue/index.tsx
@@ -33,6 +33,7 @@ export default function DeliverableDisplayVariableValue({
     case 'Text':
     case 'Number':
     case 'Date':
+    case 'Email':
     case 'Link':
       return (
         <span style={variableStyles}>

--- a/src/components/DocumentProducer/DeliverableVariableDetailsInput/index.tsx
+++ b/src/components/DocumentProducer/DeliverableVariableDetailsInput/index.tsx
@@ -14,6 +14,7 @@ import {
 } from 'src/types/documentProducer/Variable';
 import {
   VariableValueDateValue,
+  VariableValueEmailValue,
   VariableValueImageValue,
   VariableValueLinkValue,
   VariableValueNumberValue,
@@ -21,6 +22,7 @@ import {
   VariableValueTextValue,
   VariableValueValue,
 } from 'src/types/documentProducer/VariableValue';
+import { isEmailAddress } from 'src/utils/email';
 
 import DeliverableEditImages from '../DeliverableEditImages';
 import DeliverableEditTable from '../DeliverableEditTable';
@@ -86,13 +88,17 @@ const DeliverableVariableDetailsInput = ({
         setValue(selectValues[0].optionValues);
       }
       if (variable.type === 'Date') {
-        const selectValues = values as VariableValueDateValue[];
-        setValue(selectValues[0].dateValue);
+        const dateValues = values as VariableValueDateValue[];
+        setValue(dateValues[0].dateValue);
+      }
+      if (variable.type === 'Email') {
+        const emailValues = values as VariableValueEmailValue[];
+        setValue(emailValues[0].emailValue);
       }
       if (variable.type === 'Link') {
-        const selectValues = values as VariableValueLinkValue[];
-        setValue(selectValues[0].url);
-        setTitle(selectValues[0].title);
+        const linkValues = values as VariableValueLinkValue[];
+        setValue(linkValues[0].url);
+        setTitle(linkValues[0].title);
       }
     }
   }, [variable, values]);
@@ -158,6 +164,19 @@ const DeliverableVariableDetailsInput = ({
           setValues(newValues);
         } else {
           setValues([{ id: -1, listPosition: 0, dateValue: newValue, type: 'Date' }]);
+        }
+      }
+
+      if (variable.type === 'Email') {
+        if (values.length > 0) {
+          const emailValues = values as VariableValueEmailValue[];
+          const newValues = emailValues.map((ev) => ({ ...ev }));
+
+          newValues[0].emailValue = newValue;
+
+          setValues(newValues);
+        } else {
+          setValues([{ id: -1, listPosition: 0, emailValue: newValue, type: 'Email' }]);
         }
       }
 
@@ -254,6 +273,14 @@ const DeliverableVariableDetailsInput = ({
             return strings
               .formatString(strings.VARIABLE_ERROR_NUMBER_DECIMAL_PLACES, variable.decimalPlaces)
               .toString();
+          }
+        }
+        return '';
+      case 'Email':
+        if (value !== undefined) {
+          const stringValue = String(value);
+          if (stringValue !== '' && !isEmailAddress(stringValue)) {
+            return strings.INCORRECT_EMAIL_FORMAT;
           }
         }
         return '';
@@ -354,7 +381,7 @@ const DeliverableVariableDetailsInput = ({
         </>
       )}
 
-      {(variable.type === 'Number' || variable.type === 'Link') && (
+      {(variable.type === 'Number' || variable.type === 'Link' || variable.type === 'Email') && (
         <Textfield
           id='value'
           label=''

--- a/src/components/DocumentProducer/EditVariable/index.tsx
+++ b/src/components/DocumentProducer/EditVariable/index.tsx
@@ -16,6 +16,7 @@ import strings from 'src/strings';
 import { UpdateVariableWorkflowDetailsPayload, VariableWithValues } from 'src/types/documentProducer/Variable';
 import {
   NewDateValuePayload,
+  NewEmailValuePayload,
   NewLinkValuePayload,
   NewNumberValuePayload,
   NewSelectValuePayload,
@@ -23,6 +24,7 @@ import {
   Operation,
   VariableValue,
   VariableValueDateValue,
+  VariableValueEmailValue,
   VariableValueLinkValue,
   VariableValueNumberValue,
   VariableValueSelectValue,
@@ -111,6 +113,7 @@ const EditVariable = (props: EditVariableProps): JSX.Element => {
     if (values.length) {
       let newValue:
         | NewDateValuePayload
+        | NewEmailValuePayload
         | NewTextValuePayload
         | NewNumberValuePayload
         | NewSelectValuePayload
@@ -143,6 +146,11 @@ const EditVariable = (props: EditVariableProps): JSX.Element => {
         const firstValue = values[0] as VariableValueDateValue;
         valueIdToUpdate = firstValue.id;
         newValue = { type: 'Date', dateValue: firstValue.dateValue, citation: firstValue.citation };
+      }
+      if (variable.type === 'Email') {
+        const firstValue = values[0] as VariableValueEmailValue;
+        valueIdToUpdate = firstValue.id;
+        newValue = { type: 'Email', emailValue: firstValue.emailValue, citation: firstValue.citation };
       }
       if (variable.type === 'Link') {
         const firstValue = values[0] as VariableValueLinkValue;

--- a/src/components/DocumentProducer/EditableSection/DisplayVariableValue.tsx
+++ b/src/components/DocumentProducer/EditableSection/DisplayVariableValue.tsx
@@ -37,6 +37,7 @@ export default function DisplayVariableValue({
     case 'Text':
     case 'Number':
     case 'Date':
+    case 'Email':
     case 'Link':
     case 'Select':
       return (

--- a/src/components/DocumentProducer/EditableSection/EditVariableModal.tsx
+++ b/src/components/DocumentProducer/EditableSection/EditVariableModal.tsx
@@ -55,6 +55,7 @@ export default function EditVariableModal({
         />
       );
     case 'Date':
+    case 'Email':
     case 'Link':
     case 'Select':
     case 'Number':

--- a/src/components/DocumentProducer/EditableSection/helpers.ts
+++ b/src/components/DocumentProducer/EditableSection/helpers.ts
@@ -17,6 +17,7 @@ export const editorDisplayVariableWithValues = (
     case 'Number':
     case 'Link':
     case 'Date':
+    case 'Email':
       result = variable.values.map((v) => displayValue(v, placeholder)).join(separator);
       break;
     case 'Image':
@@ -49,6 +50,8 @@ export const displayValue = (value: VariableValueValue, placeholder?: string): s
       return value.title ?? value.url;
     case 'Date':
       return value.dateValue;
+    case 'Email':
+      return value.emailValue;
     default:
       return placeholder ?? '';
   }

--- a/src/components/DocumentProducer/VariableDetailsInput/index.tsx
+++ b/src/components/DocumentProducer/VariableDetailsInput/index.tsx
@@ -14,6 +14,7 @@ import {
 } from 'src/types/documentProducer/Variable';
 import {
   VariableValueDateValue,
+  VariableValueEmailValue,
   VariableValueLinkValue,
   VariableValueNumberValue,
   VariableValueSelectValue,
@@ -75,15 +76,20 @@ const VariableDetailsInput = ({
         setCitation(selectValues[0].citation);
       }
       if (variable.type === 'Date') {
-        const selectValues = values as VariableValueDateValue[];
-        setValue(selectValues[0].dateValue);
-        setCitation(selectValues[0].citation);
+        const dateValues = values as VariableValueDateValue[];
+        setValue(dateValues[0].dateValue);
+        setCitation(dateValues[0].citation);
+      }
+      if (variable.type === 'Email') {
+        const emailValues = values as VariableValueEmailValue[];
+        setValue(emailValues[0].emailValue);
+        setCitation(emailValues[0].citation);
       }
       if (variable.type === 'Link') {
-        const selectValues = values as VariableValueLinkValue[];
-        setValue(selectValues[0].url);
-        setCitation(selectValues[0].citation);
-        setTitle(selectValues[0].title);
+        const linkValues = values as VariableValueLinkValue[];
+        setValue(linkValues[0].url);
+        setCitation(linkValues[0].citation);
+        setTitle(linkValues[0].title);
       }
     }
   }, [variable, values]);
@@ -189,6 +195,20 @@ const VariableDetailsInput = ({
           setValues(newValues);
         } else {
           setValues([{ id: -1, listPosition: 0, dateValue: newValue, type: 'Date' }]);
+        }
+      }
+      if (variable.type === 'Email') {
+        if (values && values.length > 0) {
+          const emailValues = values as VariableValueEmailValue[];
+          const newValues = emailValues.map((ev) => ({ ...ev }));
+          if (id === 'citation') {
+            newValues[0].citation = newValue;
+          } else {
+            newValues[0].emailValue = newValue;
+          }
+          setValues(newValues);
+        } else {
+          setValues([{ id: -1, listPosition: 0, emailValue: newValue, type: 'Email' }]);
         }
       }
       if (variable.type === 'Link') {
@@ -347,7 +367,7 @@ const VariableDetailsInput = ({
         </>
       )}
 
-      {(variable.type === 'Number' || variable.type === 'Link') && (
+      {(variable.type === 'Number' || variable.type === 'Link' || variable.type === 'Email') && (
         <Textfield
           display={display}
           id='value'

--- a/src/components/Variables/VariableHistoryTable.tsx
+++ b/src/components/Variables/VariableHistoryTable.tsx
@@ -12,6 +12,7 @@ import strings from 'src/strings';
 import { SelectOptionPayload } from 'src/types/documentProducer/Variable';
 import {
   VariableValueDateValue,
+  VariableValueEmailValue,
   VariableValueImageValue,
   VariableValueLinkValue,
   VariableValueNumberValue,
@@ -156,6 +157,21 @@ export const VariableHistoryTable = ({ projectId, variableId }: VariableHistoryT
                 field: 'value',
                 previous: previousValue?.dateValue ?? '',
                 current: currentValue?.dateValue ?? '',
+              },
+            });
+          }
+        } else if (variable.type === 'Email') {
+          const currentValue = history.variableValues[0] as VariableValueEmailValue | undefined;
+          const previousValue = previous?.variableValues[0] as VariableValueEmailValue | undefined;
+
+          if (previousValue?.emailValue !== currentValue?.emailValue) {
+            newRows.push({
+              date: history.createdTime,
+              editedBy: history.createdBy,
+              change: {
+                field: 'value',
+                previous: previousValue?.emailValue ?? '',
+                current: currentValue?.emailValue ?? '',
               },
             });
           }

--- a/src/hooks/useProjectVariablesUpdate/util.ts
+++ b/src/hooks/useProjectVariablesUpdate/util.ts
@@ -9,6 +9,7 @@ import {
   DeletedVariableValue,
   ImageVariableValue,
   NewDateValuePayload,
+  NewEmailValuePayload,
   NewLinkValuePayload,
   NewNumberValuePayload,
   NewSelectValuePayload,
@@ -18,6 +19,7 @@ import {
   SectionVariableVariableValue,
   TableVariableValue,
   VariableValueDateValue,
+  VariableValueEmailValue,
   VariableValueLinkValue,
   VariableValueNumberValue,
   VariableValueSelectValue,
@@ -50,7 +52,13 @@ export const makeVariableValueOperations = ({
 }) => {
   const operations: Operation[] = [];
 
-  let newValue: NewDateValuePayload | NewNumberValuePayload | NewSelectValuePayload | NewLinkValuePayload | undefined;
+  let newValue:
+    | NewDateValuePayload
+    | NewEmailValuePayload
+    | NewNumberValuePayload
+    | NewSelectValuePayload
+    | NewLinkValuePayload
+    | undefined;
 
   let newTextValues: NewTextValuePayload[] = [];
   let valueIdToUpdate = -1;
@@ -83,6 +91,12 @@ export const makeVariableValueOperations = ({
     const firstValue = pendingValues[0] as VariableValueDateValue;
     valueIdToUpdate = firstValue.id;
     newValue = { type: 'Date', dateValue: firstValue.dateValue, citation: firstValue.citation };
+  }
+
+  if (variable.type === 'Email') {
+    const firstValue = pendingValues[0] as VariableValueEmailValue;
+    valueIdToUpdate = firstValue.id;
+    newValue = { type: 'Email', emailValue: firstValue.emailValue, citation: firstValue.citation };
   }
 
   if (variable.type === 'Link') {

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
@@ -12,6 +12,7 @@ import strings from 'src/strings';
 import { SelectOptionPayload, VariableWithValues } from 'src/types/documentProducer/Variable';
 import {
   VariableValueDateValue,
+  VariableValueEmailValue,
   VariableValueLinkValue,
   VariableValueNumberValue,
   VariableValueSelectValue,
@@ -61,6 +62,10 @@ const tableCellRenderer = (props: RendererProps<any>): JSX.Element => {
       if (row.type === 'Date') {
         const variableDateValue = props.value[0] as VariableValueDateValue;
         return <CellRenderer {...props} value={variableDateValue.dateValue} />;
+      }
+      if (row.type === 'Email') {
+        const variableEmailValue = props.value[0] as VariableValueEmailValue;
+        return <CellRenderer {...props} value={variableEmailValue.emailValue} />;
       }
       if (row.type === 'Link') {
         const variableLinkValue = props.value[0] as VariableValueLinkValue;

--- a/src/types/documentProducer/Variable.ts
+++ b/src/types/documentProducer/Variable.ts
@@ -18,6 +18,8 @@ export type SectionVariable = components['schemas']['SectionVariablePayload'];
 
 export type DateVariable = components['schemas']['DateVariablePayload'];
 
+export type EmailVariable = components['schemas']['EmailVariablePayload'];
+
 export type TextVariable = components['schemas']['TextVariablePayload'];
 export const isTextVariable = (input: unknown): input is TableVariable => (input as TextVariable).type === 'Text';
 
@@ -42,6 +44,7 @@ export type VariableUnion =
   | NumberVariable
   | SelectVariable
   | DateVariable
+  | EmailVariable
   | LinkVariable
   | SectionVariable;
 

--- a/src/types/documentProducer/VariableValue.ts
+++ b/src/types/documentProducer/VariableValue.ts
@@ -11,6 +11,9 @@ export const isDateVariableValue = (input: unknown): input is DateVariableValue 
   !!(input as DateVariableValue).dateValue;
 
 export type DeletedVariableValue = components['schemas']['ExistingDeletedValuePayload'];
+
+export type EmailVariableValue = components['schemas']['ExistingEmailValuePayload'];
+
 export type ImageVariableValue = components['schemas']['ExistingImageValuePayload'];
 
 export type LinkVariableValue = components['schemas']['ExistingLinkValuePayload'];
@@ -43,6 +46,7 @@ export const isTextVariableValue = (input: unknown): input is TextVariableValue 
 export type ExistingVariableValueUnion =
   | DateVariableValue
   | DeletedVariableValue
+  | EmailVariableValue
   | ImageVariableValue
   | LinkVariableValue
   | NumberVariableValue
@@ -54,6 +58,7 @@ export type ExistingVariableValueUnion =
 
 export type NewNonSectionValuePayloadUnion =
   | NewDateValuePayload
+  | NewEmailValuePayload
   | NewLinkValuePayload
   | NewNumberValuePayload
   | NewSelectValuePayload
@@ -69,6 +74,7 @@ export type CombinedInjectedValue = {
   type:
     | 'Deleted'
     | 'Date'
+    | 'Email'
     | 'Image'
     | 'Link'
     | 'Number'
@@ -95,6 +101,8 @@ export type VariableValueSelectValue = components['schemas']['ExistingSelectValu
 
 export type VariableValueDateValue = components['schemas']['ExistingDateValuePayload'];
 
+export type VariableValueEmailValue = components['schemas']['ExistingEmailValuePayload'];
+
 export type VariableValueLinkValue = components['schemas']['ExistingLinkValuePayload'];
 
 export type UpdateVariableValueRequestWithDocId = components['schemas']['UpdateValueOperationPayload'] & {
@@ -108,6 +116,8 @@ export type NewNumberValuePayload = components['schemas']['NewNumberValuePayload
 export type NewSelectValuePayload = components['schemas']['NewSelectValuePayload'];
 
 export type NewDateValuePayload = components['schemas']['NewDateValuePayload'];
+
+export type NewEmailValuePayload = components['schemas']['NewEmailValuePayload'];
 
 export type NewLinkValuePayload = components['schemas']['NewLinkValuePayload'];
 

--- a/src/utils/documentProducer/variables.ts
+++ b/src/utils/documentProducer/variables.ts
@@ -7,6 +7,7 @@ import {
 } from 'src/types/documentProducer/Variable';
 import {
   NewDateValuePayload,
+  NewEmailValuePayload,
   NewLinkValuePayload,
   NewNumberValuePayload,
   NewSelectValuePayload,
@@ -110,11 +111,19 @@ export const getRawValue = (variable: VariableWithValues): number | number[] | s
  * Check if a new varaible value is empty. This is useful for determining between append/update/delete operations
  */
 export const isValueEmpty = (
-  value: NewDateValuePayload | NewNumberValuePayload | NewSelectValuePayload | NewLinkValuePayload | NewTextValuePayload
+  value:
+    | NewDateValuePayload
+    | NewEmailValuePayload
+    | NewNumberValuePayload
+    | NewSelectValuePayload
+    | NewLinkValuePayload
+    | NewTextValuePayload
 ): boolean => {
   switch (value.type) {
     case 'Date':
       return value.dateValue === '';
+    case 'Email':
+      return value.emailValue === '';
     case 'Link':
       return value.url === '';
     case 'Text':

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -1,0 +1,17 @@
+/**
+ * Email address matching pattern equivalent to the validation logic of HTML5 email input elements.
+ *
+ * https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+ */
+const emailRegex =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+/**
+ * Returns true if a string looks like a valid email address. This uses the same pattern-based
+ * approach that browsers use in "email" input elements; like the browser's built-in validation, it
+ * does not check whether the address actually exists, and can fail on some kinds of non-ASCII email
+ * addresses.
+ */
+export function isEmailAddress(value: string) {
+  return emailRegex.test(value);
+}


### PR DESCRIPTION
Add support for variables representing email addresses. These generally work like
text variables, but they have additional input validation in the questionnaire
deliverable UI.