### PR TITLE
Remove unnecessary supported locales to numberFormatter

### DIFF
--- a/src/components/ListMapView/index.tsx
+++ b/src/components/ListMapView/index.tsx
@@ -6,7 +6,6 @@ import Card from 'src/components/common/Card';
 import ListMapSelector, { View } from 'src/components/common/ListMapSelector';
 import { useLocalization } from 'src/providers';
 import strings from 'src/strings';
-import { useSupportedLocales } from 'src/strings/locales';
 import { ZoneAggregation } from 'src/types/Observations';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import { useNumberFormatter } from 'src/utils/useNumber';
@@ -38,7 +37,6 @@ export default function ListMapView({
   const [view, setView] = useState<View>(initialView);
   const theme = useTheme();
   const { activeLocale } = useLocalization();
-  const supportedLocales = useSupportedLocales();
   const numberFormatter = useNumberFormatter();
   const { isMobile } = useDeviceInfo();
 
@@ -48,10 +46,7 @@ export default function ListMapView({
       onView(nextView);
     }
   };
-  const numericFormatter = useMemo(
-    () => numberFormatter(activeLocale, supportedLocales),
-    [activeLocale, numberFormatter, supportedLocales]
-  );
+  const numericFormatter = useMemo(() => numberFormatter(activeLocale), [activeLocale, numberFormatter]);
 
   const siteAreaHa = useMemo(() => {
     return data ? data.reduce((total, currentValue) => total + currentValue.areaHa, 0) : 0;

--- a/src/components/common/FormattedNumber.tsx
+++ b/src/components/common/FormattedNumber.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 
 import { useUser } from 'src/providers';
-import { useSupportedLocales } from 'src/strings/locales';
 import { useNumberFormatter } from 'src/utils/useNumber';
 
 interface FormattedNumberProps {
@@ -11,11 +10,7 @@ interface FormattedNumberProps {
 export default function FormattedNumber({ value }: FormattedNumberProps) {
   const user = useUser().user;
   const numberFormatter = useNumberFormatter();
-  const supportedLocales = useSupportedLocales();
-  const numericFormatter = useMemo(
-    () => numberFormatter(user?.locale, supportedLocales),
-    [user?.locale, numberFormatter, supportedLocales]
-  );
+  const numericFormatter = useMemo(() => numberFormatter(user?.locale), [user?.locale, numberFormatter]);
 
   return numericFormatter.format(value);
 }

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/ProjectProfileView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/ProjectProfileView.tsx
@@ -16,7 +16,6 @@ import VotingDecisionLink from 'src/components/ProjectField/VotingDecisionLink';
 import Card from 'src/components/common/Card';
 import { useLocalization, useUser } from 'src/providers';
 import strings from 'src/strings';
-import { useSupportedLocales } from 'src/strings/locales';
 import { AcceleratorOrg } from 'src/types/Accelerator';
 import { Application } from 'src/types/Application';
 import { ParticipantProject } from 'src/types/ParticipantProject';
@@ -46,15 +45,11 @@ const ProjectProfileView = ({
   phaseVotes,
 }: ProjectProfileViewProps) => {
   const theme = useTheme();
-  const supportedLocales = useSupportedLocales();
   const numberFormatter = useNumberFormatter();
   const { isAllowed } = useUser();
   const { activeLocale, countries } = useLocalization();
 
-  const numericFormatter = useMemo(
-    () => numberFormatter(activeLocale, supportedLocales),
-    [activeLocale, numberFormatter, supportedLocales]
-  );
+  const numericFormatter = useMemo(() => numberFormatter(activeLocale), [activeLocale, numberFormatter]);
   const isAllowedViewScoreAndVoting = isAllowed('VIEW_PARTICIPANT_PROJECT_SCORING_VOTING');
 
   const isProjectInPhase = useMemo(

--- a/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
+++ b/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
@@ -19,7 +19,6 @@ import { requestSitePopulation } from 'src/redux/features/tracking/trackingThunk
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import SimplePlantingSiteMap from 'src/scenes/PlantsDashboardRouter/components/SimplePlantingSiteMap';
 import strings from 'src/strings';
-import { useSupportedLocales } from 'src/strings/locales';
 import { PlantingSite } from 'src/types/Tracking';
 import { isAdmin } from 'src/utils/organization';
 import useMapboxToken from 'src/utils/useMapboxToken';
@@ -30,7 +29,6 @@ import StatsCardItem from './StatsCardItem';
 
 export const PlantingSiteStats = () => {
   const { activeLocale } = useLocalization();
-  const supportedLocales = useSupportedLocales();
   const numberFormatter = useNumberFormatter();
   const { isDesktop } = useDeviceInfo();
   const theme = useTheme();
@@ -47,10 +45,7 @@ export const PlantingSiteStats = () => {
   const { countries } = useLocalization();
   const dispatch = useAppDispatch();
 
-  const numericFormatter = useMemo(
-    () => numberFormatter(activeLocale, supportedLocales),
-    [activeLocale, numberFormatter, supportedLocales]
-  );
+  const numericFormatter = useMemo(() => numberFormatter(activeLocale), [activeLocale, numberFormatter]);
 
   const observation = useAppSelector((state) =>
     selectLatestObservation(state, selectedPlantingSiteId || -1, defaultTimeZone.get().id, selectedOrganization.id)

--- a/src/scenes/Home/TerrawareHomeView/index.tsx
+++ b/src/scenes/Home/TerrawareHomeView/index.tsx
@@ -25,7 +25,6 @@ import MobileAppCard from 'src/scenes/Home/MobileAppCard';
 import { useSpecies } from 'src/scenes/InventoryRouter/form/useSpecies';
 import { PreferencesService } from 'src/services';
 import strings from 'src/strings';
-import { useSupportedLocales } from 'src/strings/locales';
 import { isAdmin, isManagerOrHigher, selectedOrgHasFacilityType } from 'src/utils/organization';
 import { useNumberFormatter } from 'src/utils/useNumber';
 
@@ -33,7 +32,6 @@ import OrganizationStatsCard, { OrganizationStatsCardRow } from './OrganizationS
 
 const TerrawareHomeView = () => {
   const { activeLocale } = useLocalization();
-  const supportedLocales = useSupportedLocales();
   const numberFormatter = useNumberFormatter();
   const { user } = useUser();
   const { selectedOrganization, orgPreferences, reloadOrgPreferences } = useOrganization();
@@ -50,10 +48,7 @@ const TerrawareHomeView = () => {
 
   const [isNewApplicationModalOpen, setIsNewApplicationModalOpen] = useState<boolean>(false);
 
-  const numericFormatter = useMemo(
-    () => numberFormatter(activeLocale, supportedLocales),
-    [activeLocale, numberFormatter, supportedLocales]
-  );
+  const numericFormatter = useMemo(() => numberFormatter(activeLocale), [activeLocale, numberFormatter]);
 
   useEffect(() => {
     if (orgPreferences.showAcceleratorCard === false && showAcceleratorCard) {


### PR DESCRIPTION
The `useNumberFormatter` hook added `supportedLocales` inside it a while back, but some usages of `numberFormatter` were still passing in `supportedLocales`. The function doesn't use the passed in value anyway, so this PR removes it.