### PR TITLE
SW-6632 Remove elevation from biomass details

### DIFF
--- a/src/scenes/ObservationsRouter/BiomassMeasurementsDetails.tsx
+++ b/src/scenes/ObservationsRouter/BiomassMeasurementsDetails.tsx
@@ -59,7 +59,6 @@ export default function BiomassMeasurementsDetails(): JSX.Element {
             )
           : undefined,
       },
-      { label: strings.ELEVATION_M, value: 106.1 },
       { label: strings.TYPE_OF_FOREST, value: biomassMeasurements?.forestType },
       {
         label: strings.NUMBER_OF_SMALL_TREES,


### PR DESCRIPTION
We never implemented the code to calculate the elevation for a
biomass observation monitoring plot; we put a placeholder value in
the UI and then lost track of needing to replace it with a real
number. Remove the field from the UI for now rather than showing an
incorrect elevation.