### PR TITLE
Fix recency layer

### DIFF
--- a/src/scenes/PlantsDashboardRouter/components/ZoneLevelDataMap.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/ZoneLevelDataMap.tsx
@@ -331,26 +331,7 @@ export default function ZoneLevelDataMap({ plantingSiteId }: ZoneLevelDataMapPro
 
       baseMap.subzone.entities = entitiesToReturn;
     }
-    observationMapData.subzone?.entities?.forEach((subzoneEntity) => {
-      const subzoneReplaceIndex = baseMap.subzone?.entities?.findIndex((e) => e.id === subzoneEntity.id) ?? -1;
-      if (baseMap.subzone && subzoneReplaceIndex >= 0) {
-        const oldEntity = baseMap.subzone.entities[subzoneReplaceIndex];
-        baseMap.subzone.entities[subzoneReplaceIndex] = {
-          ...subzoneEntity,
-          properties: { ...subzoneEntity.properties, recency: oldEntity.properties.recency },
-        };
-      } else {
-        if (!baseMap.subzone) {
-          baseMap.subzone = {
-            id: 'subzones',
-            entities: [],
-          };
-        }
-        baseMap.subzone.entities.push(subzoneEntity);
-      }
-    });
-
-    return baseMap;
+    return observationMapData;
   }, [plantingSite, observation, plantingSiteHistory, defaultTimeZone, zoneObservations]);
 
   const focusEntities = useMemo(() => {


### PR DESCRIPTION
Previously we were getting the data to draw in the map from the observation, and if the observation didn't include all zone/sub-zones we needed to get the not-observed zone/subzones from a base map that has every zone/subzone, so that everything can be drawn on the map.

Now, we are getting the map data from the observation and the plantingSiteHistory, so we have every zone/subzone included. Now there is no need to add the missing zone/subzones to the map