### PR TITLE
SW-6773 Upgrade to React Router 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react-multi-carousel": "^2.8.2",
     "react-redux": "^9.0.0",
     "react-responsive": "^10.0.0",
-    "react-router-dom": "6",
+    "react-router": "^7.5.3",
     "sanitize-filename": "^1.6.3",
     "slate": "^0.112.0",
     "slate-dom": "^0.112.0",

--- a/src/AppError.tsx
+++ b/src/AppError.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 

--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { ErrorBoundary as ReactErrorBoundary } from 'react-error-boundary';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { useDeviceInfo } from '@terraware/web-components/utils';
 

--- a/src/ErrorContent.tsx
+++ b/src/ErrorContent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useErrorBoundary } from 'react-error-boundary';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 

--- a/src/components/AcceleratorReports/AcceleratorReportTargetsTable.tsx
+++ b/src/components/AcceleratorReports/AcceleratorReportTargetsTable.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Box } from '@mui/material';
 import { Select, TableColumnType, TableRowType } from '@terraware/web-components';

--- a/src/components/AcceleratorReports/AcceleratorReportsTable.tsx
+++ b/src/components/AcceleratorReports/AcceleratorReportsTable.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Box } from '@mui/material';
 import { Select, TableColumnType } from '@terraware/web-components';

--- a/src/components/AcceleratorReports/EditAcceleratorReportTargetsModal.tsx
+++ b/src/components/AcceleratorReports/EditAcceleratorReportTargetsModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Grid, Typography } from '@mui/material';
 

--- a/src/components/BatchWithdrawFlow/index.tsx
+++ b/src/components/BatchWithdrawFlow/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Typography } from '@mui/material';
 import { BusySpinner, theme } from '@terraware/web-components';

--- a/src/components/DeliverableView/DeliverableCard.tsx
+++ b/src/components/DeliverableView/DeliverableCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react-router-dom';
+import React from 'react';
 
 import DocumentDeliverableCard from './DocumentDeliverableCard';
 import QuestionsDeliverableCard from './QuestionsDeliverableCard';

--- a/src/components/DeliverableView/useFetchDeliverable.ts
+++ b/src/components/DeliverableView/useFetchDeliverable.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';

--- a/src/components/DeliverablesTable/index.tsx
+++ b/src/components/DeliverablesTable/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { TableColumnType } from '@terraware/web-components';
 

--- a/src/components/FundersTable/index.tsx
+++ b/src/components/FundersTable/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { TableRowType } from '@terraware/web-components';
 

--- a/src/components/KnowledgeBaseLink/index.tsx
+++ b/src/components/KnowledgeBaseLink/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { IconButton, useTheme } from '@mui/material';
 import { Icon, Tooltip } from '@terraware/web-components';

--- a/src/components/NotificationsDropdown.tsx
+++ b/src/components/NotificationsDropdown.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 
 import {
   Badge,

--- a/src/components/OrganizationsDropdown.tsx
+++ b/src/components/OrganizationsDropdown.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { DropdownItem, PopoverMenu } from '@terraware/web-components';
 

--- a/src/components/PageSnackbar.tsx
+++ b/src/components/PageSnackbar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { Box, Snackbar as SnackbarUI } from '@mui/material';
 import { Button, Message } from '@terraware/web-components';

--- a/src/components/PlantsPrimaryPage/index.tsx
+++ b/src/components/PlantsPrimaryPage/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import _ from 'lodash';
 

--- a/src/components/ProjectEditView/index.tsx
+++ b/src/components/ProjectEditView/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Typography } from '@mui/material';
 

--- a/src/components/ProjectNewView/index.tsx
+++ b/src/components/ProjectNewView/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Typography } from '@mui/material';
 import { FormButton, theme } from '@terraware/web-components';

--- a/src/components/ProjectView/index.tsx
+++ b/src/components/ProjectView/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Grid } from '@mui/material';
 import { DropdownItem } from '@terraware/web-components';

--- a/src/components/Projects/Router.tsx
+++ b/src/components/Projects/Router.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import ProjectEditView from 'src/components/ProjectEditView';
 import ProjectNewView from 'src/components/ProjectNewView';

--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Grid, useTheme } from '@mui/material';
 

--- a/src/components/SeedFundReports/PreSetupView.tsx
+++ b/src/components/SeedFundReports/PreSetupView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Container, useTheme } from '@mui/material';
 

--- a/src/components/SeedFundReports/ReportEdit.tsx
+++ b/src/components/SeedFundReports/ReportEdit.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { BusySpinner, FormButton } from '@terraware/web-components';

--- a/src/components/SeedFundReports/ReportSettingsEditForm.tsx
+++ b/src/components/SeedFundReports/ReportSettingsEditForm.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Grid } from '@mui/material';
 import { useDeviceInfo } from '@terraware/web-components/utils';

--- a/src/components/SeedFundReports/ReportSettingsEditFormFields.tsx
+++ b/src/components/SeedFundReports/ReportSettingsEditFormFields.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 import { Button, Checkbox } from '@terraware/web-components';

--- a/src/components/SeedFundReports/ReportView.tsx
+++ b/src/components/SeedFundReports/ReportView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Button } from '@terraware/web-components';

--- a/src/components/SeedFundReports/ReportsView.tsx
+++ b/src/components/SeedFundReports/ReportsView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Container, Grid, List, ListItem, Typography, useTheme } from '@mui/material';
 import { Message, TableColumnType, Tabs } from '@terraware/web-components';

--- a/src/components/SeedFundReports/Router.tsx
+++ b/src/components/SeedFundReports/Router.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import ReportSettingsEdit from 'src/components/SeedFundReports/ReportSettingsEdit';
 import ReportsView from 'src/components/SeedFundReports/ReportsView';

