### PR TITLE
Add relativeSplatPath react-router future flag

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,7 +24,7 @@ root.render(
   <React.Suspense fallback={strings.LOADING}>
     <Router
       future={{
-        // v7_relativeSplatPath: true,
+        v7_relativeSplatPath: true,
         v7_startTransition: true,
       }}
     >


### PR DESCRIPTION
Uncomment `v7_relativeSplatPath` future flag.

It seems that we are not using relative paths at all, so this future flag shouldn't actually affect us, but this ensures there are fewer surprises when actually upgrading to react-router v7.