### PR TITLE
SW-6760: "Seed Fund Reports" shows up in english when selected language is Spanish or French

### DIFF
--- a/src/scenes/OrgRouter/NavBar.tsx
+++ b/src/scenes/OrgRouter/NavBar.tsx
@@ -184,7 +184,7 @@ export default function NavBar({
 
   const deliverablesMenu = useMemo<JSX.Element | null>(
     () =>
-      hasDeliverables ? (
+      hasDeliverables && activeLocale ? (
         <NavItem
           label={strings.DELIVERABLES}
           icon='iconSubmit'
@@ -196,7 +196,7 @@ export default function NavBar({
           id='deliverables'
         />
       ) : null,
-    [closeAndNavigateTo, isDeliverablesRoute, isDeliverableViewRoute, hasDeliverables]
+    [activeLocale, closeAndNavigateTo, isDeliverablesRoute, isDeliverableViewRoute, hasDeliverables]
   );
 
   // TODO: get reports from API and only show reports nav menu if there are any
@@ -218,7 +218,7 @@ export default function NavBar({
 
   const seedFundReportsMenu = useMemo<JSX.Element | null>(
     () =>
-      seedFundReports.length > 0 && selectedOrganization.canSubmitReports ? (
+      seedFundReports.length > 0 && selectedOrganization.canSubmitReports && activeLocale ? (
         <NavItem
           icon='iconGraphReport'
           label={strings.SEED_FUND_REPORTS}
@@ -229,7 +229,13 @@ export default function NavBar({
           id='seed-fund-reports-list'
         />
       ) : null,
-    [closeAndNavigateTo, isSeedFundReportsRoute, seedFundReports.length, selectedOrganization.canSubmitReports]
+    [
+      activeLocale,
+      closeAndNavigateTo,
+      isSeedFundReportsRoute,
+      seedFundReports.length,
+      selectedOrganization.canSubmitReports,
+    ]
   );
 
   const modulesMenu = useMemo<JSX.Element | null>(


### PR DESCRIPTION
This PR fixes an issue where some navigation items didn’t update to the selected language:

- Deliverables
- Seed Fund Reports

**NOTE: "Modules" may look like it needs updating, but it's the same in English & French**

## Screenshots

### BEFORE

![staging terraware io_reports_year=2025 organizationId=28 tab=reports (1)](https://github.com/user-attachments/assets/57034a45-dccb-46c9-b3d7-ae7893bbc684)

### AFTER

![localhost_3000_home_organizationId=28](https://github.com/user-attachments/assets/097aa6cc-8359-4a88-a593-e0c1e930d655)
