### PR TITLE
Fix Renovate labels on major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":preserveSemverRanges"],
+  "extends": ["config:recommended", ":preserveSemverRanges"],
   "labels": ["bot", "renovate"],
   "packageRules": [
     {
@@ -10,7 +10,7 @@
     },
     {
       "matchUpdateTypes": ["major"],
-      "labels": ["UPDATE-MAJOR"],
+      "addLabels": ["UPDATE-MAJOR"],
       "schedule": ["every weekend"],
       "stabilityDays": 3
     }


### PR DESCRIPTION
Tell Renovate to add the `MAJOR-UPDATE` label to the other labels for major
package updates, rather than replacing the default list of labels.

In addition, Renovate renamed the preset with the recommended settings from
`base` to `recommended`, so change the config to use the new name.