--- a/src/components/SmallDeviceUserMenu.tsx
+++ b/src/components/SmallDeviceUserMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import {
   Box,

--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Grid, IconButton, useTheme } from '@mui/material';
 import { Svg } from '@terraware/web-components';

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { useTheme } from '@mui/material';
 import { DropdownItem, PopoverMenu } from '@terraware/web-components';

--- a/src/components/common/Link.tsx
+++ b/src/components/common/Link.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, MouseEvent, ReactNode, SyntheticEvent } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 
 import { Link as MuiLink, useTheme } from '@mui/material';
 

--- a/src/components/common/PageCard.tsx
+++ b/src/components/common/PageCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 

--- a/src/components/emptyStatePages/EmptyStatePage.tsx
+++ b/src/components/emptyStatePages/EmptyStatePage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Container, useTheme } from '@mui/material';
 

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 
 import { Box, CircularProgress, Container, Grid, useTheme } from '@mui/material';
 import { DropdownItem, Message } from '@terraware/web-components';

--- a/src/hooks/useAcceleratorConsole.ts
+++ b/src/hooks/useAcceleratorConsole.ts
@@ -1,4 +1,4 @@
-import { useMatch } from 'react-router-dom';
+import { useMatch } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import { useUser } from 'src/providers';

--- a/src/hooks/useApplicationPortal.ts
+++ b/src/hooks/useApplicationPortal.ts
@@ -1,4 +1,4 @@
-import { useMatch } from 'react-router-dom';
+import { useMatch } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 

--- a/src/hooks/useFunderPortal.ts
+++ b/src/hooks/useFunderPortal.ts
@@ -1,4 +1,4 @@
-import { useMatch } from 'react-router-dom';
+import { useMatch } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 

--- a/src/hooks/useNavigateTo.ts
+++ b/src/hooks/useNavigateTo.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import { ModuleContentType } from 'src/types/Module';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
+import { Route, BrowserRouter as Router, Routes } from 'react-router';
 
 import { ThemeProvider } from '@mui/material';
 
@@ -22,12 +22,7 @@ root.render(
   // of the HTML which is later parsed by PagedJS
   // <React.StrictMode>
   <React.Suspense fallback={strings.LOADING}>
-    <Router
-      future={{
-        v7_relativeSplatPath: true,
-        v7_startTransition: true,
-      }}
-    >
+    <Router>
       <Routes>
         <Route
           path={APP_PATHS.ERROR}

--- a/src/providers/Deliverable/DeliverableProvider.tsx
+++ b/src/providers/Deliverable/DeliverableProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useFetchDeliverable from 'src/components/DeliverableView/useFetchDeliverable';
 import { DeliverableWithOverdue } from 'src/types/Deliverables';

--- a/src/providers/DocumentProducer/Provider.tsx
+++ b/src/providers/DocumentProducer/Provider.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { BusySpinner } from '@terraware/web-components';
 import _ from 'lodash';

--- a/src/providers/FundingEntityProvider.tsx
+++ b/src/providers/FundingEntityProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import { requestFundingEntity } from 'src/redux/features/funder/fundingEntitiesAsyncThunks';

--- a/src/providers/OrganizationProvider.tsx
+++ b/src/providers/OrganizationProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';

--- a/src/providers/ParticipantProject/ParticipantProjectSpeciesProvider.tsx
+++ b/src/providers/ParticipantProject/ParticipantProjectSpeciesProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import _ from 'lodash';
 

--- a/src/providers/Project/ProjectProvider.tsx
+++ b/src/providers/Project/ProjectProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { BusySpinner } from '@terraware/web-components';
 

--- a/src/providers/UserFundingEntityProvider.tsx
+++ b/src/providers/UserFundingEntityProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import { requestFundingEntityForUser } from 'src/redux/features/funder/fundingEntitiesAsyncThunks';

--- a/src/scenes/AcceleratorRouter/Applications/ApplicationDeliverable.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationDeliverable.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import AcceleratorDeliverableCard from 'src/components/AcceleratorDeliverableView/DeliverableCard';
 import { Crumb } from 'src/components/BreadCrumbs';

--- a/src/scenes/AcceleratorRouter/Applications/ApplicationMap.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationMap.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Button } from '@terraware/web-components';
 

--- a/src/scenes/AcceleratorRouter/Applications/ApplicationReview.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationReview.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button } from '@terraware/web-components';

--- a/src/scenes/AcceleratorRouter/Applications/ApplicationView.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { DateTime } from 'luxon';

--- a/src/scenes/AcceleratorRouter/Applications/index.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/index.tsx
@@ -1,4 +1,5 @@
-import React, { Navigate, Route, Routes } from 'react-router-dom';
+import React from 'react';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import ApplicationProvider from 'src/providers/Application';

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortEditView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortEditView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import Page from 'src/components/Page';
 import { APP_PATHS } from 'src/constants';

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortNewView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortNewView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import Page from 'src/components/Page';
 import { APP_PATHS } from 'src/constants';

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, Grid, useTheme } from '@mui/material';
 

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortsListView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortsListView.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useCallback, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Card, Typography, useTheme } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';

--- a/src/scenes/AcceleratorRouter/Cohorts/index.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/index.tsx
@@ -1,4 +1,5 @@
-import React, { Navigate, Route, Routes } from 'react-router-dom';
+import React from 'react';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 

--- a/src/scenes/AcceleratorRouter/Deliverables/DeliverableRouter.tsx
+++ b/src/scenes/AcceleratorRouter/Deliverables/DeliverableRouter.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import SpeciesDeliverableRouter from '../Species/SpeciesDeliverableRouter';
 import DeliverableView from './DeliverableView';

