### PR TITLE
Fix organization navigation

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,7 +37,7 @@ export enum APP_PATHS {
   ACCELERATOR_MODULES = '/accelerator/modules',
   ACCELERATOR_MODULE_CONTENT = '/accelerator/modules/:moduleId',
   ACCELERATOR_MODULE_EVENTS_EDIT = '/accelerator/modules/:moduleId/event/edit',
-  ACCELERATOR_ORGANIZATIONS = 'accelerator/organizations',
+  ACCELERATOR_ORGANIZATIONS = '/accelerator/organizations',
   ACCELERATOR_OVERVIEW = '/accelerator/overview',
   ACCELERATOR_PARTICIPANTS = '/accelerator/participants',
   ACCELERATOR_PARTICIPANTS_EDIT = '/accelerator/participants/:participantId/edit',


### PR DESCRIPTION
As part of the upgrade to react-router 7, they changed the behavior for relative navigation. Navigating to a non-fully qualified path could end up adding the new path onto the existing path depending on how the router was setup. 
In this case, navigating from any page in the console to the organizations page was appending `accelerator/organizations` to the current path, instead of going to `/accelerator/organizations`. This PR fixes that by adding `/` to the app path. 
All other enums in APP_PATH were already fully qualified.