### PR TITLE
SW-6707 Match "Other" species on ad-hoc observations

### DIFF
--- a/src/scenes/ObservationsRouter/common/MergedSuccessMessage.tsx
+++ b/src/scenes/ObservationsRouter/common/MergedSuccessMessage.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { MergeOtherSpeciesRequestData } from 'src/redux/features/species/speciesThunks';
+
+/** Returns a message to show after "Other" species are successfully merged with known ones. */
+export default function MergedSuccessMessage(merged: MergeOtherSpeciesRequestData[]): JSX.Element {
+  return (
+    <ul style={{ paddingLeft: '24px', margin: 0 }}>
+      {merged.map((sp, index) => (
+        <li key={index}>
+          {sp.otherSpeciesName} &#8594; {sp.newName}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/scenes/ObservationsRouter/details/index.tsx
+++ b/src/scenes/ObservationsRouter/details/index.tsx
@@ -26,6 +26,7 @@ import { selectPlantingSite } from 'src/redux/features/tracking/trackingSelector
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import AggregatedPlantsStats from 'src/scenes/ObservationsRouter/common/AggregatedPlantsStats';
 import DetailsPage from 'src/scenes/ObservationsRouter/common/DetailsPage';
+import MergedSuccessMessage from 'src/scenes/ObservationsRouter/common/MergedSuccessMessage';
 import strings from 'src/strings';
 import { ObservationState } from 'src/types/Observations';
 import { FieldOptionsMap } from 'src/types/Search';
@@ -43,16 +44,6 @@ export type ObservationDetailsProps = SearchProps & {
   setFilterOptions: (value: FieldOptionsMap) => void;
   reload: () => void;
 };
-
-const MergedSuccessMessage = (merged: MergeOtherSpeciesRequestData[]): JSX.Element => (
-  <ul style={{ paddingLeft: '24px', margin: 0 }}>
-    {merged.map((sp, index) => (
-      <li key={index}>
-        {sp.otherSpeciesName} &#8594; {sp.newName}
-      </li>
-    ))}
-  </ul>
-);
 
 export default function ObservationDetails(props: ObservationDetailsProps): JSX.Element {
   const { setFilterOptions, reload } = props;

--- a/src/scenes/ObservationsRouter/index.tsx
+++ b/src/scenes/ObservationsRouter/index.tsx
@@ -175,7 +175,7 @@ const ObservationsInnerRouter = ({ reload }: { reload: () => void }): JSX.Elemen
       />
       <Route
         path={'/:plantingSiteId/results/:observationId/adHocPlot/:monitoringPlotId'}
-        element={<AdHocObservationDetails />}
+        element={<AdHocObservationDetails reload={reload} />}
       />
       <Route
         path={'/:plantingSiteId/results/:observationId'}

--- a/src/scenes/ObservationsRouter/plot/AdHocObservationDetails.tsx
+++ b/src/scenes/ObservationsRouter/plot/AdHocObservationDetails.tsx
@@ -1,27 +1,49 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
-import { Textfield } from '@terraware/web-components';
+import { Button, Message, Textfield } from '@terraware/web-components';
 import { getDateDisplayValue } from '@terraware/web-components/utils';
+import _ from 'lodash';
 
 import Card from 'src/components/common/Card';
+import OptionsMenu from 'src/components/common/OptionsMenu';
 import { APP_PATHS } from 'src/constants';
-import { useLocalization } from 'src/providers';
+import { useLocalization, useOrganization } from 'src/providers';
 import { selectAdHocObservationsResults } from 'src/redux/features/observations/observationsSelectors';
 import { getConditionString } from 'src/redux/features/observations/utils';
+import { selectMergeOtherSpecies, selectSpecies } from 'src/redux/features/species/speciesSelectors';
+import {
+  MergeOtherSpeciesRequestData,
+  requestMergeOtherSpecies,
+  requestSpecies,
+} from 'src/redux/features/species/speciesThunks';
 import { selectPlantingSite } from 'src/redux/features/tracking/trackingSelectors';
-import { useAppSelector } from 'src/redux/store';
+import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { useSpecies } from 'src/scenes/InventoryRouter/form/useSpecies';
 import DetailsPage from 'src/scenes/ObservationsRouter/common/DetailsPage';
 import SpeciesMortalityRateChart from 'src/scenes/ObservationsRouter/common/SpeciesMortalityRateChart';
 import SpeciesTotalPlantsChart from 'src/scenes/ObservationsRouter/common/SpeciesTotalPlantsChart';
+import MatchSpeciesModal, {
+  MergeOtherSpeciesPayloadPartial,
+} from 'src/scenes/ObservationsRouter/details/MatchSpeciesModal';
 import strings from 'src/strings';
 import { getShortTime } from 'src/utils/dateFormatter';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
+import useSnackbar from 'src/utils/useSnackbar';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 
 import MonitoringPlotPhotos from './MonitoringPlotPhotos';
+
+const MergedSuccessMessage = (merged: MergeOtherSpeciesRequestData[]): JSX.Element => (
+  <ul style={{ paddingLeft: '24px', margin: 0 }}>
+    {merged.map((sp, index) => (
+      <li key={index}>
+        {sp.otherSpeciesName} &#8594; {sp.newName}
+      </li>
+    ))}
+  </ul>
+);
 
 export default function AdHocObservationDetails(): JSX.Element {
   const { plantingSiteId, observationId, monitoringPlotId } = useParams<{
@@ -34,11 +56,22 @@ export default function AdHocObservationDetails(): JSX.Element {
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
   const { activeLocale } = useLocalization();
+  const { selectedOrganization } = useOrganization();
   const allAdHocObservationsResults = useAppSelector(selectAdHocObservationsResults);
   const observation = allAdHocObservationsResults?.find(
     (obsResult) => obsResult?.observationId.toString() === observationId?.toString()
   );
   const { availableSpecies } = useSpecies();
+  const dispatch = useAppDispatch();
+  const snackbar = useSnackbar();
+
+  const [unrecognizedSpecies, setUnrecognizedSpecies] = useState<string[]>([]);
+  const [showPageMessage, setShowPageMessage] = useState(false);
+  const [showMatchSpeciesModal, setShowMatchSpeciesModal] = useState(false);
+  const [mergeRequestId, setMergeRequestId] = useState<string>('');
+
+  const allSpecies = useAppSelector(selectSpecies);
+  const matchResponse = useAppSelector(selectMergeOtherSpecies(mergeRequestId));
 
   const monitoringPlot = useMemo(() => {
     const speciesToUse = observation?.adHocPlot?.species.map((sp) => {
@@ -101,12 +134,123 @@ export default function AdHocObservationDetails(): JSX.Element {
     }
   }, [navigate, monitoringPlot]);
 
+  useEffect(() => {
+    if (!allSpecies && selectedOrganization.id !== -1) {
+      dispatch(requestSpecies(selectedOrganization.id));
+    }
+  }, [dispatch, allSpecies, selectedOrganization]);
+
+  useEffect(() => {
+    const speciesWithNoIdMap = _.uniqBy(
+      (monitoringPlot?.species || []).filter((sp) => !sp.speciesId),
+      'speciesName'
+    ).map((sp) => sp.speciesName || '');
+
+    setUnrecognizedSpecies(speciesWithNoIdMap);
+    if (speciesWithNoIdMap.length > 0) {
+      setShowPageMessage(true);
+    } else {
+      setShowPageMessage(false);
+    }
+  }, [monitoringPlot]);
+
+  useEffect(() => {
+    if (matchResponse?.status === 'success' && matchResponse?.data && matchResponse.data.length > 0) {
+      // Force reload page to show updated data
+      window.location.reload();
+      snackbar.toastSuccess([MergedSuccessMessage(matchResponse.data)], strings.SPECIES_MATCHED);
+    }
+    if (matchResponse?.status === 'error') {
+      snackbar.toastError();
+    }
+  }, [matchResponse, snackbar]);
+
+  const onSaveMergedSpecies = (mergedSpeciesPayloads: MergeOtherSpeciesPayloadPartial[]) => {
+    const mergeOtherSpeciesRequestData: MergeOtherSpeciesRequestData[] = mergedSpeciesPayloads
+      .filter((sp) => !!sp.otherSpeciesName && !!sp.speciesId)
+      .map((sp) => ({
+        newName: allSpecies?.find((existing) => existing.id === sp.speciesId)?.scientificName || '',
+        otherSpeciesName: sp.otherSpeciesName!,
+        speciesId: sp.speciesId!,
+      }));
+
+    if (mergeOtherSpeciesRequestData.length > 0) {
+      const request = dispatch(
+        requestMergeOtherSpecies({
+          mergeOtherSpeciesRequestData,
+          observationId: Number(observationId),
+        })
+      );
+      setMergeRequestId(request.requestId);
+    }
+
+    setShowMatchSpeciesModal(false);
+  };
+
+  const pageMessage = (
+    <Box key='unrecognized-species-message'>
+      <Typography>{strings.UNRECOGNIZED_SPECIES_MESSAGE}</Typography>
+      <ul style={{ margin: 0 }}>
+        {unrecognizedSpecies?.map((species, index) => <li key={`species-${index}`}>{species}</li>)}
+      </ul>
+    </Box>
+  );
+
   return (
     <DetailsPage
       title={monitoringPlot?.monitoringPlotNumber?.toString() ?? ''}
       plantingSiteId={plantingSiteId}
       observationId={observationId}
+      rightComponent={
+        <OptionsMenu
+          onOptionItemClick={() => setShowMatchSpeciesModal(true)}
+          optionItems={[
+            {
+              label: strings.MATCH_UNRECOGNIZED_SPECIES,
+              value: 'match',
+              disabled: (unrecognizedSpecies?.length || 0) === 0,
+            },
+          ]}
+        />
+      }
     >
+      {showPageMessage && (
+        <Box marginTop={1} marginBottom={4} width={'100%'}>
+          <Message
+            body={pageMessage}
+            onClose={() => setShowPageMessage(false)}
+            priority='warning'
+            showCloseButton
+            title={strings.UNRECOGNIZED_SPECIES}
+            type='page'
+            pageButtons={[
+              <Button
+                onClick={() => setShowPageMessage(false)}
+                label={strings.DISMISS}
+                priority='secondary'
+                type='passive'
+                key='button-1'
+                size='small'
+              />,
+              <Button
+                onClick={() => setShowMatchSpeciesModal(true)}
+                label={strings.MATCH_SPECIES}
+                priority='secondary'
+                type='passive'
+                key='button-2'
+                size='small'
+              />,
+            ]}
+          />
+        </Box>
+      )}
+      {showMatchSpeciesModal && (
+        <MatchSpeciesModal
+          onClose={() => setShowMatchSpeciesModal(false)}
+          onSave={onSaveMergedSpecies}
+          unrecognizedSpecies={unrecognizedSpecies || []}
+        />
+      )}
       <Grid container>
         <Grid item xs={12}>
           <Card flushMobile>

--- a/src/scenes/ObservationsRouter/plot/AdHocObservationDetails.tsx
+++ b/src/scenes/ObservationsRouter/plot/AdHocObservationDetails.tsx
@@ -22,6 +22,7 @@ import { selectPlantingSite } from 'src/redux/features/tracking/trackingSelector
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { useSpecies } from 'src/scenes/InventoryRouter/form/useSpecies';
 import DetailsPage from 'src/scenes/ObservationsRouter/common/DetailsPage';
+import MergedSuccessMessage from 'src/scenes/ObservationsRouter/common/MergedSuccessMessage';
 import SpeciesMortalityRateChart from 'src/scenes/ObservationsRouter/common/SpeciesMortalityRateChart';
 import SpeciesTotalPlantsChart from 'src/scenes/ObservationsRouter/common/SpeciesTotalPlantsChart';
 import MatchSpeciesModal, {
@@ -35,17 +36,12 @@ import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 
 import MonitoringPlotPhotos from './MonitoringPlotPhotos';
 
-const MergedSuccessMessage = (merged: MergeOtherSpeciesRequestData[]): JSX.Element => (
-  <ul style={{ paddingLeft: '24px', margin: 0 }}>
-    {merged.map((sp, index) => (
-      <li key={index}>
-        {sp.otherSpeciesName} &#8594; {sp.newName}
-      </li>
-    ))}
-  </ul>
-);
+type AdHocObservationDetailsProps = {
+  reload: () => void;
+};
 
-export default function AdHocObservationDetails(): JSX.Element {
+export default function AdHocObservationDetails(props: AdHocObservationDetailsProps): JSX.Element {
+  const { reload } = props;
   const { plantingSiteId, observationId, monitoringPlotId } = useParams<{
     plantingSiteId: string;
     observationId: string;
@@ -157,7 +153,7 @@ export default function AdHocObservationDetails(): JSX.Element {
   useEffect(() => {
     if (matchResponse?.status === 'success' && matchResponse?.data && matchResponse.data.length > 0) {
       // Force reload page to show updated data
-      window.location.reload();
+      reload();
       snackbar.toastSuccess([MergedSuccessMessage(matchResponse.data)], strings.SPECIES_MATCHED);
     }
     if (matchResponse?.status === 'error') {


### PR DESCRIPTION
For assigned observations, we let users match the "Other" species
with ones on the organization's species list. Add the same
functionality for ad-hoc monitoring observations.