### PR TITLE
Allow for "Abandoned" observations to be selected from state

### DIFF
--- a/src/redux/features/observations/observationsSelectors.ts
+++ b/src/redux/features/observations/observationsSelectors.ts
@@ -13,7 +13,7 @@ import {
 
 import { mergeObservations, searchZones } from './utils';
 
-export const ALL_STATES: ObservationState[] = ['Completed', 'Overdue', 'InProgress'];
+export const ALL_STATES: ObservationState[] = ['Abandoned', 'Completed', 'Overdue', 'InProgress'];
 
 /**
  * Observations results selectors below


### PR DESCRIPTION
For abandoned observations, [this variable](https://github.com/terraware/terraware-web/blob/main/src/scenes/ObservationsRouter/details/index.tsx#L95) came back `undefined`, which caused the page to either navigate back to the observation list or appear blank.

This PR adds the "Abandoned" state to the observations selector so the variable comes back defined.