### PR TITLE
SW-6642 Add Project filter dropdown and Client Side table

### DIFF
--- a/src/redux/features/funder/fundingEntitiesAsyncThunks.ts
+++ b/src/redux/features/funder/fundingEntitiesAsyncThunks.ts
@@ -2,7 +2,6 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import FundingEntityService from 'src/services/FundingEntityService';
 import strings from 'src/strings';
-import { SearchNodePayload, SearchSortOrder } from 'src/types/Search';
 
 export const requestFundingEntity = createAsyncThunk(
   'funding-entities/get-one',
@@ -17,24 +16,12 @@ export const requestFundingEntity = createAsyncThunk(
   }
 );
 
-export const requestFundingEntities = createAsyncThunk(
-  'funding-entities/list',
-  async (
-    request: {
-      locale: string | null;
-      search?: SearchNodePayload;
-      searchSortOrder?: SearchSortOrder;
-    },
-    { rejectWithValue }
-  ) => {
-    const { locale, search, searchSortOrder } = request;
+export const requestFundingEntities = createAsyncThunk('funding-entities/list', async (_, { rejectWithValue }) => {
+  const response = await FundingEntityService.listFundingEntities();
 
-    const response = await FundingEntityService.listFundingEntities(locale, search, searchSortOrder);
-
-    if (response && response.requestSucceeded) {
-      return response;
-    }
-
-    return rejectWithValue(strings.GENERIC_ERROR);
+  if (response && response.requestSucceeded) {
+    return response;
   }
-);
+
+  return rejectWithValue(strings.GENERIC_ERROR);
+});

--- a/src/scenes/AcceleratorRouter/FundingEntities/index.tsx
+++ b/src/scenes/AcceleratorRouter/FundingEntities/index.tsx
@@ -73,8 +73,8 @@ const FundingEntitiesView = () => {
   const featuredFilters: FilterConfig[] = useMemo(
     () => [
       {
-        field: 'projects_id',
-        id: 'projects_id',
+        field: 'projects.id',
+        id: 'projects.id',
         label: strings.PROJECT,
         options: Object.entries(allProjects)
           .sort((a, b) => a[1].toLowerCase().localeCompare(b[1].toLowerCase(), activeLocale || undefined))

--- a/src/scenes/AcceleratorRouter/FundingEntities/index.tsx
+++ b/src/scenes/AcceleratorRouter/FundingEntities/index.tsx
@@ -1,15 +1,17 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { TableColumnType } from '@terraware/web-components';
 
 import Page from 'src/components/Page';
-import TableWithSearchFilters from 'src/components/TableWithSearchFilters';
+import ClientSideFilterTable from 'src/components/Tables/ClientSideFilterTable';
+import { FilterConfig } from 'src/components/common/SearchFiltersWrapperV2';
+import { useLocalization } from 'src/providers';
 import { requestFundingEntities } from 'src/redux/features/funder/fundingEntitiesAsyncThunks';
 import { selectFundingEntitiesRequest } from 'src/redux/features/funder/fundingEntitiesSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 import { FundingEntity } from 'src/types/FundingEntity';
-import { SearchNodePayload, SearchSortOrder } from 'src/types/Search';
+import { SearchSortOrder } from 'src/types/Search';
 import useSnackbar from 'src/utils/useSnackbar';
 
 import FundingEntitiesCellRenderer from './FundingEntitiesCellRenderer';
@@ -30,19 +32,19 @@ const FundingEntitiesView = () => {
   const listRequest = useAppSelector(selectFundingEntitiesRequest(listRequestId));
   const [fundingEntities, setFundingEntities] = useState<FundingEntity[]>([]);
   const snackbar = useSnackbar();
+  const { activeLocale } = useLocalization();
 
-  const defaultSearchOrder: SearchSortOrder = {
+  const defaultSortOrder: SearchSortOrder = {
     field: 'name',
     direction: 'Ascending',
   };
 
-  const dispatchSearchRequest = useCallback(
-    (locale?: string | null, search?: SearchNodePayload, searchSortOrder?: SearchSortOrder) => {
-      const request = dispatch(requestFundingEntities({ locale: locale || null, search, searchSortOrder }));
+  useEffect(() => {
+    if (activeLocale) {
+      const request = dispatch(requestFundingEntities());
       setListRequestId(request.requestId);
-    },
-    [dispatch]
-  );
+    }
+  }, [activeLocale]);
 
   useEffect(() => {
     if (!listRequest) {
@@ -56,13 +58,43 @@ const FundingEntitiesView = () => {
     }
   }, [listRequest, snackbar]);
 
+  const allProjects = useMemo<Record<string, string>>(
+    () =>
+      (fundingEntities || []).reduce(
+        (record, entity) => {
+          entity?.projects?.forEach((project) => (record[project.id] = project.name));
+          return record;
+        },
+        {} as Record<string, string>
+      ),
+    [fundingEntities]
+  );
+
+  const featuredFilters: FilterConfig[] = useMemo(
+    () => [
+      {
+        field: 'projects_id',
+        id: 'projects_id',
+        label: strings.PROJECT,
+        options: Object.entries(allProjects)
+          .sort((a, b) => a[1].toLowerCase().localeCompare(b[1].toLowerCase(), activeLocale || undefined))
+          .map((entry) => entry[0]),
+        pillValueRenderer: (values: (string | number | null)[]) => {
+          return values.map((value) => allProjects[value || ''] || '').join(', ');
+        },
+        renderOption: (id: string | number) => allProjects[id] || '',
+      },
+    ],
+    [allProjects, fundingEntities]
+  );
+
   return (
     <Page title={strings.FUNDING_ENTITIES}>
-      <TableWithSearchFilters
+      <ClientSideFilterTable
         columns={columns}
-        defaultSearchOrder={defaultSearchOrder}
-        dispatchSearchRequest={dispatchSearchRequest}
+        defaultSortOrder={defaultSortOrder}
         fuzzySearchColumns={fuzzySearchColumns}
+        featuredFilters={featuredFilters}
         id='fundingEntitiesTable'
         rows={fundingEntities}
         isClickable={() => false}

--- a/src/services/FundingEntityService.ts
+++ b/src/services/FundingEntityService.ts
@@ -1,8 +1,6 @@
 import { paths } from 'src/api/types/generated-schema';
 import { FundingEntity } from 'src/types/FundingEntity';
 
-import { SearchNodePayload, SearchSortOrder } from '../types/Search';
-import { SearchOrderConfig, searchAndSort } from '../utils/searchAndSort';
 import HttpService, { Response } from './HttpService';
 
 /**
@@ -58,22 +56,9 @@ const getUserFundingEntity = async (userId: number): Promise<UserFundingEntityRe
   return response;
 };
 
-const listFundingEntities = async (
-  locale: string | null,
-  search?: SearchNodePayload,
-  searchSortOrder?: SearchSortOrder
-): Promise<FundingEntitiesResponse> => {
-  let searchOrderConfig: SearchOrderConfig | undefined;
-  if (searchSortOrder) {
-    searchOrderConfig = {
-      locale,
-      sortOrder: searchSortOrder,
-      numberFields: ['id'],
-    };
-  }
-
+const listFundingEntities = async (): Promise<FundingEntitiesResponse> => {
   return await httpUserFundingEntities.get<FundingEntitiesServerResponse, FundingEntitiesData>({}, (data) => ({
-    fundingEntities: searchAndSort(data?.fundingEntities || [], search, searchOrderConfig),
+    fundingEntities: data?.fundingEntities || [],
   }));
 };
 


### PR DESCRIPTION
Change Funding Entities table to new `ClientSideFilterTable` component

Add Projects filter dropdown. Utilizes new nested object filter support that was added up-stack. 

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Gd93CNnCsYqInZuuYUOX/41e3ae79-4806-4b1d-95e8-126c78ae7443.png)

