### PR TITLE
Prefix staging build app version with "x"

### DIFF
--- a/.github/scripts/set-environment.sh
+++ b/.github/scripts/set-environment.sh
@@ -14,6 +14,7 @@ if [[ "$GITHUB_REF" =~ refs/tags/(v[0-9]+\.[0-9.]+) ]]; then
 elif [[ "$GITHUB_REF" == refs/heads/main ]]; then
   export TIER=STAGING
   export IS_CD=true
+  APP_VERSION=x$APP_VERSION
 elif [[ "$GITHUB_REF" == refs/heads/qa ]]; then
   export TIER=QA
   export IS_CD=true


### PR DESCRIPTION
Because the short commit hash has a chance at producing a number (for example 8774464e947), it can break the "app version checker" in staging. Production builds are always prefixed with a "v". 

This adds an "x" to the staging app version, so a number can never be produced.