### PR TITLE
SW-6389 Stop using monitoring plot names

### DIFF
--- a/src/redux/features/observations/plantingSiteDetailsSelectors.ts
+++ b/src/redux/features/observations/plantingSiteDetailsSelectors.ts
@@ -186,7 +186,7 @@ export const searchPlantingSiteMonitoringPlots = createCachedSelector(
       plantingSubzones: [
         {
           ...subzone,
-          monitoringPlots: subzone.monitoringPlots.filter((plot) => regexMatch(plot.monitoringPlotName, query)),
+          monitoringPlots: subzone.monitoringPlots.filter((plot) => regexMatch(`${plot.monitoringPlotNumber}`, query)),
         },
       ],
     } as ZoneAggregation;

--- a/src/redux/features/observations/utils.ts
+++ b/src/redux/features/observations/utils.ts
@@ -30,7 +30,8 @@ export const searchResultPlots = (search: string, plotType?: boolean, zone?: Obs
         ...subzone,
         monitoringPlots: subzone.monitoringPlots.filter(
           (plot: ObservationMonitoringPlotResults) =>
-            regexMatch(plot.monitoringPlotName, search) && (plotType === undefined || plot.isPermanent === plotType)
+            regexMatch(`${plot.monitoringPlotNumber}`, search) &&
+            (plotType === undefined || plot.isPermanent === plotType)
         ),
       }))
       .filter((subzone: ObservationPlantingSubzoneResults) => subzone.monitoringPlots.length > 0),

--- a/src/redux/features/tracking/trackingSelectors.ts
+++ b/src/redux/features/tracking/trackingSelectors.ts
@@ -40,4 +40,4 @@ export const selectZoneProgress = createCachedSelector(
   }
 )((state: RootState, plantingSiteId: number) => `${plantingSiteId}`);
 
-export const selectMonitoringPlots = (state: RootState, requestId: string) => (state.monitoringPlots as any)[requestId];
+export const selectMonitoringPlots = (state: RootState, requestId: string) => state.monitoringPlots[requestId];

--- a/src/scenes/ObservationsRouter/plot/index.tsx
+++ b/src/scenes/ObservationsRouter/plot/index.tsx
@@ -143,7 +143,7 @@ export default function ObservationMonitoringPlot(): JSX.Element {
                 .replace(':plantingZoneId', Number(plantingZoneId).toString())
                 .replace(':monitoringPlotId', found.monitoringPlotId.toString())}
             >
-              {found.monitoringPlotName}
+              {found.monitoringPlotNumber}
             </Link>
           );
         }