--- a/src/scenes/AcceleratorRouter/Deliverables/DeliverableView.tsx
+++ b/src/scenes/AcceleratorRouter/Deliverables/DeliverableView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, useTheme } from '@mui/material';
 import { BusySpinner, Button, DropdownItem } from '@terraware/web-components';

--- a/src/scenes/AcceleratorRouter/Deliverables/index.tsx
+++ b/src/scenes/AcceleratorRouter/Deliverables/index.tsx
@@ -1,4 +1,5 @@
-import React, { Navigate, Route, Routes } from 'react-router-dom';
+import React from 'react';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import DeliverableProvider from 'src/providers/Deliverable/DeliverableProvider';

--- a/src/scenes/AcceleratorRouter/Documents/DocumentsView/index.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentsView/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 import { IconName, Separator } from '@terraware/web-components';

--- a/src/scenes/AcceleratorRouter/Documents/index.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/index.tsx
@@ -1,4 +1,5 @@
-import React, { Route, Routes } from 'react-router-dom';
+import React from 'react';
+import { Route, Routes } from 'react-router';
 
 import DocumentProducerProvider from 'src/providers/DocumentProducer/Provider';
 

--- a/src/scenes/AcceleratorRouter/FundingEntities/DeleteFundingEntityModal.tsx
+++ b/src/scenes/AcceleratorRouter/FundingEntities/DeleteFundingEntityModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Typography } from '@mui/material';
 

--- a/src/scenes/AcceleratorRouter/FundingEntities/InviteView.tsx
+++ b/src/scenes/AcceleratorRouter/FundingEntities/InviteView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Container, Grid, Typography, useTheme } from '@mui/material';
 import { Textfield } from '@terraware/web-components';

--- a/src/scenes/AcceleratorRouter/FundingEntities/index.tsx
+++ b/src/scenes/AcceleratorRouter/FundingEntities/index.tsx
@@ -1,4 +1,5 @@
-import React, { Route, Routes } from 'react-router-dom';
+import React from 'react';
+import { Route, Routes } from 'react-router';
 
 import FundingEntityProvider from 'src/providers/FundingEntityProvider';
 

--- a/src/scenes/AcceleratorRouter/Modules/EventEdit.tsx
+++ b/src/scenes/AcceleratorRouter/Modules/EventEdit.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { DateTime } from 'luxon';

--- a/src/scenes/AcceleratorRouter/Modules/Events.tsx
+++ b/src/scenes/AcceleratorRouter/Modules/Events.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button, TableColumnType } from '@terraware/web-components';

--- a/src/scenes/AcceleratorRouter/Modules/ModuleView.tsx
+++ b/src/scenes/AcceleratorRouter/Modules/ModuleView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Tabs } from '@terraware/web-components';

--- a/src/scenes/AcceleratorRouter/NavBar.tsx
+++ b/src/scenes/AcceleratorRouter/NavBar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useMatch, useNavigate } from 'react-router-dom';
+import { useMatch, useNavigate } from 'react-router';
 
 import { NavSection } from '@terraware/web-components';
 

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/EditMetricModal.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/EditMetricModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Grid } from '@mui/material';
 import { Checkbox, Dropdown } from '@terraware/web-components';

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/EditSettings.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/EditSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Container, Grid, Typography, useTheme } from '@mui/material';
 import { useDeviceInfo } from '@terraware/web-components/utils';

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/NewProjectSpecificMetric.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/NewProjectSpecificMetric.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Container, Grid, Typography, useTheme } from '@mui/material';
 import { Dropdown } from '@terraware/web-components';

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem } from '@terraware/web-components';

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportsSettings.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportsSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button, TableColumnType, Textfield } from '@terraware/web-components';

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/index.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/index.tsx
@@ -1,4 +1,5 @@
-import React, { Navigate, Route, Routes, useParams } from 'react-router-dom';
+import React from 'react';
+import { Navigate, Route, Routes, useParams } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Scoring/index.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Scoring/index.tsx
@@ -1,4 +1,5 @@
-import React, { Navigate, Route, Routes, useParams } from 'react-router-dom';
+import React from 'react';
+import { Navigate, Route, Routes, useParams } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingEdit.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingEdit.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, useTheme } from '@mui/material';
 

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingProvider.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import { selectProject } from 'src/redux/features/projects/projectsSelectors';

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, useTheme } from '@mui/material';
 import { Button } from '@terraware/web-components';

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/index.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/index.tsx
@@ -1,4 +1,5 @@
-import React, { Navigate, Route, Routes, useParams } from 'react-router-dom';
+import React from 'react';
+import { Navigate, Route, Routes, useParams } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/index.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/index.tsx
@@ -1,4 +1,5 @@
-import React, { Navigate, Route, Routes } from 'react-router-dom';
+import React from 'react';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import isEnabled from 'src/features';

--- a/src/scenes/AcceleratorRouter/Participants/ParticipantsEdit.tsx
+++ b/src/scenes/AcceleratorRouter/Participants/ParticipantsEdit.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { BusySpinner } from '@terraware/web-components';
 

--- a/src/scenes/AcceleratorRouter/Participants/ParticipantsList.tsx
+++ b/src/scenes/AcceleratorRouter/Participants/ParticipantsList.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem, TableColumnType } from '@terraware/web-components';

--- a/src/scenes/AcceleratorRouter/Participants/ParticipantsView.tsx
+++ b/src/scenes/AcceleratorRouter/Participants/ParticipantsView.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { BusySpinner, Button, DropdownItem, Textfield } from '@terraware/web-components';

