### PR TITLE
SW-6242 Export correct description column in CSV

### DIFF
--- a/src/services/ObservationsService.ts
+++ b/src/services/ObservationsService.ts
@@ -96,7 +96,7 @@ const exportBiomassObservationsCsv = async (organizationId: number, plantingSite
     prefix: 'plantingSites.observations',
     fields: [
       'observationPlots_monitoringPlot_plotNumber',
-      'observationPlots_notes',
+      'observationPlots_biomassDetails_description',
       'plantingSite_name',
       'startDate',
       'observationPlots_biomassDetails_numPlants',


### PR DESCRIPTION
The biomass observation list CSV export was exporting
the wrong column for the plot description.