### PR TITLE
SW-6577 Limit organization type details to 100 characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@mui/styled-engine-sc": "^5.14.12",
     "@mui/styles": "^6.2.0",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^3.4.11",
+    "@terraware/web-components": "^3.4.12",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/src/components/AddNewOrganizationModal.tsx
+++ b/src/components/AddNewOrganizationModal.tsx
@@ -267,6 +267,7 @@ export default function AddNewOrganizationModal(props: AddNewOrganizationModalPr
               label={strings.DESCRIBE_ORGANIZATION_TYPE_DETAILS}
               id='create-org-question-website'
               display={false}
+              maxLength={100}
               onChange={(value) => {
                 onChange('organizationTypeDetails', value);
                 setOrganizationTypeDetailsError('');

--- a/src/scenes/OrganizationRouter/EditOrganizationView.tsx
+++ b/src/scenes/OrganizationRouter/EditOrganizationView.tsx
@@ -208,8 +208,9 @@ export default function OrganizationView({ organization, reloadOrganizationData 
                   required
                   type='text'
                   label={strings.DESCRIBE_ORGANIZATION_TYPE_DETAILS}
-                  id='edit-org-question-website'
+                  id='edit-org-question-type-details'
                   display={false}
+                  maxLength={100}
                   onChange={(value) => {
                     onChange('organizationTypeDetails', value);
                     setOrganizationTypeDetailsError('');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4095,10 +4095,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^3.4.11":
-  version "3.4.11"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.4.11.tgz#6a39e7d67c760371ed6a7f11e8e8e6fe056f55f1"
-  integrity sha512-rp+/0EVRwTt+rHcrDOTDefP/sbpS44KHeJamgZnbMQczkJe2gpg5Zoh7IlMFdPXwrcDW460+UKh15NWwV1Ai+g==
+"@terraware/web-components@^3.4.12":
+  version "3.4.12"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.4.12.tgz#f50657d39123357d78de5996f37faf6adb25197a"
+  integrity sha512-phdP9FZbYGnGkEg+qS0ZEWhU9OXJPijfDCgaUfsZFqaZbf+zizayEBu/37m3/1lQBpEliSOJYvfPNAToYkv9WA==
   dependencies:
     "@dnd-kit/core" "^6.0.7"
     "@dnd-kit/sortable" "^7.0.2"


### PR DESCRIPTION
The type details field that's required when users pick an organization type of
"Other" has a server-side limit of 100 characters but we weren't limiting the
inputs in the UI. This caused organization creation/edit to fail if the user
entered more than 100 characters into the field.