--- a/src/scenes/AcceleratorRouter/Participants/index.tsx
+++ b/src/scenes/AcceleratorRouter/Participants/index.tsx
@@ -1,4 +1,5 @@
-import React, { Navigate, Route, Routes } from 'react-router-dom';
+import React from 'react';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 

--- a/src/scenes/AcceleratorRouter/People/EditView.tsx
+++ b/src/scenes/AcceleratorRouter/People/EditView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import Page from 'src/components/Page';
 import { APP_PATHS } from 'src/constants';

--- a/src/scenes/AcceleratorRouter/People/ListView.tsx
+++ b/src/scenes/AcceleratorRouter/People/ListView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, useTheme } from '@mui/material';
 import { TableRowType } from '@terraware/web-components';

--- a/src/scenes/AcceleratorRouter/People/NewView.tsx
+++ b/src/scenes/AcceleratorRouter/People/NewView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import Page from 'src/components/Page';
 import { APP_PATHS } from 'src/constants';

--- a/src/scenes/AcceleratorRouter/People/PersonProvider.tsx
+++ b/src/scenes/AcceleratorRouter/People/PersonProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { requestGetUser } from 'src/redux/features/user/usersAsyncThunks';
 import { selectUserRequest } from 'src/redux/features/user/usersSelectors';

--- a/src/scenes/AcceleratorRouter/People/SingleView.tsx
+++ b/src/scenes/AcceleratorRouter/People/SingleView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Grid, useTheme } from '@mui/material';
 

--- a/src/scenes/AcceleratorRouter/People/index.tsx
+++ b/src/scenes/AcceleratorRouter/People/index.tsx
@@ -1,4 +1,5 @@
-import React, { Navigate, Route, Routes } from 'react-router-dom';
+import React from 'react';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 

--- a/src/scenes/AcceleratorRouter/Species/SpeciesDeliverableRouter.tsx
+++ b/src/scenes/AcceleratorRouter/Species/SpeciesDeliverableRouter.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import ParticipantProjectSpeciesProvider from 'src/providers/ParticipantProject/ParticipantProjectSpeciesProvider';
 

--- a/src/scenes/AcceleratorRouter/index.tsx
+++ b/src/scenes/AcceleratorRouter/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { Box, Slide, useTheme } from '@mui/material';
 

--- a/src/scenes/AccessionsRouter/Accession2CreateView.tsx
+++ b/src/scenes/AccessionsRouter/Accession2CreateView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Container, Grid, Typography, useTheme } from '@mui/material';
 import { Dropdown } from '@terraware/web-components';

--- a/src/scenes/AccessionsRouter/Accession2View.tsx
+++ b/src/scenes/AccessionsRouter/Accession2View.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, Grid, Link as LinkMUI, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem, Icon, Tabs } from '@terraware/web-components';

--- a/src/scenes/AccessionsRouter/edit/DeleteAccessionModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/DeleteAccessionModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Typography } from '@mui/material';
 

--- a/src/scenes/AccessionsRouter/index.tsx
+++ b/src/scenes/AccessionsRouter/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import Accession2CreateView from 'src/scenes/AccessionsRouter/Accession2CreateView';
 import Accession2View from 'src/scenes/AccessionsRouter/Accession2View';

--- a/src/scenes/ApplicationRouter/index.tsx
+++ b/src/scenes/ApplicationRouter/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import ApplicationsList from './ApplicationsList';
 import OverviewView from './portal/Overview';

--- a/src/scenes/ApplicationRouter/portal/ApplicationPage.tsx
+++ b/src/scenes/ApplicationRouter/portal/ApplicationPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Crumb } from 'src/components/BreadCrumbs';
 import Page from 'src/components/Page';

--- a/src/scenes/ApplicationRouter/portal/Deliverable/index.tsx
+++ b/src/scenes/ApplicationRouter/portal/Deliverable/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Box } from '@mui/material';
 import { Button } from '@terraware/web-components';

--- a/src/scenes/ApplicationRouter/portal/DeliverableEdit/index.tsx
+++ b/src/scenes/ApplicationRouter/portal/DeliverableEdit/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import QuestionsDeliverableEditForm from 'src/components/DeliverableView/QuestionsDeliverableEditForm';
 import useNavigateTo from 'src/hooks/useNavigateTo';

--- a/src/scenes/ApplicationRouter/portal/NavBar.tsx
+++ b/src/scenes/ApplicationRouter/portal/NavBar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { matchPath, useMatch, useNavigate } from 'react-router-dom';
+import { matchPath, useMatch, useNavigate } from 'react-router';
 
 import { NavSection, theme } from '@terraware/web-components';
 

--- a/src/scenes/ApplicationRouter/portal/Overview/ListApplicationModulesContent.tsx
+++ b/src/scenes/ApplicationRouter/portal/Overview/ListApplicationModulesContent.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Button } from '@terraware/web-components';

--- a/src/scenes/ApplicationRouter/portal/Sections/index.tsx
+++ b/src/scenes/ApplicationRouter/portal/Sections/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Crumb } from 'src/components/BreadCrumbs';
 import { APP_PATHS } from 'src/constants';

--- a/src/scenes/ApplicationRouter/portal/index.tsx
+++ b/src/scenes/ApplicationRouter/portal/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { Box, Slide, useTheme } from '@mui/material';
 

--- a/src/scenes/BatchBulkWithdrawView/index.tsx
+++ b/src/scenes/BatchBulkWithdrawView/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import BatchWithdrawFlow from 'src/components/BatchWithdrawFlow';
 import { APP_PATHS } from 'src/constants';

--- a/src/scenes/CheckIn/index.tsx
+++ b/src/scenes/CheckIn/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Container, Grid, useTheme } from '@mui/material';
 import { BusySpinner } from '@terraware/web-components';

