### PR TITLE
Fix jsdoc-indentation linting issues

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,17 +27,18 @@ export default fixupConfigRules([
       'plugin:@typescript-eslint/recommended-requiring-type-checking',
       'plugin:react/recommended',
       'plugin:jest-react/recommended',
+      // 'plugin:storybook/recommended',
       'prettier'
     )
     .map((config) => ({
       ...config,
       files: ['**/*.ts', '**/*.tsx'],
-      ignores: ['**/*.test.ts'],
+      ignores: ['**/generated-schema.ts'],
     })),
   {
     files: ['**/*.ts', '**/*.tsx'],
 
-    ignores: ['**/*.test.ts', 'generated-schema.ts'],
+    ignores: ['**/generated-schema.ts'],
 
     plugins: {
       jsdoc,
@@ -136,7 +137,7 @@ export default fixupConfigRules([
       ],
 
       '@typescript-eslint/naming-convention': [
-        'off',
+        'error',
         {
           selector: 'variable',
           format: ['camelCase', 'UPPER_CASE', 'PascalCase'],

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "generate-strings": "node scripts/generate-strings.js && node scripts/unused-strings.js",
     "generate-types": "node scripts/openapi-typescript-formatter.mjs",
     "license-report": "license-report --only=prod --department.value=terraware --relatedTo.value=terraware-web --output=html > docs/license-report.html",
-    "lint": "ESLINT_USE_FLAT_CONFIG=true eslint src/**/*.ts src/**/*.tsx ",
+    "lint": "eslint src/**/*.ts src/**/*.tsx ",
     "ts": "tsc --project ./tsconfig.json",
     "format": "prettier --write .",
     "docker:start": "./scripts/launch_server.sh",

--- a/src/services/HttpService.ts
+++ b/src/services/HttpService.ts
@@ -193,17 +193,17 @@ const HttpUtils = {
  *
  * Usage examples:
  *
- *   // with url context
- *   const someService = HttpService.root('/someapi');
- *   someService.get({ params: { key: value }).then(...);
- *   someService.post({ entity: { name: 'some name' } });
+ * // with url context
+ * const someService = HttpService.root('/someapi');
+ * someService.get({ params: { key: value }).then(...);
+ * someService.post({ entity: { name: 'some name' } });
  *
- *   // without url context
- *   const genericService = HttpService;
- *   genericService.post({ url: '/api/{id}', replacements: { '{id}': 123 }, entity: { name: 'some name' });
+ * // without url context
+ * const genericService = HttpService;
+ * genericService.post({ url: '/api/{id}', replacements: { '{id}': 123 }, entity: { name: 'some name' });
  *
- *   // utils
- *   HttpService.setDefaultHeaders({ header-name: <header-value> });
+ * // utils
+ * HttpService.setDefaultHeaders({ header-name: <header-value> });
  */
 const HttpService = {
   // http api, closure with url context

--- a/src/services/SearchService.ts
+++ b/src/services/SearchService.ts
@@ -50,10 +50,10 @@ const httpSearchValues = HttpService.root(SEARCH_VALUES_ENDPOINT);
  * organization ID.
  *
  * @param criteria Search criteria in the type of SearchCriteria, which is used by the application,
- *   or an array of SearchNodePayload
+ * or an array of SearchNodePayload
  * @param organizationId ID of organization to search.
  * @return SearchNodePayload suitable for use in a search request. This will currently always be
- *   an AndNodePayload.
+ * an AndNodePayload.
  */
 function convertToSearchNodePayload(
   criteria: SearchCriteria | SearchNodePayload[],

--- a/src/types/Map.ts
+++ b/src/types/Map.ts
@@ -20,6 +20,7 @@ export type MapGeometry = number[][][][];
 
 /**
  * Example of a boundary:
+ * ```json
  * [
  *   [
  *     [
@@ -50,6 +51,7 @@ export type MapGeometry = number[][][][];
  *     ]
  *   ]
  * ]
+ * ```
  */
 
 export type MapSourceProperties = { [key: string]: any };

--- a/src/utils/searchAndSort.test.ts
+++ b/src/utils/searchAndSort.test.ts
@@ -25,39 +25,47 @@ type MockResultWithSubProperties = {
   name?: string;
   subObject?: MockResult;
   subsets?: MockResult[];
-}
+};
 
 describe('splitTrigrams', () => {
   it('should split a string into trigrams in the same way postgres does', () => {
     /**
+     * ```
      * select show_trgm('cat');
      *         show_trgm
      * -------------------------
      * {'  c',' ca','at ',cat}
+     * ```
      */
     expect(splitTrigrams('cat')).toEqual(new Set(['  c', ' ca', 'at ', 'cat']));
 
     /**
+     * ```
      * select show_trgm('foo|bar');
      *                   show_trgm
      * -----------------------------------------------
      * {'  b','  f',' ba',' fo','ar ',bar,foo,'oo '}
+     * ```
      */
     expect(splitTrigrams('foo|bar')).toEqual(new Set(['  b', '  f', ' ba', ' fo', 'ar ', 'bar', 'foo', 'oo ']));
 
     /**
+     * ```
      * select show_trgm('olyolyoxenfree');
      *                           show_trgm
      * -------------------------------------------------------------
      * {'  o',' ol','ee ',enf,fre,lyo,nfr,oly,oxe,ree,xen,yol,yox}
+     * ```
      */
     expect(splitTrigrams('olyolyoxenfree')).toEqual(new Set(['  o', ' ol', 'ee ', 'enf', 'fre', 'lyo', 'nfr', 'oly', 'oxe', 'ree', 'xen', 'yol', 'yox']));
 
     /**
+     * ```
      * select show_trgm('sam');
      *         show_trgm
      * -------------------------
      * {'  s',' sa','am ',sam}
+     * ```
      */
     expect(splitTrigrams('sam')).toEqual(new Set(['  s', ' sa', 'am ', 'sam']));
   });
@@ -66,26 +74,32 @@ describe('splitTrigrams', () => {
 describe('trigramWordSimilarity', () => {
   it('should calculate the trigram word similarity same way postgres does', () => {
     /**
+     * ```
      * SELECT word_similarity('sam', 'sampson road');
      *  word_similarity
      * -----------------
      *            0.75
+     * ```
      */
     expect(trigramWordSimilarity('sam', 'sampson')).toEqual(0.375);
 
     /**
+     * ```
      * SELECT word_similarity('sampson', 'sam');
      * word_similarity
      * -----------------
      *           0.375
+     * ```
      */
     expect(trigramWordSimilarity('sampson', 'sam')).toEqual(0.375);
 
     /**
+     * ```
      * SELECT word_similarity('andro', 'project andromeda');
      * word_similarity
      * -----------------
      *       0.8333333
+     * ```
      */
     expect(trigramWordSimilarity('andro', 'project andromeda')).toEqual(0.2777777777777778);
 
@@ -99,12 +113,15 @@ describe('trigramWordSimilarity', () => {
      * search here.
      */
     /**
+     * ```
      * SELECT word_similarity('pronect', 'pripro');
      * word_similarity
      * -----------------
      *       0.27272728
+     * ```
      */
     /**
+     * ```
      * SELECT UNNEST(show_trgm('pronect')) INTERSECT SELECT UNNEST(show_trgm('pripro'));
      * unnest
      * --------
@@ -129,6 +146,7 @@ describe('trigramWordSimilarity', () => {
      * one
      * ect
      * (12 rows)
+     * ```
      */
     expect(trigramWordSimilarity('pronect', 'pripro')).toEqual(0.375);
   });
@@ -952,7 +970,7 @@ describe('searchAndSort', () => {
           },
         },
       },
-    ]
+    ];
 
     expect(searchAndSort(results, search)).toEqual(filteredResults);
   });

--- a/src/utils/searchAndSort.ts
+++ b/src/utils/searchAndSort.ts
@@ -219,11 +219,13 @@ export type SearchAndSortFn<T extends Record<string, unknown>> = (
  * @param results         The list of results you want to search and sort
  * @param search          (optional) The SearchNodePayload which contains filter conditions to apply to the results
  * @param sortOrderConfig (optional) The sort order configuration contains:
+ * ```md
  *    - a `locale`, used for sorting strings,
  *    - the `sortOrder` which defines the field and order
  *    - (optional) a list of `numberFields`, used to sort applicable fields numerically
  *      - fields not supplied will be sorted as strings
  *      - can be used to cast a string to a number, useful for SearchElementResponse numbers which come back as strings
+ * ```
  */
 export const searchAndSort = <T extends Record<string, unknown>>(
   results: T[],


### PR DESCRIPTION
Fix `jsdoc-indentation` linting issues.

Enable `naming-convention` rule to match old tslint config.

Updating `lint` command to remove unnecessary flag.

Also add test files back to being linted.