### PR TITLE
SW-6402 Better error on species rename conflict

### DIFF
--- a/src/scenes/Species/SpeciesEditView.tsx
+++ b/src/scenes/Species/SpeciesEditView.tsx
@@ -168,6 +168,8 @@ export default function SpeciesEditView(): JSX.Element {
         ) {
           goToSpecies(record.id);
         }
+      } else if (response.statusCode === 409) {
+        snackbar.toastError(strings.formatString(strings.EXISTING_SPECIES_MSG, record.scientificName));
       } else {
         snackbar.toastError();
       }


### PR DESCRIPTION
If the user tries to rename a species and the scientific name already
exists in the organization, show an error message to that effect
rather than the generic "an error occurred" one.