--- a/src/scenes/DeliverablesRouter/DeliverableView.tsx
+++ b/src/scenes/DeliverablesRouter/DeliverableView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Box } from '@mui/material';
 import { Button } from '@terraware/web-components';

--- a/src/scenes/DeliverablesRouter/QuestionsDeliverableEditView.tsx
+++ b/src/scenes/DeliverablesRouter/QuestionsDeliverableEditView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import QuestionsDeliverableEditForm from 'src/components/DeliverableView/QuestionsDeliverableEditForm';
 import useFetchDeliverable from 'src/components/DeliverableView/useFetchDeliverable';

--- a/src/scenes/DeliverablesRouter/index.tsx
+++ b/src/scenes/DeliverablesRouter/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import DeliverableProvider from 'src/providers/Deliverable/DeliverableProvider';
 import ParticipantProvider from 'src/providers/Participant/ParticipantProvider';

--- a/src/scenes/FunderReport/FunderReportView.tsx
+++ b/src/scenes/FunderReport/FunderReportView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { SelectT } from '@terraware/web-components';

--- a/src/scenes/FunderRouter/index.tsx
+++ b/src/scenes/FunderRouter/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Route, Routes, useNavigate } from 'react-router-dom';
+import { Route, Routes, useNavigate } from 'react-router';
 
 import { Box } from '@mui/material';
 

--- a/src/scenes/HelpSupportRouter/ContactUsForm.tsx
+++ b/src/scenes/HelpSupportRouter/ContactUsForm.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 import { useDeviceInfo } from '@terraware/web-components/utils';

--- a/src/scenes/HelpSupportRouter/index.tsx
+++ b/src/scenes/HelpSupportRouter/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 

--- a/src/scenes/HelpSupportRouter/provider/index.tsx
+++ b/src/scenes/HelpSupportRouter/provider/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 
 import { requestListSupportRequestTypes } from 'src/redux/features/support/supportAsyncThunks';
 import { selectSupportRequestTypesByRequest } from 'src/redux/features/support/supportSelectors';

--- a/src/scenes/Home/OnboardingHomeView/index.tsx
+++ b/src/scenes/Home/OnboardingHomeView/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Container, Grid, Typography } from '@mui/material';
 import { IconName } from '@terraware/web-components';

--- a/src/scenes/Home/ParticipantHomeView/ToDoProvider/index.tsx
+++ b/src/scenes/Home/ParticipantHomeView/ToDoProvider/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 
 import { useLocalization } from 'src/providers';
 import { useParticipantData } from 'src/providers/Participant/ParticipantContext';

--- a/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
+++ b/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Icon } from '@terraware/web-components';

--- a/src/scenes/Home/TerrawareHomeView/index.tsx
+++ b/src/scenes/Home/TerrawareHomeView/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Container, Grid, Typography } from '@mui/material';
 import { IconName } from '@terraware/web-components';

--- a/src/scenes/InventoryRouter/InventoryBatchView.tsx
+++ b/src/scenes/InventoryRouter/InventoryBatchView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button, Tabs } from '@terraware/web-components';

--- a/src/scenes/InventoryRouter/InventoryCreateView.tsx
+++ b/src/scenes/InventoryRouter/InventoryCreateView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 

--- a/src/scenes/InventoryRouter/InventoryForNurseryView.tsx
+++ b/src/scenes/InventoryRouter/InventoryForNurseryView.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 

--- a/src/scenes/InventoryRouter/InventoryForSpeciesView.tsx
+++ b/src/scenes/InventoryRouter/InventoryForSpeciesView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 

--- a/src/scenes/InventoryRouter/InventoryTable.tsx
+++ b/src/scenes/InventoryRouter/InventoryTable.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Grid } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';

--- a/src/scenes/InventoryRouter/InventoryV2View.tsx
+++ b/src/scenes/InventoryRouter/InventoryV2View.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Container, Grid, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem, Tabs } from '@terraware/web-components';

--- a/src/scenes/InventoryRouter/SpeciesBulkWithdrawView.tsx
+++ b/src/scenes/InventoryRouter/SpeciesBulkWithdrawView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import BatchWithdrawFlow from 'src/components/BatchWithdrawFlow';
 import { APP_PATHS } from 'src/constants';

--- a/src/scenes/InventoryRouter/index.tsx
+++ b/src/scenes/InventoryRouter/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import { useOrganization } from 'src/providers';
 import { selectSpecies } from 'src/redux/features/species/speciesSelectors';

--- a/src/scenes/InventoryRouter/view/InventorySeedlingsTable.tsx
+++ b/src/scenes/InventoryRouter/view/InventorySeedlingsTable.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem, TableColumnType } from '@terraware/web-components';

--- a/src/scenes/ModulesRouter/ModuleContentView.tsx
+++ b/src/scenes/ModulesRouter/ModuleContentView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Box, Card, Grid, Typography, useTheme } from '@mui/material';
 

--- a/src/scenes/ModulesRouter/ModuleEventSessionView.tsx
+++ b/src/scenes/ModulesRouter/ModuleEventSessionView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Box, Card, Grid, Typography, useTheme } from '@mui/material';
 import { Button } from '@terraware/web-components';

--- a/src/scenes/ModulesRouter/ModuleView.tsx
+++ b/src/scenes/ModulesRouter/ModuleView.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { DateTime } from 'luxon';
 

--- a/src/scenes/ModulesRouter/index.tsx
+++ b/src/scenes/ModulesRouter/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import ListView from './ListView';
 import ModuleContentView from './ModuleContentView';

--- a/src/scenes/MyAccountRouter/MyAccountForm.tsx
+++ b/src/scenes/MyAccountRouter/MyAccountForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, FormControlLabel, Grid, Radio, RadioGroup, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem } from '@terraware/web-components';

