### PR TITLE
Fix redirect when creating a new org

### DIFF
--- a/playwright/e2e/suites/locations.spec.ts
+++ b/playwright/e2e/suites/locations.spec.ts
@@ -125,8 +125,6 @@ export default function LocationTests() {
     await page.locator('#create-org-question-website').getByRole('textbox').fill('fakeuniversity.edu');
     await page.getByRole('button', { name: 'Save' }).click();
     await expect(page.getByRole('heading', { name: `You have created ${newOrgName}!` })).toBeVisible();
-    await page.getByRole('button', { name: 'Terraformation (staging)' }).click();
-    await page.getByRole('menuitem', { name: newOrgName }).click();
     await page.getByRole('button', { name: 'Organization' }).click();
     await expect(page.getByText(`Organization Name${newOrgName}`)).toBeVisible();
     await expect(page.getByText('DescriptionThis is my new')).toBeVisible();

--- a/src/components/OrganizationsDropdown.tsx
+++ b/src/components/OrganizationsDropdown.tsx
@@ -19,7 +19,7 @@ export default function OrganizationsDropdown(): JSX.Element {
   const selectOrganization = (newlySelectedOrg: Organization) => {
     setSelectedOrganization((currentlySelectedOrg: Organization | undefined) => {
       if (newlySelectedOrg.id !== currentlySelectedOrg?.id) {
-        navigate({ pathname: APP_PATHS.HOME });
+        navigate({ pathname: APP_PATHS.HOME, search: `organizationId=${newlySelectedOrg.id}` });
       }
       return newlySelectedOrg;
     });
@@ -49,8 +49,8 @@ export default function OrganizationsDropdown(): JSX.Element {
       <AddNewOrganizationModal
         open={newOrganizationModalOpened}
         onCancel={onCloseCreateOrganizationModal}
-        onSuccess={(organization: Organization) => {
-          reloadOrganizations();
+        onSuccess={async (organization: Organization) => {
+          await reloadOrganizations(organization.id);
           redirectAndNotify(organization);
         }}
       />

--- a/src/components/SmallDeviceUserMenu.tsx
+++ b/src/components/SmallDeviceUserMenu.tsx
@@ -101,7 +101,7 @@ export default function SmallDeviceUserMenu({
   const selectOrganization = (newlySelectedOrg: Organization) => {
     setSelectedOrganization((currentlySelectedOrg: Organization | undefined) => {
       if (newlySelectedOrg.id !== currentlySelectedOrg?.id) {
-        navigate({ pathname: APP_PATHS.HOME });
+        navigate({ pathname: APP_PATHS.HOME, search: `organizationId=${newlySelectedOrg.id}` });
       }
       return newlySelectedOrg;
     });

--- a/src/providers/OrganizationProvider.tsx
+++ b/src/providers/OrganizationProvider.tsx
@@ -7,10 +7,8 @@ import { store } from 'src/redux/store';
 import { OrganizationService, PreferencesService } from 'src/services';
 import strings from 'src/strings';
 import { Organization } from 'src/types/Organization';
-import useDeviceInfo from 'src/utils/useDeviceInfo';
 import useEnvironment from 'src/utils/useEnvironment';
 import useQuery from 'src/utils/useQuery';
-import useSnackbar from 'src/utils/useSnackbar';
 import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
 
 import { PreferencesType, ProvidedOrganizationData } from './DataTypes';
@@ -29,8 +27,6 @@ enum APIRequestStatus {
 }
 
 export default function OrganizationProvider({ children }: OrganizationProviderProps): JSX.Element {
-  const { isDesktop } = useDeviceInfo();
-  const snackbar = useSnackbar();
   const [bootstrapped, setBootstrapped] = useState<boolean>(false);
   const [selectedOrganization, setSelectedOrganization] = useState<Organization>();
   const [orgPreferences, setOrgPreferences] = useState<PreferencesType>({});
@@ -88,16 +84,9 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
     getOrgPreferences();
   }, [selectedOrganization]);
 
-  const redirectAndNotify = useCallback(
-    (organization: Organization) => {
-      navigate({ pathname: APP_PATHS.HOME });
-      snackbar.pageSuccess(
-        isDesktop ? strings.ORGANIZATION_CREATED_MSG_DESKTOP : strings.ORGANIZATION_CREATED_MSG,
-        strings.formatString(strings.ORGANIZATION_CREATED_TITLE, organization.name)
-      );
-    },
-    [snackbar, isDesktop]
-  );
+  const redirectAndNotify = (organization: Organization) => {
+    navigate({ pathname: APP_PATHS.HOME, search: `organizationId=${organization.id}&newOrg=true` });
+  };
 
   useEffect(() => {
     reloadOrganizations();
@@ -114,15 +103,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
       orgPreferenceForId,
       reloadOrgPreferences,
     }));
-  }, [
-    redirectAndNotify,
-    selectedOrganization,
-    organizations,
-    orgPreferences,
-    bootstrapped,
-    orgPreferenceForId,
-    reloadOrgPreferences,
-  ]);
+  }, [selectedOrganization, organizations, orgPreferences, bootstrapped, orgPreferenceForId, reloadOrgPreferences]);
 
   useEffect(() => {
     reloadOrgPreferences();

--- a/src/scenes/Home/OnboardingHomeView/index.tsx
+++ b/src/scenes/Home/OnboardingHomeView/index.tsx
@@ -23,6 +23,8 @@ import strings from 'src/strings';
 import { Species } from 'src/types/Species';
 import { OrganizationUser } from 'src/types/User';
 import { isAdmin, isManagerOrHigher, isOwner } from 'src/utils/organization';
+import useQuery from 'src/utils/useQuery';
+import useSnackbar from 'src/utils/useSnackbar';
 
 const OnboardingHomeView = () => {
   const { user } = useUser();
@@ -34,6 +36,17 @@ const OnboardingHomeView = () => {
   const [people, setPeople] = useState<OrganizationUser[]>();
   const [allSpecies, setAllSpecies] = useState<Species[]>();
   const [showAcceleratorCard, setShowAcceleratorCard] = useState(true);
+  const snackbar = useSnackbar();
+  const query = useQuery();
+
+  useEffect(() => {
+    if (selectedOrganization && query.get('newOrg') === 'true') {
+      snackbar.toastSuccess(
+        isDesktop ? strings.ORGANIZATION_CREATED_MSG_DESKTOP : strings.ORGANIZATION_CREATED_MSG,
+        strings.formatString(strings.ORGANIZATION_CREATED_TITLE, selectedOrganization.name)
+      );
+    }
+  }, [snackbar, selectedOrganization, isDesktop, query]);
 
   useEffect(() => {
     if (orgPreferences.showAcceleratorCard === false && showAcceleratorCard) {


### PR DESCRIPTION
Fix redirect so that it goes to the new org's home page after user creates a new org.

Also add a couple related explicit search fields in to prepare for react router 7.