### PR TITLE
SW-6430 Switching organizations loads onboarding page incorrectly

### DIFF
--- a/src/scenes/Home/index.tsx
+++ b/src/scenes/Home/index.tsx
@@ -3,9 +3,6 @@ import React, { useEffect, useMemo, useState } from 'react';
 import Page from 'src/components/Page';
 import { useOrganization } from 'src/providers';
 import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
-import { selectSpecies } from 'src/redux/features/species/speciesSelectors';
-import { requestSpecies } from 'src/redux/features/species/speciesThunks';
-import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { OrganizationUserService } from 'src/services';
 import { OrganizationUser } from 'src/types/User';
 import { isManagerOrHigher } from 'src/utils/organization';
@@ -15,12 +12,10 @@ import OnboardingHomeView from './OnboardingHomeView';
 import ParticipantHomeView from './ParticipantHomeView';
 import TerrawareHomeView from './TerrawareHomeView';
 
-export default function Home(): JSX.Element {
+export default function Home({ selectedOrgHasSpecies }: { selectedOrgHasSpecies: () => boolean }): JSX.Element {
   const { orgHasModules } = useParticipantData();
   const { selectedOrganization, orgPreferences } = useOrganization();
   const [people, setPeople] = useState<OrganizationUser[]>();
-  const allSpecies = useAppSelector(selectSpecies);
-  const dispatch = useAppDispatch();
 
   useEffect(() => {
     const populatePeople = async () => {
@@ -34,23 +29,17 @@ export default function Home(): JSX.Element {
     populatePeople();
   }, [selectedOrganization]);
 
-  useEffect(() => {
-    if (!allSpecies && selectedOrganization.id !== -1) {
-      dispatch(requestSpecies(selectedOrganization.id));
-    }
-  }, [allSpecies, selectedOrganization]);
-
   const homeScreen = useMemo((): JSX.Element => {
-    if (orgHasModules === undefined || allSpecies === undefined) {
+    if (orgHasModules === undefined) {
       return <Page isLoading={true} />;
     }
 
-    if ((people?.length === 1 && !orgPreferences['singlePersonOrg']) || allSpecies.length === 0) {
+    if ((people?.length === 1 && !orgPreferences['singlePersonOrg']) || !selectedOrgHasSpecies()) {
       return <OnboardingHomeView />;
     } else {
       return orgHasModules && isManagerOrHigher(selectedOrganization) ? <ParticipantHomeView /> : <TerrawareHomeView />;
     }
-  }, [orgHasModules, people, allSpecies, selectedOrganization, orgPreferences]);
+  }, [orgHasModules, people, selectedOrgHasSpecies, selectedOrganization, orgPreferences]);
 
   return homeScreen;
 }

--- a/src/scenes/OrgRouter/index.tsx
+++ b/src/scenes/OrgRouter/index.tsx
@@ -211,7 +211,7 @@ const OrgRouter = ({ showNavBar, setShowNavBar }: OrgRouterProps) => {
           <ErrorBoundary setShowNavBar={setShowNavBar}>
             <Routes>
               {/* Routes, in order of their appearance down the side NavBar */}
-              <Route path={APP_PATHS.HOME} element={<Home />} />
+              <Route path={APP_PATHS.HOME} element={<Home selectedOrgHasSpecies={selectedOrgHasSpecies} />} />
               <Route path={APP_PATHS.SEEDS_DASHBOARD} element={<SeedsDashboard />} />
               <Route path={APP_PATHS.CHECKIN} element={<CheckIn />} />
               <Route


### PR DESCRIPTION
When switching organizations the allSpecies value, was set with the old value. Get the species value from the router directly to avoid this