### PR TITLE
SW-6734 Clicking back to Reports page from a Report should keep table filters

### DIFF
--- a/src/components/AcceleratorReports/AcceleratorReportsTable.tsx
+++ b/src/components/AcceleratorReports/AcceleratorReportsTable.tsx
@@ -17,6 +17,7 @@ import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 import { AcceleratorReport, AcceleratorReportStatuses } from 'src/types/AcceleratorReport';
 import { SearchSortOrder } from 'src/types/Search';
+import useQuery from 'src/utils/useQuery';
 
 import AcceleratorReportCellRenderer from './AcceleratorReportCellRenderer';
 
@@ -84,6 +85,8 @@ export default function AcceleratorReportsTable(): JSX.Element {
 
   const pathParams = useParams<{ projectId: string }>();
   const projectId = isAcceleratorRoute ? String(pathParams.projectId) : currentParticipantProject?.id?.toString();
+  const query = useQuery();
+  const yearQuery = query.get('year');
 
   const currentYear = DateTime.now().year;
 
@@ -198,6 +201,10 @@ export default function AcceleratorReportsTable(): JSX.Element {
 
   useEffect(() => {
     if (!!allAcceleratorReports?.length && !!allReportYears.length) {
+      if (yearQuery) {
+        setYearFilter(yearQuery);
+        return;
+      }
       if (allReportYears.includes(currentYear)) {
         setYearFilter(currentYear.toString());
       } else {
@@ -210,7 +217,7 @@ export default function AcceleratorReportsTable(): JSX.Element {
         }
       }
     }
-  }, [allAcceleratorReports, allReportYears]);
+  }, [allAcceleratorReports, allReportYears, yearQuery]);
 
   const featuredFilters: FilterConfigWithValues[] = useMemo(() => {
     const rejectedStatus = activeLocale ? (isAcceleratorRoute ? strings.UPDATE_REQUESTED : strings.UPDATE_NEEDED) : '';

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportView.tsx
@@ -132,14 +132,20 @@ const ReportView = () => {
     }
   }, [reportId, reports]);
 
+  const year = useMemo(() => {
+    return selectedReport?.startDate.split('-')[0];
+  }, [selectedReport]);
+
   const crumbs: Crumb[] = useMemo(
     () => [
       {
         name: activeLocale ? strings.REPORTS : '',
-        to: APP_PATHS.ACCELERATOR_PROJECT_REPORTS.replace(':projectId', projectId),
+        to: year
+          ? `${APP_PATHS.ACCELERATOR_PROJECT_REPORTS.replace(':projectId', projectId)}?year=${year}`
+          : APP_PATHS.ACCELERATOR_PROJECT_REPORTS.replace(':projectId', projectId),
       },
     ],
-    [activeLocale]
+    [activeLocale, year]
   );
 
   const callToAction = useMemo(() => {
@@ -176,7 +182,6 @@ const ReportView = () => {
     [callToAction]
   );
 
-  const year = selectedReport?.startDate.split('-')[0];
   const reportName = selectedReport
     ? selectedReport.frequency === 'Annual'
       ? `${year}`

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportsView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportsView.tsx
@@ -46,7 +46,7 @@ const ReportsView = () => {
     defaultTab: 'reports',
     tabs,
     viewIdentifier: 'project-reports',
-    keepQuery: false,
+    keepQuery: true,
   });
 
   return (

--- a/src/scenes/Reports/AcceleratorReportView.tsx
+++ b/src/scenes/Reports/AcceleratorReportView.tsx
@@ -76,14 +76,18 @@ const AcceleratorReportView = () => {
     }
   }, [reportId, reports]);
 
+  const year = useMemo(() => {
+    return selectedReport?.startDate.split('-')[0];
+  }, [selectedReport]);
+
   const crumbs: Crumb[] = useMemo(
     () => [
       {
         name: activeLocale ? strings.REPORTS : '',
-        to: APP_PATHS.REPORTS,
+        to: year ? `${APP_PATHS.REPORTS}?year=${year}` : APP_PATHS.REPORTS,
       },
     ],
-    [activeLocale]
+    [activeLocale, year]
   );
 
   const callToAction = useMemo(() => {
@@ -121,7 +125,6 @@ const AcceleratorReportView = () => {
     [callToAction]
   );
 
-  const year = selectedReport?.startDate.split('-')[0];
   const reportName =
     selectedReport?.frequency === 'Annual' ? year : selectedReport?.quarter ? `${year}-${selectedReport?.quarter}` : '';
 

--- a/src/scenes/Reports/AcceleratorReportsView.tsx
+++ b/src/scenes/Reports/AcceleratorReportsView.tsx
@@ -59,7 +59,7 @@ const AcceleratorReportsView = () => {
     defaultTab: 'reports',
     tabs,
     viewIdentifier: 'accelerator-reports',
-    keepQuery: false,
+    keepQuery: true,
   });
 
   const PageHeaderLeftComponent = useMemo(

--- a/src/utils/useStickyTabs.ts
+++ b/src/utils/useStickyTabs.ts
@@ -45,7 +45,7 @@ const useStickyTabs = ({ defaultTab, tabs, viewIdentifier, keepQuery = true }: S
       navigate(getLocation(location.pathname, location, keepQuery ? query.toString() : emptyQuery.toString()));
       writeTabToSession(viewIdentifier, newTab);
     },
-    [navigate, location, query, viewIdentifier]
+    [navigate, location, query, viewIdentifier, keepQuery]
   );
 
   useEffect(() => {


### PR DESCRIPTION
The status filter was already kept. The year filter, since it's not a real filter, was not. So added a query param to keep it