### PR TITLE
Refactor & Rename Accelerator Reports Components, Refactor Reports List/Table

### DIFF
--- a/src/components/AcceleratorReports/AcceleratorReportCellRenderer.tsx
+++ b/src/components/AcceleratorReports/AcceleratorReportCellRenderer.tsx
@@ -12,13 +12,13 @@ import { selectUser } from 'src/redux/features/user/usersSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { AcceleratorReportStatus } from 'src/types/AcceleratorReport';
 
-import ReportStatusBadge from './ReportStatusBadge';
+import AcceleratorReportStatusBadge from './AcceleratorReportStatusBadge';
 
-type ReportCellRenderer = {
+type AcceleratorReportCellRenderer = {
   projectId: string;
 };
 
-export default function ReportCellRenderer({ projectId }: ReportCellRenderer) {
+export default function AcceleratorReportCellRenderer({ projectId }: AcceleratorReportCellRenderer) {
   // eslint-disable-next-line react/display-name
   return (props: RendererProps<TableRowType>): JSX.Element => {
     const { column, row, index, value } = props;
@@ -93,7 +93,7 @@ export default function ReportCellRenderer({ projectId }: ReportCellRenderer) {
           column={column}
           index={index}
           row={row}
-          value={activeLocale ? <ReportStatusBadge status={value as AcceleratorReportStatus} /> : ''}
+          value={activeLocale ? <AcceleratorReportStatusBadge status={value as AcceleratorReportStatus} /> : ''}
         />
       );
     }

--- a/src/components/AcceleratorReports/AcceleratorReportStatusBadge.tsx
+++ b/src/components/AcceleratorReports/AcceleratorReportStatusBadge.tsx
@@ -9,11 +9,11 @@ import { useLocalization } from 'src/providers/hooks';
 import strings from 'src/strings';
 import { AcceleratorReportStatus } from 'src/types/AcceleratorReport';
 
-type ReportStatusBadgeProps = {
+type AcceleratorReportStatusBadgeProps = {
   status: AcceleratorReportStatus;
 };
 
-const ReportStatusBadge = (props: ReportStatusBadgeProps): JSX.Element => {
+const AcceleratorReportStatusBadge = (props: AcceleratorReportStatusBadgeProps): JSX.Element => {
   const { status } = props;
   const { activeLocale } = useLocalization();
   const theme = useTheme();
@@ -68,4 +68,4 @@ const ReportStatusBadge = (props: ReportStatusBadgeProps): JSX.Element => {
   return <>{badgeProps && <Badge {...badgeProps} />}</>;
 };
 
-export default ReportStatusBadge;
+export default AcceleratorReportStatusBadge;

--- a/src/components/AcceleratorReports/AcceleratorReportTargetsCellRenderer.tsx
+++ b/src/components/AcceleratorReports/AcceleratorReportTargetsCellRenderer.tsx
@@ -4,7 +4,7 @@ import Link from 'src/components/common/Link';
 import CellRenderer, { TableRowType } from 'src/components/common/table/TableCellRenderer';
 import { RendererProps } from 'src/components/common/table/types';
 
-export default function ReportsTargetsCellRenderer(props: RendererProps<TableRowType>): JSX.Element {
+export default function AcceleratorReportsTargetsCellRenderer(props: RendererProps<TableRowType>): JSX.Element {
   const { column, row, value, index, onRowClick } = props;
 
   if (column.key === 'name' && onRowClick) {

--- a/src/components/AcceleratorReports/AcceleratorReportTargetsTable.tsx
+++ b/src/components/AcceleratorReports/AcceleratorReportTargetsTable.tsx
@@ -16,8 +16,8 @@ import strings from 'src/strings';
 import { AcceleratorReport, MetricType } from 'src/types/AcceleratorReport';
 import { SearchSortOrder } from 'src/types/Search';
 
-import EditTargetsModal from './EditTargetsModal';
-import ReportsTargetsCellRenderer from './ReportsTargetsCellRenderer';
+import AcceleratorReportsTargetsCellRenderer from './AcceleratorReportTargetsCellRenderer';
+import EditAcceleratorReportTargetsModal from './EditAcceleratorReportTargetsModal';
 
 const columns = (activeLocale: string | null): TableColumnType[] =>
   activeLocale
@@ -96,7 +96,7 @@ export type RowMetric = {
   q4ReportId?: number;
 };
 
-export default function ReportsTargets(): JSX.Element {
+export default function AcceleratorReportTargetsTable(): JSX.Element {
   const { isAcceleratorRoute } = useAcceleratorConsole();
   const { currentParticipantProject } = useParticipantData();
   const [allReportsRequestId, setAllReportsRequestId] = useState<string>('');
@@ -325,14 +325,18 @@ export default function ReportsTargets(): JSX.Element {
   return (
     <>
       {editOpenModal && selectedMetric && (
-        <EditTargetsModal onClose={() => setEditOpenModal(false)} reload={reload} row={selectedMetric} />
+        <EditAcceleratorReportTargetsModal
+          onClose={() => setEditOpenModal(false)}
+          reload={reload}
+          row={selectedMetric}
+        />
       )}
       <ClientSideFilterTable
         busy={reportsResults?.status === 'pending'}
         columns={columns}
         defaultSortOrder={defaultSearchOrder}
         id='reports-targets-table'
-        Renderer={ReportsTargetsCellRenderer}
+        Renderer={AcceleratorReportsTargetsCellRenderer}
         rows={metricsToUse || []}
         title={strings.TARGETS}
         fuzzySearchColumns={fuzzySearchColumns}

--- a/src/components/AcceleratorReports/AcceleratorReportsTable.tsx
+++ b/src/components/AcceleratorReports/AcceleratorReportsTable.tsx
@@ -16,7 +16,7 @@ import strings from 'src/strings';
 import { AcceleratorReport, AcceleratorReportStatuses } from 'src/types/AcceleratorReport';
 import { SearchSortOrder } from 'src/types/Search';
 
-import ReportCellRenderer from './ReportCellRenderer';
+import AcceleratorReportCellRenderer from './AcceleratorReportCellRenderer';
 
 type AcceleratorReportRow = AcceleratorReport & {
   reportName?: string;
@@ -28,7 +28,7 @@ const defaultSearchOrder: SearchSortOrder = {
   direction: 'Descending',
 };
 
-export default function ReportsList(): JSX.Element {
+export default function AcceleratorReportsTable(): JSX.Element {
   const dispatch = useAppDispatch();
   const { activeLocale } = useLocalization();
   const { currentParticipantProject } = useParticipantData();
@@ -181,7 +181,7 @@ export default function ReportsList(): JSX.Element {
       fuzzySearchColumns={fuzzySearchColumns}
       id='accelerator-reports-table'
       isClickable={() => false}
-      Renderer={ReportCellRenderer({ projectId })}
+      Renderer={AcceleratorReportCellRenderer({ projectId })}
       rows={acceleratorReports}
       stickyFilters
       title={strings.REPORTS}

--- a/src/components/AcceleratorReports/EditAcceleratorReportTargetsModal.tsx
+++ b/src/components/AcceleratorReports/EditAcceleratorReportTargetsModal.tsx
@@ -20,7 +20,7 @@ import {
 import useForm from 'src/utils/useForm';
 import useSnackbar from 'src/utils/useSnackbar';
 
-import { RowMetric } from './ReportsTargets';
+import { RowMetric } from './AcceleratorReportTargetsTable';
 
 export interface EditTargetsModalProp {
   onClose: () => void;
@@ -28,7 +28,7 @@ export interface EditTargetsModalProp {
   row: RowMetric;
 }
 
-export default function EditTargetsModal(props: EditTargetsModalProp): JSX.Element {
+export default function EditAcceleratorReportTargetsModal(props: EditTargetsModalProp): JSX.Element {
   const { isAcceleratorRoute } = useAcceleratorConsole();
   const { currentParticipantProject } = useParticipantData();
   const { onClose, row, reload } = props;

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/Metadata.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/Metadata.tsx
@@ -2,10 +2,10 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { Box, useTheme } from '@mui/material';
 
+import AcceleratorReportStatusBadge from 'src/components/AcceleratorReports/AcceleratorReportStatusBadge';
 import { selectReviewAcceleratorReport } from 'src/redux/features/reports/reportsSelectors';
 import { requestReviewAcceleratorReport } from 'src/redux/features/reports/reportsThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
-import ReportStatusBadge from 'src/scenes/Reports/ReportStatusBadge';
 import strings from 'src/strings';
 import { AcceleratorReport, AcceleratorReportStatus } from 'src/types/AcceleratorReport';
 import useSnackbar from 'src/utils/useSnackbar';
@@ -51,7 +51,7 @@ const Metadata = (props: MetadataProps): JSX.Element => {
       <Box border={`1px solid ${theme.palette.TwClrBaseGray100}`} borderRadius='8px' marginBottom='16px' padding='16px'>
         {report.status !== 'Needs Update' && (
           <div style={{ float: 'right', marginBottom: '0px', marginLeft: '16px' }}>
-            <ReportStatusBadge status={report.status} />
+            <AcceleratorReportStatusBadge status={report.status} />
           </div>
         )}
         <InternalComment entity={report} update={onUpdateInternalComment} />

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportsList.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportsList.tsx
@@ -3,5 +3,5 @@ import React from 'react';
 import ReportsList from 'src/scenes/Reports/ReportsList';
 
 export default function ConsoleReportsList(): JSX.Element {
-  return <ReportsList fromConsole />;
+  return <ReportsList />;
 }

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportsList.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportsList.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-import ReportsList from 'src/scenes/Reports/ReportsList';
-
-export default function ConsoleReportsList(): JSX.Element {
-  return <ReportsList />;
-}

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportsView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportsView.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react';
 import { Box } from '@mui/material';
 import Tabs from '@terraware/web-components/components/Tabs';
 
+import AcceleratorReportsTable from 'src/components/AcceleratorReports/AcceleratorReportsTable';
 import ReportsTargets from 'src/components/AcceleratorReports/ReportsTargets';
 import Page from 'src/components/Page';
 import { APP_PATHS } from 'src/constants';
@@ -11,7 +12,6 @@ import strings from 'src/strings';
 import useStickyTabs from 'src/utils/useStickyTabs';
 
 import { useParticipantProjectData } from '../ParticipantProjectContext';
-import ReportsList from './ReportsList';
 import ReportsSettings from './ReportsSettings';
 
 const ReportsView = () => {
@@ -27,7 +27,7 @@ const ReportsView = () => {
       {
         id: 'reports',
         label: strings.REPORTS,
-        children: <ReportsList />,
+        children: <AcceleratorReportsTable />,
       },
       {
         id: 'targets',

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportsView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportsView.tsx
@@ -3,8 +3,8 @@ import React, { useMemo } from 'react';
 import { Box } from '@mui/material';
 import Tabs from '@terraware/web-components/components/Tabs';
 
+import AcceleratorReportTargetsTable from 'src/components/AcceleratorReports/AcceleratorReportTargetsTable';
 import AcceleratorReportsTable from 'src/components/AcceleratorReports/AcceleratorReportsTable';
-import ReportsTargets from 'src/components/AcceleratorReports/ReportsTargets';
 import Page from 'src/components/Page';
 import { APP_PATHS } from 'src/constants';
 import { useLocalization } from 'src/providers';
@@ -32,7 +32,7 @@ const ReportsView = () => {
       {
         id: 'targets',
         label: strings.TARGETS,
-        children: <ReportsTargets />,
+        children: <AcceleratorReportTargetsTable />,
       },
       {
         id: 'settings',

--- a/src/scenes/Reports/ReportsView.tsx
+++ b/src/scenes/Reports/ReportsView.tsx
@@ -4,6 +4,7 @@ import { Box, Grid, Typography } from '@mui/material';
 import { Separator } from '@terraware/web-components';
 import Tabs from '@terraware/web-components/components/Tabs';
 
+import AcceleratorReportsTable from 'src/components/AcceleratorReports/AcceleratorReportsTable';
 import ReportsTargets from 'src/components/AcceleratorReports/ReportsTargets';
 import Page from 'src/components/Page';
 import ProjectsDropdown from 'src/components/ProjectsDropdown';
@@ -12,8 +13,6 @@ import { useParticipantData } from 'src/providers/Participant/ParticipantContext
 import strings from 'src/strings';
 import theme from 'src/theme';
 import useStickyTabs from 'src/utils/useStickyTabs';
-
-import ReportsList from './ReportsList';
 
 const ReportsView = () => {
   const { activeLocale } = useLocalization();
@@ -46,7 +45,7 @@ const ReportsView = () => {
       {
         id: 'reports',
         label: strings.REPORTS,
-        children: <ReportsList />,
+        children: <AcceleratorReportsTable />,
       },
       {
         id: 'targets',

--- a/src/scenes/Reports/ReportsView.tsx
+++ b/src/scenes/Reports/ReportsView.tsx
@@ -4,8 +4,8 @@ import { Box, Grid, Typography } from '@mui/material';
 import { Separator } from '@terraware/web-components';
 import Tabs from '@terraware/web-components/components/Tabs';
 
+import AcceleratorReportTargetsTable from 'src/components/AcceleratorReports/AcceleratorReportTargetsTable';
 import AcceleratorReportsTable from 'src/components/AcceleratorReports/AcceleratorReportsTable';
-import ReportsTargets from 'src/components/AcceleratorReports/ReportsTargets';
 import Page from 'src/components/Page';
 import ProjectsDropdown from 'src/components/ProjectsDropdown';
 import { useLocalization } from 'src/providers';
@@ -50,7 +50,7 @@ const ReportsView = () => {
       {
         id: 'targets',
         label: strings.TARGETS,
-        children: <ReportsTargets />,
+        children: <AcceleratorReportTargetsTable />,
       },
     ];
   }, [activeLocale, projectFilter?.projectId]);


### PR DESCRIPTION
This PR includes changes to rename and refactor components related to Accelerator Reports.

It also includes a change to refactor the Accelerator Reports List/Table to use a single `projectId` variable.