### PR TITLE
SW-6331 Allow project labels to be unassigned

### DIFF
--- a/src/components/ProjectAssignModal/index.tsx
+++ b/src/components/ProjectAssignModal/index.tsx
@@ -36,7 +36,7 @@ function ProjectAssignModal<T extends ProjectAssignableEntity>(props: ProjectAss
   const projectRequest = useAppSelector((state) => selectProjectRequest(state, requestId));
 
   const handleSave = useCallback(() => {
-    if (onUnAssign && entity.projectId === null) {
+    if (onUnAssign && !entity.projectId) {
       onUnAssign();
     }
 


### PR DESCRIPTION
When unassigning the project label on batches or accessions the ID is undefined.