### PR TITLE
Fix empty-function, empty-object, object-shorthand linting issues

### DIFF
--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -67,7 +67,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
 
   const onHandleLogout = () => {
     mixpanel?.reset();
-    window.location.href = `/sso/logout`;
+    window.location.href = '/sso/logout';
   };
 
   const handleTopBarClick = () => {
@@ -112,7 +112,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
         />
         {userFundingEntity && <SettingsLink />}
         <div style={separatorStyles} />
-        <UserMenu hasOrganizations={organizations && organizations.length > 0} />
+        <UserMenu />
       </Box>
     </>
   ) : (

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -11,11 +11,7 @@ import { useUser } from 'src/providers';
 import strings from 'src/strings';
 import useEnvironment from 'src/utils/useEnvironment';
 
-type UserMenuProps = {
-  hasOrganizations?: boolean;
-};
-
-export default function UserMenu({}: UserMenuProps): JSX.Element {
+export default function UserMenu(): JSX.Element {
   const theme = useTheme();
   const { user } = useUser();
   const { isProduction } = useEnvironment();

--- a/src/providers/FundingEntityProvider.tsx
+++ b/src/providers/FundingEntityProvider.tsx
@@ -31,7 +31,10 @@ export default function FundingEntityProvider({ children }: FundingEntityProvide
   const getFundingEntityRequest = useAppSelector(selectFundingEntityRequest(pathFundingEntityId));
   const [fundingEntityData, setFundingEntityData] = useState<ProvidedFundingEntityData>({
     fundingEntity: undefined,
-    reload: () => {},
+    reload: () => {
+      // default no-op implementation
+      return;
+    },
   });
 
   const pathParamExists = () => !isNaN(pathFundingEntityId) && pathFundingEntityId !== -1;

--- a/src/providers/contexts.ts
+++ b/src/providers/contexts.ts
@@ -80,5 +80,8 @@ export const UserFundingEntityContext = createContext<ProvidedUserFundingEntityD
 
 export const FundingEntityContext = createContext<ProvidedFundingEntityData>({
   fundingEntity: undefined,
-  reload: () => {},
+  reload: () => {
+    // default no-op implementation
+    return;
+  },
 });

--- a/src/services/FundingEntityService.ts
+++ b/src/services/FundingEntityService.ts
@@ -166,7 +166,7 @@ const deleteFundingEntity = async (fundingEntityId: number): Promise<Response> =
 
 const inviteFunder = async (fundingEntityId: number, email: string): Promise<InviteFunderResponse> => {
   const serverResponse: Response = await httpFundingEntityUsers.post({
-    entity: { email: email },
+    entity: { email },
     urlReplacements: {
       '{fundingEntityId}': fundingEntityId.toString(),
     },

--- a/src/services/ParticipantProjectService.ts
+++ b/src/services/ParticipantProjectService.ts
@@ -142,7 +142,7 @@ const list = async (
   if (sortOrder) {
     searchOrderConfig = {
       locale: locale ?? null,
-      sortOrder: sortOrder,
+      sortOrder,
       numberFields: ['id'],
     };
   }

--- a/src/utils/numbers.test.ts
+++ b/src/utils/numbers.test.ts
@@ -6,7 +6,7 @@ describe('formatNumberScale', () => {
     expect(formatNumberScale('not a number')).toBe('not a number');
     expect(formatNumberScale('')).toBe('');
     expect(formatNumberScale(undefined)).toBe('');
-  })
+  });
 
   test('numbers', () => {
     expect(formatNumberScale(12000000)).toBe('12M');


### PR DESCRIPTION
Fix `no-empty-function` and `no-empty-pattern` for objects.

Fix `object-shorthand` using `yarn lint --fix`.

A missing semicolon also got included with an automatic prettier fix.