### PR TITLE
SW-6561 Use custom PostgreSQL 17 image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: 'postgis/postgis:13-3.3'
+    image: 'terraware/postgres:v20250227.1'
     ports:
       - '5432:5432'
     volumes:


### PR DESCRIPTION
Use PostgreSQL 17, rather than 13, for the local server+database
stack that's used for Playwright tests and sometimes for local
development.

This uses a custom image that includes the extensions that will be
needed by the server for some upcoming features. The image supports
both ARM and x86, replacing the x86-only PostgreSQL 13 image we
were using; in ARM dev environments, this should give a slight
performance increase.

Note that the new version isn't compatible with data files from the
old version. People with existing database files in their local
environments will need to either dump the existing data and restore
it, or remove the data files so they start from a clean slate.