### PR TITLE
SW-6724 Fix Redirect issue

### DIFF
--- a/src/scenes/FunderRouter/index.tsx
+++ b/src/scenes/FunderRouter/index.tsx
@@ -22,7 +22,7 @@ export default function FunderRouter() {
 
   useEffect(() => {
     if (navigate && user && user.userType !== 'Funder') {
-      navigate(APP_PATHS.WELCOME);
+      navigate(APP_PATHS.HOME);
     }
   }, [navigate, user]);
 


### PR DESCRIPTION
There appears to be an occasional issue with react-router where it sometimes will not do a double redirect when using the Navigate component. 

Currently, `/funder` redirects to `/welcome` if the user is not a funder. For users with an organization, `/welcome` then redirects to `/home`. For users without an organization, both `/welcome` and `/home` display the same welcome component anyway.

In this instance, we didn't really need to redirect to `/welcome` instead of `/home`, so this PR just changes the redirect from `/funder` to `/home`. 