--- a/src/scenes/MyAccountRouter/index.tsx
+++ b/src/scenes/MyAccountRouter/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import { useOrganization } from 'src/providers';
 import MyAccountPage from 'src/scenes/MyAccountRouter/MyAccountPage';

--- a/src/scenes/NoOrgRouter/index.tsx
+++ b/src/scenes/NoOrgRouter/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 
 import NoOrgApplicationLandingPage from 'src/components/emptyStatePages/NoOrgApplicationLandingPage';
 import NoOrgLandingPage from 'src/components/emptyStatePages/NoOrgLandingPage';

--- a/src/scenes/NurseriesRouter/NurseriesListView.tsx
+++ b/src/scenes/NurseriesRouter/NurseriesListView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button, TableColumnType } from '@terraware/web-components';

--- a/src/scenes/NurseriesRouter/NurseryDetailsView.tsx
+++ b/src/scenes/NurseriesRouter/NurseryDetailsView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 

--- a/src/scenes/NurseriesRouter/NurseryView.tsx
+++ b/src/scenes/NurseriesRouter/NurseryView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { getDateDisplayValue } from '@terraware/web-components/utils';

--- a/src/scenes/NurseriesRouter/index.tsx
+++ b/src/scenes/NurseriesRouter/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import EmptyStatePage from 'src/components/emptyStatePages/EmptyStatePage';
 import { useOrganization } from 'src/providers';

--- a/src/scenes/NurseryRouter/NurseryPlantingsAndWithdrawalsView.tsx
+++ b/src/scenes/NurseryRouter/NurseryPlantingsAndWithdrawalsView.tsx
@@ -2,7 +2,7 @@
  * Nursery plantings and withdrawals
  */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Tabs } from '@terraware/web-components';

--- a/src/scenes/NurseryRouter/NurseryReassignmentView.tsx
+++ b/src/scenes/NurseryRouter/NurseryReassignmentView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, CircularProgress, Grid, useTheme } from '@mui/material';
 import { ErrorBox, TableColumnType } from '@terraware/web-components';

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Button, Message, Tabs } from '@terraware/web-components';

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Grid } from '@mui/material';
 import { SortOrder } from '@terraware/web-components';

--- a/src/scenes/NurseryRouter/WithdrawalLogRenderer.tsx
+++ b/src/scenes/NurseryRouter/WithdrawalLogRenderer.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { useTheme } from '@mui/material';
 

--- a/src/scenes/NurseryRouter/index.tsx
+++ b/src/scenes/NurseryRouter/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import { useLocalization, useOrganization } from 'src/providers';
 import { selectSpecies } from 'src/redux/features/species/speciesSelectors';

--- a/src/scenes/ObservationsRouter/ObservationsHome.tsx
+++ b/src/scenes/ObservationsRouter/ObservationsHome.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box } from '@mui/material';
 import { Tabs } from '@terraware/web-components';

--- a/src/scenes/ObservationsRouter/adhoc/AdHocObservationDetails.tsx
+++ b/src/scenes/ObservationsRouter/adhoc/AdHocObservationDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Textfield } from '@terraware/web-components';

--- a/src/scenes/ObservationsRouter/adhoc/index.tsx
+++ b/src/scenes/ObservationsRouter/adhoc/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, Grid, Tooltip, Typography, useTheme } from '@mui/material';
 import { Icon, Textfield } from '@terraware/web-components';

--- a/src/scenes/ObservationsRouter/biomass/BiomassMeasurementsDetails.tsx
+++ b/src/scenes/ObservationsRouter/biomass/BiomassMeasurementsDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Textfield } from '@terraware/web-components';

--- a/src/scenes/ObservationsRouter/details/ObservationDetailsList.tsx
+++ b/src/scenes/ObservationsRouter/details/ObservationDetailsList.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { TableColumnType } from '@terraware/web-components';
 

--- a/src/scenes/ObservationsRouter/details/index.tsx
+++ b/src/scenes/ObservationsRouter/details/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Grid } from '@mui/material';
 import _ from 'lodash';

--- a/src/scenes/ObservationsRouter/index.tsx
+++ b/src/scenes/ObservationsRouter/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import { CircularProgress } from '@mui/material';
 import { Option } from '@terraware/web-components/components/table/types';

--- a/src/scenes/ObservationsRouter/org/OrgObservationsListView.tsx
+++ b/src/scenes/ObservationsRouter/org/OrgObservationsListView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, useTheme } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';

--- a/src/scenes/ObservationsRouter/schedule/RescheduleObservation.tsx
+++ b/src/scenes/ObservationsRouter/schedule/RescheduleObservation.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import { useOrganization } from 'src/providers';

--- a/src/scenes/ObservationsRouter/schedule/ScheduleObservation.tsx
+++ b/src/scenes/ObservationsRouter/schedule/ScheduleObservation.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import { useOrganization } from 'src/providers';

--- a/src/scenes/ObservationsRouter/zone/index.tsx
+++ b/src/scenes/ObservationsRouter/zone/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, Grid } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';

--- a/src/scenes/OrgRouter/NavBar.tsx
+++ b/src/scenes/OrgRouter/NavBar.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useMatch, useNavigate } from 'react-router-dom';
+import { useMatch, useNavigate } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Icon } from '@terraware/web-components';

--- a/src/scenes/OrgRouter/index.tsx
+++ b/src/scenes/OrgRouter/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { Box, Slide, useTheme } from '@mui/material';
 

--- a/src/scenes/OrganizationRouter/EditOrganizationView.tsx
+++ b/src/scenes/OrganizationRouter/EditOrganizationView.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Dropdown } from '@terraware/web-components';

