### PR TITLE
Add labels to Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":preserveSemverRanges"],
+  "labels": ["bot", "renovate"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
Add the "bot" and "renovate" labels to PRs generated by Renovate so we can easily
differentiate them in tools that work with GitHub.