### PR TITLE
Fix react nesting warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@mui/styled-engine-sc": "^5.14.12",
     "@mui/styles": "^6.2.0",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^3.4.18",
+    "@terraware/web-components": "^3.4.19",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/src/scenes/Home/CTACard.tsx
+++ b/src/scenes/Home/CTACard.tsx
@@ -63,7 +63,7 @@ const CTACard = ({
         <Box>
           {title && (
             <Typography
-              component='p'
+              component='div'
               variant='h6'
               sx={{
                 color: theme.palette.TwClrTxt,
@@ -76,7 +76,7 @@ const CTACard = ({
             </Typography>
           )}
           <Typography
-            component='p'
+            component='div'
             variant='h6'
             sx={{
               color: theme.palette.TwClrTxt,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4095,10 +4095,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^3.4.18":
-  version "3.4.18"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.4.18.tgz#59957ed64d67e8f2c62547eec02db246cb78f35b"
-  integrity sha512-DJ3erQ6yZP6I8EYvG8wd7f+VocYfAhWX9kXORsGn78/hWLgr8hmBPEjbozhteESKtJ/P8YANVQzRdOeODuf5/g==
+"@terraware/web-components@^3.4.19":
+  version "3.4.19"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.4.19.tgz#153bc233cf3db81a0b6ea8d5fb5787fafd5fde01"
+  integrity sha512-sJJbsCrs2kMRlBENWYhqXy8XKMYUSTGjCo9S/v871UaqCugF2Bw6iy2srte1Tgvv1joS01OrlQqspTlHwWRACg==
   dependencies:
     "@dnd-kit/core" "^6.0.7"
     "@dnd-kit/sortable" "^7.0.2"


### PR DESCRIPTION
In development, the following error showed up on several pages, because of `CTACard`'s title and description `Typography` components:
```
<div> cannot appear as a descendant of <p>
```

This error annoyed me so I decided to create a PR to fix it.