### PR TITLE
SW-6807: Project Org Admin should be able to edit metric targets

### DIFF
--- a/src/components/AcceleratorReports/AcceleratorReportTargetsCellRenderer.tsx
+++ b/src/components/AcceleratorReports/AcceleratorReportTargetsCellRenderer.tsx
@@ -1,20 +1,26 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import Link from 'src/components/common/Link';
 import CellRenderer, { TableRowType } from 'src/components/common/table/TableCellRenderer';
 import { RendererProps } from 'src/components/common/table/types';
-import { useUser } from 'src/providers';
+import { useOrganization, useUser } from 'src/providers';
 
 export default function AcceleratorReportTargetsCellRenderer(props: RendererProps<TableRowType>): JSX.Element {
   const { column, row, value, index, onRowClick } = props;
   const { isAllowed } = useUser();
+  const { selectedOrganization } = useOrganization();
+
+  const isAllowedUpdateReportsTargets = useMemo(
+    () => isAllowed('UPDATE_REPORTS_TARGETS', { organization: selectedOrganization }),
+    [isAllowed, selectedOrganization]
+  );
 
   if (column.key === 'name' && onRowClick) {
     return (
       <CellRenderer
         column={column}
         value={
-          isAllowed('UPDATE_REPORTS_SETTINGS') ? (
+          isAllowedUpdateReportsTargets ? (
             <Link fontSize='16px' onClick={() => onRowClick()}>
               {value as React.ReactNode}
             </Link>

--- a/src/utils/acl.ts
+++ b/src/utils/acl.ts
@@ -21,7 +21,11 @@ import { isAdmin, isManagerOrHigher, isMember } from './organization';
 /**
  * We split the permissions up loosely by the entity that the user is being authorized to interact with or view
  */
-type PermissionAcceleratorReports = 'UPDATE_REPORTS_SETTINGS' | 'EDIT_REPORTS' | 'READ_REPORTS';
+type PermissionAcceleratorReports =
+  | 'EDIT_REPORTS'
+  | 'READ_REPORTS'
+  | 'UPDATE_REPORTS_SETTINGS'
+  | 'UPDATE_REPORTS_TARGETS';
 type PermissionApplication =
   | 'READ_ALL_APPLICATIONS'
   | 'UPDATE_APPLICATION_INTERNAL_COMMENTS'
@@ -147,6 +151,19 @@ const isAllowedReadReports: PermissionCheckFn<ReadReportsMetadata> = (
 };
 
 /**
+ * Function related to updating accelerator report targets, since the permission also applies to
+ * org roles, we need to check the passed-in organization
+ */
+type UpdateReportsTargetsMetadata = { organization: Organization };
+const isAllowedUpdateReportsTargets: PermissionCheckFn<UpdateReportsTargetsMetadata> = (
+  user: User,
+  _: GlobalRolePermission,
+  metadata?: UpdateReportsTargetsMetadata
+): boolean => {
+  return isAcceleratorAdmin(user) || isAdmin(metadata?.organization);
+};
+
+/**
  * This is the main ACL entrypoint where all permissions are indicated through a global role
  * array or a function that returns a boolean
  */
@@ -181,6 +198,7 @@ const ACL: Record<GlobalRolePermission, UserGlobalRoles | PermissionCheckFn> = {
   UPDATE_PARTICIPANTS: AcceleratorAdminPlus,
   UPDATE_PARTICIPANT_PROJECT_SCORING_VOTING: TFExpertPlus,
   UPDATE_REPORTS_SETTINGS: AcceleratorAdminPlus,
+  UPDATE_REPORTS_TARGETS: isAllowedUpdateReportsTargets,
   UPDATE_PARTICIPANT_PROJECT: TFExpertPlus,
   UPDATE_SUBMISSION_STATUS: TFExpertPlus,
   VIEW_CONSOLE: ReadOnlyPlus,


### PR DESCRIPTION
This PR includes changes to allow org admins to edit report targets.