### PR TITLE
SW-6580 Use localized numbers on home dashboard

### DIFF
--- a/src/scenes/Home/TerrawareHomeView/index.tsx
+++ b/src/scenes/Home/TerrawareHomeView/index.tsx
@@ -25,12 +25,16 @@ import MobileAppCard from 'src/scenes/Home/MobileAppCard';
 import { useSpecies } from 'src/scenes/InventoryRouter/form/useSpecies';
 import { PreferencesService } from 'src/services';
 import strings from 'src/strings';
+import { useSupportedLocales } from 'src/strings/locales';
 import { isAdmin, isManagerOrHigher, selectedOrgHasFacilityType } from 'src/utils/organization';
+import { useNumberFormatter } from 'src/utils/useNumber';
 
 import OrganizationStatsCard, { OrganizationStatsCardRow } from './OrganizationStatsCard';
 
 const TerrawareHomeView = () => {
   const { activeLocale } = useLocalization();
+  const supportedLocales = useSupportedLocales();
+  const numberFormatter = useNumberFormatter();
   const { user } = useUser();
   const { selectedOrganization, orgPreferences, reloadOrgPreferences } = useOrganization();
   const { isTablet, isMobile, isDesktop } = useDeviceInfo();
@@ -45,6 +49,11 @@ const TerrawareHomeView = () => {
   const [showAcceleratorCard, setShowAcceleratorCard] = useState(true);
 
   const [isNewApplicationModalOpen, setIsNewApplicationModalOpen] = useState<boolean>(false);
+
+  const numericFormatter = useMemo(
+    () => numberFormatter(activeLocale, supportedLocales),
+    [activeLocale, numberFormatter, supportedLocales]
+  );
 
   useEffect(() => {
     if (orgPreferences.showAcceleratorCard === false && showAcceleratorCard) {
@@ -125,7 +134,7 @@ const TerrawareHomeView = () => {
             },
         icon: 'seeds' as IconName,
         statsCardItems: [
-          { label: strings.TOTAL_SPECIES, value: availableSpecies?.length.toString() },
+          { label: strings.TOTAL_SPECIES, value: numericFormatter.format(availableSpecies?.length ?? 0) },
           {
             label: strings.SPECIES_LAST_UPDATED,
             value: speciesLastModifiedDate,
@@ -157,7 +166,7 @@ const TerrawareHomeView = () => {
         statsCardItems: [
           {
             label: strings.TOTAL_SEED_COUNT,
-            value: seedBankSummary?.value?.seedsRemaining.total?.toString(),
+            value: numericFormatter.format(seedBankSummary?.value?.seedsRemaining.total ?? 0),
           },
           {
             label: strings.TOTAL_ACTIVE_ACCESSIONS,
@@ -165,7 +174,7 @@ const TerrawareHomeView = () => {
               navigate(APP_PATHS.SEEDS_DASHBOARD);
             },
             linkText: strings.VIEW_FULL_DASHBOARD,
-            value: seedBankSummary?.value?.activeAccessions?.toString(),
+            value: numericFormatter.format(seedBankSummary?.value?.activeAccessions ?? 0),
           },
         ],
         title: strings.SEEDS,
@@ -192,10 +201,13 @@ const TerrawareHomeView = () => {
             },
         icon: 'iconSeedling' as IconName,
         statsCardItems: [
-          { label: strings.TOTAL_SEEDLINGS_COUNT, value: orgNurserySummary?.totalQuantity?.toString() },
+          {
+            label: strings.TOTAL_SEEDLINGS_COUNT,
+            value: numericFormatter.format(orgNurserySummary?.totalQuantity ?? 0),
+          },
           {
             label: strings.TOTAL_WITHDRAWN_FOR_PLANTING,
-            value: orgNurserySummary?.totalWithdrawn?.toString(),
+            value: numericFormatter.format(orgNurserySummary?.totalWithdrawn ?? 0),
             linkOnClick: () => {
               navigate(APP_PATHS.NURSERY_WITHDRAWALS);
             },


### PR DESCRIPTION
The numbers (total seeds, etc.) on the home page weren't
being localized. Use the correct formatting for the active
locale for all of them.