--- a/src/scenes/OrganizationRouter/OrganizationView.tsx
+++ b/src/scenes/OrganizationRouter/OrganizationView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { getDateDisplayValue } from '@terraware/web-components/utils';

--- a/src/scenes/OrganizationRouter/index.tsx
+++ b/src/scenes/OrganizationRouter/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import { useOrganization } from 'src/providers';
 import EditOrganizationView from 'src/scenes/OrganizationRouter/EditOrganizationView';

--- a/src/scenes/PeopleRouter/NewPersonView.tsx
+++ b/src/scenes/PeopleRouter/NewPersonView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, Grid, useTheme } from '@mui/material';
 import { Dropdown } from '@terraware/web-components';

--- a/src/scenes/PeopleRouter/PeopleListView.tsx
+++ b/src/scenes/PeopleRouter/PeopleListView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Grid, useTheme } from '@mui/material';
 

--- a/src/scenes/PeopleRouter/PersonDetailsView.tsx
+++ b/src/scenes/PeopleRouter/PersonDetailsView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 import { getDateDisplayValue } from '@terraware/web-components/utils';

--- a/src/scenes/PeopleRouter/index.tsx
+++ b/src/scenes/PeopleRouter/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import NewPersonView from 'src/scenes/PeopleRouter/NewPersonView';
 import PeopleListView from 'src/scenes/PeopleRouter/PeopleListView';

--- a/src/scenes/PlantingSitesRouter/edit/DeleteDraftPlantingSiteModal.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/DeleteDraftPlantingSiteModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Typography } from '@mui/material';
 import { BusySpinner, Button, DialogBox } from '@terraware/web-components';

--- a/src/scenes/PlantingSitesRouter/edit/DeletePlantingSiteModal.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/DeletePlantingSiteModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Typography } from '@mui/material';
 import { BusySpinner, Button, DialogBox } from '@terraware/web-components';

--- a/src/scenes/PlantingSitesRouter/edit/PlantingSiteCreate.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/PlantingSiteCreate.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, Container, Grid, Typography, useTheme } from '@mui/material';
 import { MultiPolygon } from 'geojson';

--- a/src/scenes/PlantingSitesRouter/edit/PlantingSiteDraftEdit.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/PlantingSiteDraftEdit.tsx
@@ -1,4 +1,5 @@
-import React, { useParams } from 'react-router-dom';
+import React from 'react';
+import { useParams } from 'react-router';
 
 import { BusySpinner } from '@terraware/web-components';
 

--- a/src/scenes/PlantingSitesRouter/edit/PlantingSiteTypeSelect.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/PlantingSiteTypeSelect.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import { SiteType } from 'src/types/PlantingSite';

--- a/src/scenes/PlantingSitesRouter/edit/editor/Editor.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Editor.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { BusySpinner, Button, Message } from '@terraware/web-components';

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import { Statuses } from 'src/redux/features/asyncUtils';

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteGet.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteGet.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import { Statuses } from 'src/redux/features/asyncUtils';

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import { Statuses } from 'src/redux/features/asyncUtils';

--- a/src/scenes/PlantingSitesRouter/index.tsx
+++ b/src/scenes/PlantingSitesRouter/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useParams } from 'react-router';
 
 import { CircularProgress } from '@mui/material';
 

--- a/src/scenes/PlantingSitesRouter/view/GenericSiteView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/GenericSiteView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Grid, List, ListItem, Typography, useTheme } from '@mui/material';
 import { DropdownItem } from '@terraware/web-components';

--- a/src/scenes/PlantingSitesRouter/view/GenericZoneView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/GenericZoneView.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';

--- a/src/scenes/PlantingSitesRouter/view/PlantingSiteDraftView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSiteDraftView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { BusySpinner } from '@terraware/web-components';
 

--- a/src/scenes/PlantingSitesRouter/view/PlantingSiteDraftZoneView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSiteDraftZoneView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { BusySpinner } from '@terraware/web-components';
 

--- a/src/scenes/PlantingSitesRouter/view/PlantingSiteSubzoneView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSiteSubzoneView.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';

--- a/src/scenes/PlantingSitesRouter/view/PlantingSiteView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSiteView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { BusySpinner } from '@terraware/web-components';
 

--- a/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
+++ b/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { getDateDisplayValue, useDeviceInfo } from '@terraware/web-components/utils';

--- a/src/scenes/PlantsDashboardRouter/index.tsx
+++ b/src/scenes/PlantsDashboardRouter/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import PlantsDashboardView from 'src/scenes/PlantsDashboardRouter/PlantsDashboardView';
 

--- a/src/scenes/RedirectsRouter/index.tsx
+++ b/src/scenes/RedirectsRouter/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 

--- a/src/scenes/Reports/AcceleratorReportEdit.tsx
+++ b/src/scenes/Reports/AcceleratorReportEdit.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import Page from 'src/components/Page';
 import TitleBar from 'src/components/common/TitleBar';

--- a/src/scenes/Reports/AcceleratorReportEditForm.tsx
+++ b/src/scenes/Reports/AcceleratorReportEditForm.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 

--- a/src/scenes/Reports/AcceleratorReportView.tsx
+++ b/src/scenes/Reports/AcceleratorReportView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Button } from '@terraware/web-components';

--- a/src/scenes/Reports/index.tsx
+++ b/src/scenes/Reports/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import isEnabled from 'src/features';

--- a/src/scenes/SeedBanksRouter/SeedBankDetailsView.tsx
+++ b/src/scenes/SeedBanksRouter/SeedBankDetailsView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 

--- a/src/scenes/SeedBanksRouter/SeedBankView.tsx
+++ b/src/scenes/SeedBanksRouter/SeedBankView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 

