### PR TITLE
Add Nested Object filter support

### DIFF
--- a/src/utils/searchAndSort.test.ts
+++ b/src/utils/searchAndSort.test.ts
@@ -17,7 +17,7 @@ type MockResult = {
   numberFieldAsString?: string;
   projectName?: string;
   status?: string;
-  field_with_underscore?: number;
+  'field.with.dots'?: number;
   deepNestedResult?: MockResultWithSubProperties;
 };
 
@@ -614,7 +614,7 @@ describe('searchAndSort', () => {
 
     const search: SearchNodePayload = {
       operation: 'field',
-      field: 'subsets_id',
+      field: 'subsets.id',
       type: 'Exact',
       values: ['1'],
     };
@@ -678,7 +678,7 @@ describe('searchAndSort', () => {
 
     const search: SearchNodePayload = {
       operation: 'field',
-      field: 'subsets_name',
+      field: 'subsets.name',
       type: 'Exact',
       values: ['Project 2'],
     };
@@ -739,7 +739,7 @@ describe('searchAndSort', () => {
 
     const search: SearchNodePayload = {
       operation: 'field',
-      field: 'subsets_id',
+      field: 'subsets.id',
       type: 'Exact',
       values: ['1', '3'],
     };
@@ -802,7 +802,7 @@ describe('searchAndSort', () => {
 
     const search: SearchNodePayload = {
       operation: 'field',
-      field: 'subObject_id',
+      field: 'subObject.id',
       type: 'Exact',
       values: ['1'],
     };
@@ -827,26 +827,26 @@ describe('searchAndSort', () => {
     expect(searchAndSort(results, search)).toEqual(filteredResults);
   });
 
-  it('should filter the results as expected - supports properties that actually have underscores in the field', () => {
+  it('should filter the results as expected - supports properties that actually have dots in the field', () => {
     const results: MockResult[] = [
       {
         name: 'Result 1',
-        field_with_underscore: 42,
+        'field.with.dots': 42,
       },
       {
         name: 'Result 2',
-        field_with_underscore: 43,
+        'field.with.dots': 43,
       },
       {
         name: 'Result 1',
-        field_with_underscore: 42,
+        'field.with.dots': 42,
       },
     ];
 
 
     const search: SearchNodePayload = {
       operation: 'field',
-      field: 'field_with_underscore',
+      field: 'field.with.dots',
       type: 'Exact',
       values: ['42'],
     };
@@ -854,11 +854,11 @@ describe('searchAndSort', () => {
     const filteredResults: MockResult[] = [
       {
         name: 'Result 1',
-        field_with_underscore: 42,
+        'field.with.dots': 42,
       },
       {
         name: 'Result 1',
-        field_with_underscore: 42,
+        'field.with.dots': 42,
       },
     ];
 
@@ -916,7 +916,7 @@ describe('searchAndSort', () => {
 
     const search: SearchNodePayload = {
       operation: 'field',
-      field: 'subObject_deepNestedResult_subsets_name',
+      field: 'subObject.deepNestedResult.subsets.name',
       type: 'Exact',
       values: ['Last 100'],
     };

--- a/src/utils/searchAndSort.test.ts
+++ b/src/utils/searchAndSort.test.ts
@@ -17,7 +17,15 @@ type MockResult = {
   numberFieldAsString?: string;
   projectName?: string;
   status?: string;
+  field_with_underscore?: number;
+  deepNestedResult?: MockResultWithSubProperties;
 };
+
+type MockResultWithSubProperties = {
+  name?: string;
+  subObject?: MockResult;
+  subsets?: MockResult[];
+}
 
 describe('splitTrigrams', () => {
   it('should split a string into trigrams in the same way postgres does', () => {
@@ -35,7 +43,7 @@ describe('splitTrigrams', () => {
      * -----------------------------------------------
      * {'  b','  f',' ba',' fo','ar ',bar,foo,'oo '}
      */
-    expect(splitTrigrams('foo|bar')).toEqual(new Set(['  b','  f',' ba',' fo','ar ','bar','foo','oo ']));
+    expect(splitTrigrams('foo|bar')).toEqual(new Set(['  b', '  f', ' ba', ' fo', 'ar ', 'bar', 'foo', 'oo ']));
 
     /**
      * select show_trgm('olyolyoxenfree');
@@ -43,7 +51,7 @@ describe('splitTrigrams', () => {
      * -------------------------------------------------------------
      * {'  o',' ol','ee ',enf,fre,lyo,nfr,oly,oxe,ree,xen,yol,yox}
      */
-    expect(splitTrigrams('olyolyoxenfree')).toEqual(new Set(['  o',' ol','ee ','enf','fre','lyo','nfr','oly','oxe','ree','xen','yol','yox']));
+    expect(splitTrigrams('olyolyoxenfree')).toEqual(new Set(['  o', ' ol', 'ee ', 'enf', 'fre', 'lyo', 'nfr', 'oly', 'oxe', 'ree', 'xen', 'yol', 'yox']));
 
     /**
      * select show_trgm('sam');
@@ -51,7 +59,7 @@ describe('splitTrigrams', () => {
      * -------------------------
      * {'  s',' sa','am ',sam}
      */
-    expect(splitTrigrams('sam')).toEqual(new Set(['  s',' sa','am ','sam']));
+    expect(splitTrigrams('sam')).toEqual(new Set(['  s', ' sa', 'am ', 'sam']));
   });
 });
 
@@ -575,6 +583,380 @@ describe('searchAndSort', () => {
     expect(searchAndSort(results, search, searchOrderConfig)).toEqual(filteredResults);
   });
 
+  it('should filter the results as expected - field filter on subsets using numbers', () => {
+    const results: MockResultWithSubProperties[] = [
+      {
+        name: 'Funding Entity No Projects',
+      },
+      {
+        name: 'Funding Entity A',
+        subsets: [
+          {
+            id: 1,
+            name: 'Project 1',
+          },
+        ],
+      },
+      {
+        name: 'Funding Entity B',
+        subsets: [
+          {
+            id: 2,
+            name: 'Project 2',
+          },
+          {
+            id: 1,
+            name: 'Project 1',
+          },
+        ],
+      },
+    ];
+
+    const search: SearchNodePayload = {
+      operation: 'field',
+      field: 'subsets_id',
+      type: 'Exact',
+      values: ['1'],
+    };
+
+    const filteredResults: MockResultWithSubProperties[] = [
+      {
+        name: 'Funding Entity A',
+        subsets: [
+          {
+            id: 1,
+            name: 'Project 1',
+          },
+        ],
+      },
+      {
+        name: 'Funding Entity B',
+        subsets: [
+          {
+            id: 2,
+            name: 'Project 2',
+          },
+          {
+            id: 1,
+            name: 'Project 1',
+          },
+        ],
+      },
+    ];
+
+    expect(searchAndSort(results, search)).toEqual(filteredResults);
+  });
+
+  it('should filter the results as expected - field filter on subsets using strings', () => {
+    const results: MockResultWithSubProperties[] = [
+      {
+        name: 'Funding Entity No Projects',
+      },
+      {
+        name: 'Funding Entity A',
+        subsets: [
+          {
+            id: 1,
+            name: 'Project 1',
+          },
+        ],
+      },
+      {
+        name: 'Funding Entity B',
+        subsets: [
+          {
+            id: 2,
+            name: 'Project 2',
+          },
+          {
+            id: 1,
+            name: 'Project 1',
+          },
+        ],
+      },
+    ];
+
+    const search: SearchNodePayload = {
+      operation: 'field',
+      field: 'subsets_name',
+      type: 'Exact',
+      values: ['Project 2'],
+    };
+
+    const filteredResults: MockResultWithSubProperties[] = [
+      {
+        name: 'Funding Entity B',
+        subsets: [
+          {
+            id: 2,
+            name: 'Project 2',
+          },
+          {
+            id: 1,
+            name: 'Project 1',
+          },
+        ],
+      },
+    ];
+
+    expect(searchAndSort(results, search)).toEqual(filteredResults);
+  });
+
+  it('should filter the results as expected - field filter on subsets - multiple values', () => {
+    const results: MockResultWithSubProperties[] = [
+      {
+        name: 'Funding Entity A',
+        subsets: [
+          {
+            id: 1,
+            name: 'Project 1',
+          },
+          {
+            id: 2,
+            name: 'Project 2',
+          },
+        ],
+      },
+      {
+        name: 'Funding Entity B',
+        subsets: [
+          {
+            id: 2,
+            name: 'Project 2',
+          },
+        ],
+      },
+      {
+        name: 'Funding Entity C',
+        subsets: [
+          {
+            id: 3,
+            name: 'Project 3',
+          },
+        ],
+      },
+    ];
+
+    const search: SearchNodePayload = {
+      operation: 'field',
+      field: 'subsets_id',
+      type: 'Exact',
+      values: ['1', '3'],
+    };
+
+    const filteredResults: MockResultWithSubProperties[] = [
+      {
+        name: 'Funding Entity A',
+        subsets: [
+          {
+            id: 1,
+            name: 'Project 1',
+          },
+          {
+            id: 2,
+            name: 'Project 2',
+          },
+        ],
+      },
+      {
+        name: 'Funding Entity C',
+        subsets: [
+          {
+            id: 3,
+            name: 'Project 3',
+          },
+        ],
+      },
+    ];
+
+    expect(searchAndSort(results, search)).toEqual(filteredResults);
+  });
+
+  it('should filter the results as expected - field filter on sub objects', () => {
+    const results: MockResultWithSubProperties[] = [
+      {
+        name: 'No SubObject',
+      },
+      {
+        name: 'Funding Entity A',
+        subObject: {
+          id: 1,
+          name: 'Object 1',
+        },
+      },
+      {
+        name: 'Funding Entity B',
+        subObject: {
+          id: 1,
+          name: 'Object 1',
+        },
+      },
+      {
+        name: 'Funding Entity C',
+        subObject: {
+          id: 2,
+          name: 'Object 2',
+        },
+      },
+    ];
+
+    const search: SearchNodePayload = {
+      operation: 'field',
+      field: 'subObject_id',
+      type: 'Exact',
+      values: ['1'],
+    };
+
+    const filteredResults: MockResultWithSubProperties[] = [
+      {
+        name: 'Funding Entity A',
+        subObject: {
+          id: 1,
+          name: 'Object 1',
+        },
+      },
+      {
+        name: 'Funding Entity B',
+        subObject: {
+          id: 1,
+          name: 'Object 1',
+        },
+      },
+    ];
+
+    expect(searchAndSort(results, search)).toEqual(filteredResults);
+  });
+
+  it('should filter the results as expected - supports properties that actually have underscores in the field', () => {
+    const results: MockResult[] = [
+      {
+        name: 'Result 1',
+        field_with_underscore: 42,
+      },
+      {
+        name: 'Result 2',
+        field_with_underscore: 43,
+      },
+      {
+        name: 'Result 1',
+        field_with_underscore: 42,
+      },
+    ];
+
+
+    const search: SearchNodePayload = {
+      operation: 'field',
+      field: 'field_with_underscore',
+      type: 'Exact',
+      values: ['42'],
+    };
+
+    const filteredResults: MockResult[] = [
+      {
+        name: 'Result 1',
+        field_with_underscore: 42,
+      },
+      {
+        name: 'Result 1',
+        field_with_underscore: 42,
+      },
+    ];
+
+    expect(searchAndSort(results, search)).toEqual(filteredResults);
+  });
+
+  it('should filter the results as expected - complex deeply nested property works', () => {
+    const results: MockResultWithSubProperties[] = [
+      {
+        name: 'Top Level A',
+        subObject: {
+          id: 1,
+          deepNestedResult: {
+            name: 'Mid 10',
+            subsets: [
+              {
+                id: 112,
+                name: 'Last 100',
+              },
+            ],
+          },
+        },
+      },
+      {
+        name: 'Top Level B',
+        subObject: {
+          id: 2,
+          deepNestedResult: {
+            name: 'Mid 20',
+            subsets: [
+              {
+                id: 113,
+                name: 'Last 100',
+              },
+            ],
+          },
+        },
+      },
+      {
+        name: 'Top Level C',
+        subObject: {
+          id: 3,
+          deepNestedResult: {
+            name: 'Mid 30',
+            subsets: [
+              {
+                id: 120,
+                name: 'Last Level 200',
+              },
+            ],
+          },
+        },
+      },
+    ];
+
+    const search: SearchNodePayload = {
+      operation: 'field',
+      field: 'subObject_deepNestedResult_subsets_name',
+      type: 'Exact',
+      values: ['Last 100'],
+    };
+
+    const filteredResults: MockResultWithSubProperties[] = [
+      {
+        name: 'Top Level A',
+        subObject: {
+          id: 1,
+          deepNestedResult: {
+            name: 'Mid 10',
+            subsets: [
+              {
+                id: 112,
+                name: 'Last 100',
+              },
+            ],
+          },
+        },
+      },
+      {
+        name: 'Top Level B',
+        subObject: {
+          id: 2,
+          deepNestedResult: {
+            name: 'Mid 20',
+            subsets: [
+              {
+                id: 113,
+                name: 'Last 100',
+              },
+            ],
+          },
+        },
+      },
+    ]
+
+    expect(searchAndSort(results, search)).toEqual(filteredResults);
+  });
+
   it('should sort the results as expected for a string field', () => {
     const searchOrderConfig: SearchOrderConfig = {
       locale: 'en',
@@ -804,7 +1186,8 @@ describe('searchAndSort', () => {
 
     expect(searchAndSort(results, undefined, searchOrderConfig)).toEqual(sortedResultsDescending);
   });
-});
+})
+;
 
 describe('modifySearchNode', () => {
   it('modifies nested search nodes as expected - with condition and append operation', () => {

--- a/src/utils/searchAndSort.ts
+++ b/src/utils/searchAndSort.ts
@@ -110,7 +110,7 @@ export const fuzzyMatch = (a: string, b: string) => {
 
 const searchConditionMet = <T extends Record<string, unknown>>(result: T, condition: SearchNodePayload): boolean => {
   // `as SearchNodePayload` casts below are because the SearchNodePayload in the generated types only has `operation`
-  // The the union type from our types has the correct properties
+  // The union type from our types has the correct properties
   if (isNotNodePayload(condition)) {
     return !searchConditionMet(result, condition.child as SearchNodePayload);
   } else if (isAndNodePayload(condition)) {
@@ -118,10 +118,10 @@ const searchConditionMet = <T extends Record<string, unknown>>(result: T, condit
   } else if (isOrNodePayload(condition)) {
     return (condition.children as SearchNodePayload[]).some((_condition) => searchConditionMet(result, _condition));
   } else if (isFieldNodePayload(condition)) {
-    // check for underscore in field, attempt to do a nested property search if exists
-    if (condition.field.includes('_')) {
-      // split on underscore to figure out how to process from there
-      const index = condition.field.indexOf('_');
+    // check for "." in field, attempt to do a nested property search if exists
+    if (condition.field.includes('.')) {
+      // split on "." to figure out how to process from there
+      const index = condition.field.indexOf('.');
       const first = condition.field.substring(0, index);
       const last = condition.field.substring(index + 1);
       const resultValue = result[first];
@@ -140,7 +140,7 @@ const searchConditionMet = <T extends Record<string, unknown>>(result: T, condit
         });
       }
 
-      // don't return false here, in case the field actually just has an underscore in it instead of representing a sub-property
+      // don't return false here, in case the field actually just has an "." in it instead of representing a sub-property
     }
 
     // Only 'Exact' and 'Fuzzy' condition types are supported


### PR DESCRIPTION
Happy to add additional test cases if anything is missing.

AI Summary:

### TL;DR

Added support for nested property filtering in the searchAndSort utility.

### What changed?

- Enhanced the `searchConditionMet` function to support filtering on nested properties using underscore notation
- Added support for:
  - Filtering on array subsets (e.g., `subsets_id`)
  - Filtering on nested objects (e.g., `subObject_id`)
  - Filtering on deeply nested properties (e.g., `subObject_deepNestedResult_subsets_name`)
  - Preserving fields that actually contain underscores in their names
- Added test cases for new filtering capabilities
