### PR TITLE
Accelerator Reports follow-up

### DIFF
--- a/src/components/AcceleratorReports/AcceleratorReportCellRenderer.tsx
+++ b/src/components/AcceleratorReports/AcceleratorReportCellRenderer.tsx
@@ -35,7 +35,7 @@ export default function AcceleratorReportCellRenderer({ projectId }: Accelerator
       const to = reportUrl.replace(':reportId', `${row.id}`).replace(':projectId', projectId);
 
       const year = row.startDate.split('-')[0];
-      const reportName = row.frequency === 'Annual' ? `${year}` : `${year}-Q${row.quarter}`;
+      const reportName = row.frequency === 'Annual' ? `${year}` : `${year}-${row.quarter}`;
 
       return (
         <Link to={to}>

--- a/src/components/AcceleratorReports/AcceleratorReportsTable.tsx
+++ b/src/components/AcceleratorReports/AcceleratorReportsTable.tsx
@@ -97,7 +97,7 @@ export default function AcceleratorReportsTable(): JSX.Element {
       setAllAcceleratorReports(() => {
         const reports = listAllAcceleratorReportsRequest?.data?.map((report) => {
           const year = report.startDate.split('-')[0];
-          const reportName = report.frequency === 'Annual' ? `${year}` : `${year}-Q${report.quarter}`;
+          const reportName = report.frequency === 'Annual' ? `${year}` : `${year}-${report.quarter}`;
 
           return {
             ...report,
@@ -115,7 +115,7 @@ export default function AcceleratorReportsTable(): JSX.Element {
       setAcceleratorReports(() => {
         const reports = listAcceleratorReportsRequest?.data?.map((report) => {
           const year = report.startDate.split('-')[0];
-          const reportName = report.frequency === 'Annual' ? `${year}` : `${year}-Q${report.quarter}`;
+          const reportName = report.frequency === 'Annual' ? `${year}` : `${year}-${report.quarter}`;
 
           return {
             ...report,


### PR DESCRIPTION
This PR includes a fix to remove an unnecessary "Q" prefix being applied to report quarters in the accelerator reports table.

Result: "QQ1" --> "Q1"