@@ -156,7 +156,7 @@ export default function ObservationMonitoringPlot(): JSX.Element {
 
   return (
     <DetailsPage
-      title={monitoringPlot?.monitoringPlotName ?? ''}
+      title={monitoringPlot?.monitoringPlotNumber.toString() ?? ''}
       plantingSiteId={plantingSiteId}
       observationId={observationId}
       plantingZoneId={plantingZoneId}

--- a/src/scenes/ObservationsRouter/replacePlot/ReplaceObservationPlotModal.tsx
+++ b/src/scenes/ObservationsRouter/replacePlot/ReplaceObservationPlotModal.tsx
@@ -101,8 +101,8 @@ export default function ReplaceObservationPlotModal(props: ReplaceObservationPlo
     }
     if (plots && plots.status === 'success') {
       // show page message of status
-      const addedPlotsNames = addedPlotIds.map((id) => plots.data[Number(id)]?.fullName).join(', ');
-      const removedPlotsNames = removedPlotIds.map((id) => plots.data[Number(id)]?.fullName).join(', ');
+      const addedPlotNumbers = addedPlotIds.map((id) => plots.data![Number(id)]?.plotNumber).join(', ');
+      const removedPlotNumbers = removedPlotIds.map((id) => plots.data![Number(id)]?.plotNumber).join(', ');
 
       // we don't add new plots for a permanent plot if the site has completed observations
       const noReplacedPlotsFound = !addedPlotIds.length && (!monitoringPlot.isPermanent || !hasCompletedObservations);
@@ -110,7 +110,7 @@ export default function ReplaceObservationPlotModal(props: ReplaceObservationPlo
       if (noReplacedPlotsFound) {
         snackbar.pageWarning(
           [
-            strings.formatString(strings.REASSIGNMENT_REQUEST_PLOTS_REMOVED, removedPlotsNames) as string,
+            strings.formatString(strings.REASSIGNMENT_REQUEST_PLOTS_REMOVED, removedPlotNumbers) as string,
             <br key='warn' />,
             strings.REASSIGNMENT_REQUEST_NO_PLOTS_ADDED_WARNING,
           ],
@@ -120,10 +120,10 @@ export default function ReplaceObservationPlotModal(props: ReplaceObservationPlo
       } else {
         snackbar.pageInfo(
           [
-            strings.formatString(strings.REASSIGNMENT_REQUEST_PLOTS_REMOVED, removedPlotsNames) as string,
+            strings.formatString(strings.REASSIGNMENT_REQUEST_PLOTS_REMOVED, removedPlotNumbers) as string,
             <br key='info' />,
             addedPlotIds.length
-              ? (strings.formatString(strings.REASSIGNMENT_REQUEST_PLOTS_ADDED, addedPlotsNames) as string)
+              ? (strings.formatString(strings.REASSIGNMENT_REQUEST_PLOTS_ADDED, addedPlotNumbers) as string)
               : strings.REASSIGNMENT_REQUEST_NO_PLOTS_ADDED,
           ],
           strings.REASSIGNMENT_REQUEST_STATUS,
@@ -175,7 +175,7 @@ export default function ReplaceObservationPlotModal(props: ReplaceObservationPlo
           <Grid item xs={12}>
             <Textfield
               id='monitoringPlot'
-              value={monitoringPlot.monitoringPlotName}
+              value={monitoringPlot.monitoringPlotNumber}
               type='text'
               label={strings.MONITORING_PLOT}
               display={true}

--- a/src/scenes/ObservationsRouter/zone/ObservationPlantingZoneRenderer.tsx
+++ b/src/scenes/ObservationsRouter/zone/ObservationPlantingZoneRenderer.tsx
@@ -39,7 +39,7 @@ const ObservationPlantingZoneRenderer =
       return <CellRenderer {...props} value={''} />;
     }
 
-    if (column.key === 'monitoringPlotName') {
+    if (column.key === 'monitoringPlotNumber') {
       return (
         <CellRenderer
           {...props}

--- a/src/scenes/ObservationsRouter/zone/index.tsx
+++ b/src/scenes/ObservationsRouter/zone/index.tsx
@@ -26,7 +26,7 @@ import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 import ObservationPlantingZoneRenderer from './ObservationPlantingZoneRenderer';
 
 const defaultColumns = (): TableColumnType[] => [
-  { key: 'monitoringPlotName', name: strings.MONITORING_PLOT, type: 'string' },
+  { key: 'monitoringPlotNumber', name: strings.MONITORING_PLOT, type: 'string' },
   { key: 'subzoneName', name: strings.SUBZONE, type: 'string' },
   { key: 'completedDate', name: strings.DATE, type: 'string' },
   { key: 'status', name: strings.STATUS, type: 'string' },

--- a/src/scenes/PlantingSitesRouter/view/BoundariesAndZones.tsx
+++ b/src/scenes/PlantingSitesRouter/view/BoundariesAndZones.tsx
@@ -206,7 +206,7 @@ const contextRenderer =
         .flatMap((z) => z.plantingSubzones)
         .flatMap((sz) => sz.monitoringPlots)
         .find((mp) => mp.monitoringPlotId === entity.id);
-      title = plot?.monitoringPlotName;
+      title = plot?.monitoringPlotNumber.toString();
       properties = [
         { key: strings.PLOT_TYPE, value: plot ? (plot.isPermanent ? strings.PERMANENT : strings.TEMPORARY) : '' },
         {

--- a/src/scenes/PlantingSitesRouter/view/PlantingSiteSubzoneView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSiteSubzoneView.tsx
@@ -21,7 +21,7 @@ import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 
 const columns = (): TableColumnType[] => [
   {
-    key: 'monitoringPlotName',
+    key: 'monitoringPlotNumber',
     name: strings.MONITORING_PLOT,
     type: 'string',
   },
@@ -102,7 +102,7 @@ export default function PlantingSiteZoneView(): JSX.Element {
             id='planting-site-subzone-details-table'
             columns={columns}
             rows={plantingZone?.plantingSubzones[0]?.monitoringPlots ?? []}
-            orderBy='monitoringPlotName'
+            orderBy='monitoringPlotNumber'
             Renderer={DetailsRenderer(timeZone)}
           />
         </Box>

--- a/src/services/MapService.ts
+++ b/src/services/MapService.ts
@@ -360,7 +360,7 @@ const getMonitoringPlotMapData = (
       id: plot.monitoringPlotId,
       properties: {
         id: plot.monitoringPlotId,
-        name: plot.monitoringPlotName,
+        name: plot.monitoringPlotNumber,
         type: permanent ? 'permanentPlot' : 'temporaryPlot',
       },
       boundary: [plot.boundary.coordinates],

--- a/src/services/ObservationsService.ts
+++ b/src/services/ObservationsService.ts
@@ -53,7 +53,7 @@ const exportCsv = async (observationId: number): Promise<any> => {
       'observationPlots_isPermanent',
       'observationPlots_monitoringPlot_plantingSubzone_plantingZone_name',
       'observationPlots_monitoringPlot_plantingSubzone_name',
-      'observationPlots_monitoringPlot_fullName',
+      'observationPlots_monitoringPlot_plotNumber',
       'observationPlots_monitoringPlot_southwestLatitude',
       'observationPlots_monitoringPlot_southwestLongitude',
       'observationPlots_monitoringPlot_northwestLatitude',

--- a/src/services/TrackingService.ts
+++ b/src/services/TrackingService.ts
@@ -329,7 +329,7 @@ async function searchMonitoringPlots(
   } as SearchSortOrder;
 
   const params: SearchRequestPayload = {
-    fields: ['id', 'fullName'],
+    fields: ['id', 'plotNumber'],
     prefix: 'plantingSites.plantingZones.plantingSubzones.monitoringPlots',
     sortOrder: [defaultSortOrder],
     search: {

--- a/src/types/Tracking.ts
+++ b/src/types/Tracking.ts
@@ -57,7 +57,7 @@ export type PlantingSiteSubzoneWithReportedPlants = PlantingSubzone &
 // monitoring plots
 export type MonitoringPlotSearchResult = {
   id: number;
-  fullName: string;
+  plotNumber: number;
 };
 
 // planting seasons


### PR DESCRIPTION
Explicitly use monitoring plot numbers rather than relying on the API to populate
monitoring plot names with the plot numbers for backward compatibility. This will
pave the way for removing the backward-compatibility fields from the API.

There should be no change in user-visible behavior here.