### PR TITLE
SW-6242 Minor biomass CSV export fixes

### DIFF
--- a/src/scenes/ObservationsRouter/BiomassMeasurementsDetails.tsx
+++ b/src/scenes/ObservationsRouter/BiomassMeasurementsDetails.tsx
@@ -162,7 +162,7 @@ export default function BiomassMeasurementsDetails(): JSX.Element {
   };
 
   const exportDetailsCsv = useCallback(async () => {
-    await downloadCsv(strings.BIOMASS_MEASUREMENTS, ObservationsService.exportBiomassDetailsCsv);
+    await downloadCsv(strings.BIOMASS_MONITORING, ObservationsService.exportBiomassDetailsCsv);
   }, [observation, plantingSite]);
 
   const exportSpeciesCsv = useCallback(async () => {

--- a/src/services/ObservationsService.ts
+++ b/src/services/ObservationsService.ts
@@ -128,7 +128,6 @@ const exportBiomassDetailsCsv = async (observationId: number): Promise<any> => {
     prefix: 'plantingSites.observations',
     fields: [
       'observationPlots_monitoringPlot_plotNumber',
-      'observationPlots_notes',
       'plantingSite_name',
       'observationPlots_completedTime',
       'observationPlots_monitoringPlot_southwestLatitude',
@@ -153,6 +152,7 @@ const exportBiomassDetailsCsv = async (observationId: number): Promise<any> => {
       'observationPlots_biomassDetails_numPlants',
       'observationPlots_biomassDetails_numSpecies',
       'observationPlots.conditions_condition',
+      'observationPlots_notes',
     ],
     sortOrder: [{ field: 'observationPlots_monitoringPlot_plotNumber' }],
     search: {


### PR DESCRIPTION
Change the filename for the observation details CSV to use the word
"monitoring" instead of "measurements" and move the "Field notes"
column to the end, per feedback from QA of the feature.