--- a/src/scenes/SeedBanksRouter/SeedBanksListView.tsx
+++ b/src/scenes/SeedBanksRouter/SeedBanksListView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Grid, useTheme } from '@mui/material';
 

--- a/src/scenes/SeedBanksRouter/index.tsx
+++ b/src/scenes/SeedBanksRouter/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import EmptyStatePage from 'src/components/emptyStatePages/EmptyStatePage';
 import { useOrganization } from 'src/providers';

--- a/src/scenes/SeedsDashboard/AccessionByStatus.tsx
+++ b/src/scenes/SeedsDashboard/AccessionByStatus.tsx
@@ -1,4 +1,5 @@
-import React, { Link } from 'react-router-dom';
+import React from 'react';
+import { Link } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 

--- a/src/scenes/SeedsDashboard/index.tsx
+++ b/src/scenes/SeedsDashboard/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, CircularProgress, Container, Grid, SxProps, Typography, useTheme } from '@mui/material';
 import Cookies from 'cookies-js';

--- a/src/scenes/Species/SpeciesAddView.tsx
+++ b/src/scenes/Species/SpeciesAddView.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Container, Grid, Typography, useTheme } from '@mui/material';
 import { BusySpinner } from '@terraware/web-components';

--- a/src/scenes/Species/SpeciesDetailView.tsx
+++ b/src/scenes/Species/SpeciesDetailView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, Grid, GridProps, Typography, useTheme } from '@mui/material';
 import { BusySpinner } from '@terraware/web-components';

--- a/src/scenes/Species/SpeciesEditView.tsx
+++ b/src/scenes/Species/SpeciesEditView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { BusySpinner } from '@terraware/web-components';

--- a/src/scenes/Species/SpeciesListView.tsx
+++ b/src/scenes/Species/SpeciesListView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Box, Grid, useTheme } from '@mui/material';
 import { DropdownItem, SortOrder } from '@terraware/web-components';

--- a/src/scenes/Species/index.tsx
+++ b/src/scenes/Species/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import { BusySpinner } from '@terraware/web-components';
 

--- a/src/scenes/TerrawareRouter/index.tsx
+++ b/src/scenes/TerrawareRouter/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { matchPath, useNavigate } from 'react-router-dom';
+import { matchPath, useNavigate } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import { useOrganization, useUserFundingEntity } from 'src/providers';

--- a/src/utils/filterHooks/useSessionFilters.ts
+++ b/src/utils/filterHooks/useSessionFilters.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import {
   FiltersType,

--- a/src/utils/useQuery.ts
+++ b/src/utils/useQuery.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 // A custom hook that builds on useLocation to parse
 // the query string for you.

--- a/src/utils/useStateLocation.tsx
+++ b/src/utils/useStateLocation.tsx
@@ -1,4 +1,4 @@
-import { Location, useLocation } from 'react-router-dom';
+import { Location, useLocation } from 'react-router';
 
 type State = {
   from?: string;

--- a/src/utils/useStickyTabs.ts
+++ b/src/utils/useStickyTabs.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Tab } from '@terraware/web-components';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3076,11 +3076,6 @@
     redux-thunk "^2.4.2"
     reselect "^4.1.8"
 
-"@remix-run/router@1.23.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.0.tgz#35390d0e7779626c026b11376da6789eb8389242"
-  integrity sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==
-
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz#04bc0608f4aa4b2e4b1aebf284344d0f68fda283"
@@ -6697,6 +6692,11 @@ cookie@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
+
+cookie@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.0.2.tgz#27360701532116bd3f1f9416929d176afe1e4610"
+  integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
 
 cookies-js@^1.2.3:
   version "1.2.3"
@@ -13877,20 +13877,14 @@ react-responsive@^9.0.2:
     prop-types "^15.6.1"
     shallow-equal "^1.2.1"
 
-react-router-dom@6:
-  version "6.30.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.0.tgz#a64774104508bff56b1affc2796daa3f7e76b7df"
-  integrity sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==
+react-router@^7.5.3:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.5.3.tgz#9e5420832af8c3690740c1797d4fa54613fea06d"
+  integrity sha512-3iUDM4/fZCQ89SXlDa+Ph3MevBrozBAI655OAfWQlTm9nBR0IKlrmNwFow5lPHttbwvITZfkeeeZFP6zt3F7pw==
   dependencies:
-    "@remix-run/router" "1.23.0"
-    react-router "6.30.0"
-
-react-router@6.30.0:
-  version "6.30.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.0.tgz#9789d775e63bc0df60f39ced77c8c41f1e01ff90"
-  integrity sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==
-  dependencies:
-    "@remix-run/router" "1.23.0"
+    cookie "^1.0.1"
+    set-cookie-parser "^2.6.0"
+    turbo-stream "2.4.0"
 
 react-scripts@^5.0.1:
   version "5.0.1"
@@ -14691,6 +14685,11 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
+
+set-cookie-parser@^2.6.0:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz#3016f150072202dfbe90fadee053573cc89d2943"
+  integrity sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==
 
 set-function-length@^1.2.1, set-function-length@^1.2.2:
   version "1.2.2"
@@ -15935,6 +15934,11 @@ tsutils@^3.21.0:
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
+
+turbo-stream@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/turbo-stream/-/turbo-stream-2.4.0.tgz#1e4fca6725e90fa14ac4adb782f2d3759a5695f0"
+  integrity sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==
 
 tweakpane@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
Upgrade `react-router-dom` to v7, replace with `react-router`.

Most of this PR is updating the imports from `react-router-dom` to `react-router`.

Also fix a few imports of `React` from `react-router-dom` to be from `react` instead.

Remove now non-extant future flags.

Wait until right after a deployment to merge this one, so it gets plenty of time in staging to find issues.