### PR TITLE
SW-6418 Add missing dependency to home page rows

### DIFF
--- a/src/scenes/Home/TerrawareHomeView/index.tsx
+++ b/src/scenes/Home/TerrawareHomeView/index.tsx
@@ -229,6 +229,7 @@ const TerrawareHomeView = () => {
     activeLocale,
     availableSpecies,
     orgNurserySummary,
+    plantingSites,
     seedBankSummary,
     selectedOrganization,
     speciesLastModifiedDate,


### PR DESCRIPTION
Use memo was missing this dependency which causes some display issues in production that we didn't see in prod.