### PR TITLE
SW-6773 Update to latest react-router 6, add startTransition future flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-multi-carousel": "^2.8.2",
     "react-redux": "^9.0.0",
     "react-responsive": "^10.0.0",
-    "react-router-dom": "^6.20.0",
+    "react-router-dom": "6",
     "sanitize-filename": "^1.6.3",
     "slate": "^0.112.0",
     "slate-dom": "^0.112.0",

--- a/playwright/e2e/suites/inventory.spec.ts
+++ b/playwright/e2e/suites/inventory.spec.ts
@@ -314,7 +314,8 @@ export default function InventoryTests() {
 
     await page.getByRole('button', { name: 'Seedlings' }).click();
     await page.getByRole('button', { name: 'Withdrawals' }).click();
-    await page.getByText('Map').click();
+    const mapTab = page.locator('p.MuiTypography-root').filter({ hasText: 'Map', hasNotText: 'show for this' });
+    await mapTab.click();
     await page.mouse.down();
     await expect(page.getByLabel('Planting Progress').getByText('Planting Progress')).toBeVisible();
     await page.waitForTimeout(6000); //Wait for map to load

--- a/playwright/e2e/suites/species.spec.ts
+++ b/playwright/e2e/suites/species.spec.ts
@@ -52,6 +52,7 @@ export default function SpeciesTests() {
     await expect(page.getByRole('main')).toContainText('Growth FormTree');
     await expect(page.getByRole('main')).toContainText('Seed Storage BehaviorOrthodox');
     await page.getByRole('link', { name: 'Species' }).click();
+    await page.waitForTimeout(250); //Wait for table to load
     await expect(page.getByText(newSpeciesName)).toBeVisible();
     await expect(page.locator('#row1-scientificName')).toContainText(newSpeciesName);
     await page.getByRole('link', { name: 'Acacia koa-' }).click();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,16 +15,15 @@ import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import { useAppVersion } from 'src/hooks/useAppVersion';
 import { useLocalization, useUser } from 'src/providers';
 import { store } from 'src/redux/store';
+import AcceleratorRouter from 'src/scenes/AcceleratorRouter';
+import FunderRouter from 'src/scenes/FunderRouter';
+import TerrawareRouter from 'src/scenes/TerrawareRouter';
 import { getRgbaFromHex } from 'src/utils/color';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 
 import useApplicationPortal from './hooks/useApplicationPortal';
 import useFunderPortal from './hooks/useFunderPortal';
 import ApplicationPortalRouter from './scenes/ApplicationRouter/portal';
-
-const AcceleratorRouter = React.lazy(() => import('src/scenes/AcceleratorRouter'));
-const TerrawareRouter = React.lazy(() => import('src/scenes/TerrawareRouter'));
-const FunderRouter = React.lazy(() => import('src/scenes/FunderRouter'));
 
 // Mixpanel setup
 const MIXPANEL_TOKEN = process.env.REACT_APP_MIXPANEL_TOKEN;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,7 +22,12 @@ root.render(
   // of the HTML which is later parsed by PagedJS
   // <React.StrictMode>
   <React.Suspense fallback={strings.LOADING}>
-    <Router>
+    <Router
+      future={{
+        // v7_relativeSplatPath: true,
+        v7_startTransition: true,
+      }}
+    >
       <Routes>
         <Route
           path={APP_PATHS.ERROR}

--- a/src/scenes/TerrawareRouter/index.tsx
+++ b/src/scenes/TerrawareRouter/index.tsx
@@ -3,10 +3,9 @@ import { matchPath, useNavigate } from 'react-router-dom';
 
 import { APP_PATHS } from 'src/constants';
 import { useOrganization, useUserFundingEntity } from 'src/providers';
+import NoOrgRouter from 'src/scenes/NoOrgRouter';
+import OrgRouter from 'src/scenes/OrgRouter';
 import useStateLocation from 'src/utils/useStateLocation';
-
-const OrgRouter = React.lazy(() => import('src/scenes/OrgRouter'));
-const NoOrgRouter = React.lazy(() => import('src/scenes/NoOrgRouter'));
 
 interface TerrawareRouterProps {
   showNavBar: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3076,10 +3076,10 @@
     redux-thunk "^2.4.2"
     reselect "^4.1.8"
 
-"@remix-run/router@1.15.3":
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.15.3.tgz#d2509048d69dbb72d5389a14945339f1430b2d3c"
-  integrity sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==
+"@remix-run/router@1.23.0":
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.0.tgz#35390d0e7779626c026b11376da6789eb8389242"
+  integrity sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==
 
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
@@ -13798,20 +13798,20 @@ react-responsive@^9.0.2:
     prop-types "^15.6.1"
     shallow-equal "^1.2.1"
 
-react-router-dom@^6.20.0:
-  version "6.22.3"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.22.3.tgz#9781415667fd1361a475146c5826d9f16752a691"
-  integrity sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==
+react-router-dom@6:
+  version "6.30.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.0.tgz#a64774104508bff56b1affc2796daa3f7e76b7df"
+  integrity sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==
   dependencies:
-    "@remix-run/router" "1.15.3"
-    react-router "6.22.3"
+    "@remix-run/router" "1.23.0"
+    react-router "6.30.0"
 
-react-router@6.22.3:
-  version "6.22.3"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.22.3.tgz#9d9142f35e08be08c736a2082db5f0c9540a885e"
-  integrity sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==
+react-router@6.30.0:
+  version "6.30.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.0.tgz#9789d775e63bc0df60f39ced77c8c41f1e01ff90"
+  integrity sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==
   dependencies:
-    "@remix-run/router" "1.15.3"
+    "@remix-run/router" "1.23.0"
 
 react-scripts@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
Update to latest version of react-router 6.

Add future flag of `v7_startTransition` to prepare for react-router 7. 
Remove `React.lazy` imports since react-router 7 does not support them with it's useTransition logic - [Upgrade Docs](https://reactrouter.com/upgrading/v6#v7_starttransition) and [Changelog](https://github.com/remix-run/react-router/blob/main/CHANGELOG.md#futurev7_starttransition)

Note that this PR should not be merged until right after a release so that it sits in staging for a week for issues to be found.