### PR TITLE
SW-6396 Disable clickable rows in people table

### DIFF
--- a/src/scenes/PeopleRouter/PeopleListView.tsx
+++ b/src/scenes/PeopleRouter/PeopleListView.tsx
@@ -399,6 +399,7 @@ export default function PeopleListView(): JSX.Element {
                       rows={results}
                       orderBy='name'
                       Renderer={TableCellRenderer}
+                      isClickable={() => false}
                       showCheckbox={isAdmin(selectedOrganization)}
                       selectedRows={selectedPeopleRows}
                       setSelectedRows={setSelectedPeopleRows}


### PR DESCRIPTION
A previous PR removed the checkboxes for non-admins, but the rows were still clickable.  Remove that functionality as well.  Checkboxes still work for admins.