### PR TITLE
SW-6812: Add Deliverables tab to Project Profile in Console (Follow-up)

### DIFF
--- a/src/scenes/AcceleratorRouter/ParticipantProjects/ProjectDeliverablesView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/ProjectDeliverablesView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, useTheme } from '@mui/material';
+import { useTheme } from '@mui/material';
 
 import Card from 'src/components/common/Card';
 import DeliverablesList from 'src/scenes/DeliverablesRouter/DeliverablesList';
@@ -19,9 +19,7 @@ const ProjectDeliverablesView = ({ projectId }: ProjectDeliverablesViewProps) =>
         padding: 0,
       }}
     >
-      <Box marginX={`-${theme.spacing(4)}`}>
-        <DeliverablesList projectId={projectId} />
-      </Box>
+      <DeliverablesList projectId={projectId} />
     </Card>
   );
 };

--- a/src/scenes/DeliverablesRouter/DeliverablesList.tsx
+++ b/src/scenes/DeliverablesRouter/DeliverablesList.tsx
@@ -155,11 +155,27 @@ const DeliverablesList = ({ projectId }: DeliverablesListProps): JSX.Element => 
     [activeLocale, currentParticipantProject, projectFilter]
   );
 
+  const Wrapper = projectId ? Box : TfMain;
+
   return (
-    <TfMain>
-      <PageHeaderWrapper>
-        <PageHeader title={strings.DELIVERABLES} leftComponent={PageHeaderLeftComponent} />
-      </PageHeaderWrapper>
+    <Wrapper>
+      {projectId ? (
+        <Typography
+          sx={{
+            fontSize: '20px',
+            fontWeight: 600,
+            lineHeight: '28px',
+            padding: '24px',
+          }}
+          variant='h4'
+        >
+          {strings.DELIVERABLES}
+        </Typography>
+      ) : (
+        <PageHeaderWrapper>
+          <PageHeader title={strings.DELIVERABLES} leftComponent={PageHeaderLeftComponent} />
+        </PageHeaderWrapper>
+      )}
 
       <DeliverablesTable
         extraTableFilters={extraTableFilters}
@@ -169,7 +185,7 @@ const DeliverablesList = ({ projectId }: DeliverablesListProps): JSX.Element => 
         tableId={'participantDeliverablesTable'}
         projectId={projectId}
       />
-    </TfMain>
+    </Wrapper>
   );
 };
 


### PR DESCRIPTION
This PR adds follow-up changes to dynamically adjust the content wrapper and title component, fixing rendering issues and ensuring consistent styles for tab/table headers.

Context: There were two `TfMain` & `PageHeaderWrapper` components being rendered in the Deliverables Tab of the new Project Profile Page.

## Screenshots

### Issues

![staging terraware io_accelerator_projects_52](https://github.com/user-attachments/assets/58c9364d-a5f1-4721-bcf9-5438b8cc15fc)

![staging terraware io_accelerator_projects_52 (1)](https://github.com/user-attachments/assets/62503e92-5bec-487b-8f06-d59a1e8eb0b9)
