### PR TITLE
Fix node warning in console: `util._extend` API is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,5 +205,10 @@
     "wrap-ansi": "7.0.0",
     "string-width": "4.2.3",
     "strip-ansi": "6.0.1"
+  },
+  "overrides": {
+    "http-proxy-middleware": {
+      "http-proxy": "github:nikeee/node-http-proxy#b42c38fc3486ee8ad4374cc2397458b6e4cd99ca"
+    }
   }
 }


### PR DESCRIPTION
This PR uses `overrides` in `package.json` to use the commit from the [PR that was submitted to the http-proxy package](https://github.com/http-party/node-http-proxy/pull/1666).

Summary:

- Root issue is a deprecated Node API (`util._extend`) is being used by a dependency that hasn't been updated in multiple years ([http-proxy](https://github.com/http-party/node-http-proxy/))
- A [PR was submitted to the http-proxy package](https://github.com/http-party/node-http-proxy/pull/1666) but not been merged yet
- [Open issue in http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware/issues/1017) discusses the issue and links to the PR in `http-proxy`