### PR TITLE
SW-6579 Format numbers on plants dashboard

### DIFF
--- a/src/scenes/PlantsDashboardRouter/components/NumberOfSpeciesPlantedCard.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/NumberOfSpeciesPlantedCard.tsx
@@ -4,6 +4,7 @@ import { Box, Typography, useTheme } from '@mui/material';
 import { Icon, Tooltip } from '@terraware/web-components';
 
 import BarChart from 'src/components/common/Chart/BarChart';
+import FormattedNumber from 'src/components/common/FormattedNumber';
 import OverviewItemCard from 'src/components/common/OverviewItemCard';
 import { useUser } from 'src/providers';
 import { selectPlantingsForSite } from 'src/redux/features/plantings/plantingsSelectors';
@@ -219,7 +220,7 @@ const ChartData = ({ labels, values, totalSpecies, newVersion }: ChartDataProps)
           </Typography>
           <Box display='flex' alignItems='flex-end' flexWrap='wrap' marginBottom={theme.spacing(3)}>
             <Typography fontSize='48px' fontWeight={600} lineHeight={1}>
-              {totalSpecies}
+              {totalSpecies !== undefined && <FormattedNumber value={totalSpecies} />}
             </Typography>
             &nbsp;
             <Typography fontSize='24px' fontWeight={600}>

--- a/src/scenes/PlantsDashboardRouter/components/PlantingSiteDensityCard.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/PlantingSiteDensityCard.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react';
 import { Box, Typography, useTheme } from '@mui/material';
 import { Icon } from '@terraware/web-components';
 
+import FormattedNumber from 'src/components/common/FormattedNumber';
 import useObservationSummaries from 'src/hooks/useObservationSummaries';
 import { selectPlantingSite } from 'src/redux/features/tracking/trackingSelectors';
 import { useAppSelector } from 'src/redux/store';
@@ -34,7 +35,7 @@ export default function PlantingSiteDensityCard({ plantingSiteId }: PlantingSite
   return (
     <Box>
       <Typography fontSize='48px' fontWeight={600} lineHeight={1} marginBottom={theme.spacing(2)}>
-        {summaries?.[0]?.plantingDensity ?? 0}
+        <FormattedNumber value={summaries?.[0]?.plantingDensity ?? 0} />
       </Typography>
       <Typography fontSize='16px' fontWeight={600} lineHeight={1} marginBottom={theme.spacing(2)}>
         {`${strings.PLANTS_PER_HECTARE.charAt(0).toUpperCase()}${strings.PLANTS_PER_HECTARE.slice(1)}`}

--- a/src/scenes/PlantsDashboardRouter/components/PlantsAndSpeciesCard.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/PlantsAndSpeciesCard.tsx
@@ -64,7 +64,7 @@ export default function PlantsAndSpeciesCard({
             </Tooltip>
           </Box>
           <Typography fontSize={'48px'} fontWeight={600} marginTop={1}>
-            {siteReportedPlants?.totalPlants}
+            {siteReportedPlants && <FormattedNumber value={siteReportedPlants.totalPlants} />}
           </Typography>
         </Box>
         <Box marginTop={3}>


### PR DESCRIPTION
A few of the numbers on the plants dashboard were being displayed in raw form
rather than formatted with locale-appropriate separators. Wrap them in
`<FormattedNumber>` to make them more human-friendly.