### PR TITLE
Refactor Accelerator Report render to use a single .map for metrics

### DIFF
--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportView.tsx
@@ -24,12 +24,7 @@ import {
 } from 'src/redux/features/reports/reportsThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
-import {
-  AcceleratorReport,
-  ReportProjectMetric,
-  ReportStandardMetric,
-  ReportSystemMetric,
-} from 'src/types/AcceleratorReport';
+import { AcceleratorReport, MetricType } from 'src/types/AcceleratorReport';
 
 import { useParticipantProjectData } from '../ParticipantProjectContext';
 import ApproveReportDialog from './ApproveReportDialog';
@@ -242,48 +237,29 @@ const ReportView = () => {
                 </Typography>
               </Box>
             )}
-            {selectedReport?.systemMetrics.map((systemMetric: ReportSystemMetric, index: number) => (
-              <MetricBox
-                key={index}
-                editingId={editingId}
-                index={index}
-                projectId={projectId}
-                reload={reload}
-                setEditingId={setEditingId}
-                metric={systemMetric}
-                type={'system'}
-                reportId={Number(reportId)}
-                isConsoleView={true}
-              />
-            ))}
-            {selectedReport?.projectMetrics.map((projectMetric: ReportProjectMetric, index: number) => (
-              <MetricBox
-                key={index}
-                editingId={editingId}
-                index={index}
-                projectId={projectId}
-                reload={reload}
-                setEditingId={setEditingId}
-                metric={projectMetric}
-                type={'project'}
-                reportId={Number(reportId)}
-                isConsoleView={true}
-              />
-            ))}
-            {selectedReport?.standardMetrics.map((standardMetric: ReportStandardMetric, index: number) => (
-              <MetricBox
-                key={index}
-                editingId={editingId}
-                index={index}
-                projectId={projectId}
-                reload={reload}
-                setEditingId={setEditingId}
-                metric={standardMetric}
-                type={'standard'}
-                reportId={selectedReport.id}
-                isConsoleView={true}
-              />
-            ))}
+            {['system', 'project', 'standard'].map((type) => {
+              const metrics =
+                type === 'system'
+                  ? selectedReport?.systemMetrics
+                  : type === 'project'
+                    ? selectedReport?.projectMetrics
+                    : selectedReport?.standardMetrics;
+
+              return metrics?.map((metric, index) => (
+                <MetricBox
+                  editingId={editingId}
+                  index={index}
+                  isConsoleView
+                  key={`${type}-${index}`}
+                  metric={metric}
+                  projectId={projectId}
+                  reload={reload}
+                  reportId={Number(reportId)}
+                  setEditingId={setEditingId}
+                  type={type as MetricType}
+                />
+              ));
+            })}
           </Card>
         </Box>
       </Page>

--- a/src/scenes/Reports/AcceleratorReportView.tsx
+++ b/src/scenes/Reports/AcceleratorReportView.tsx
@@ -171,7 +171,6 @@ const AcceleratorReportView = () => {
 
             return metrics?.map((metric, index) => (
               <MetricBox
-                // editingId={editingId}
                 index={index}
                 isConsoleView={false}
                 key={`${type}-${index}`}

--- a/src/scenes/Reports/AcceleratorReportView.tsx
+++ b/src/scenes/Reports/AcceleratorReportView.tsx
@@ -19,12 +19,7 @@ import { selectListAcceleratorReports } from 'src/redux/features/reports/reports
 import { requestListAcceleratorReports } from 'src/redux/features/reports/reportsThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
-import {
-  AcceleratorReport,
-  ReportProjectMetric,
-  ReportStandardMetric,
-  ReportSystemMetric,
-} from 'src/types/AcceleratorReport';
+import { AcceleratorReport, MetricType } from 'src/types/AcceleratorReport';
 
 const AcceleratorReportView = () => {
   const { activeLocale } = useLocalization();
@@ -166,45 +161,29 @@ const AcceleratorReportView = () => {
               </Typography>
             </Box>
           )}
-          {selectedReport?.systemMetrics.map((systemMetric: ReportSystemMetric, index: number) => (
-            <MetricBox
-              key={index}
-              index={index}
-              projectId={projectId}
-              reload={() => true}
-              setEditingId={() => {}}
-              showEditOnHover={false}
-              metric={systemMetric}
-              type={'system'}
-              reportId={Number(reportId)}
-            />
-          ))}
-          {selectedReport?.projectMetrics.map((projectMetric: ReportProjectMetric, index: number) => (
-            <MetricBox
-              key={index}
-              index={index}
-              projectId={projectId}
-              reload={() => true}
-              setEditingId={() => {}}
-              showEditOnHover={false}
-              metric={projectMetric}
-              type={'project'}
-              reportId={Number(reportId)}
-            />
-          ))}
-          {selectedReport?.standardMetrics.map((standardMetric: ReportStandardMetric, index: number) => (
-            <MetricBox
-              key={index}
-              index={index}
-              projectId={projectId}
-              reload={() => true}
-              setEditingId={() => {}}
-              showEditOnHover={false}
-              metric={standardMetric}
-              type={'standard'}
-              reportId={selectedReport.id}
-            />
-          ))}
+          {['system', 'project', 'standard'].map((type) => {
+            const metrics =
+              type === 'system'
+                ? selectedReport?.systemMetrics
+                : type === 'project'
+                  ? selectedReport?.projectMetrics
+                  : selectedReport?.standardMetrics;
+
+            return metrics?.map((metric, index) => (
+              <MetricBox
+                // editingId={editingId}
+                index={index}
+                isConsoleView={false}
+                key={`${type}-${index}`}
+                metric={metric}
+                projectId={projectId}
+                reload={reload}
+                reportId={Number(reportId)}
+                setEditingId={() => {}}
+                type={type as MetricType}
+              />
+            ));
+          })}
         </Card>
       </Box>
     </Page>


### PR DESCRIPTION
This PR refactors the render functions for accelerator reports to use a single `.map` for metrics.