### PR TITLE
Fix react-router-v7 update to navigate being a promise (linting issue)

### DIFF
--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -1,8 +1,9 @@
 import React, { ReactNode } from 'react';
 import { ErrorBoundary as ReactErrorBoundary } from 'react-error-boundary';
-import { useNavigate } from 'react-router';
 
 import { useDeviceInfo } from '@terraware/web-components/utils';
+
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import ErrorContent from './ErrorContent';
 import { APP_PATHS } from './constants';
@@ -13,7 +14,7 @@ interface Props {
 }
 
 const ErrorBoundary = (props: Props) => {
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { isDesktop } = useDeviceInfo();
 
   return (
@@ -24,7 +25,7 @@ const ErrorBoundary = (props: Props) => {
         if (isDesktop) {
           props.setShowNavBar?.(true);
         }
-        void navigate(APP_PATHS.HOME);
+        navigate(APP_PATHS.HOME);
       }}
     >
       {props.children}

--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -24,7 +24,7 @@ const ErrorBoundary = (props: Props) => {
         if (isDesktop) {
           props.setShowNavBar?.(true);
         }
-        navigate(APP_PATHS.HOME);
+        void navigate(APP_PATHS.HOME);
       }}
     >
       {props.children}

--- a/src/ErrorContent.tsx
+++ b/src/ErrorContent.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { useErrorBoundary } from 'react-error-boundary';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import strings from 'src/strings';
 
 import Button from './components/common/button/Button';

--- a/src/ErrorContent.tsx
+++ b/src/ErrorContent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useErrorBoundary } from 'react-error-boundary';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 
@@ -16,7 +16,7 @@ interface ErrorContentProps {
 
 export default function ErrorContent({ text, inApp }: ErrorContentProps) {
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { resetBoundary } = useErrorBoundary();
 
   return (

--- a/src/components/BatchWithdrawFlow/index.tsx
+++ b/src/components/BatchWithdrawFlow/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Typography } from '@mui/material';
 import { BusySpinner, theme } from '@terraware/web-components';
@@ -44,7 +44,7 @@ export default function BatchWithdrawFlow(props: BatchWithdrawFlowProps): JSX.El
   const [showEmptyBatchesModalFor, setShowEmptyBatchesModalFor] = useState<NurseryWithdrawal | null>(null);
   const [filterProjectId, setFilterProjectId] = useState<number>();
   const snackbar = useSnackbar();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
 
   useEffect(() => {
     if (selectedOrganization.id !== -1) {
@@ -183,9 +183,9 @@ export default function BatchWithdrawFlow(props: BatchWithdrawFlowProps): JSX.El
 
   const goToInventory = () => {
     if (sourcePage && sourcePage.startsWith(APP_PATHS.INVENTORY)) {
-      void navigate({ pathname: sourcePage });
+      navigate({ pathname: sourcePage });
     } else {
-      void navigate({ pathname: APP_PATHS.INVENTORY });
+      navigate({ pathname: APP_PATHS.INVENTORY });
     }
   };
 

--- a/src/components/BatchWithdrawFlow/index.tsx
+++ b/src/components/BatchWithdrawFlow/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Typography } from '@mui/material';
 import { BusySpinner, theme } from '@terraware/web-components';
@@ -7,6 +6,7 @@ import { getTodaysDateFormatted } from '@terraware/web-components/utils';
 
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
 import { NurseryBatchService, NurseryWithdrawalService } from 'src/services';
 import strings from 'src/strings';

--- a/src/components/BatchWithdrawFlow/index.tsx
+++ b/src/components/BatchWithdrawFlow/index.tsx
@@ -183,9 +183,9 @@ export default function BatchWithdrawFlow(props: BatchWithdrawFlowProps): JSX.El
 
   const goToInventory = () => {
     if (sourcePage && sourcePage.startsWith(APP_PATHS.INVENTORY)) {
-      navigate({ pathname: sourcePage });
+      void navigate({ pathname: sourcePage });
     } else {
-      navigate({ pathname: APP_PATHS.INVENTORY });
+      void navigate({ pathname: APP_PATHS.INVENTORY });
     }
   };
 

--- a/src/components/DeliverableView/useFetchDeliverable.ts
+++ b/src/components/DeliverableView/useFetchDeliverable.ts
@@ -41,7 +41,7 @@ export default function useFetchDeliverable({ deliverableId, projectId }: Props)
   const deliverableData = useAppSelector(selectDeliverableData(deliverableId, projectId));
 
   const goToDeliverables = useCallback(() => {
-    navigate(isAcceleratorRoute ? APP_PATHS.ACCELERATOR_DELIVERABLES : APP_PATHS.DELIVERABLES);
+    void navigate(isAcceleratorRoute ? APP_PATHS.ACCELERATOR_DELIVERABLES : APP_PATHS.DELIVERABLES);
   }, [navigate, isAcceleratorRoute]);
 
   useEffect(() => {

--- a/src/components/DeliverableView/useFetchDeliverable.ts
+++ b/src/components/DeliverableView/useFetchDeliverable.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
@@ -31,7 +31,7 @@ export type Response = {
 export default function useFetchDeliverable({ deliverableId, projectId }: Props): Response {
   const { isAcceleratorRoute } = useAcceleratorConsole();
   const snackbar = useSnackbar();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const dispatch = useAppDispatch();
 
   const [requestId, setRequestId] = useState('');
@@ -41,7 +41,7 @@ export default function useFetchDeliverable({ deliverableId, projectId }: Props)
   const deliverableData = useAppSelector(selectDeliverableData(deliverableId, projectId));
 
   const goToDeliverables = useCallback(() => {
-    void navigate(isAcceleratorRoute ? APP_PATHS.ACCELERATOR_DELIVERABLES : APP_PATHS.DELIVERABLES);
+    navigate(isAcceleratorRoute ? APP_PATHS.ACCELERATOR_DELIVERABLES : APP_PATHS.DELIVERABLES);
   }, [navigate, isAcceleratorRoute]);
 
   useEffect(() => {

--- a/src/components/DeliverableView/useFetchDeliverable.ts
+++ b/src/components/DeliverableView/useFetchDeliverable.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { Statuses } from 'src/redux/features/asyncUtils';
 import { requestGetDeliverable } from 'src/redux/features/deliverables/deliverablesAsyncThunks';
 import {

--- a/src/components/DeliverablesTable/index.tsx
+++ b/src/components/DeliverablesTable/index.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { TableColumnType } from '@terraware/web-components';
 
 import { FilterConfig, FilterConfigWithValues } from 'src/components/common/SearchFiltersWrapperV2';
 import { useParticipants } from 'src/hooks/useParticipants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useLocalization, useOrganization, useUser } from 'src/providers';
 import { requestListDeliverables } from 'src/redux/features/deliverables/deliverablesAsyncThunks';

--- a/src/components/DeliverablesTable/index.tsx
+++ b/src/components/DeliverablesTable/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { TableColumnType } from '@terraware/web-components';
 
@@ -130,7 +130,7 @@ const DeliverablesTable = ({
   const deliverablesSearchRequest = useAppSelector(selectDeliverablesSearchRequest(deliverablesSearchRequestId));
   const query = useQuery();
   const projectParam = query.get('projectId');
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const mixpanel = useMixpanel();
 
@@ -165,7 +165,7 @@ const DeliverablesTable = ({
   const removeParam = () => {
     if (projectParam) {
       query.delete('projectId');
-      void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+      navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
     }
   };
 

--- a/src/components/DeliverablesTable/index.tsx
+++ b/src/components/DeliverablesTable/index.tsx
@@ -165,7 +165,7 @@ const DeliverablesTable = ({
   const removeParam = () => {
     if (projectParam) {
       query.delete('projectId');
-      navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+      void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
     }
   };
 

--- a/src/components/FundersTable/index.tsx
+++ b/src/components/FundersTable/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { TableRowType } from '@terraware/web-components';
 
@@ -56,7 +56,7 @@ type FundersTableProps = {
 const FundersTable = ({ fundingEntityId }: FundersTableProps) => {
   const dispatch = useAppDispatch();
   const snackbar = useSnackbar();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { isAllowed } = useUser();
 
   const [listFundersRequestId, setListFundersRequestId] = useState<string>('');

--- a/src/components/FundersTable/index.tsx
+++ b/src/components/FundersTable/index.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { TableRowType } from '@terraware/web-components';
 
@@ -7,6 +6,7 @@ import ClientSideFilterTable from 'src/components/Tables/ClientSideFilterTable';
 import Button from 'src/components/common/button/Button';
 import { TableColumnType } from 'src/components/common/table/types';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useUser } from 'src/providers';
 import { requestDeleteFunders, requestListFunders } from 'src/redux/features/funder/fundingEntitiesAsyncThunks';
 import {

--- a/src/components/ModuleDetailsCard/index.tsx
+++ b/src/components/ModuleDetailsCard/index.tsx
@@ -45,7 +45,7 @@ const MODULE_CONTENTS = (module: ModuleDetails, navigate: (type: ModuleContentTy
       type: 'additionalResources',
       label: strings.ADDITIONAL_RESOURCES,
       onClick: (type) => {
-        navigate(type);
+        void navigate(type);
       },
     });
   }
@@ -55,7 +55,7 @@ const MODULE_CONTENTS = (module: ModuleDetails, navigate: (type: ModuleContentTy
       type: 'preparationMaterials',
       label: strings.PREPARATION_MATERIALS,
       onClick: (type) => {
-        navigate(type);
+        void navigate(type);
       },
     });
   }

--- a/src/components/ModuleDetailsCard/index.tsx
+++ b/src/components/ModuleDetailsCard/index.tsx
@@ -45,7 +45,7 @@ const MODULE_CONTENTS = (module: ModuleDetails, navigate: (type: ModuleContentTy
       type: 'additionalResources',
       label: strings.ADDITIONAL_RESOURCES,
       onClick: (type) => {
-        void navigate(type);
+        navigate(type);
       },
     });
   }
@@ -55,7 +55,7 @@ const MODULE_CONTENTS = (module: ModuleDetails, navigate: (type: ModuleContentTy
       type: 'preparationMaterials',
       label: strings.PREPARATION_MATERIALS,
       onClick: (type) => {
-        void navigate(type);
+        navigate(type);
       },
     });
   }

--- a/src/components/NotificationsDropdown.tsx
+++ b/src/components/NotificationsDropdown.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Link, useNavigate } from 'react-router';
+import { Link } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import {
   Badge,
@@ -56,7 +57,7 @@ type NotificationsDropdownProps = {
 
 export default function NotificationsDropdown(props: NotificationsDropdownProps): JSX.Element {
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { organizationId, reloadOrganizationData } = props;
   // notificationsInterval value is only being used when it is set.
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
@@ -134,7 +135,7 @@ export default function NotificationsDropdown(props: NotificationsDropdownProps)
   };
 
   const goToSettings = () => {
-    void navigate({ pathname: APP_PATHS.MY_ACCOUNT });
+    navigate({ pathname: APP_PATHS.MY_ACCOUNT });
     onPopoverClose();
   };
 

--- a/src/components/NotificationsDropdown.tsx
+++ b/src/components/NotificationsDropdown.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import {
   Badge,
@@ -18,6 +17,7 @@ import { Button, Tooltip } from '@terraware/web-components';
 import { DateTime } from 'luxon';
 
 import { API_PULL_INTERVAL, APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { NotificationsService } from 'src/services';
 import { NotificationsResponse } from 'src/services/NotificationsService';
 import strings from 'src/strings';

--- a/src/components/NotificationsDropdown.tsx
+++ b/src/components/NotificationsDropdown.tsx
@@ -134,7 +134,7 @@ export default function NotificationsDropdown(props: NotificationsDropdownProps)
   };
 
   const goToSettings = () => {
-    navigate({ pathname: APP_PATHS.MY_ACCOUNT });
+    void navigate({ pathname: APP_PATHS.MY_ACCOUNT });
     onPopoverClose();
   };
 

--- a/src/components/OrganizationsDropdown.tsx
+++ b/src/components/OrganizationsDropdown.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { DropdownItem, PopoverMenu } from '@terraware/web-components';
 
@@ -13,13 +13,13 @@ import AddNewOrganizationModal from './AddNewOrganizationModal';
 export default function OrganizationsDropdown(): JSX.Element {
   const { selectedOrganization, setSelectedOrganization, organizations, redirectAndNotify, reloadOrganizations } =
     useOrganization();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const [newOrganizationModalOpened, setNewOrganizationModalOpened] = useState(false);
 
   const selectOrganization = (newlySelectedOrg: Organization) => {
     setSelectedOrganization((currentlySelectedOrg: Organization | undefined) => {
       if (newlySelectedOrg.id !== currentlySelectedOrg?.id) {
-        void navigate({ pathname: APP_PATHS.HOME, search: `organizationId=${newlySelectedOrg.id}` });
+        navigate({ pathname: APP_PATHS.HOME, search: `organizationId=${newlySelectedOrg.id}` });
       }
       return newlySelectedOrg;
     });

--- a/src/components/OrganizationsDropdown.tsx
+++ b/src/components/OrganizationsDropdown.tsx
@@ -19,7 +19,7 @@ export default function OrganizationsDropdown(): JSX.Element {
   const selectOrganization = (newlySelectedOrg: Organization) => {
     setSelectedOrganization((currentlySelectedOrg: Organization | undefined) => {
       if (newlySelectedOrg.id !== currentlySelectedOrg?.id) {
-        navigate({ pathname: APP_PATHS.HOME, search: `organizationId=${newlySelectedOrg.id}` });
+        void navigate({ pathname: APP_PATHS.HOME, search: `organizationId=${newlySelectedOrg.id}` });
       }
       return newlySelectedOrg;
     });

--- a/src/components/OrganizationsDropdown.tsx
+++ b/src/components/OrganizationsDropdown.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { DropdownItem, PopoverMenu } from '@terraware/web-components';
 
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
 import strings from 'src/strings';
 import { Organization } from 'src/types/Organization';

--- a/src/components/PlantsPrimaryPage/index.tsx
+++ b/src/components/PlantsPrimaryPage/index.tsx
@@ -118,7 +118,7 @@ export default function PlantsPrimaryPage({
           onSelect(site);
           setSelectedPlantingSite(site);
         } else {
-          navigate(pagePath.replace(':plantingSiteId', site.id.toString()));
+          void navigate(pagePath.replace(':plantingSiteId', site.id.toString()));
         }
       }
     },

--- a/src/components/PlantsPrimaryPage/index.tsx
+++ b/src/components/PlantsPrimaryPage/index.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import _ from 'lodash';
 
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
 import { CachedUserService, PreferencesService, TrackingService } from 'src/services';
 import strings from 'src/strings';

--- a/src/components/PlantsPrimaryPage/index.tsx
+++ b/src/components/PlantsPrimaryPage/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import _ from 'lodash';
 
@@ -64,7 +65,7 @@ export default function PlantsPrimaryPage({
   const [selectedPlantingSite, setSelectedPlantingSite] = useState<PlantingSite>();
   const [plantingSites, setPlantingSites] = useState<PlantingSite[]>();
   const { plantingSiteId } = useParams<{ plantingSiteId: string }>();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
   const { activeLocale } = useLocalization();
 
@@ -118,7 +119,7 @@ export default function PlantsPrimaryPage({
           onSelect(site);
           setSelectedPlantingSite(site);
         } else {
-          void navigate(pagePath.replace(':plantingSiteId', site.id.toString()));
+          navigate(pagePath.replace(':plantingSiteId', site.id.toString()));
         }
       }
     },

--- a/src/components/ProjectEditView/index.tsx
+++ b/src/components/ProjectEditView/index.tsx
@@ -44,7 +44,7 @@ export default function ProjectEditView(): JSX.Element {
 
   const goToProject = useCallback(() => {
     if (pathParams.projectId) {
-      navigate(getLocation(APP_PATHS.PROJECT_VIEW.replace(':projectId', pathParams.projectId), location));
+      void navigate(getLocation(APP_PATHS.PROJECT_VIEW.replace(':projectId', pathParams.projectId), location));
     }
   }, [navigate, location, pathParams.projectId]);
 

--- a/src/components/ProjectEditView/index.tsx
+++ b/src/components/ProjectEditView/index.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Typography } from '@mui/material';
 
 import ProjectForm from 'src/components/ProjectNewView/flow/ProjectForm';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { requestProjectUpdate } from 'src/redux/features/projects/projectsAsyncThunks';
 import { selectProject, selectProjectRequest } from 'src/redux/features/projects/projectsSelectors';
 import { requestProject } from 'src/redux/features/projects/projectsThunks';

--- a/src/components/ProjectEditView/index.tsx
+++ b/src/components/ProjectEditView/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Typography } from '@mui/material';
 
@@ -19,7 +20,7 @@ export default function ProjectEditView(): JSX.Element {
   const dispatch = useAppDispatch();
 
   const snackbar = useSnackbar();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const pathParams = useParams<{ projectId: string }>();
   const projectId = Number(pathParams.projectId);
@@ -44,7 +45,7 @@ export default function ProjectEditView(): JSX.Element {
 
   const goToProject = useCallback(() => {
     if (pathParams.projectId) {
-      void navigate(getLocation(APP_PATHS.PROJECT_VIEW.replace(':projectId', pathParams.projectId), location));
+      navigate(getLocation(APP_PATHS.PROJECT_VIEW.replace(':projectId', pathParams.projectId), location));
     }
   }, [navigate, location, pathParams.projectId]);
 

--- a/src/components/ProjectNewView/index.tsx
+++ b/src/components/ProjectNewView/index.tsx
@@ -49,7 +49,7 @@ export default function ProjectNewView({ reloadData }: ProjectNewViewProps): JSX
   const [projectPlantingSites, setProjectPlantingSites] = useState<PlantingSiteSearchResult[]>([]);
 
   const goToProjects = useCallback(() => {
-    navigate({ pathname: APP_PATHS.PROJECTS });
+    void navigate({ pathname: APP_PATHS.PROJECTS });
   }, [navigate]);
 
   const saveProject = useCallback(async () => {

--- a/src/components/ProjectNewView/index.tsx
+++ b/src/components/ProjectNewView/index.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Typography } from '@mui/material';
 import { FormButton, theme } from '@terraware/web-components';
 
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
 import { SearchResponseBatches } from 'src/services/NurseryBatchService';
 import ProjectsService from 'src/services/ProjectsService';

--- a/src/components/ProjectNewView/index.tsx
+++ b/src/components/ProjectNewView/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Typography } from '@mui/material';
 import { FormButton, theme } from '@terraware/web-components';
@@ -32,7 +32,7 @@ type ProjectNewViewProps = {
 export default function ProjectNewView({ reloadData }: ProjectNewViewProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const snackbar = useSnackbar();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
 
   const [record, setRecord] = useForm<CreateProjectRequest>({
     name: '',
@@ -49,7 +49,7 @@ export default function ProjectNewView({ reloadData }: ProjectNewViewProps): JSX
   const [projectPlantingSites, setProjectPlantingSites] = useState<PlantingSiteSearchResult[]>([]);
 
   const goToProjects = useCallback(() => {
-    void navigate({ pathname: APP_PATHS.PROJECTS });
+    navigate({ pathname: APP_PATHS.PROJECTS });
   }, [navigate]);
 
   const saveProject = useCallback(async () => {

--- a/src/components/ProjectView/index.tsx
+++ b/src/components/ProjectView/index.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid } from '@mui/material';
 import { DropdownItem } from '@terraware/web-components';
@@ -13,6 +12,7 @@ import OptionsMenu from 'src/components/common/OptionsMenu';
 import TextField from 'src/components/common/Textfield/Textfield';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
 import { requestProjectDelete } from 'src/redux/features/projects/projectsAsyncThunks';
 import { selectProject, selectProjectRequest } from 'src/redux/features/projects/projectsSelectors';

--- a/src/components/ProjectView/index.tsx
+++ b/src/components/ProjectView/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid } from '@mui/material';
 import { DropdownItem } from '@terraware/web-components';
@@ -25,7 +26,7 @@ export default function ProjectView(): JSX.Element {
   const dispatch = useAppDispatch();
 
   const snackbar = useSnackbar();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const { activeLocale } = useLocalization();
   const { selectedOrganization } = useOrganization();
@@ -60,7 +61,7 @@ export default function ProjectView(): JSX.Element {
 
   const goToEditProject = useCallback(() => {
     if (pathParams.projectId) {
-      void navigate(getLocation(APP_PATHS.PROJECT_EDIT.replace(':projectId', pathParams.projectId), location));
+      navigate(getLocation(APP_PATHS.PROJECT_EDIT.replace(':projectId', pathParams.projectId), location));
     }
   }, [navigate, location, pathParams.projectId]);
 

--- a/src/components/ProjectView/index.tsx
+++ b/src/components/ProjectView/index.tsx
@@ -60,7 +60,7 @@ export default function ProjectView(): JSX.Element {
 
   const goToEditProject = useCallback(() => {
     if (pathParams.projectId) {
-      navigate(getLocation(APP_PATHS.PROJECT_EDIT.replace(':projectId', pathParams.projectId), location));
+      void navigate(getLocation(APP_PATHS.PROJECT_EDIT.replace(':projectId', pathParams.projectId), location));
     }
   }, [navigate, location, pathParams.projectId]);
 

--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -70,7 +70,7 @@ export default function ProjectsList(): JSX.Element {
     const newProjectLocation = {
       pathname: APP_PATHS.PROJECTS_NEW,
     };
-    navigate(newProjectLocation);
+    void navigate(newProjectLocation);
   };
 
   const clearSearch = () => {

--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, useTheme } from '@mui/material';
 
@@ -13,6 +12,7 @@ import Button from 'src/components/common/button/Button';
 import Table from 'src/components/common/table';
 import { TableColumnType } from 'src/components/common/table/types';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
 import ProjectsService from 'src/services/ProjectsService';
 import strings from 'src/strings';

--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, useTheme } from '@mui/material';
 
@@ -31,7 +31,7 @@ const columns = (): TableColumnType[] => [
 export default function ProjectsList(): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const [temporalSearchValue, setTemporalSearchValue] = useState('');
   const debouncedSearchTerm = useDebounce(temporalSearchValue, 250);
   const [results, setResults] = useState<Project[]>();
@@ -70,7 +70,7 @@ export default function ProjectsList(): JSX.Element {
     const newProjectLocation = {
       pathname: APP_PATHS.PROJECTS_NEW,
     };
-    void navigate(newProjectLocation);
+    navigate(newProjectLocation);
   };
 
   const clearSearch = () => {

--- a/src/components/SeedFundReports/PreSetupView.tsx
+++ b/src/components/SeedFundReports/PreSetupView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, useTheme } from '@mui/material';
 
@@ -11,12 +11,12 @@ import strings from 'src/strings';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 
 const PreSetupView = () => {
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
 
   const goToSettings = () => {
-    void navigate({
+    navigate({
       pathname: APP_PATHS.SEED_FUND_REPORTS_SETTINGS_EDIT,
     });
   };

--- a/src/components/SeedFundReports/PreSetupView.tsx
+++ b/src/components/SeedFundReports/PreSetupView.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, useTheme } from '@mui/material';
 
@@ -7,6 +6,7 @@ import PageHeader from 'src/components/PageHeader';
 import TfMain from 'src/components/common/TfMain';
 import EmptyStateContent from 'src/components/emptyStatePages/EmptyStateContent';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import strings from 'src/strings';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 

--- a/src/components/SeedFundReports/PreSetupView.tsx
+++ b/src/components/SeedFundReports/PreSetupView.tsx
@@ -16,7 +16,7 @@ const PreSetupView = () => {
   const theme = useTheme();
 
   const goToSettings = () => {
-    navigate({
+    void navigate({
       pathname: APP_PATHS.SEED_FUND_REPORTS_SETTINGS_EDIT,
     });
   };

--- a/src/components/SeedFundReports/ReportEdit.tsx
+++ b/src/components/SeedFundReports/ReportEdit.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { BusySpinner, FormButton } from '@terraware/web-components';
@@ -32,7 +33,7 @@ export default function ReportEdit(): JSX.Element {
   const { user } = useUser();
   const theme = useTheme();
 
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
 
   const snackbar = useSnackbar();
 
@@ -154,7 +155,7 @@ export default function ReportEdit(): JSX.Element {
 
       // then navigate to view
       if (reportId) {
-        void navigate({ pathname: APP_PATHS.SEED_FUND_REPORTS_VIEW.replace(':reportId', reportId) });
+        navigate({ pathname: APP_PATHS.SEED_FUND_REPORTS_VIEW.replace(':reportId', reportId) });
       }
     }
   };
@@ -351,7 +352,7 @@ export default function ReportEdit(): JSX.Element {
         const submitResult = await SeedFundReportService.submitReport(reportIdInt);
         if (submitResult.requestSucceeded && reportId && selectedOrganization.id !== -1) {
           reloadOrganizations(selectedOrganization.id);
-          void navigate(
+          navigate(
             { pathname: APP_PATHS.SEED_FUND_REPORTS_VIEW.replace(':reportId', reportId) },
             { replace: true }
           );
@@ -397,7 +398,7 @@ export default function ReportEdit(): JSX.Element {
 
   const redirectToReportView = () => {
     if (reportId) {
-      void navigate(APP_PATHS.SEED_FUND_REPORTS_VIEW.replace(':reportId', reportId));
+      navigate(APP_PATHS.SEED_FUND_REPORTS_VIEW.replace(':reportId', reportId));
     }
   };
 

--- a/src/components/SeedFundReports/ReportEdit.tsx
+++ b/src/components/SeedFundReports/ReportEdit.tsx
@@ -154,7 +154,7 @@ export default function ReportEdit(): JSX.Element {
 
       // then navigate to view
       if (reportId) {
-        navigate({ pathname: APP_PATHS.SEED_FUND_REPORTS_VIEW.replace(':reportId', reportId) });
+        void navigate({ pathname: APP_PATHS.SEED_FUND_REPORTS_VIEW.replace(':reportId', reportId) });
       }
     }
   };
@@ -351,7 +351,10 @@ export default function ReportEdit(): JSX.Element {
         const submitResult = await SeedFundReportService.submitReport(reportIdInt);
         if (submitResult.requestSucceeded && reportId && selectedOrganization.id !== -1) {
           reloadOrganizations(selectedOrganization.id);
-          navigate({ pathname: APP_PATHS.SEED_FUND_REPORTS_VIEW.replace(':reportId', reportId) }, { replace: true });
+          void navigate(
+            { pathname: APP_PATHS.SEED_FUND_REPORTS_VIEW.replace(':reportId', reportId) },
+            { replace: true }
+          );
         } else {
           snackbar.toastError(strings.GENERIC_ERROR, strings.REPORT_COULD_NOT_SUBMIT);
         }
@@ -394,7 +397,7 @@ export default function ReportEdit(): JSX.Element {
 
   const redirectToReportView = () => {
     if (reportId) {
-      navigate(APP_PATHS.SEED_FUND_REPORTS_VIEW.replace(':reportId', reportId));
+      void navigate(APP_PATHS.SEED_FUND_REPORTS_VIEW.replace(':reportId', reportId));
     }
   };
 

--- a/src/components/SeedFundReports/ReportEdit.tsx
+++ b/src/components/SeedFundReports/ReportEdit.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { BusySpinner, FormButton } from '@terraware/web-components';
@@ -18,6 +17,7 @@ import SubmitConfirmationDialog from 'src/components/SeedFundReports/SubmitConfi
 import PageForm from 'src/components/common/PageForm';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization, useUser } from 'src/providers';
 import SeedFundReportService from 'src/services/SeedFundReportService';
 import strings from 'src/strings';
@@ -352,10 +352,7 @@ export default function ReportEdit(): JSX.Element {
         const submitResult = await SeedFundReportService.submitReport(reportIdInt);
         if (submitResult.requestSucceeded && reportId && selectedOrganization.id !== -1) {
           reloadOrganizations(selectedOrganization.id);
-          navigate(
-            { pathname: APP_PATHS.SEED_FUND_REPORTS_VIEW.replace(':reportId', reportId) },
-            { replace: true }
-          );
+          navigate({ pathname: APP_PATHS.SEED_FUND_REPORTS_VIEW.replace(':reportId', reportId) }, { replace: true });
         } else {
           snackbar.toastError(strings.GENERIC_ERROR, strings.REPORT_COULD_NOT_SUBMIT);
         }

--- a/src/components/SeedFundReports/ReportSettingsEditForm.tsx
+++ b/src/components/SeedFundReports/ReportSettingsEditForm.tsx
@@ -41,7 +41,7 @@ const ReportSettingsEditForm = ({ reportsSettings, isEditing }: ReportSettingsEd
         return;
       }
 
-      navigate(APP_PATHS.SEED_FUND_REPORTS_SETTINGS);
+      void navigate(APP_PATHS.SEED_FUND_REPORTS_SETTINGS);
     }
   }, [navigate, localReportsSettings, selectedOrganization.id, snackbar]);
 

--- a/src/components/SeedFundReports/ReportSettingsEditForm.tsx
+++ b/src/components/SeedFundReports/ReportSettingsEditForm.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid } from '@mui/material';
 import { useDeviceInfo } from '@terraware/web-components/utils';
@@ -21,7 +21,7 @@ interface ReportSettingsEditFormProps {
 const ReportSettingsEditForm = ({ reportsSettings, isEditing }: ReportSettingsEditFormProps) => {
   const { isMobile } = useDeviceInfo();
   const { selectedOrganization } = useOrganization();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
 
   const [localReportsSettings, setLocalReportsSettings] = useState(reportsSettings);
@@ -41,7 +41,7 @@ const ReportSettingsEditForm = ({ reportsSettings, isEditing }: ReportSettingsEd
         return;
       }
 
-      void navigate(APP_PATHS.SEED_FUND_REPORTS_SETTINGS);
+      navigate(APP_PATHS.SEED_FUND_REPORTS_SETTINGS);
     }
   }, [navigate, localReportsSettings, selectedOrganization.id, snackbar]);
 

--- a/src/components/SeedFundReports/ReportSettingsEditForm.tsx
+++ b/src/components/SeedFundReports/ReportSettingsEditForm.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid } from '@mui/material';
 import { useDeviceInfo } from '@terraware/web-components/utils';
 
 import PageForm from 'src/components/common/PageForm';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers';
 import ReportSettingsService, { ReportsSettings } from 'src/services/ReportSettingsService';
 import useSnackbar from 'src/utils/useSnackbar';

--- a/src/components/SeedFundReports/ReportSettingsEditFormFields.tsx
+++ b/src/components/SeedFundReports/ReportSettingsEditFormFields.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 import { Button, Checkbox } from '@terraware/web-components';
@@ -30,7 +30,7 @@ interface ReportsSettingsCheckboxConfig {
 const ReportSettingsEditFormFields = ({ isEditing, onChange, reportsSettings }: ReportSettingsEditFormFieldsProps) => {
   const dispatch = useAppDispatch();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { selectedOrganization } = useOrganization();
 
   const projects = useAppSelector(selectProjects);

--- a/src/components/SeedFundReports/ReportSettingsEditFormFields.tsx
+++ b/src/components/SeedFundReports/ReportSettingsEditFormFields.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useEffect } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 import { Button, Checkbox } from '@terraware/web-components';
 
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers';
 import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
 import { requestProjects } from 'src/redux/features/projects/projectsThunks';

--- a/src/components/SeedFundReports/ReportView.tsx
+++ b/src/components/SeedFundReports/ReportView.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Button } from '@terraware/web-components';
@@ -23,7 +24,7 @@ export default function ReportView(): JSX.Element {
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
 
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
 
   const snackbar = useSnackbar();
 
@@ -60,7 +61,7 @@ export default function ReportView(): JSX.Element {
 
       if (lockResult.requestSucceeded && reportId) {
         // then navigate to editing
-        void navigate({ pathname: APP_PATHS.SEED_FUND_REPORTS_EDIT.replace(':reportId', reportId) });
+        navigate({ pathname: APP_PATHS.SEED_FUND_REPORTS_EDIT.replace(':reportId', reportId) });
       } else {
         snackbar.toastError(strings.GENERIC_ERROR, strings.REPORT_COULD_NOT_EDIT);
       }

--- a/src/components/SeedFundReports/ReportView.tsx
+++ b/src/components/SeedFundReports/ReportView.tsx
@@ -60,7 +60,7 @@ export default function ReportView(): JSX.Element {
 
       if (lockResult.requestSucceeded && reportId) {
         // then navigate to editing
-        navigate({ pathname: APP_PATHS.SEED_FUND_REPORTS_EDIT.replace(':reportId', reportId) });
+        void navigate({ pathname: APP_PATHS.SEED_FUND_REPORTS_EDIT.replace(':reportId', reportId) });
       } else {
         snackbar.toastError(strings.GENERIC_ERROR, strings.REPORT_COULD_NOT_EDIT);
       }

--- a/src/components/SeedFundReports/ReportView.tsx
+++ b/src/components/SeedFundReports/ReportView.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Button } from '@terraware/web-components';
@@ -11,6 +10,7 @@ import useReportFiles from 'src/components/SeedFundReports/useReportFiles';
 import BackToLink from 'src/components/common/BackToLink';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import SeedFundReportService from 'src/services/SeedFundReportService';
 import strings from 'src/strings';
 import { Report } from 'src/types/Report';

--- a/src/components/SeedFundReports/ReportsView.tsx
+++ b/src/components/SeedFundReports/ReportsView.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, Grid, List, ListItem, Typography, useTheme } from '@mui/material';
 import { Message, TableColumnType, Tabs } from '@terraware/web-components';
@@ -12,6 +11,7 @@ import ReportsCellRenderer from 'src/components/SeedFundReports/TableCellRendere
 import TfMain from 'src/components/common/TfMain';
 import Table from 'src/components/common/table';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers';
 import { selectReportsSettings } from 'src/redux/features/reportsSettings/reportsSettingsSelectors';
 import { requestReportsSettings } from 'src/redux/features/reportsSettings/reportsSettingsThunks';

--- a/src/components/SeedFundReports/ReportsView.tsx
+++ b/src/components/SeedFundReports/ReportsView.tsx
@@ -58,11 +58,11 @@ export default function ReportsView(props: ReportsViewProps): JSX.Element {
 
       switch (newTab) {
         case 'reports': {
-          navigate(APP_PATHS.SEED_FUND_REPORTS);
+          void navigate(APP_PATHS.SEED_FUND_REPORTS);
           break;
         }
         case 'settings': {
-          navigate(APP_PATHS.SEED_FUND_REPORTS_SETTINGS);
+          void navigate(APP_PATHS.SEED_FUND_REPORTS_SETTINGS);
         }
       }
     },

--- a/src/components/SeedFundReports/ReportsView.tsx
+++ b/src/components/SeedFundReports/ReportsView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, Grid, List, ListItem, Typography, useTheme } from '@mui/material';
 import { Message, TableColumnType, Tabs } from '@terraware/web-components';
@@ -45,7 +45,7 @@ export default function ReportsView(props: ReportsViewProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
 
   const reportsSettings = useAppSelector(selectReportsSettings);
 
@@ -58,11 +58,11 @@ export default function ReportsView(props: ReportsViewProps): JSX.Element {
 
       switch (newTab) {
         case 'reports': {
-          void navigate(APP_PATHS.SEED_FUND_REPORTS);
+          navigate(APP_PATHS.SEED_FUND_REPORTS);
           break;
         }
         case 'settings': {
-          void navigate(APP_PATHS.SEED_FUND_REPORTS_SETTINGS);
+          navigate(APP_PATHS.SEED_FUND_REPORTS_SETTINGS);
         }
       }
     },

--- a/src/components/SmallDeviceUserMenu.tsx
+++ b/src/components/SmallDeviceUserMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import {
   Box,
@@ -40,7 +40,7 @@ export default function SmallDeviceUserMenu({
     useOrganization();
   const { user } = useUser();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const [newOrganizationModalOpened, setNewOrganizationModalOpened] = useState(false);
   const [open, setOpen] = React.useState(false);
   const anchorRef = React.useRef<HTMLButtonElement>(null);
@@ -68,7 +68,7 @@ export default function SmallDeviceUserMenu({
   };
 
   const navigateTo = (url: string) => {
-    void navigate(url);
+    navigate(url);
   };
 
   const handleToggle = () => {
@@ -101,7 +101,7 @@ export default function SmallDeviceUserMenu({
   const selectOrganization = (newlySelectedOrg: Organization) => {
     setSelectedOrganization((currentlySelectedOrg: Organization | undefined) => {
       if (newlySelectedOrg.id !== currentlySelectedOrg?.id) {
-        void navigate({ pathname: APP_PATHS.HOME, search: `organizationId=${newlySelectedOrg.id}` });
+        navigate({ pathname: APP_PATHS.HOME, search: `organizationId=${newlySelectedOrg.id}` });
       }
       return newlySelectedOrg;
     });

--- a/src/components/SmallDeviceUserMenu.tsx
+++ b/src/components/SmallDeviceUserMenu.tsx
@@ -68,7 +68,7 @@ export default function SmallDeviceUserMenu({
   };
 
   const navigateTo = (url: string) => {
-    navigate(url);
+    void navigate(url);
   };
 
   const handleToggle = () => {
@@ -101,7 +101,7 @@ export default function SmallDeviceUserMenu({
   const selectOrganization = (newlySelectedOrg: Organization) => {
     setSelectedOrganization((currentlySelectedOrg: Organization | undefined) => {
       if (newlySelectedOrg.id !== currentlySelectedOrg?.id) {
-        navigate({ pathname: APP_PATHS.HOME, search: `organizationId=${newlySelectedOrg.id}` });
+        void navigate({ pathname: APP_PATHS.HOME, search: `organizationId=${newlySelectedOrg.id}` });
       }
       return newlySelectedOrg;
     });

--- a/src/components/SmallDeviceUserMenu.tsx
+++ b/src/components/SmallDeviceUserMenu.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { useEffect, useRef } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import {
   Box,
@@ -18,6 +17,7 @@ import {
 } from '@mui/material';
 
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useUser } from 'src/providers';
 import { useOrganization } from 'src/providers/hooks';
 import strings from 'src/strings';

--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -72,7 +72,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
 
   const handleTopBarClick = () => {
     mixpanel?.track(MIXPANEL_EVENTS.TOP_BAR_HOME);
-    navigate(APP_PATHS.HOME);
+    void navigate(APP_PATHS.HOME);
   };
 
   return isDesktop ? (

--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, IconButton, useTheme } from '@mui/material';
 import { Svg } from '@terraware/web-components';
@@ -29,7 +29,7 @@ type TopBarProps = {
 };
 
 export default function TopBarContent(props: TopBarProps): JSX.Element | null {
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const theme = useTheme();
   const { selectedOrganization, organizations, reloadOrganizations } = useOrganization();
   const { userFundingEntity } = useUserFundingEntity();
@@ -72,7 +72,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
 
   const handleTopBarClick = () => {
     mixpanel?.track(MIXPANEL_EVENTS.TOP_BAR_HOME);
-    void navigate(APP_PATHS.HOME);
+    navigate(APP_PATHS.HOME);
   };
 
   return isDesktop ? (

--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, IconButton, useTheme } from '@mui/material';
 import { Svg } from '@terraware/web-components';
@@ -18,6 +17,7 @@ import { APP_PATHS } from 'src/constants';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import useApplicationPortal from 'src/hooks/useApplicationPortal';
 import useFunderPortal from 'src/hooks/useFunderPortal';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useOrganization, useUser, useUserFundingEntity } from 'src/providers/hooks';
 import useDeviceInfo from 'src/utils/useDeviceInfo';

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -35,7 +35,7 @@ export default function UserMenu(): JSX.Element {
         break;
       }
       default: {
-        navigate(selectedItem.value);
+        void navigate(selectedItem.value);
         break;
       }
     }

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { useTheme } from '@mui/material';
 import { DropdownItem, PopoverMenu } from '@terraware/web-components';
@@ -15,7 +15,7 @@ export default function UserMenu(): JSX.Element {
   const theme = useTheme();
   const { user } = useUser();
   const { isProduction } = useEnvironment();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const docLinks = useDocLinks();
   const mixpanel = useMixpanel();
 
@@ -35,7 +35,7 @@ export default function UserMenu(): JSX.Element {
         break;
       }
       default: {
-        void navigate(selectedItem.value);
+        navigate(selectedItem.value);
         break;
       }
     }

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,12 +1,12 @@
 import React, { useMemo } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { useTheme } from '@mui/material';
 import { DropdownItem, PopoverMenu } from '@terraware/web-components';
 
 import { APP_PATHS } from 'src/constants';
 import { useDocLinks } from 'src/docLinks';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useUser } from 'src/providers';
 import strings from 'src/strings';
 import useEnvironment from 'src/utils/useEnvironment';

--- a/src/components/common/PageCard.tsx
+++ b/src/components/common/PageCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 
@@ -35,11 +35,11 @@ const stopBubblingEvent = (event?: React.MouseEvent) => {
 export default function PageCard(props: PageCardProps): JSX.Element {
   const { cardIsClickable = true, description, icon, id, link, linkStyle, linkText, name, onClick } = props;
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { isMobile } = useDeviceInfo();
 
   const goToPage = () => {
-    void navigate({ pathname: link });
+    navigate({ pathname: link });
   };
 
   const handleOnClick = () => {

--- a/src/components/common/PageCard.tsx
+++ b/src/components/common/PageCard.tsx
@@ -39,7 +39,7 @@ export default function PageCard(props: PageCardProps): JSX.Element {
   const { isMobile } = useDeviceInfo();
 
   const goToPage = () => {
-    navigate({ pathname: link });
+    void navigate({ pathname: link });
   };
 
   const handleOnClick = () => {

--- a/src/components/common/PageCard.tsx
+++ b/src/components/common/PageCard.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 
 import Button from 'src/components/common/button/Button';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import stopPropagation from 'src/utils/stopPropagationEvent';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 

--- a/src/components/emptyStatePages/EmptyStatePage.tsx
+++ b/src/components/emptyStatePages/EmptyStatePage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, useTheme } from '@mui/material';
 
@@ -39,14 +39,14 @@ export default function EmptyStatePage({ pageName, reloadData }: EmptyStatePageP
   const { selectedOrganization } = useOrganization();
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
 
   const goToNewLocation = () => {
     const newLocation = {
       pathname: content.linkLocation,
     };
-    void navigate(newLocation);
+    navigate(newLocation);
   };
 
   const downloadCsvTemplateHandler = () => {
@@ -92,7 +92,7 @@ export default function EmptyStatePage({ pageName, reloadData }: EmptyStatePageP
         buttonText: strings.ADD_SPECIES,
         buttonIcon: 'plus',
         onClickButton: () => {
-          void navigate(APP_PATHS.SPECIES_NEW);
+          navigate(APP_PATHS.SPECIES_NEW);
         },
       },
     ],
@@ -121,7 +121,7 @@ export default function EmptyStatePage({ pageName, reloadData }: EmptyStatePageP
         buttonText: strings.ADD_INVENTORY,
         buttonIcon: 'plus',
         onClickButton: () => {
-          void navigate(APP_PATHS.INVENTORY_NEW);
+          navigate(APP_PATHS.INVENTORY_NEW);
         },
       },
     ],
@@ -222,7 +222,7 @@ export default function EmptyStatePage({ pageName, reloadData }: EmptyStatePageP
       if (reloadData) {
         reloadData();
       }
-      void navigate({ pathname: APP_PATHS.SPECIES, search: '?checkData' });
+      navigate({ pathname: APP_PATHS.SPECIES, search: '?checkData' });
     }
     setImportSpeciesModalOpened(false);
     if (snackbarMessage) {
@@ -235,7 +235,7 @@ export default function EmptyStatePage({ pageName, reloadData }: EmptyStatePageP
       if (reloadData) {
         reloadData();
       }
-      void navigate(APP_PATHS.INVENTORY);
+      navigate(APP_PATHS.INVENTORY);
     }
     setImportInventoryModalOpened(false);
     if (snackbarMessage) {

--- a/src/components/emptyStatePages/EmptyStatePage.tsx
+++ b/src/components/emptyStatePages/EmptyStatePage.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, useTheme } from '@mui/material';
 
@@ -8,6 +7,7 @@ import EmptyMessage from 'src/components/common/EmptyMessage';
 import { IconName } from 'src/components/common/icon/icons';
 import EmptyStateContent, { ListItemContent } from 'src/components/emptyStatePages/EmptyStateContent';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
 import ImportInventoryModal, { downloadInventoryCsvTemplate } from 'src/scenes/InventoryRouter/ImportInventoryModal';
 import PlantingSiteTypeSelect from 'src/scenes/PlantingSitesRouter/edit/PlantingSiteTypeSelect';

--- a/src/components/emptyStatePages/EmptyStatePage.tsx
+++ b/src/components/emptyStatePages/EmptyStatePage.tsx
@@ -46,7 +46,7 @@ export default function EmptyStatePage({ pageName, reloadData }: EmptyStatePageP
     const newLocation = {
       pathname: content.linkLocation,
     };
-    navigate(newLocation);
+    void navigate(newLocation);
   };
 
   const downloadCsvTemplateHandler = () => {
@@ -92,7 +92,7 @@ export default function EmptyStatePage({ pageName, reloadData }: EmptyStatePageP
         buttonText: strings.ADD_SPECIES,
         buttonIcon: 'plus',
         onClickButton: () => {
-          navigate(APP_PATHS.SPECIES_NEW);
+          void navigate(APP_PATHS.SPECIES_NEW);
         },
       },
     ],
@@ -121,7 +121,7 @@ export default function EmptyStatePage({ pageName, reloadData }: EmptyStatePageP
         buttonText: strings.ADD_INVENTORY,
         buttonIcon: 'plus',
         onClickButton: () => {
-          navigate(APP_PATHS.INVENTORY_NEW);
+          void navigate(APP_PATHS.INVENTORY_NEW);
         },
       },
     ],
@@ -222,7 +222,7 @@ export default function EmptyStatePage({ pageName, reloadData }: EmptyStatePageP
       if (reloadData) {
         reloadData();
       }
-      navigate({ pathname: APP_PATHS.SPECIES, search: '?checkData' });
+      void navigate({ pathname: APP_PATHS.SPECIES, search: '?checkData' });
     }
     setImportSpeciesModalOpened(false);
     if (snackbarMessage) {
@@ -235,7 +235,7 @@ export default function EmptyStatePage({ pageName, reloadData }: EmptyStatePageP
       if (reloadData) {
         reloadData();
       }
-      navigate(APP_PATHS.INVENTORY);
+      void navigate(APP_PATHS.INVENTORY);
     }
     setImportInventoryModalOpened(false);
     if (snackbarMessage) {

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, CircularProgress, Container, Grid, useTheme } from '@mui/material';
 import { DropdownItem, Message } from '@terraware/web-components';
@@ -20,6 +19,7 @@ import { BaseTable as Table } from 'src/components/common/table';
 import { SortOrder as Order } from 'src/components/common/table/sort';
 import { APP_PATHS } from 'src/constants';
 import useNavigateTo from 'src/hooks/useNavigateTo';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization, useUser } from 'src/providers/hooks';
 import { selectMessage } from 'src/redux/features/message/messageSelectors';
 import { sendMessage } from 'src/redux/features/message/messageSlice';

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -301,7 +301,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
     }
 
     if ((facilityId && selectedOrganization) || subLocationName) {
-      navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+      void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
       setSearchCriteria(newSearchCriteria);
 
       // add seed bank and sub-location columns to show the filtered values as needed
@@ -470,7 +470,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
         // eslint-disable-next-line no-restricted-globals
         state: { from: location.pathname },
       };
-      navigate(seedCollectionLocation);
+      void navigate(seedCollectionLocation);
     }
   };
 
@@ -518,14 +518,14 @@ export default function Database(props: DatabaseProps): JSX.Element {
   };
 
   const handleViewCollections = () => {
-    navigate(APP_PATHS.CHECKIN);
+    void navigate(APP_PATHS.CHECKIN);
   };
 
   const goTo = (appPath: string) => {
     const appPathLocation = {
       pathname: appPath,
     };
-    navigate(appPathLocation);
+    void navigate(appPathLocation);
   };
 
   const onSeedBankForImportSelected = (selectedFacilityOnModal: Facility | undefined) => {

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Link, useNavigate } from 'react-router';
+import { Link } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, CircularProgress, Container, Grid, useTheme } from '@mui/material';
 import { DropdownItem, Message } from '@terraware/web-components';
@@ -95,7 +96,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
   const { reloadUserPreferences } = useUser();
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const query = useQuery();
   const location = useStateLocation();
   const { sessionFilters, setSessionFilters } = useSessionFilters('accessions');
@@ -301,7 +302,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
     }
 
     if ((facilityId && selectedOrganization) || subLocationName) {
-      void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+      navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
       setSearchCriteria(newSearchCriteria);
 
       // add seed bank and sub-location columns to show the filtered values as needed
@@ -470,7 +471,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
         // eslint-disable-next-line no-restricted-globals
         state: { from: location.pathname },
       };
-      void navigate(seedCollectionLocation);
+      navigate(seedCollectionLocation);
     }
   };
 
@@ -518,14 +519,14 @@ export default function Database(props: DatabaseProps): JSX.Element {
   };
 
   const handleViewCollections = () => {
-    void navigate(APP_PATHS.CHECKIN);
+    navigate(APP_PATHS.CHECKIN);
   };
 
   const goTo = (appPath: string) => {
     const appPathLocation = {
       pathname: appPath,
     };
-    void navigate(appPathLocation);
+    navigate(appPathLocation);
   };
 
   const onSeedBankForImportSelected = (selectedFacilityOnModal: Facility | undefined) => {

--- a/src/hooks/useNavigateTo.ts
+++ b/src/hooks/useNavigateTo.ts
@@ -28,7 +28,9 @@ export default function useNavigateTo() {
       },
 
       goToAcceleratorApplicationMap: (applicationId: number) => {
-        void navigate({ pathname: APP_PATHS.ACCELERATOR_APPLICATION_MAP.replace(':applicationId', `${applicationId}`) });
+        void navigate({
+          pathname: APP_PATHS.ACCELERATOR_APPLICATION_MAP.replace(':applicationId', `${applicationId}`),
+        });
       },
 
       goToAcceleratorProject: (projectId: number) => {

--- a/src/hooks/useNavigateTo.ts
+++ b/src/hooks/useNavigateTo.ts
@@ -1,25 +1,26 @@
 import { useMemo } from 'react';
-import { useNavigate } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
 import { ModuleContentType } from 'src/types/Module';
 import { SupportRequestType, getSupportRequestSubpath } from 'src/types/Support';
 
+import { useSyncNavigate } from './useSyncNavigate';
+
 export default function useNavigateTo() {
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
 
   return useMemo(
     () => ({
       goToAccelerator: () => {
-        void navigate({ pathname: APP_PATHS.ACCELERATOR });
+        navigate({ pathname: APP_PATHS.ACCELERATOR });
       },
 
       goToAcceleratorApplication: (applicationId: number) => {
-        void navigate({ pathname: APP_PATHS.ACCELERATOR_APPLICATION.replace(':applicationId', `${applicationId}`) });
+        navigate({ pathname: APP_PATHS.ACCELERATOR_APPLICATION.replace(':applicationId', `${applicationId}`) });
       },
 
       goToAcceleratorApplicationDeliverable: (applicationId: number, deliverableId: number) => {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.ACCELERATOR_APPLICATION_DELIVERABLE.replace(':applicationId', `${applicationId}`).replace(
             ':deliverableId',
             `${deliverableId}`
@@ -28,81 +29,81 @@ export default function useNavigateTo() {
       },
 
       goToAcceleratorApplicationMap: (applicationId: number) => {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.ACCELERATOR_APPLICATION_MAP.replace(':applicationId', `${applicationId}`),
         });
       },
 
       goToAcceleratorProject: (projectId: number) => {
-        void navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_VOTES.replace(':projectId', `${projectId}`) });
+        navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_VOTES.replace(':projectId', `${projectId}`) });
       },
 
       goToAcceleratorProjectScore: (projectId: number) => {
-        void navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_SCORES.replace(':projectId', `${projectId}`) });
+        navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_SCORES.replace(':projectId', `${projectId}`) });
       },
 
       goToAcceleratorProjectScoreEdit: (projectId: number) => {
-        void navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_SCORES_EDIT.replace(':projectId', `${projectId}`) });
+        navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_SCORES_EDIT.replace(':projectId', `${projectId}`) });
       },
 
       goToAcceleratorProjectVote: (projectId: number) => {
-        void navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_VOTES.replace(':projectId', `${projectId}`) });
+        navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_VOTES.replace(':projectId', `${projectId}`) });
       },
 
       goToAcceleratorProjectVoteEdit: (projectId: number) => {
-        void navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_VOTES_EDIT.replace(':projectId', `${projectId}`) });
+        navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_VOTES_EDIT.replace(':projectId', `${projectId}`) });
       },
 
       goToAcceleratorReport: (reportId: number, projectId: number) =>
-        void navigate({
+        navigate({
           pathname: APP_PATHS.REPORTS_VIEW.replace(':reportId', `${reportId}`).replace(':projectId', `${projectId}`),
         }),
 
       goToAcceleratorReportEdit: (reportId: number, projectId: number) =>
-        void navigate({
+        navigate({
           pathname: APP_PATHS.REPORTS_EDIT.replace(':reportId', `${reportId}`).replace(':projectId', `${projectId}`),
         }),
 
       goToApplication: (applicationId: number) => {
-        void navigate({ pathname: APP_PATHS.APPLICATION_OVERVIEW.replace(':applicationId', `${applicationId}`) });
+        navigate({ pathname: APP_PATHS.APPLICATION_OVERVIEW.replace(':applicationId', `${applicationId}`) });
       },
 
       goToApplicationList: () => {
-        void navigate({ pathname: APP_PATHS.APPLICATIONS });
+        navigate({ pathname: APP_PATHS.APPLICATIONS });
       },
 
       goToApplicationMap: (applicationId: number) => {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.APPLICATION_MAP.replace(':applicationId', `${applicationId}`),
         });
       },
 
       goToApplicationMapUpdate: (applicationId: number) => {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.APPLICATION_MAP_UPDATE.replace(':applicationId', `${applicationId}`),
         });
       },
 
       goToApplicationPrescreen: (applicationId: number) => {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.APPLICATION_PRESCREEN.replace(':applicationId', `${applicationId}`),
         });
       },
 
       goToApplicationPrescreenResult: (applicationId: number) => {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.APPLICATION_PRESCREEN_RESULT.replace(':applicationId', `${applicationId}`),
         });
       },
 
       goToApplicationReview: (applicationId: number) => {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.APPLICATION_REVIEW.replace(':applicationId', `${applicationId}`),
         });
       },
 
       goToApplicationSection: (applicationId: number, sectionId: number) => {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.APPLICATION_SECTION.replace(':applicationId', `${applicationId}`).replace(
             ':sectionId',
             `${sectionId}`
@@ -111,7 +112,7 @@ export default function useNavigateTo() {
       },
 
       goToApplicationSectionDeliverable: (applicationId: number, sectionId: number, deliverableId: number) => {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.APPLICATION_SECTION_DELIVERABLE.replace(':applicationId', `${applicationId}`)
             .replace(':sectionId', `${sectionId}`)
             .replace(':deliverableId', `${deliverableId}`),
@@ -124,7 +125,7 @@ export default function useNavigateTo() {
         deliverableId: number,
         variableId?: number
       ) => {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.APPLICATION_SECTION_DELIVERABLE_EDIT.replace(':applicationId', `${applicationId}`)
             .replace(':sectionId', `${sectionId}`)
             .replace(':deliverableId', `${deliverableId}`),
@@ -133,13 +134,13 @@ export default function useNavigateTo() {
       },
 
       goToContactUsForm: (requestType: SupportRequestType) => {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.HELP_SUPPORT_FORM.replace(':requestType', getSupportRequestSubpath(requestType)),
         });
       },
 
       goToDeliverable: (deliverableId: number, projectId: number) =>
-        void navigate({
+        navigate({
           pathname: APP_PATHS.DELIVERABLE_VIEW.replace(':deliverableId', `${deliverableId}`).replace(
             ':projectId',
             `${projectId}`
@@ -147,7 +148,7 @@ export default function useNavigateTo() {
         }),
 
       goToDeliverableEdit: (deliverableId: number, projectId: number, variableId?: number) =>
-        void navigate({
+        navigate({
           pathname: APP_PATHS.DELIVERABLE_EDIT.replace(':deliverableId', `${deliverableId}`).replace(
             ':projectId',
             `${projectId}`
@@ -156,38 +157,38 @@ export default function useNavigateTo() {
         }),
 
       goToDocuments: () =>
-        void navigate({
+        navigate({
           pathname: APP_PATHS.ACCELERATOR_DOCUMENT_PRODUCER_DOCUMENTS,
         }),
 
       goToDocumentNew: () =>
-        void navigate({
+        navigate({
           pathname: APP_PATHS.ACCELERATOR_DOCUMENT_PRODUCER_DOCUMENT_NEW,
         }),
 
       goToEditFundingEntity: (fundingEntityId: number | string) =>
-        void navigate(APP_PATHS.ACCELERATOR_FUNDING_ENTITIES_EDIT.replace(':fundingEntityId', `${fundingEntityId}`)),
+        navigate(APP_PATHS.ACCELERATOR_FUNDING_ENTITIES_EDIT.replace(':fundingEntityId', `${fundingEntityId}`)),
 
       goToFundingEntities: () => navigate({ pathname: APP_PATHS.ACCELERATOR_FUNDING_ENTITIES }),
 
       goToFundingEntity: (fundingEntityId: number | string) =>
-        void navigate({
+        navigate({
           pathname: APP_PATHS.ACCELERATOR_FUNDING_ENTITIES_VIEW.replace(':fundingEntityId', String(fundingEntityId)),
         }),
 
       goToNewFundingEntity: () => navigate({ pathname: APP_PATHS.ACCELERATOR_FUNDING_ENTITIES_NEW }),
 
       goToHelpSupport: () => {
-        void navigate({ pathname: APP_PATHS.HELP_SUPPORT });
+        navigate({ pathname: APP_PATHS.HELP_SUPPORT });
       },
 
       goToHome: () =>
-        void navigate({
+        navigate({
           pathname: APP_PATHS.HOME,
         }),
 
       goToModule: (projectId: number, moduleId: number) => {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.PROJECT_MODULE.replace(':projectId', `${projectId}`).replace(':moduleId', `${moduleId}`),
         });
         window.scrollTo(0, 0);
@@ -205,55 +206,55 @@ export default function useNavigateTo() {
             return;
         }
 
-        void navigate({
+        navigate({
           pathname: pathname.replace(':projectId', `${projectId}`).replace(':moduleId', `${moduleId}`),
         });
       },
 
       goToModuleEventSession: (projectId: number, moduleId: number, sessionId: number) =>
-        void navigate({
+        navigate({
           pathname: APP_PATHS.PROJECT_MODULE_SESSION.replace(':projectId', `${projectId}`)
             .replace(':moduleId', `${moduleId}`)
             .replace(':sessionId', `${sessionId}`),
         }),
 
       goToModules: (projectId: number) =>
-        void navigate({
+        navigate({
           pathname: APP_PATHS.PROJECT_MODULES.replace(':projectId', `${projectId}`),
         }),
 
       goToNewAccession: () => {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.ACCESSIONS2_NEW,
         });
         window.scrollTo(0, 0);
       },
 
       goToParticipant: (participantId: number) =>
-        void navigate({
+        navigate({
           pathname: APP_PATHS.ACCELERATOR_PARTICIPANTS_VIEW.replace(':participantId', `${participantId}`),
         }),
 
       goToParticipantsList: () =>
-        void navigate({
+        navigate({
           pathname: APP_PATHS.ACCELERATOR_OVERVIEW,
           search: 'tab=participants',
         }),
 
       goToParticipantProject: (projectId: number) =>
-        void navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_VIEW.replace(':projectId', `${projectId}`) }),
+        navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_VIEW.replace(':projectId', `${projectId}`) }),
 
       goToParticipantProjectEdit: (projectId: number) =>
-        void navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_EDIT.replace(':projectId', `${projectId}`) }),
+        navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_EDIT.replace(':projectId', `${projectId}`) }),
 
       goToParticipantProjectList: () =>
-        void navigate({
+        navigate({
           pathname: APP_PATHS.ACCELERATOR_OVERVIEW,
           search: 'tab=projects',
         }),
 
       goToParticipantProjectSpecies: (deliverableId: number, projectId: number, participantProjectSpeciesId: number) =>
-        void navigate({
+        navigate({
           pathname: APP_PATHS.ACCELERATOR_SPECIES.replace(
             ':participantProjectSpeciesId',
             `${participantProjectSpeciesId}`
@@ -267,23 +268,23 @@ export default function useNavigateTo() {
         projectId: number,
         participantProjectSpeciesId: number
       ) =>
-        void navigate(
+        navigate(
           APP_PATHS.ACCELERATOR_SPECIES_EDIT.replace(':participantProjectSpeciesId', `${participantProjectSpeciesId}`)
             .replace(':projectId', `${projectId}`)
             .replace(':deliverableId', `${deliverableId}`)
         ),
 
       goToPlantingSiteView: (plantingSiteId: number) =>
-        void navigate(APP_PATHS.PLANTING_SITES_VIEW.replace(':plantingSiteId', `${plantingSiteId}`)),
+        navigate(APP_PATHS.PLANTING_SITES_VIEW.replace(':plantingSiteId', `${plantingSiteId}`)),
       goToPlantingSitesView: (newSite: boolean) => navigate(`${APP_PATHS.PLANTING_SITES}${newSite ? '?new=true' : ''}`),
 
       goToSettings: () => navigate(APP_PATHS.SETTINGS),
 
       goToAcceleratorEditReportSettings: (projectId: string) =>
-        void navigate(APP_PATHS.ACCELERATOR_PROJECT_REPORTS_EDIT.replace(':projectId', projectId)),
+        navigate(APP_PATHS.ACCELERATOR_PROJECT_REPORTS_EDIT.replace(':projectId', projectId)),
 
       goToNewProjectMetric: (projectId: string) =>
-        void navigate(APP_PATHS.ACCELERATOR_PROJECT_REPORTS_METRICS_NEW.replace(':projectId', projectId)),
+        navigate(APP_PATHS.ACCELERATOR_PROJECT_REPORTS_METRICS_NEW.replace(':projectId', projectId)),
     }),
     [navigate]
   );

--- a/src/hooks/useNavigateTo.ts
+++ b/src/hooks/useNavigateTo.ts
@@ -11,15 +11,15 @@ export default function useNavigateTo() {
   return useMemo(
     () => ({
       goToAccelerator: () => {
-        navigate({ pathname: APP_PATHS.ACCELERATOR });
+        void navigate({ pathname: APP_PATHS.ACCELERATOR });
       },
 
       goToAcceleratorApplication: (applicationId: number) => {
-        navigate({ pathname: APP_PATHS.ACCELERATOR_APPLICATION.replace(':applicationId', `${applicationId}`) });
+        void navigate({ pathname: APP_PATHS.ACCELERATOR_APPLICATION.replace(':applicationId', `${applicationId}`) });
       },
 
       goToAcceleratorApplicationDeliverable: (applicationId: number, deliverableId: number) => {
-        navigate({
+        void navigate({
           pathname: APP_PATHS.ACCELERATOR_APPLICATION_DELIVERABLE.replace(':applicationId', `${applicationId}`).replace(
             ':deliverableId',
             `${deliverableId}`
@@ -28,79 +28,79 @@ export default function useNavigateTo() {
       },
 
       goToAcceleratorApplicationMap: (applicationId: number) => {
-        navigate({ pathname: APP_PATHS.ACCELERATOR_APPLICATION_MAP.replace(':applicationId', `${applicationId}`) });
+        void navigate({ pathname: APP_PATHS.ACCELERATOR_APPLICATION_MAP.replace(':applicationId', `${applicationId}`) });
       },
 
       goToAcceleratorProject: (projectId: number) => {
-        navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_VOTES.replace(':projectId', `${projectId}`) });
+        void navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_VOTES.replace(':projectId', `${projectId}`) });
       },
 
       goToAcceleratorProjectScore: (projectId: number) => {
-        navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_SCORES.replace(':projectId', `${projectId}`) });
+        void navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_SCORES.replace(':projectId', `${projectId}`) });
       },
 
       goToAcceleratorProjectScoreEdit: (projectId: number) => {
-        navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_SCORES_EDIT.replace(':projectId', `${projectId}`) });
+        void navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_SCORES_EDIT.replace(':projectId', `${projectId}`) });
       },
 
       goToAcceleratorProjectVote: (projectId: number) => {
-        navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_VOTES.replace(':projectId', `${projectId}`) });
+        void navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_VOTES.replace(':projectId', `${projectId}`) });
       },
 
       goToAcceleratorProjectVoteEdit: (projectId: number) => {
-        navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_VOTES_EDIT.replace(':projectId', `${projectId}`) });
+        void navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_VOTES_EDIT.replace(':projectId', `${projectId}`) });
       },
 
       goToAcceleratorReport: (reportId: number, projectId: number) =>
-        navigate({
+        void navigate({
           pathname: APP_PATHS.REPORTS_VIEW.replace(':reportId', `${reportId}`).replace(':projectId', `${projectId}`),
         }),
 
       goToAcceleratorReportEdit: (reportId: number, projectId: number) =>
-        navigate({
+        void navigate({
           pathname: APP_PATHS.REPORTS_EDIT.replace(':reportId', `${reportId}`).replace(':projectId', `${projectId}`),
         }),
 
       goToApplication: (applicationId: number) => {
-        navigate({ pathname: APP_PATHS.APPLICATION_OVERVIEW.replace(':applicationId', `${applicationId}`) });
+        void navigate({ pathname: APP_PATHS.APPLICATION_OVERVIEW.replace(':applicationId', `${applicationId}`) });
       },
 
       goToApplicationList: () => {
-        navigate({ pathname: APP_PATHS.APPLICATIONS });
+        void navigate({ pathname: APP_PATHS.APPLICATIONS });
       },
 
       goToApplicationMap: (applicationId: number) => {
-        navigate({
+        void navigate({
           pathname: APP_PATHS.APPLICATION_MAP.replace(':applicationId', `${applicationId}`),
         });
       },
 
       goToApplicationMapUpdate: (applicationId: number) => {
-        navigate({
+        void navigate({
           pathname: APP_PATHS.APPLICATION_MAP_UPDATE.replace(':applicationId', `${applicationId}`),
         });
       },
 
       goToApplicationPrescreen: (applicationId: number) => {
-        navigate({
+        void navigate({
           pathname: APP_PATHS.APPLICATION_PRESCREEN.replace(':applicationId', `${applicationId}`),
         });
       },
 
       goToApplicationPrescreenResult: (applicationId: number) => {
-        navigate({
+        void navigate({
           pathname: APP_PATHS.APPLICATION_PRESCREEN_RESULT.replace(':applicationId', `${applicationId}`),
         });
       },
 
       goToApplicationReview: (applicationId: number) => {
-        navigate({
+        void navigate({
           pathname: APP_PATHS.APPLICATION_REVIEW.replace(':applicationId', `${applicationId}`),
         });
       },
 
       goToApplicationSection: (applicationId: number, sectionId: number) => {
-        navigate({
+        void navigate({
           pathname: APP_PATHS.APPLICATION_SECTION.replace(':applicationId', `${applicationId}`).replace(
             ':sectionId',
             `${sectionId}`
@@ -109,7 +109,7 @@ export default function useNavigateTo() {
       },
 
       goToApplicationSectionDeliverable: (applicationId: number, sectionId: number, deliverableId: number) => {
-        navigate({
+        void navigate({
           pathname: APP_PATHS.APPLICATION_SECTION_DELIVERABLE.replace(':applicationId', `${applicationId}`)
             .replace(':sectionId', `${sectionId}`)
             .replace(':deliverableId', `${deliverableId}`),
@@ -122,7 +122,7 @@ export default function useNavigateTo() {
         deliverableId: number,
         variableId?: number
       ) => {
-        navigate({
+        void navigate({
           pathname: APP_PATHS.APPLICATION_SECTION_DELIVERABLE_EDIT.replace(':applicationId', `${applicationId}`)
             .replace(':sectionId', `${sectionId}`)
             .replace(':deliverableId', `${deliverableId}`),
@@ -131,13 +131,13 @@ export default function useNavigateTo() {
       },
 
       goToContactUsForm: (requestType: SupportRequestType) => {
-        navigate({
+        void navigate({
           pathname: APP_PATHS.HELP_SUPPORT_FORM.replace(':requestType', getSupportRequestSubpath(requestType)),
         });
       },
 
       goToDeliverable: (deliverableId: number, projectId: number) =>
-        navigate({
+        void navigate({
           pathname: APP_PATHS.DELIVERABLE_VIEW.replace(':deliverableId', `${deliverableId}`).replace(
             ':projectId',
             `${projectId}`
@@ -145,7 +145,7 @@ export default function useNavigateTo() {
         }),
 
       goToDeliverableEdit: (deliverableId: number, projectId: number, variableId?: number) =>
-        navigate({
+        void navigate({
           pathname: APP_PATHS.DELIVERABLE_EDIT.replace(':deliverableId', `${deliverableId}`).replace(
             ':projectId',
             `${projectId}`
@@ -154,38 +154,38 @@ export default function useNavigateTo() {
         }),
 
       goToDocuments: () =>
-        navigate({
+        void navigate({
           pathname: APP_PATHS.ACCELERATOR_DOCUMENT_PRODUCER_DOCUMENTS,
         }),
 
       goToDocumentNew: () =>
-        navigate({
+        void navigate({
           pathname: APP_PATHS.ACCELERATOR_DOCUMENT_PRODUCER_DOCUMENT_NEW,
         }),
 
       goToEditFundingEntity: (fundingEntityId: number | string) =>
-        navigate(APP_PATHS.ACCELERATOR_FUNDING_ENTITIES_EDIT.replace(':fundingEntityId', `${fundingEntityId}`)),
+        void navigate(APP_PATHS.ACCELERATOR_FUNDING_ENTITIES_EDIT.replace(':fundingEntityId', `${fundingEntityId}`)),
 
       goToFundingEntities: () => navigate({ pathname: APP_PATHS.ACCELERATOR_FUNDING_ENTITIES }),
 
       goToFundingEntity: (fundingEntityId: number | string) =>
-        navigate({
+        void navigate({
           pathname: APP_PATHS.ACCELERATOR_FUNDING_ENTITIES_VIEW.replace(':fundingEntityId', String(fundingEntityId)),
         }),
 
       goToNewFundingEntity: () => navigate({ pathname: APP_PATHS.ACCELERATOR_FUNDING_ENTITIES_NEW }),
 
       goToHelpSupport: () => {
-        navigate({ pathname: APP_PATHS.HELP_SUPPORT });
+        void navigate({ pathname: APP_PATHS.HELP_SUPPORT });
       },
 
       goToHome: () =>
-        navigate({
+        void navigate({
           pathname: APP_PATHS.HOME,
         }),
 
       goToModule: (projectId: number, moduleId: number) => {
-        navigate({
+        void navigate({
           pathname: APP_PATHS.PROJECT_MODULE.replace(':projectId', `${projectId}`).replace(':moduleId', `${moduleId}`),
         });
         window.scrollTo(0, 0);
@@ -203,55 +203,55 @@ export default function useNavigateTo() {
             return;
         }
 
-        navigate({
+        void navigate({
           pathname: pathname.replace(':projectId', `${projectId}`).replace(':moduleId', `${moduleId}`),
         });
       },
 
       goToModuleEventSession: (projectId: number, moduleId: number, sessionId: number) =>
-        navigate({
+        void navigate({
           pathname: APP_PATHS.PROJECT_MODULE_SESSION.replace(':projectId', `${projectId}`)
             .replace(':moduleId', `${moduleId}`)
             .replace(':sessionId', `${sessionId}`),
         }),
 
       goToModules: (projectId: number) =>
-        navigate({
+        void navigate({
           pathname: APP_PATHS.PROJECT_MODULES.replace(':projectId', `${projectId}`),
         }),
 
       goToNewAccession: () => {
-        navigate({
+        void navigate({
           pathname: APP_PATHS.ACCESSIONS2_NEW,
         });
         window.scrollTo(0, 0);
       },
 
       goToParticipant: (participantId: number) =>
-        navigate({
+        void navigate({
           pathname: APP_PATHS.ACCELERATOR_PARTICIPANTS_VIEW.replace(':participantId', `${participantId}`),
         }),
 
       goToParticipantsList: () =>
-        navigate({
+        void navigate({
           pathname: APP_PATHS.ACCELERATOR_OVERVIEW,
           search: 'tab=participants',
         }),
 
       goToParticipantProject: (projectId: number) =>
-        navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_VIEW.replace(':projectId', `${projectId}`) }),
+        void navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_VIEW.replace(':projectId', `${projectId}`) }),
 
       goToParticipantProjectEdit: (projectId: number) =>
-        navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_EDIT.replace(':projectId', `${projectId}`) }),
+        void navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_EDIT.replace(':projectId', `${projectId}`) }),
 
       goToParticipantProjectList: () =>
-        navigate({
+        void navigate({
           pathname: APP_PATHS.ACCELERATOR_OVERVIEW,
           search: 'tab=projects',
         }),
 
       goToParticipantProjectSpecies: (deliverableId: number, projectId: number, participantProjectSpeciesId: number) =>
-        navigate({
+        void navigate({
           pathname: APP_PATHS.ACCELERATOR_SPECIES.replace(
             ':participantProjectSpeciesId',
             `${participantProjectSpeciesId}`
@@ -265,23 +265,23 @@ export default function useNavigateTo() {
         projectId: number,
         participantProjectSpeciesId: number
       ) =>
-        navigate(
+        void navigate(
           APP_PATHS.ACCELERATOR_SPECIES_EDIT.replace(':participantProjectSpeciesId', `${participantProjectSpeciesId}`)
             .replace(':projectId', `${projectId}`)
             .replace(':deliverableId', `${deliverableId}`)
         ),
 
       goToPlantingSiteView: (plantingSiteId: number) =>
-        navigate(APP_PATHS.PLANTING_SITES_VIEW.replace(':plantingSiteId', `${plantingSiteId}`)),
+        void navigate(APP_PATHS.PLANTING_SITES_VIEW.replace(':plantingSiteId', `${plantingSiteId}`)),
       goToPlantingSitesView: (newSite: boolean) => navigate(`${APP_PATHS.PLANTING_SITES}${newSite ? '?new=true' : ''}`),
 
       goToSettings: () => navigate(APP_PATHS.SETTINGS),
 
       goToAcceleratorEditReportSettings: (projectId: string) =>
-        navigate(APP_PATHS.ACCELERATOR_PROJECT_REPORTS_EDIT.replace(':projectId', projectId)),
+        void navigate(APP_PATHS.ACCELERATOR_PROJECT_REPORTS_EDIT.replace(':projectId', projectId)),
 
       goToNewProjectMetric: (projectId: string) =>
-        navigate(APP_PATHS.ACCELERATOR_PROJECT_REPORTS_METRICS_NEW.replace(':projectId', projectId)),
+        void navigate(APP_PATHS.ACCELERATOR_PROJECT_REPORTS_METRICS_NEW.replace(':projectId', projectId)),
     }),
     [navigate]
   );

--- a/src/hooks/useSyncNavigate.ts
+++ b/src/hooks/useSyncNavigate.ts
@@ -1,0 +1,27 @@
+import { useCallback } from 'react';
+import { useNavigate as useNavigateRouter } from 'react-router';
+import { N as NavigateOptions, T as To } from 'react-router/dist/development/route-data-C12CLHiN';
+
+interface SyncNavigateFunction {
+  (to: To, options?: NavigateOptions): void;
+
+  (delta: number): void;
+}
+
+/**
+ * Replaces the useNavigate hook to remove the need for adding `void navigate` to all usages to fix linting issues
+ */
+export const useSyncNavigate = (): SyncNavigateFunction => {
+  const routerNavigate = useNavigateRouter();
+
+  return useCallback(
+    (toOrDelta, options?: NavigateOptions) => {
+      if (typeof toOrDelta === 'number') {
+        void routerNavigate(toOrDelta);
+      } else {
+        void routerNavigate(toOrDelta, options);
+      }
+    },
+    [routerNavigate]
+  );
+};

--- a/src/providers/FundingEntityProvider.tsx
+++ b/src/providers/FundingEntityProvider.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { requestFundingEntity } from 'src/redux/features/funder/fundingEntitiesAsyncThunks';
 import { selectFundingEntityRequest } from 'src/redux/features/funder/fundingEntitiesSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';

--- a/src/providers/FundingEntityProvider.tsx
+++ b/src/providers/FundingEntityProvider.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
 import { requestFundingEntity } from 'src/redux/features/funder/fundingEntitiesAsyncThunks';
@@ -26,7 +27,7 @@ export default function FundingEntityProvider({ children }: FundingEntityProvide
   const pathFundingEntityId = Number(pathParams.fundingEntityId);
   const dispatch = useAppDispatch();
   const [entityAPIRequestStatus, setEntityAPIRequestStatus] = useState<APIRequestStatus>(APIRequestStatus.AWAITING);
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { isDev, isStaging } = useEnvironment();
   const getFundingEntityRequest = useAppSelector(selectFundingEntityRequest(pathFundingEntityId));
   const [fundingEntityData, setFundingEntityData] = useState<ProvidedFundingEntityData>({
@@ -74,7 +75,7 @@ export default function FundingEntityProvider({ children }: FundingEntityProvide
           window.location.reload();
         }
       } else {
-        void navigate(APP_PATHS.ERROR_FAILED_TO_FETCH_ORG_DATA);
+        navigate(APP_PATHS.ERROR_FAILED_TO_FETCH_ORG_DATA);
       }
     }
   }, [entityAPIRequestStatus]);

--- a/src/providers/FundingEntityProvider.tsx
+++ b/src/providers/FundingEntityProvider.tsx
@@ -47,7 +47,7 @@ export default function FundingEntityProvider({ children }: FundingEntityProvide
 
   useEffect(() => {
     if (pathParamExists()) {
-      dispatch(requestFundingEntity(pathFundingEntityId));
+      void dispatch(requestFundingEntity(pathFundingEntityId));
     }
   }, [pathFundingEntityId, dispatch]);
 
@@ -74,7 +74,7 @@ export default function FundingEntityProvider({ children }: FundingEntityProvide
           window.location.reload();
         }
       } else {
-        navigate(APP_PATHS.ERROR_FAILED_TO_FETCH_ORG_DATA);
+        void navigate(APP_PATHS.ERROR_FAILED_TO_FETCH_ORG_DATA);
       }
     }
   }, [entityAPIRequestStatus]);

--- a/src/providers/OrganizationProvider.tsx
+++ b/src/providers/OrganizationProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
@@ -33,7 +33,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
   const [orgPreferenceForId, setOrgPreferenceForId] = useState<number>(defaultSelectedOrg.id);
   const [orgAPIRequestStatus, setOrgAPIRequestStatus] = useState<APIRequestStatus>(APIRequestStatus.AWAITING);
   const [organizations, setOrganizations] = useState<Organization[]>();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const query = useQuery();
   const location = useStateLocation();
   const { user, userPreferences, updateUserPreferences, bootstrapped: userBootstrapped } = useUser();
@@ -85,7 +85,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
   }, [selectedOrganization]);
 
   const redirectAndNotify = (organization: Organization) => {
-    void navigate({ pathname: APP_PATHS.HOME, search: `organizationId=${organization.id}&newOrg=true` });
+    navigate({ pathname: APP_PATHS.HOME, search: `organizationId=${organization.id}&newOrg=true` });
   };
 
   useEffect(() => {
@@ -129,7 +129,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
           }
           if (queryOrganizationId !== orgToUse.id.toString()) {
             query.set('organizationId', orgToUse.id.toString());
-            void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+            navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
           }
         }
       }
@@ -137,7 +137,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
       if (queryOrganizationId && (!orgToUse || isAcceleratorRoute)) {
         // user does not belong to any orgs, clear the url param org id
         query.delete('organizationId');
-        void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+        navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
       }
     }
   }, [
@@ -170,7 +170,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
           window.location.reload();
         }
       } else {
-        void navigate(APP_PATHS.ERROR_FAILED_TO_FETCH_ORG_DATA);
+        navigate(APP_PATHS.ERROR_FAILED_TO_FETCH_ORG_DATA);
       }
     }
   }, [orgAPIRequestStatus]);

--- a/src/providers/OrganizationProvider.tsx
+++ b/src/providers/OrganizationProvider.tsx
@@ -85,7 +85,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
   }, [selectedOrganization]);
 
   const redirectAndNotify = (organization: Organization) => {
-    navigate({ pathname: APP_PATHS.HOME, search: `organizationId=${organization.id}&newOrg=true` });
+    void navigate({ pathname: APP_PATHS.HOME, search: `organizationId=${organization.id}&newOrg=true` });
   };
 
   useEffect(() => {
@@ -129,7 +129,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
           }
           if (queryOrganizationId !== orgToUse.id.toString()) {
             query.set('organizationId', orgToUse.id.toString());
-            navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+            void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
           }
         }
       }
@@ -137,7 +137,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
       if (queryOrganizationId && (!orgToUse || isAcceleratorRoute)) {
         // user does not belong to any orgs, clear the url param org id
         query.delete('organizationId');
-        navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+        void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
       }
     }
   }, [
@@ -170,7 +170,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
           window.location.reload();
         }
       } else {
-        navigate(APP_PATHS.ERROR_FAILED_TO_FETCH_ORG_DATA);
+        void navigate(APP_PATHS.ERROR_FAILED_TO_FETCH_ORG_DATA);
       }
     }
   }, [orgAPIRequestStatus]);

--- a/src/providers/OrganizationProvider.tsx
+++ b/src/providers/OrganizationProvider.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { store } from 'src/redux/store';
 import { OrganizationService, PreferencesService } from 'src/services';
 import strings from 'src/strings';

--- a/src/providers/UserFundingEntityProvider.tsx
+++ b/src/providers/UserFundingEntityProvider.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { requestFundingEntityForUser } from 'src/redux/features/funder/fundingEntitiesAsyncThunks';
 import { selectUserFundingEntityRequest } from 'src/redux/features/funder/fundingEntitiesSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';

--- a/src/providers/UserFundingEntityProvider.tsx
+++ b/src/providers/UserFundingEntityProvider.tsx
@@ -63,7 +63,7 @@ export default function UserFundingEntityProvider({ children }: UserFundingEntit
           window.location.reload();
         }
       } else {
-        navigate(APP_PATHS.ERROR_FAILED_TO_FETCH_ORG_DATA);
+        void navigate(APP_PATHS.ERROR_FAILED_TO_FETCH_ORG_DATA);
       }
     }
   }, [entityAPIRequestStatus]);

--- a/src/providers/UserFundingEntityProvider.tsx
+++ b/src/providers/UserFundingEntityProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
 import { requestFundingEntityForUser } from 'src/redux/features/funder/fundingEntitiesAsyncThunks';
@@ -26,7 +26,7 @@ export default function UserFundingEntityProvider({ children }: UserFundingEntit
   const { user, bootstrapped: userBootstrapped } = useUser();
   const dispatch = useAppDispatch();
   const [entityAPIRequestStatus, setEntityAPIRequestStatus] = useState<APIRequestStatus>(APIRequestStatus.AWAITING);
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { isDev, isStaging } = useEnvironment();
   const getUserFundingEntityRequest = useAppSelector(selectUserFundingEntityRequest(user?.id));
   const [fundingEntityData, setFundingEntityData] = useState<ProvidedUserFundingEntityData>({
@@ -63,7 +63,7 @@ export default function UserFundingEntityProvider({ children }: UserFundingEntit
           window.location.reload();
         }
       } else {
-        void navigate(APP_PATHS.ERROR_FAILED_TO_FETCH_ORG_DATA);
+        navigate(APP_PATHS.ERROR_FAILED_TO_FETCH_ORG_DATA);
       }
     }
   }, [entityAPIRequestStatus]);

--- a/src/scenes/AcceleratorRouter/Applications/ApplicationReview.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationReview.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useState } from 'react';
-import { useNavigate } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button } from '@terraware/web-components';
 
 import ProjectFieldTextAreaDisplay from 'src/components/ProjectField/TextAreaDisplay';
 import useNavigateTo from 'src/hooks/useNavigateTo';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useUser } from 'src/providers';
 import { useApplicationData } from 'src/providers/Application/Context';
 import strings from 'src/strings';
@@ -26,7 +26,7 @@ const ApplicationReview = ({ application }: ApplicationReviewProps) => {
   const color = getApplicationStatusColor(application.status, theme);
 
   const { reload } = useApplicationData();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
 
   const [isReviewModalOpen, setIsReviewModalOpen] = useState<boolean>(false);
 

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortEditView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortEditView.tsx
@@ -68,7 +68,7 @@ export default function CohortEditView(): JSX.Element {
   );
 
   const goToCohortView = useCallback(() => {
-    navigate({ pathname: APP_PATHS.ACCELERATOR_COHORTS_VIEW.replace(':cohortId', `${cohortId}`) });
+    void navigate({ pathname: APP_PATHS.ACCELERATOR_COHORTS_VIEW.replace(':cohortId', `${cohortId}`) });
   }, [navigate, cohortId]);
 
   useEffect(() => {

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortEditView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortEditView.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import Page from 'src/components/Page';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import {
   requestDeleteManyCohortModule,
   requestUpdateManyCohortModule,

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortEditView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortEditView.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import Page from 'src/components/Page';
 import { APP_PATHS } from 'src/constants';
@@ -23,7 +24,7 @@ import CohortForm from './CohortForm';
 
 export default function CohortEditView(): JSX.Element {
   const dispatch = useAppDispatch();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
 
   const pathParams = useParams<{ cohortId: string }>();
@@ -68,7 +69,7 @@ export default function CohortEditView(): JSX.Element {
   );
 
   const goToCohortView = useCallback(() => {
-    void navigate({ pathname: APP_PATHS.ACCELERATOR_COHORTS_VIEW.replace(':cohortId', `${cohortId}`) });
+    navigate({ pathname: APP_PATHS.ACCELERATOR_COHORTS_VIEW.replace(':cohortId', `${cohortId}`) });
   }, [navigate, cohortId]);
 
   useEffect(() => {

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortNewView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortNewView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import Page from 'src/components/Page';
 import { APP_PATHS } from 'src/constants';
@@ -12,7 +12,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 import CohortForm from './CohortForm';
 
 export default function CohortNewView(): JSX.Element {
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const [isBusy, setIsBusy] = useState<boolean>(false);
   const snackbar = useSnackbar();
 
@@ -22,12 +22,12 @@ export default function CohortNewView(): JSX.Element {
   });
 
   const goToCohortsList = useCallback(() => {
-    void navigate({ pathname: APP_PATHS.ACCELERATOR_COHORTS });
+    navigate({ pathname: APP_PATHS.ACCELERATOR_COHORTS });
   }, [navigate]);
 
   const goToCohortView = useCallback(
     (cohortId: number) => {
-      void navigate({ pathname: APP_PATHS.ACCELERATOR_COHORTS_VIEW.replace(':cohortId', `${cohortId}`) });
+      navigate({ pathname: APP_PATHS.ACCELERATOR_COHORTS_VIEW.replace(':cohortId', `${cohortId}`) });
     },
     [navigate]
   );

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortNewView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortNewView.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import Page from 'src/components/Page';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import CohortService from 'src/services/CohortService';
 import strings from 'src/strings';
 import { CreateCohortRequestPayload } from 'src/types/Cohort';

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortNewView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortNewView.tsx
@@ -22,12 +22,12 @@ export default function CohortNewView(): JSX.Element {
   });
 
   const goToCohortsList = useCallback(() => {
-    navigate({ pathname: APP_PATHS.ACCELERATOR_COHORTS });
+    void navigate({ pathname: APP_PATHS.ACCELERATOR_COHORTS });
   }, [navigate]);
 
   const goToCohortView = useCallback(
     (cohortId: number) => {
-      navigate({ pathname: APP_PATHS.ACCELERATOR_COHORTS_VIEW.replace(':cohortId', `${cohortId}`) });
+      void navigate({ pathname: APP_PATHS.ACCELERATOR_COHORTS_VIEW.replace(':cohortId', `${cohortId}`) });
     },
     [navigate]
   );

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortView.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, useTheme } from '@mui/material';
 
@@ -21,7 +22,7 @@ import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
 
 const CohortView = () => {
   const dispatch = useAppDispatch();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const { activeLocale } = useLocalization();
   const { isAllowed } = useUser();
@@ -43,7 +44,7 @@ const CohortView = () => {
 
   const goToEditCohort = useCallback(() => {
     if (pathParams.cohortId) {
-      void navigate(
+      navigate(
         getLocation(APP_PATHS.ACCELERATOR_COHORTS_EDIT.replace(':cohortId', pathParams.cohortId), location)
       );
     }

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortView.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, useTheme } from '@mui/material';
 
@@ -12,6 +11,7 @@ import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
 import useListCohortModules from 'src/hooks/useListCohortModules';
 import useListModules from 'src/hooks/useListModules';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useUser } from 'src/providers';
 import { requestCohort } from 'src/redux/features/cohorts/cohortsAsyncThunks';
 import { selectCohort } from 'src/redux/features/cohorts/cohortsSelectors';
@@ -44,9 +44,7 @@ const CohortView = () => {
 
   const goToEditCohort = useCallback(() => {
     if (pathParams.cohortId) {
-      navigate(
-        getLocation(APP_PATHS.ACCELERATOR_COHORTS_EDIT.replace(':cohortId', pathParams.cohortId), location)
-      );
+      navigate(getLocation(APP_PATHS.ACCELERATOR_COHORTS_EDIT.replace(':cohortId', pathParams.cohortId), location));
     }
   }, [navigate, location, pathParams.cohortId]);
 

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortView.tsx
@@ -43,7 +43,7 @@ const CohortView = () => {
 
   const goToEditCohort = useCallback(() => {
     if (pathParams.cohortId) {
-      navigate(getLocation(APP_PATHS.ACCELERATOR_COHORTS_EDIT.replace(':cohortId', pathParams.cohortId), location));
+      void navigate(getLocation(APP_PATHS.ACCELERATOR_COHORTS_EDIT.replace(':cohortId', pathParams.cohortId), location));
     }
   }, [navigate, location, pathParams.cohortId]);
 

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortView.tsx
@@ -43,7 +43,9 @@ const CohortView = () => {
 
   const goToEditCohort = useCallback(() => {
     if (pathParams.cohortId) {
-      void navigate(getLocation(APP_PATHS.ACCELERATOR_COHORTS_EDIT.replace(':cohortId', pathParams.cohortId), location));
+      void navigate(
+        getLocation(APP_PATHS.ACCELERATOR_COHORTS_EDIT.replace(':cohortId', pathParams.cohortId), location)
+      );
     }
   }, [navigate, location, pathParams.cohortId]);
 

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortsListView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortsListView.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useCallback, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Card, Typography, useTheme } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
@@ -54,7 +54,7 @@ const columns = (activeLocale: string | null): TableColumnType[] =>
 const CohortsListView = ({ filterModifiers, extraTableFilters }: CohortsListViewProps) => {
   const dispatch = useAppDispatch();
   const { activeLocale } = useLocalization();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { isAllowed } = useUser();
   const { isMobile } = useDeviceInfo();
 
@@ -78,7 +78,7 @@ const CohortsListView = ({ filterModifiers, extraTableFilters }: CohortsListView
     const newProjectLocation = {
       pathname: APP_PATHS.ACCELERATOR_COHORTS_NEW,
     };
-    void navigate(newProjectLocation);
+    navigate(newProjectLocation);
   }, [navigate]);
 
   const dispatchSearchRequest = useCallback(

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortsListView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortsListView.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode, useCallback, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Card, Typography, useTheme } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
@@ -8,6 +7,7 @@ import TableWithSearchFilters from 'src/components/TableWithSearchFilters';
 import { FilterConfig } from 'src/components/common/SearchFiltersWrapperV2';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useUser } from 'src/providers';
 import { requestCohorts } from 'src/redux/features/cohorts/cohortsAsyncThunks';
 import { selectCohorts } from 'src/redux/features/cohorts/cohortsSelectors';

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortsListView.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortsListView.tsx
@@ -78,7 +78,7 @@ const CohortsListView = ({ filterModifiers, extraTableFilters }: CohortsListView
     const newProjectLocation = {
       pathname: APP_PATHS.ACCELERATOR_COHORTS_NEW,
     };
-    navigate(newProjectLocation);
+    void navigate(newProjectLocation);
   }, [navigate]);
 
   const dispatchSearchRequest = useCallback(

--- a/src/scenes/AcceleratorRouter/Deliverables/DeliverableView.tsx
+++ b/src/scenes/AcceleratorRouter/Deliverables/DeliverableView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, useTheme } from '@mui/material';
 import { BusySpinner, Button, DropdownItem } from '@terraware/web-components';
@@ -34,7 +34,7 @@ const DeliverableView = () => {
 
   const query = useQuery();
   const location = useStateLocation();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { isMobile } = useDeviceInfo();
   const { status: requestStatus, update } = useUpdateDeliverable();
   const theme = useTheme();
@@ -47,7 +47,7 @@ const DeliverableView = () => {
     if (_source) {
       setSource(_source);
       query.delete('source');
-      void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+      navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
     }
   }, [query]);
 

--- a/src/scenes/AcceleratorRouter/Deliverables/DeliverableView.tsx
+++ b/src/scenes/AcceleratorRouter/Deliverables/DeliverableView.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, useTheme } from '@mui/material';
 import { BusySpinner, Button, DropdownItem } from '@terraware/web-components';
@@ -13,6 +12,7 @@ import TitleBar from 'src/components/DeliverableView/TitleBar';
 import Page from 'src/components/Page';
 import OptionsMenu from 'src/components/common/OptionsMenu';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useUser } from 'src/providers';
 import { useDeliverableData } from 'src/providers/Deliverable/DeliverableContext';
 import strings from 'src/strings';

--- a/src/scenes/AcceleratorRouter/Deliverables/DeliverableView.tsx
+++ b/src/scenes/AcceleratorRouter/Deliverables/DeliverableView.tsx
@@ -47,7 +47,7 @@ const DeliverableView = () => {
     if (_source) {
       setSource(_source);
       query.delete('source');
-      navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+      void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
     }
   }, [query]);
 

--- a/src/scenes/AcceleratorRouter/Documents/DocumentsView/index.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentsView/index.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useMemo } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 import { IconName, Separator } from '@terraware/web-components';
@@ -8,6 +7,7 @@ import Page from 'src/components/Page';
 import ProjectsDropdown from 'src/components/ProjectsDropdown';
 import useNavigateTo from 'src/hooks/useNavigateTo';
 import { useParticipants } from 'src/hooks/useParticipants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization } from 'src/providers';
 import strings from 'src/strings';
 import useQuery from 'src/utils/useQuery';

--- a/src/scenes/AcceleratorRouter/Documents/DocumentsView/index.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentsView/index.tsx
@@ -42,7 +42,7 @@ export default function DocumentsView(): JSX.Element | null {
   }, [availableProjects, query.get('dealName')]);
 
   const resetFilter = useCallback(() => {
-    navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+    void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
   }, [location, query]);
 
   const PageHeaderLeftComponent = useMemo(

--- a/src/scenes/AcceleratorRouter/Documents/DocumentsView/index.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentsView/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 import { IconName, Separator } from '@terraware/web-components';
@@ -16,7 +16,7 @@ import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
 import DocumentsTable from './DocumentsTable';
 
 export default function DocumentsView(): JSX.Element | null {
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const { goToDocumentNew } = useNavigateTo();
   const { activeLocale } = useLocalization();
@@ -42,7 +42,7 @@ export default function DocumentsView(): JSX.Element | null {
   }, [availableProjects, query.get('dealName')]);
 
   const resetFilter = useCallback(() => {
-    void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+    navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
   }, [location, query]);
 
   const PageHeaderLeftComponent = useMemo(

--- a/src/scenes/AcceleratorRouter/FundingEntities/DeleteFundingEntityModal.tsx
+++ b/src/scenes/AcceleratorRouter/FundingEntities/DeleteFundingEntityModal.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Typography } from '@mui/material';
 
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import FundingEntityService from 'src/services/FundingEntityService';
 import strings from 'src/strings';
 import { FundingEntity } from 'src/types/FundingEntity';

--- a/src/scenes/AcceleratorRouter/FundingEntities/DeleteFundingEntityModal.tsx
+++ b/src/scenes/AcceleratorRouter/FundingEntities/DeleteFundingEntityModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Typography } from '@mui/material';
 
@@ -18,13 +18,13 @@ export interface DeleteFundingEntityModalProps {
 }
 
 const DeleteFundingEntityModal = ({ onClose, open, fundingEntity }: DeleteFundingEntityModalProps): JSX.Element => {
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
 
   const deleteHandler = async () => {
     const response = await FundingEntityService.deleteFundingEntity(fundingEntity.id);
     if (response.requestSucceeded) {
-      void navigate(APP_PATHS.ACCELERATOR_FUNDING_ENTITIES);
+      navigate(APP_PATHS.ACCELERATOR_FUNDING_ENTITIES);
     } else {
       snackbar.toastError();
     }

--- a/src/scenes/AcceleratorRouter/FundingEntities/DeleteFundingEntityModal.tsx
+++ b/src/scenes/AcceleratorRouter/FundingEntities/DeleteFundingEntityModal.tsx
@@ -24,7 +24,7 @@ const DeleteFundingEntityModal = ({ onClose, open, fundingEntity }: DeleteFundin
   const deleteHandler = async () => {
     const response = await FundingEntityService.deleteFundingEntity(fundingEntity.id);
     if (response.requestSucceeded) {
-      navigate(APP_PATHS.ACCELERATOR_FUNDING_ENTITIES);
+      void navigate(APP_PATHS.ACCELERATOR_FUNDING_ENTITIES);
     } else {
       snackbar.toastError();
     }

--- a/src/scenes/AcceleratorRouter/Modules/EventEdit.tsx
+++ b/src/scenes/AcceleratorRouter/Modules/EventEdit.tsx
@@ -85,7 +85,7 @@ export default function EventEditView(): JSX.Element {
   }, [responseDelete]);
 
   const goToEvent = () => {
-    navigate(APP_PATHS.ACCELERATOR_MODULE_CONTENT.replace(':moduleId', moduleId || ''));
+    void navigate(APP_PATHS.ACCELERATOR_MODULE_CONTENT.replace(':moduleId', moduleId || ''));
   };
 
   const save = () => {

--- a/src/scenes/AcceleratorRouter/Modules/EventEdit.tsx
+++ b/src/scenes/AcceleratorRouter/Modules/EventEdit.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { DateTime } from 'luxon';
@@ -31,7 +32,7 @@ import EventsTable from './EventsTable';
 
 export default function EventEditView(): JSX.Element {
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { moduleId } = useParams<{ moduleId: string }>();
 
   const { events, module } = useGetModule(Number(moduleId));
@@ -85,7 +86,7 @@ export default function EventEditView(): JSX.Element {
   }, [responseDelete]);
 
   const goToEvent = () => {
-    void navigate(APP_PATHS.ACCELERATOR_MODULE_CONTENT.replace(':moduleId', moduleId || ''));
+    navigate(APP_PATHS.ACCELERATOR_MODULE_CONTENT.replace(':moduleId', moduleId || ''));
   };
 
   const save = () => {

--- a/src/scenes/AcceleratorRouter/Modules/EventEdit.tsx
+++ b/src/scenes/AcceleratorRouter/Modules/EventEdit.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { DateTime } from 'luxon';
@@ -10,6 +9,7 @@ import PageForm from 'src/components/common/PageForm';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
 import useGetModule from 'src/hooks/useGetModule';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import {
   requestCreateModuleEvent,
   requestEventDeleteMany,

--- a/src/scenes/AcceleratorRouter/Modules/Events.tsx
+++ b/src/scenes/AcceleratorRouter/Modules/Events.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button, TableColumnType } from '@terraware/web-components';
@@ -7,6 +6,7 @@ import { Button, TableColumnType } from '@terraware/web-components';
 import Card from 'src/components/common/Card';
 import Table from 'src/components/common/table';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import EventsCellRenderer from 'src/scenes/AcceleratorRouter/Modules/EventsCellRenderer';
 import strings from 'src/strings';
 import { Module, ModuleEvent } from 'src/types/Module';

--- a/src/scenes/AcceleratorRouter/Modules/Events.tsx
+++ b/src/scenes/AcceleratorRouter/Modules/Events.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button, TableColumnType } from '@terraware/web-components';
@@ -61,7 +61,7 @@ const columns = (): TableColumnType[] => [
 
 export default function ModuleEvents({ events, module }: ModuleEventsProps): JSX.Element {
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
 
   const liveSessions = events?.filter((ev) => ev.type === 'Live Session');
   const oneOnOneSessions = events?.filter((ev) => ev.type === 'One-on-One Session');
@@ -91,7 +91,7 @@ export default function ModuleEvents({ events, module }: ModuleEventsProps): JSX
                   id='edit'
                   label={strings.EDIT}
                   onClick={() =>
-                    void navigate({
+                    navigate({
                       pathname: APP_PATHS.ACCELERATOR_MODULE_EVENTS_EDIT.replace(':moduleId', `${module.id}`),
                       search: '?type=live',
                     })
@@ -127,7 +127,7 @@ export default function ModuleEvents({ events, module }: ModuleEventsProps): JSX
                   id='edit'
                   label={strings.EDIT}
                   onClick={() =>
-                    void navigate({
+                    navigate({
                       pathname: APP_PATHS.ACCELERATOR_MODULE_EVENTS_EDIT.replace(':moduleId', `${module.id}`),
                       search: '?type=one-on-one',
                     })
@@ -163,7 +163,7 @@ export default function ModuleEvents({ events, module }: ModuleEventsProps): JSX
                   id='edit'
                   label={strings.EDIT}
                   onClick={() =>
-                    void navigate({
+                    navigate({
                       pathname: APP_PATHS.ACCELERATOR_MODULE_EVENTS_EDIT.replace(':moduleId', `${module.id}`),
                       search: '?type=recorded',
                     })
@@ -199,7 +199,7 @@ export default function ModuleEvents({ events, module }: ModuleEventsProps): JSX
                   id='edit'
                   label={strings.EDIT}
                   onClick={() =>
-                    void navigate({
+                    navigate({
                       pathname: APP_PATHS.ACCELERATOR_MODULE_EVENTS_EDIT.replace(':moduleId', `${module.id}`),
                       search: '?type=workshop',
                     })

--- a/src/scenes/AcceleratorRouter/Modules/Events.tsx
+++ b/src/scenes/AcceleratorRouter/Modules/Events.tsx
@@ -91,7 +91,7 @@ export default function ModuleEvents({ events, module }: ModuleEventsProps): JSX
                   id='edit'
                   label={strings.EDIT}
                   onClick={() =>
-                    navigate({
+                    void navigate({
                       pathname: APP_PATHS.ACCELERATOR_MODULE_EVENTS_EDIT.replace(':moduleId', `${module.id}`),
                       search: '?type=live',
                     })
@@ -127,7 +127,7 @@ export default function ModuleEvents({ events, module }: ModuleEventsProps): JSX
                   id='edit'
                   label={strings.EDIT}
                   onClick={() =>
-                    navigate({
+                    void navigate({
                       pathname: APP_PATHS.ACCELERATOR_MODULE_EVENTS_EDIT.replace(':moduleId', `${module.id}`),
                       search: '?type=one-on-one',
                     })
@@ -163,7 +163,7 @@ export default function ModuleEvents({ events, module }: ModuleEventsProps): JSX
                   id='edit'
                   label={strings.EDIT}
                   onClick={() =>
-                    navigate({
+                    void navigate({
                       pathname: APP_PATHS.ACCELERATOR_MODULE_EVENTS_EDIT.replace(':moduleId', `${module.id}`),
                       search: '?type=recorded',
                     })
@@ -199,7 +199,7 @@ export default function ModuleEvents({ events, module }: ModuleEventsProps): JSX
                   id='edit'
                   label={strings.EDIT}
                   onClick={() =>
-                    navigate({
+                    void navigate({
                       pathname: APP_PATHS.ACCELERATOR_MODULE_EVENTS_EDIT.replace(':moduleId', `${module.id}`),
                       search: '?type=workshop',
                     })

--- a/src/scenes/AcceleratorRouter/NavBar.tsx
+++ b/src/scenes/AcceleratorRouter/NavBar.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
 import { useMatch } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { NavSection } from '@terraware/web-components';
 
@@ -11,6 +10,7 @@ import NavItem from 'src/components/common/Navbar/NavItem';
 import Navbar from 'src/components/common/Navbar/Navbar';
 import { APP_PATHS } from 'src/constants';
 import isEnabled from 'src/features';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useUser } from 'src/providers';
 import strings from 'src/strings';

--- a/src/scenes/AcceleratorRouter/NavBar.tsx
+++ b/src/scenes/AcceleratorRouter/NavBar.tsx
@@ -45,7 +45,7 @@ export default function NavBar({ backgroundTransparent, setShowNavBar }: NavBarP
   const closeAndNavigateTo = (path: string) => {
     closeNavBar();
     if (path) {
-      navigate(path);
+      void navigate(path);
     }
   };
 

--- a/src/scenes/AcceleratorRouter/NavBar.tsx
+++ b/src/scenes/AcceleratorRouter/NavBar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useMatch, useNavigate } from 'react-router';
+import { useMatch } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { NavSection } from '@terraware/web-components';
 
@@ -21,7 +22,7 @@ type NavBarProps = {
 };
 export default function NavBar({ backgroundTransparent, setShowNavBar }: NavBarProps): JSX.Element | null {
   const { isDesktop } = useDeviceInfo();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { isAllowed } = useUser();
   const mixpanel = useMixpanel();
 
@@ -45,7 +46,7 @@ export default function NavBar({ backgroundTransparent, setShowNavBar }: NavBarP
   const closeAndNavigateTo = (path: string) => {
     closeNavBar();
     if (path) {
-      void navigate(path);
+      navigate(path);
     }
   };
 

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/EditSettings.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/EditSettings.tsx
@@ -64,7 +64,7 @@ export default function EditSettings(): JSX.Element {
   }, [updateReportConfigResponse]);
 
   const goToProjectReports = () => {
-    navigate(`${APP_PATHS.ACCELERATOR_PROJECT_REPORTS.replace(':projectId', projectId.toString())}?tab=settings`);
+    void navigate(`${APP_PATHS.ACCELERATOR_PROJECT_REPORTS.replace(':projectId', projectId.toString())}?tab=settings`);
   };
 
   const [newConfig, , onChange] = useForm<NewAcceleratorReportConfig>({

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/EditSettings.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/EditSettings.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Container, Grid, Typography, useTheme } from '@mui/material';
 import { useDeviceInfo } from '@terraware/web-components/utils';
@@ -29,7 +30,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 
 export default function EditSettings(): JSX.Element {
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const pathParams = useParams<{ projectId: string }>();
   const projectId = String(pathParams.projectId);
   const dispatch = useAppDispatch();
@@ -64,7 +65,7 @@ export default function EditSettings(): JSX.Element {
   }, [updateReportConfigResponse]);
 
   const goToProjectReports = () => {
-    void navigate(`${APP_PATHS.ACCELERATOR_PROJECT_REPORTS.replace(':projectId', projectId.toString())}?tab=settings`);
+    navigate(`${APP_PATHS.ACCELERATOR_PROJECT_REPORTS.replace(':projectId', projectId.toString())}?tab=settings`);
   };
 
   const [newConfig, , onChange] = useForm<NewAcceleratorReportConfig>({

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/EditSettings.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/EditSettings.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Container, Grid, Typography, useTheme } from '@mui/material';
 import { useDeviceInfo } from '@terraware/web-components/utils';
@@ -12,6 +11,7 @@ import DatePicker from 'src/components/common/DatePicker';
 import PageForm from 'src/components/common/PageForm';
 import TextField from 'src/components/common/Textfield/Textfield';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import {
   selectCreateReportConfig,
   selectProjectReportConfig,

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/NewProjectSpecificMetric.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/NewProjectSpecificMetric.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Container, Grid, Typography, useTheme } from '@mui/material';
 import { Dropdown } from '@terraware/web-components';
@@ -38,7 +39,7 @@ export const metricComponentOptions = () => {
 
 export default function NewProjectSpecificMetric(): JSX.Element {
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const pathParams = useParams<{ projectId: string }>();
   const projectId = String(pathParams.projectId);
   const dispatch = useAppDispatch();
@@ -61,7 +62,7 @@ export default function NewProjectSpecificMetric(): JSX.Element {
   }, [createProjectMetricResponse]);
 
   const goToProjectReports = () => {
-    void navigate(`${APP_PATHS.ACCELERATOR_PROJECT_REPORTS.replace(':projectId', projectId)}?tab=settings`);
+    navigate(`${APP_PATHS.ACCELERATOR_PROJECT_REPORTS.replace(':projectId', projectId)}?tab=settings`);
   };
 
   const [newMetric, , onChange] = useForm<NewMetric>({

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/NewProjectSpecificMetric.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/NewProjectSpecificMetric.tsx
@@ -61,7 +61,7 @@ export default function NewProjectSpecificMetric(): JSX.Element {
   }, [createProjectMetricResponse]);
 
   const goToProjectReports = () => {
-    navigate(`${APP_PATHS.ACCELERATOR_PROJECT_REPORTS.replace(':projectId', projectId)}?tab=settings`);
+    void navigate(`${APP_PATHS.ACCELERATOR_PROJECT_REPORTS.replace(':projectId', projectId)}?tab=settings`);
   };
 
   const [newMetric, , onChange] = useForm<NewMetric>({

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/NewProjectSpecificMetric.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/NewProjectSpecificMetric.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Container, Grid, Typography, useTheme } from '@mui/material';
 import { Dropdown } from '@terraware/web-components';
@@ -12,6 +11,7 @@ import Checkbox from 'src/components/common/Checkbox';
 import PageForm from 'src/components/common/PageForm';
 import TextField from 'src/components/common/Textfield/Textfield';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { selectCreateProjectMetric } from 'src/redux/features/reports/reportsSelectors';
 import { requestCreateProjectMetric, requestProjectReportConfig } from 'src/redux/features/reports/reportsThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingEdit.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingEdit.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, useTheme } from '@mui/material';
 
 import Card from 'src/components/common/Card';
 import PageForm from 'src/components/common/PageForm';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { requestProjectVotesUpdate } from 'src/redux/features/votes/votesAsyncThunks';
 import { selectProjectVotesEditRequest } from 'src/redux/features/votes/votesSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingEdit.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingEdit.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, useTheme } from '@mui/material';
 
@@ -20,7 +20,7 @@ import { useVotingData } from './VotingContext';
 import VotingWrapper from './VotingWrapper';
 
 const VotingEdit = () => {
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const query = useQuery();
   const dispatch = useAppDispatch();
@@ -37,7 +37,7 @@ const VotingEdit = () => {
     if (!project) {
       return;
     }
-    void navigate(
+    navigate(
       getLocation(
         APP_PATHS.ACCELERATOR_PROJECT_VOTES.replace(':projectId', `${project.id}`),
         location,

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingEdit.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingEdit.tsx
@@ -37,7 +37,7 @@ const VotingEdit = () => {
     if (!project) {
       return;
     }
-    navigate(
+    void navigate(
       getLocation(
         APP_PATHS.ACCELERATOR_PROJECT_VOTES.replace(':projectId', `${project.id}`),
         location,

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingProvider.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingProvider.tsx
@@ -34,7 +34,7 @@ const VotingProvider = ({ children }: Props): JSX.Element => {
   const [votingData, setVotingData] = useState<VotingData>({ project });
 
   const goToProjects = useCallback(() => {
-    navigate({ pathname: APP_PATHS.ACCELERATOR_OVERVIEW }); // TODO switch to project management lists page
+    void navigate({ pathname: APP_PATHS.ACCELERATOR_OVERVIEW }); // TODO switch to project management lists page
   }, [navigate]);
 
   // Redirect to project management list page if projectId is invalid.

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingProvider.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingProvider.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { selectProject } from 'src/redux/features/projects/projectsSelectors';
 import { requestProjectVotesGet } from 'src/redux/features/votes/votesAsyncThunks';
 import { selectProjectVotes } from 'src/redux/features/votes/votesSelectors';

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingProvider.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingProvider.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
 import { selectProject } from 'src/redux/features/projects/projectsSelectors';
@@ -17,7 +18,7 @@ export type Props = {
 };
 
 const VotingProvider = ({ children }: Props): JSX.Element => {
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const query = useQuery();
   const dispatch = useAppDispatch();
   const snackbar = useSnackbar();
@@ -34,7 +35,7 @@ const VotingProvider = ({ children }: Props): JSX.Element => {
   const [votingData, setVotingData] = useState<VotingData>({ project });
 
   const goToProjects = useCallback(() => {
-    void navigate({ pathname: APP_PATHS.ACCELERATOR_OVERVIEW }); // TODO switch to project management lists page
+    navigate({ pathname: APP_PATHS.ACCELERATOR_OVERVIEW }); // TODO switch to project management lists page
   }, [navigate]);
 
   // Redirect to project management list page if projectId is invalid.

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingView.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useMemo } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, useTheme } from '@mui/material';
 import { Button } from '@terraware/web-components';
 
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization } from 'src/providers';
 import strings from 'src/strings';
 import useDeviceInfo from 'src/utils/useDeviceInfo';

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingView.tsx
@@ -29,7 +29,7 @@ const VotingView = () => {
       return;
     }
     // keep query state for edit view
-    navigate(
+    void navigate(
       getLocation(
         APP_PATHS.ACCELERATOR_PROJECT_VOTES_EDIT.replace(':projectId', `${project.id}`),
         location,

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Voting/VotingView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, useTheme } from '@mui/material';
 import { Button } from '@terraware/web-components';
@@ -16,7 +16,7 @@ import { useVotingData } from './VotingContext';
 import VotingWrapper from './VotingWrapper';
 
 const VotingView = () => {
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const query = useQuery();
   const { activeLocale } = useLocalization();
@@ -29,7 +29,7 @@ const VotingView = () => {
       return;
     }
     // keep query state for edit view
-    void navigate(
+    navigate(
       getLocation(
         APP_PATHS.ACCELERATOR_PROJECT_VOTES_EDIT.replace(':projectId', `${project.id}`),
         location,

--- a/src/scenes/AcceleratorRouter/Participants/ParticipantsList.tsx
+++ b/src/scenes/AcceleratorRouter/Participants/ParticipantsList.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem, TableColumnType } from '@terraware/web-components';
@@ -10,6 +9,7 @@ import ExportCsvModal from 'src/components/common/ExportCsvModal';
 import OptionsMenu from 'src/components/common/OptionsMenu';
 import { FilterConfig } from 'src/components/common/SearchFiltersWrapperV2';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useUser } from 'src/providers';
 import { requestListParticipants } from 'src/redux/features/participants/participantsAsyncThunks';
 import { selectParticipantListRequest } from 'src/redux/features/participants/participantsSelectors';

--- a/src/scenes/AcceleratorRouter/Participants/ParticipantsList.tsx
+++ b/src/scenes/AcceleratorRouter/Participants/ParticipantsList.tsx
@@ -109,7 +109,7 @@ export default function ParticipantList(): JSX.Element {
   );
 
   const goToNewParticipant = useCallback(() => {
-    navigate(APP_PATHS.ACCELERATOR_PARTICIPANTS_NEW);
+    void navigate(APP_PATHS.ACCELERATOR_PARTICIPANTS_NEW);
   }, [navigate]);
 
   const cohorts = useMemo<Record<string, string>>(

--- a/src/scenes/AcceleratorRouter/Participants/ParticipantsList.tsx
+++ b/src/scenes/AcceleratorRouter/Participants/ParticipantsList.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem, TableColumnType } from '@terraware/web-components';
@@ -55,7 +55,7 @@ const defaultSearchOrder: SearchSortOrder = {
 };
 
 export default function ParticipantList(): JSX.Element {
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { activeLocale } = useLocalization();
   const { isAllowed } = useUser();
   const { isMobile } = useDeviceInfo();
@@ -109,7 +109,7 @@ export default function ParticipantList(): JSX.Element {
   );
 
   const goToNewParticipant = useCallback(() => {
-    void navigate(APP_PATHS.ACCELERATOR_PARTICIPANTS_NEW);
+    navigate(APP_PATHS.ACCELERATOR_PARTICIPANTS_NEW);
   }, [navigate]);
 
   const cohorts = useMemo<Record<string, string>>(

--- a/src/scenes/AcceleratorRouter/Participants/ParticipantsView.tsx
+++ b/src/scenes/AcceleratorRouter/Participants/ParticipantsView.tsx
@@ -1,6 +1,5 @@
 import React, { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { BusySpinner, Button, DropdownItem, Textfield } from '@terraware/web-components';
@@ -15,6 +14,7 @@ import { APP_PATHS } from 'src/constants';
 import useListCohortModules from 'src/hooks/useListCohortModules';
 import useNavigateTo from 'src/hooks/useNavigateTo';
 import { useParticipant } from 'src/hooks/useParticipant';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useUser } from 'src/providers';
 import { requestGetParticipantProject } from 'src/redux/features/participantProjects/participantProjectsAsyncThunks';
 import { selectParticipantProjectRequest } from 'src/redux/features/participantProjects/participantProjectsSelectors';

--- a/src/scenes/AcceleratorRouter/Participants/ParticipantsView.tsx
+++ b/src/scenes/AcceleratorRouter/Participants/ParticipantsView.tsx
@@ -55,7 +55,7 @@ export default function ParticipantsView(): JSX.Element {
   }, [participant, listCohortModules]);
 
   const goToEdit = useCallback(() => {
-    navigate(APP_PATHS.ACCELERATOR_PARTICIPANTS_EDIT.replace(':participantId', `${participantId}`));
+    void navigate(APP_PATHS.ACCELERATOR_PARTICIPANTS_EDIT.replace(':participantId', `${participantId}`));
   }, [navigate, participantId]);
 
   const onOptionItemClick = useCallback((optionItem: DropdownItem) => {

--- a/src/scenes/AcceleratorRouter/Participants/ParticipantsView.tsx
+++ b/src/scenes/AcceleratorRouter/Participants/ParticipantsView.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { BusySpinner, Button, DropdownItem, Textfield } from '@terraware/web-components';
@@ -34,7 +35,7 @@ type ProjectsByOrg = {
 };
 
 export default function ParticipantsView(): JSX.Element {
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const theme = useTheme();
   const { activeLocale } = useLocalization();
   const { isAllowed } = useUser();
@@ -55,7 +56,7 @@ export default function ParticipantsView(): JSX.Element {
   }, [participant, listCohortModules]);
 
   const goToEdit = useCallback(() => {
-    void navigate(APP_PATHS.ACCELERATOR_PARTICIPANTS_EDIT.replace(':participantId', `${participantId}`));
+    navigate(APP_PATHS.ACCELERATOR_PARTICIPANTS_EDIT.replace(':participantId', `${participantId}`));
   }, [navigate, participantId]);
 
   const onOptionItemClick = useCallback((optionItem: DropdownItem) => {

--- a/src/scenes/AcceleratorRouter/People/EditView.tsx
+++ b/src/scenes/AcceleratorRouter/People/EditView.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import Page from 'src/components/Page';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { UserWithInternalnterests } from 'src/scenes/AcceleratorRouter/People/UserWithInternalInterests';
 import useUpdatePerson from 'src/scenes/AcceleratorRouter/People/useUpdatePerson';
 import useStateLocation, { getLocation } from 'src/utils/useStateLocation';

--- a/src/scenes/AcceleratorRouter/People/EditView.tsx
+++ b/src/scenes/AcceleratorRouter/People/EditView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import Page from 'src/components/Page';
 import { APP_PATHS } from 'src/constants';
@@ -11,7 +11,7 @@ import { usePersonData } from './PersonContext';
 import PersonForm from './PersonForm';
 
 const EditView = () => {
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const personData = usePersonData();
   const updatePerson = useUpdatePerson();

--- a/src/scenes/AcceleratorRouter/People/ListView.tsx
+++ b/src/scenes/AcceleratorRouter/People/ListView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, useTheme } from '@mui/material';
 import { TableRowType } from '@terraware/web-components';
@@ -75,7 +75,7 @@ const PeopleView = () => {
   const snackbar = useSnackbar();
   const { activeLocale } = useLocalization();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
 
   const [selectedRows, setSelectedRows] = useState<TableRowType[]>([]);
   const [globalRoleUsers, setGlobalRoleUsers] = useState<UserWithGlobalRoles[]>([]);
@@ -89,7 +89,7 @@ const PeopleView = () => {
   const deleteRolesRequest = useAppSelector(selectGlobalRolesUsersRemoveRequest(deleteRolesRequestId));
 
   const goToAddPerson = useCallback(() => {
-    void navigate({ pathname: APP_PATHS.ACCELERATOR_PERSON_NEW });
+    navigate({ pathname: APP_PATHS.ACCELERATOR_PERSON_NEW });
   }, [navigate]);
 
   const dispatchSearchRequest = useCallback(

--- a/src/scenes/AcceleratorRouter/People/ListView.tsx
+++ b/src/scenes/AcceleratorRouter/People/ListView.tsx
@@ -89,7 +89,7 @@ const PeopleView = () => {
   const deleteRolesRequest = useAppSelector(selectGlobalRolesUsersRemoveRequest(deleteRolesRequestId));
 
   const goToAddPerson = useCallback(() => {
-    navigate({ pathname: APP_PATHS.ACCELERATOR_PERSON_NEW });
+    void navigate({ pathname: APP_PATHS.ACCELERATOR_PERSON_NEW });
   }, [navigate]);
 
   const dispatchSearchRequest = useCallback(

--- a/src/scenes/AcceleratorRouter/People/ListView.tsx
+++ b/src/scenes/AcceleratorRouter/People/ListView.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, useTheme } from '@mui/material';
 import { TableRowType } from '@terraware/web-components';
@@ -9,6 +8,7 @@ import TableWithSearchFilters from 'src/components/TableWithSearchFilters';
 import Button from 'src/components/common/button/Button';
 import { TableColumnType } from 'src/components/common/table/types';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization } from 'src/providers';
 import {
   requestDeleteGlobalRolesForUsers,

--- a/src/scenes/AcceleratorRouter/People/NewView.tsx
+++ b/src/scenes/AcceleratorRouter/People/NewView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import Page from 'src/components/Page';
 import { APP_PATHS } from 'src/constants';
@@ -18,7 +18,7 @@ import PersonForm from './PersonForm';
 
 const NewView = () => {
   const dispatch = useAppDispatch();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const updatePerson = useUpdatePerson();
 

--- a/src/scenes/AcceleratorRouter/People/NewView.tsx
+++ b/src/scenes/AcceleratorRouter/People/NewView.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import Page from 'src/components/Page';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { requestSearchUserByEmail } from 'src/redux/features/user/usersAsyncThunks';
 import { selectUserByEmailRequest } from 'src/redux/features/user/usersSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';

--- a/src/scenes/AcceleratorRouter/People/SingleView.tsx
+++ b/src/scenes/AcceleratorRouter/People/SingleView.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useMemo } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, useTheme } from '@mui/material';
 
@@ -9,6 +8,7 @@ import Card from 'src/components/common/Card';
 import TextField from 'src/components/common/Textfield/Textfield';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useUser } from 'src/providers';
 import strings from 'src/strings';
 import { getHighestGlobalRole } from 'src/types/GlobalRoles';

--- a/src/scenes/AcceleratorRouter/People/SingleView.tsx
+++ b/src/scenes/AcceleratorRouter/People/SingleView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, useTheme } from '@mui/material';
 
@@ -18,7 +18,7 @@ import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
 import { usePersonData } from './PersonContext';
 
 const SingleView = () => {
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const { activeLocale } = useLocalization();
   const { isAllowed } = useUser();

--- a/src/scenes/AccessionsRouter/Accession2CreateView.tsx
+++ b/src/scenes/AccessionsRouter/Accession2CreateView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, Grid, Typography, useTheme } from '@mui/material';
 import { Dropdown } from '@terraware/web-components';
@@ -49,7 +49,7 @@ export default function CreateAccession(): JSX.Element | null {
   const { activeLocale } = useLocalization();
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
   const [validateFields, setValidateFields] = useState<boolean>(false);
   const [selectedSeedBank, setSelectedSeedBank] = useState<Facility>();
@@ -129,7 +129,7 @@ export default function CreateAccession(): JSX.Element | null {
   };
 
   const goToAccessions = () => {
-    void navigate(accessionsDatabase);
+    navigate(accessionsDatabase);
   };
 
   const hasErrors = () => {
@@ -149,8 +149,8 @@ export default function CreateAccession(): JSX.Element | null {
         await SeedBankService.uploadAccessionPhotos(response.id, photos);
       }
 
-      void navigate(accessionsDatabase, { replace: true });
-      void navigate({
+      navigate(accessionsDatabase, { replace: true });
+      navigate({
         pathname: APP_PATHS.ACCESSIONS2_ITEM.replace(':accessionId', response.id.toString()),
       });
     } else {

--- a/src/scenes/AccessionsRouter/Accession2CreateView.tsx
+++ b/src/scenes/AccessionsRouter/Accession2CreateView.tsx
@@ -129,7 +129,7 @@ export default function CreateAccession(): JSX.Element | null {
   };
 
   const goToAccessions = () => {
-    navigate(accessionsDatabase);
+    void navigate(accessionsDatabase);
   };
 
   const hasErrors = () => {
@@ -149,8 +149,8 @@ export default function CreateAccession(): JSX.Element | null {
         await SeedBankService.uploadAccessionPhotos(response.id, photos);
       }
 
-      navigate(accessionsDatabase, { replace: true });
-      navigate({
+      void navigate(accessionsDatabase, { replace: true });
+      void navigate({
         pathname: APP_PATHS.ACCESSIONS2_ITEM.replace(':accessionId', response.id.toString()),
       });
     } else {

--- a/src/scenes/AccessionsRouter/Accession2CreateView.tsx
+++ b/src/scenes/AccessionsRouter/Accession2CreateView.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, Grid, Typography, useTheme } from '@mui/material';
 import { Dropdown } from '@terraware/web-components';
@@ -13,6 +12,7 @@ import Textfield from 'src/components/common/Textfield/Textfield';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
 import { useProjects } from 'src/hooks/useProjects';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
 import SeedBankService, { AccessionPostRequestBody } from 'src/services/SeedBankService';
 import strings from 'src/strings';

--- a/src/scenes/AccessionsRouter/Accession2View.tsx
+++ b/src/scenes/AccessionsRouter/Accession2View.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Link as LinkMUI, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem, Icon, Tabs } from '@terraware/web-components';
@@ -49,7 +50,7 @@ export default function Accession2View(): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const { userPreferences } = useUser();
   const query = useQuery();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const { accessionId } = useParams<{ accessionId: string }>();
   const [accession, setAccession] = useState<Accession>();
@@ -179,7 +180,7 @@ export default function Accession2View(): JSX.Element {
 
   const handleChange = (newValue: string) => {
     query.set('tab', newValue);
-    void navigate(getLocation(location.pathname, location, query.toString()));
+    navigate(getLocation(location.pathname, location, query.toString()));
   };
 
   const linkStyle = {

--- a/src/scenes/AccessionsRouter/Accession2View.tsx
+++ b/src/scenes/AccessionsRouter/Accession2View.tsx
@@ -179,7 +179,7 @@ export default function Accession2View(): JSX.Element {
 
   const handleChange = (newValue: string) => {
     query.set('tab', newValue);
-    navigate(getLocation(location.pathname, location, query.toString()));
+    void navigate(getLocation(location.pathname, location, query.toString()));
   };
 
   const linkStyle = {

--- a/src/scenes/AccessionsRouter/Accession2View.tsx
+++ b/src/scenes/AccessionsRouter/Accession2View.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Link as LinkMUI, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem, Icon, Tabs } from '@terraware/web-components';
@@ -14,6 +13,7 @@ import BackToLink from 'src/components/common/BackToLink';
 import OptionsMenu from 'src/components/common/OptionsMenu';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useUser } from 'src/providers';
 import { useOrganization } from 'src/providers/hooks';
 import { AccessionService, FacilityService } from 'src/services';

--- a/src/scenes/AccessionsRouter/edit/DeleteAccessionModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/DeleteAccessionModal.tsx
@@ -25,7 +25,7 @@ export default function DeleteAccessionModal(props: DeleteAccessionModalProps): 
   const deleteHandler = async () => {
     const response = await AccessionService.deleteAccession(accession.id);
     if (response.requestSucceeded) {
-      navigate(APP_PATHS.ACCESSIONS);
+      void navigate(APP_PATHS.ACCESSIONS);
     } else {
       snackbar.toastError();
     }

--- a/src/scenes/AccessionsRouter/edit/DeleteAccessionModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/DeleteAccessionModal.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Typography } from '@mui/material';
 
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import AccessionService from 'src/services/AccessionService';
 import strings from 'src/strings';
 import { Accession } from 'src/types/Accession';

--- a/src/scenes/AccessionsRouter/edit/DeleteAccessionModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/DeleteAccessionModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Typography } from '@mui/material';
 
@@ -19,13 +19,13 @@ export interface DeleteAccessionModalProps {
 
 export default function DeleteAccessionModal(props: DeleteAccessionModalProps): JSX.Element {
   const { onClose, open, accession } = props;
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
 
   const deleteHandler = async () => {
     const response = await AccessionService.deleteAccession(accession.id);
     if (response.requestSucceeded) {
-      void navigate(APP_PATHS.ACCESSIONS);
+      navigate(APP_PATHS.ACCESSIONS);
     } else {
       snackbar.toastError();
     }

--- a/src/scenes/ApplicationRouter/portal/NavBar.tsx
+++ b/src/scenes/ApplicationRouter/portal/NavBar.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
 import { matchPath, useMatch } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { NavSection, theme } from '@terraware/web-components';
 
@@ -9,6 +8,7 @@ import NavFooter from 'src/components/common/Navbar/NavFooter';
 import NavItem from 'src/components/common/Navbar/NavItem';
 import Navbar from 'src/components/common/Navbar/Navbar';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import strings from 'src/strings';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 

--- a/src/scenes/ApplicationRouter/portal/NavBar.tsx
+++ b/src/scenes/ApplicationRouter/portal/NavBar.tsx
@@ -36,7 +36,7 @@ export default function NavBar({ backgroundTransparent, setShowNavBar }: NavBarP
     (path: string) => {
       closeNavBar();
       if (path && selectedApplication) {
-        navigate(path.replace(':applicationId', `${selectedApplication.id}`));
+        void navigate(path.replace(':applicationId', `${selectedApplication.id}`));
       }
     },
     [selectedApplication]

--- a/src/scenes/ApplicationRouter/portal/NavBar.tsx
+++ b/src/scenes/ApplicationRouter/portal/NavBar.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
-import { matchPath, useMatch, useNavigate } from 'react-router';
+import { matchPath, useMatch } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { NavSection, theme } from '@terraware/web-components';
 
@@ -19,7 +20,7 @@ type NavBarProps = {
 };
 export default function NavBar({ backgroundTransparent, setShowNavBar }: NavBarProps): JSX.Element | null {
   const { isDesktop } = useDeviceInfo();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
 
   const { applicationSections, selectedApplication } = useApplicationData();
 
@@ -36,7 +37,7 @@ export default function NavBar({ backgroundTransparent, setShowNavBar }: NavBarP
     (path: string) => {
       closeNavBar();
       if (path && selectedApplication) {
-        void navigate(path.replace(':applicationId', `${selectedApplication.id}`));
+        navigate(path.replace(':applicationId', `${selectedApplication.id}`));
       }
     },
     [selectedApplication]

--- a/src/scenes/BatchBulkWithdrawView/index.tsx
+++ b/src/scenes/BatchBulkWithdrawView/index.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import BatchWithdrawFlow from 'src/components/BatchWithdrawFlow';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import useQuery from 'src/utils/useQuery';
 
 type BatchBulkWithdrawViewProps = {

--- a/src/scenes/BatchBulkWithdrawView/index.tsx
+++ b/src/scenes/BatchBulkWithdrawView/index.tsx
@@ -21,7 +21,7 @@ export default function BatchBulkWithdrawView(props: BatchBulkWithdrawViewProps)
       setSource(query.get('source'));
     } else {
       // invalid url params
-      navigate({ pathname: APP_PATHS.INVENTORY });
+      void navigate({ pathname: APP_PATHS.INVENTORY });
     }
   }, [query, navigate]);
 

--- a/src/scenes/BatchBulkWithdrawView/index.tsx
+++ b/src/scenes/BatchBulkWithdrawView/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import BatchWithdrawFlow from 'src/components/BatchWithdrawFlow';
 import { APP_PATHS } from 'src/constants';
@@ -13,7 +13,7 @@ export default function BatchBulkWithdrawView(props: BatchBulkWithdrawViewProps)
   const [batchIds, setBatchIds] = useState<string[]>();
   const [source, setSource] = useState<string | null>();
   const query = useQuery();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
 
   useEffect(() => {
     if (query.getAll('batchId').length > 0) {
@@ -21,7 +21,7 @@ export default function BatchBulkWithdrawView(props: BatchBulkWithdrawViewProps)
       setSource(query.get('source'));
     } else {
       // invalid url params
-      void navigate({ pathname: APP_PATHS.INVENTORY });
+      navigate({ pathname: APP_PATHS.INVENTORY });
     }
   }, [query, navigate]);
 

--- a/src/scenes/CheckIn/index.tsx
+++ b/src/scenes/CheckIn/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, Grid, useTheme } from '@mui/material';
 import { BusySpinner } from '@terraware/web-components';
@@ -27,7 +27,7 @@ export default function CheckIn(): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const [pendingAccessions, setPendingAccessions] = useState<SearchResponseElement[] | null>();
   const contentRef = useRef(null);
@@ -75,7 +75,7 @@ export default function CheckIn(): JSX.Element {
         reloadData();
         setCheckInAllConfirmationDialogOpen(false);
         snackbar.toastSuccess(strings.ALL_ACCESSIONS_CHECKED_IN);
-        void navigate(APP_PATHS.ACCESSIONS);
+        navigate(APP_PATHS.ACCESSIONS);
       } catch (e) {
         setBusy(false);
         snackbar.toastError();
@@ -111,7 +111,7 @@ export default function CheckIn(): JSX.Element {
       // eslint-disable-next-line no-restricted-globals
       state: { from: location.pathname },
     };
-    void navigate(accessionLocation);
+    navigate(accessionLocation);
   };
 
   const pendingAccessionsById = transformPendingAccessions();

--- a/src/scenes/CheckIn/index.tsx
+++ b/src/scenes/CheckIn/index.tsx
@@ -75,7 +75,7 @@ export default function CheckIn(): JSX.Element {
         reloadData();
         setCheckInAllConfirmationDialogOpen(false);
         snackbar.toastSuccess(strings.ALL_ACCESSIONS_CHECKED_IN);
-        navigate(APP_PATHS.ACCESSIONS);
+        void navigate(APP_PATHS.ACCESSIONS);
       } catch (e) {
         setBusy(false);
         snackbar.toastError();
@@ -111,7 +111,7 @@ export default function CheckIn(): JSX.Element {
       // eslint-disable-next-line no-restricted-globals
       state: { from: location.pathname },
     };
-    navigate(accessionLocation);
+    void navigate(accessionLocation);
   };
 
   const pendingAccessionsById = transformPendingAccessions();

--- a/src/scenes/CheckIn/index.tsx
+++ b/src/scenes/CheckIn/index.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, Grid, useTheme } from '@mui/material';
 import { BusySpinner } from '@terraware/web-components';
@@ -10,6 +9,7 @@ import TextField from 'src/components/common/Textfield/Textfield';
 import TfMain from 'src/components/common/TfMain';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
 import { SeedBankService } from 'src/services';
 import { AccessionService } from 'src/services';

--- a/src/scenes/FunderReport/FunderReportView.tsx
+++ b/src/scenes/FunderReport/FunderReportView.tsx
@@ -57,7 +57,7 @@ const FunderReportView = () => {
         const found = reports?.find((r) => r.reportId.toString() === query.get('reportId'));
         setSelectedReport(found || reports[0]);
         query.delete('reportId');
-        navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+        void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
       } else {
         setSelectedReport(reports[0]);
       }

--- a/src/scenes/FunderReport/FunderReportView.tsx
+++ b/src/scenes/FunderReport/FunderReportView.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { SelectT } from '@terraware/web-components';
@@ -9,6 +8,7 @@ import AchievementsBox from 'src/components/AcceleratorReports/AchievementsBox';
 import ChallengesMitigationBox from 'src/components/AcceleratorReports/ChallengesMitigationBox';
 import MetricStatusBadge from 'src/components/AcceleratorReports/MetricStatusBadge';
 import Card from 'src/components/common/Card';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useUserFundingEntity } from 'src/providers';
 import { requestListFunderReports } from 'src/redux/features/funder/fundingEntitiesAsyncThunks';
 import { selectListFunderReports } from 'src/redux/features/funder/fundingEntitiesSelectors';

--- a/src/scenes/FunderReport/FunderReportView.tsx
+++ b/src/scenes/FunderReport/FunderReportView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { SelectT } from '@terraware/web-components';
@@ -30,7 +30,7 @@ const FunderReportView = () => {
   const [selectedReport, setSelectedReport] = useState<PublishedReport>();
   const query = useQuery();
   const location = useStateLocation();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { isDesktop, isMobile } = useDeviceInfo();
 
   useEffect(() => {
@@ -57,7 +57,7 @@ const FunderReportView = () => {
         const found = reports?.find((r) => r.reportId.toString() === query.get('reportId'));
         setSelectedReport(found || reports[0]);
         query.delete('reportId');
-        void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+        navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
       } else {
         setSelectedReport(reports[0]);
       }

--- a/src/scenes/FunderRouter/index.tsx
+++ b/src/scenes/FunderRouter/index.tsx
@@ -22,7 +22,7 @@ export default function FunderRouter() {
 
   useEffect(() => {
     if (navigate && user && user.userType !== 'Funder') {
-      navigate(APP_PATHS.HOME);
+      void navigate(APP_PATHS.HOME);
     }
   }, [navigate, user]);
 

--- a/src/scenes/FunderRouter/index.tsx
+++ b/src/scenes/FunderRouter/index.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect } from 'react';
 import { Route, Routes } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box } from '@mui/material';
 
 import ErrorBoundary from 'src/ErrorBoundary';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useUser } from 'src/providers';
 import FunderHome from 'src/scenes/FunderHome';
 

--- a/src/scenes/FunderRouter/index.tsx
+++ b/src/scenes/FunderRouter/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
-import { Route, Routes, useNavigate } from 'react-router';
+import { Route, Routes } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box } from '@mui/material';
 
@@ -10,7 +11,7 @@ import FunderHome from 'src/scenes/FunderHome';
 
 export default function FunderRouter() {
   const { user } = useUser();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
 
   const contentStyles = {
     height: '100%',
@@ -22,7 +23,7 @@ export default function FunderRouter() {
 
   useEffect(() => {
     if (navigate && user && user.userType !== 'Funder') {
-      void navigate(APP_PATHS.HOME);
+      navigate(APP_PATHS.HOME);
     }
   }, [navigate, user]);
 

--- a/src/scenes/Home/OnboardingHomeView/index.tsx
+++ b/src/scenes/Home/OnboardingHomeView/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, Grid, Typography } from '@mui/material';
 import { IconName } from '@terraware/web-components';
@@ -10,6 +9,7 @@ import PageHeader from 'src/components/PageHeader';
 import Link from 'src/components/common/Link';
 import TfMain from 'src/components/common/TfMain';
 import { ACCELERATOR_LINK, APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useOrganization, useUser } from 'src/providers';
 import { requestObservations, requestObservationsResults } from 'src/redux/features/observations/observationsThunks';

--- a/src/scenes/Home/OnboardingHomeView/index.tsx
+++ b/src/scenes/Home/OnboardingHomeView/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, Grid, Typography } from '@mui/material';
 import { IconName } from '@terraware/web-components';
@@ -31,7 +31,7 @@ const OnboardingHomeView = () => {
   const { selectedOrganization, orgPreferences, reloadOrgPreferences } = useOrganization();
   const { isMobile, isDesktop } = useDeviceInfo();
   const mixpanel = useMixpanel();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const dispatch = useAppDispatch();
   const [people, setPeople] = useState<OrganizationUser[]>();
   const [allSpecies, setAllSpecies] = useState<Species[]>();
@@ -110,7 +110,7 @@ const OnboardingHomeView = () => {
             buttonProps: {
               label: strings.ADD_PEOPLE,
               onClick: () => {
-                void navigate(APP_PATHS.PEOPLE_NEW);
+                navigate(APP_PATHS.PEOPLE_NEW);
               },
             },
             secondaryButtonProps: {
@@ -128,7 +128,7 @@ const OnboardingHomeView = () => {
             buttonProps: {
               label: strings.ADD_SPECIES,
               onClick: () => {
-                void navigate(APP_PATHS.SPECIES_NEW);
+                navigate(APP_PATHS.SPECIES_NEW);
               },
             },
 
@@ -144,7 +144,7 @@ const OnboardingHomeView = () => {
               buttonProps: {
                 label: strings.ADD_SPECIES,
                 onClick: () => {
-                  void navigate(APP_PATHS.SPECIES_NEW);
+                  navigate(APP_PATHS.SPECIES_NEW);
                 },
               },
               icon: 'species' as IconName,

--- a/src/scenes/Home/OnboardingHomeView/index.tsx
+++ b/src/scenes/Home/OnboardingHomeView/index.tsx
@@ -110,7 +110,7 @@ const OnboardingHomeView = () => {
             buttonProps: {
               label: strings.ADD_PEOPLE,
               onClick: () => {
-                navigate(APP_PATHS.PEOPLE_NEW);
+                void navigate(APP_PATHS.PEOPLE_NEW);
               },
             },
             secondaryButtonProps: {
@@ -128,7 +128,7 @@ const OnboardingHomeView = () => {
             buttonProps: {
               label: strings.ADD_SPECIES,
               onClick: () => {
-                navigate(APP_PATHS.SPECIES_NEW);
+                void navigate(APP_PATHS.SPECIES_NEW);
               },
             },
 
@@ -144,7 +144,7 @@ const OnboardingHomeView = () => {
               buttonProps: {
                 label: strings.ADD_SPECIES,
                 onClick: () => {
-                  navigate(APP_PATHS.SPECIES_NEW);
+                  void navigate(APP_PATHS.SPECIES_NEW);
                 },
               },
               icon: 'species' as IconName,

--- a/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
+++ b/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Icon } from '@terraware/web-components';
@@ -32,7 +32,7 @@ export const PlantingSiteStats = () => {
   const numberFormatter = useNumberFormatter();
   const { isDesktop } = useDeviceInfo();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { selectedOrganization } = useOrganization();
   const plantingSites = useAppSelector(selectOrgPlantingSites(selectedOrganization.id));
   const { token } = useMapboxToken();
@@ -254,7 +254,7 @@ export const PlantingSiteStats = () => {
           <Grid item xs={primaryGridSize} sx={{ textAlign: isDesktop ? 'left' : 'center' }}>
             <Link
               onClick={() => {
-                void navigate(`${APP_PATHS.PLANTS_DASHBOARD}/${selectedPlantingSiteId}`);
+                navigate(`${APP_PATHS.PLANTS_DASHBOARD}/${selectedPlantingSiteId}`);
               }}
               style={{ textWrap: 'wrap', textAlign: 'left' }}
             >
@@ -267,7 +267,7 @@ export const PlantingSiteStats = () => {
                   id='add-planting-site'
                   large={false}
                   onClick={() => {
-                    void navigate(`${APP_PATHS.PLANTING_SITES}?new=true`);
+                    navigate(`${APP_PATHS.PLANTING_SITES}?new=true`);
                   }}
                   text={strings.ADD_PLANTING_SITE}
                 />

--- a/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
+++ b/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
@@ -254,7 +254,7 @@ export const PlantingSiteStats = () => {
           <Grid item xs={primaryGridSize} sx={{ textAlign: isDesktop ? 'left' : 'center' }}>
             <Link
               onClick={() => {
-                navigate(`${APP_PATHS.PLANTS_DASHBOARD}/${selectedPlantingSiteId}`);
+                void navigate(`${APP_PATHS.PLANTS_DASHBOARD}/${selectedPlantingSiteId}`);
               }}
               style={{ textWrap: 'wrap', textAlign: 'left' }}
             >
@@ -267,7 +267,7 @@ export const PlantingSiteStats = () => {
                   id='add-planting-site'
                   large={false}
                   onClick={() => {
-                    navigate(`${APP_PATHS.PLANTING_SITES}?new=true`);
+                    void navigate(`${APP_PATHS.PLANTING_SITES}?new=true`);
                   }}
                   text={strings.ADD_PLANTING_SITE}
                 />

--- a/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
+++ b/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Icon } from '@terraware/web-components';
@@ -9,6 +8,7 @@ import AddLink from 'src/components/common/AddLink';
 import Link from 'src/components/common/Link';
 import PlantingSiteSelector from 'src/components/common/PlantingSiteSelector';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
 import { selectLatestObservation } from 'src/redux/features/observations/observationsSelectors';
 import { selectPlantingsForSite } from 'src/redux/features/plantings/plantingsSelectors';

--- a/src/scenes/Home/TerrawareHomeView/index.tsx
+++ b/src/scenes/Home/TerrawareHomeView/index.tsx
@@ -118,13 +118,13 @@ const TerrawareHomeView = () => {
           ? {
               label: strings.ADD_SPECIES,
               onClick: () => {
-                navigate(APP_PATHS.SPECIES_NEW);
+                void navigate(APP_PATHS.SPECIES_NEW);
               },
             }
           : {
               label: strings.VIEW_SPECIES_LIST,
               onClick: () => {
-                navigate(APP_PATHS.SPECIES);
+                void navigate(APP_PATHS.SPECIES);
               },
             },
         icon: 'species' as IconName,
@@ -166,7 +166,7 @@ const TerrawareHomeView = () => {
           {
             label: strings.TOTAL_ACTIVE_ACCESSIONS,
             linkOnClick: () => {
-              navigate(APP_PATHS.SEEDS_DASHBOARD);
+              void navigate(APP_PATHS.SEEDS_DASHBOARD);
             },
             linkText: strings.VIEW_FULL_DASHBOARD,
             value: numericFormatter.format(seedBankSummary?.value?.activeAccessions ?? 0),
@@ -204,7 +204,7 @@ const TerrawareHomeView = () => {
             label: strings.TOTAL_WITHDRAWN_FOR_PLANTING,
             value: numericFormatter.format(orgNurserySummary?.totalWithdrawn ?? 0),
             linkOnClick: () => {
-              navigate(APP_PATHS.NURSERY_WITHDRAWALS);
+              void navigate(APP_PATHS.NURSERY_WITHDRAWALS);
             },
             linkText: strings.VIEW_PLANTING_PROGRESS,
           },
@@ -218,7 +218,7 @@ const TerrawareHomeView = () => {
         buttonProps: {
           label: strings.ADD_PLANTING_SITE,
           onClick: () => {
-            navigate(`${APP_PATHS.PLANTING_SITES}?new=true`);
+            void navigate(`${APP_PATHS.PLANTING_SITES}?new=true`);
           },
         },
         icon: 'iconRestorationSite' as IconName,

--- a/src/scenes/Home/TerrawareHomeView/index.tsx
+++ b/src/scenes/Home/TerrawareHomeView/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, Grid, Typography } from '@mui/material';
 import { IconName } from '@terraware/web-components';
@@ -14,6 +13,7 @@ import { ACCELERATOR_LINK, APP_PATHS } from 'src/constants';
 import useNavigateTo from 'src/hooks/useNavigateTo';
 import { useOrgNurserySummary } from 'src/hooks/useOrgNurserySummary';
 import { useSeedBankSummary } from 'src/hooks/useSeedBankSummary';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useLocalization, useOrganization, useUser } from 'src/providers';
 import { requestObservations, requestObservationsResults } from 'src/redux/features/observations/observationsThunks';

--- a/src/scenes/Home/TerrawareHomeView/index.tsx
+++ b/src/scenes/Home/TerrawareHomeView/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, Grid, Typography } from '@mui/material';
 import { IconName } from '@terraware/web-components';
@@ -37,7 +37,7 @@ const TerrawareHomeView = () => {
   const { selectedOrganization, orgPreferences, reloadOrgPreferences } = useOrganization();
   const { isTablet, isMobile, isDesktop } = useDeviceInfo();
   const mixpanel = useMixpanel();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const dispatch = useAppDispatch();
   const { goToNewAccession } = useNavigateTo();
   const plantingSites = useAppSelector(selectPlantingSites);
@@ -118,13 +118,13 @@ const TerrawareHomeView = () => {
           ? {
               label: strings.ADD_SPECIES,
               onClick: () => {
-                void navigate(APP_PATHS.SPECIES_NEW);
+                navigate(APP_PATHS.SPECIES_NEW);
               },
             }
           : {
               label: strings.VIEW_SPECIES_LIST,
               onClick: () => {
-                void navigate(APP_PATHS.SPECIES);
+                navigate(APP_PATHS.SPECIES);
               },
             },
         icon: 'species' as IconName,
@@ -166,7 +166,7 @@ const TerrawareHomeView = () => {
           {
             label: strings.TOTAL_ACTIVE_ACCESSIONS,
             linkOnClick: () => {
-              void navigate(APP_PATHS.SEEDS_DASHBOARD);
+              navigate(APP_PATHS.SEEDS_DASHBOARD);
             },
             linkText: strings.VIEW_FULL_DASHBOARD,
             value: numericFormatter.format(seedBankSummary?.value?.activeAccessions ?? 0),
@@ -204,7 +204,7 @@ const TerrawareHomeView = () => {
             label: strings.TOTAL_WITHDRAWN_FOR_PLANTING,
             value: numericFormatter.format(orgNurserySummary?.totalWithdrawn ?? 0),
             linkOnClick: () => {
-              void navigate(APP_PATHS.NURSERY_WITHDRAWALS);
+              navigate(APP_PATHS.NURSERY_WITHDRAWALS);
             },
             linkText: strings.VIEW_PLANTING_PROGRESS,
           },
@@ -218,7 +218,7 @@ const TerrawareHomeView = () => {
         buttonProps: {
           label: strings.ADD_PLANTING_SITE,
           onClick: () => {
-            void navigate(`${APP_PATHS.PLANTING_SITES}?new=true`);
+            navigate(`${APP_PATHS.PLANTING_SITES}?new=true`);
           },
         },
         icon: 'iconRestorationSite' as IconName,

--- a/src/scenes/InventoryRouter/InventoryBatchView.tsx
+++ b/src/scenes/InventoryRouter/InventoryBatchView.tsx
@@ -101,7 +101,7 @@ export default function InventoryBatchView({ origin, species }: InventoryBatchPr
   const onTabChange = useCallback(
     (newTab: string) => {
       query.set('tab', newTab);
-      navigate(getLocation(location.pathname, location, query.toString()));
+      void navigate(getLocation(location.pathname, location, query.toString()));
     },
     [query, navigate, location]
   );
@@ -179,7 +179,7 @@ export default function InventoryBatchView({ origin, species }: InventoryBatchPr
               <Button
                 label={strings.WITHDRAW}
                 onClick={() =>
-                  navigate({
+                  void navigate({
                     pathname: APP_PATHS.BATCH_WITHDRAW,
                     search: `?batchId=${batchId.toString()}&source=${window.location.pathname}`,
                   })

--- a/src/scenes/InventoryRouter/InventoryBatchView.tsx
+++ b/src/scenes/InventoryRouter/InventoryBatchView.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button, Tabs } from '@terraware/web-components';
@@ -10,6 +9,7 @@ import BackToLink from 'src/components/common/BackToLink';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers';
 import { requestFetchBatch } from 'src/redux/features/batches/batchesAsyncThunks';
 import { selectBatch } from 'src/redux/features/batches/batchesSelectors';

--- a/src/scenes/InventoryRouter/InventoryBatchView.tsx
+++ b/src/scenes/InventoryRouter/InventoryBatchView.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button, Tabs } from '@terraware/web-components';
@@ -50,7 +51,7 @@ export default function InventoryBatchView({ origin, species }: InventoryBatchPr
   const batch = useAppSelector(selectBatch(batchId || -1));
   const tab = initializeTab(query.get('tab'));
   const [activeTab, setActiveTab] = useState<string>(tab);
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const [inventorySpecies, setInventorySpecies] = useState<Species>();
   const [inventoryNursery, setInventoryNursery] = useState<Facility>();
@@ -101,7 +102,7 @@ export default function InventoryBatchView({ origin, species }: InventoryBatchPr
   const onTabChange = useCallback(
     (newTab: string) => {
       query.set('tab', newTab);
-      void navigate(getLocation(location.pathname, location, query.toString()));
+      navigate(getLocation(location.pathname, location, query.toString()));
     },
     [query, navigate, location]
   );
@@ -179,7 +180,7 @@ export default function InventoryBatchView({ origin, species }: InventoryBatchPr
               <Button
                 label={strings.WITHDRAW}
                 onClick={() =>
-                  void navigate({
+                  navigate({
                     pathname: APP_PATHS.BATCH_WITHDRAW,
                     search: `?batchId=${batchId.toString()}&source=${window.location.pathname}`,
                   })

--- a/src/scenes/InventoryRouter/InventoryCreateView.tsx
+++ b/src/scenes/InventoryRouter/InventoryCreateView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 
@@ -18,7 +18,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 export default function InventoryCreateView(): JSX.Element {
   const dispatch = useAppDispatch();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
   const { userPreferences } = useUser();
   const originInventoryViewType: InventoryListType =
@@ -54,13 +54,13 @@ export default function InventoryCreateView(): JSX.Element {
   );
 
   const goToInventory = useCallback(() => {
-    void navigate(inventoryLocation);
+    navigate(inventoryLocation);
   }, [navigate, inventoryLocation]);
 
   useEffect(() => {
     if (batchesRequest?.status === 'success') {
       setBusy(false);
-      void navigate(inventoryLocation, { replace: true });
+      navigate(inventoryLocation, { replace: true });
 
       const batchId = batchesRequest?.data?.batch?.id;
       const facilityId = batchesRequest?.data?.batch?.facilityId;
@@ -69,18 +69,18 @@ export default function InventoryCreateView(): JSX.Element {
       // we can assume the batchId, facilityId and speciesId will be valid upon a successful create
 
       if (originInventoryViewType === InventoryListTypes.BATCHES_BY_NURSERY) {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.INVENTORY_BATCH_FOR_NURSERY.replace(':nurseryId', `${facilityId}`).replace(
             ':batchId',
             `${batchId}`
           ),
         });
       } else if (originInventoryViewType === InventoryListTypes.BATCHES_BY_BATCH) {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.INVENTORY_BATCH.replace(':batchId', `${batchId}`),
         });
       } else {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.INVENTORY_BATCH_FOR_SPECIES.replace(':speciesId', `${speciesId}`).replace(
             ':batchId',
             `${batchId}`

--- a/src/scenes/InventoryRouter/InventoryCreateView.tsx
+++ b/src/scenes/InventoryRouter/InventoryCreateView.tsx
@@ -54,13 +54,13 @@ export default function InventoryCreateView(): JSX.Element {
   );
 
   const goToInventory = useCallback(() => {
-    navigate(inventoryLocation);
+    void navigate(inventoryLocation);
   }, [navigate, inventoryLocation]);
 
   useEffect(() => {
     if (batchesRequest?.status === 'success') {
       setBusy(false);
-      navigate(inventoryLocation, { replace: true });
+      void navigate(inventoryLocation, { replace: true });
 
       const batchId = batchesRequest?.data?.batch?.id;
       const facilityId = batchesRequest?.data?.batch?.facilityId;
@@ -69,18 +69,18 @@ export default function InventoryCreateView(): JSX.Element {
       // we can assume the batchId, facilityId and speciesId will be valid upon a successful create
 
       if (originInventoryViewType === InventoryListTypes.BATCHES_BY_NURSERY) {
-        navigate({
+        void navigate({
           pathname: APP_PATHS.INVENTORY_BATCH_FOR_NURSERY.replace(':nurseryId', `${facilityId}`).replace(
             ':batchId',
             `${batchId}`
           ),
         });
       } else if (originInventoryViewType === InventoryListTypes.BATCHES_BY_BATCH) {
-        navigate({
+        void navigate({
           pathname: APP_PATHS.INVENTORY_BATCH.replace(':batchId', `${batchId}`),
         });
       } else {
-        navigate({
+        void navigate({
           pathname: APP_PATHS.INVENTORY_BATCH_FOR_SPECIES.replace(':speciesId', `${speciesId}`).replace(
             ':batchId',
             `${batchId}`

--- a/src/scenes/InventoryRouter/InventoryCreateView.tsx
+++ b/src/scenes/InventoryRouter/InventoryCreateView.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 
 import PageForm from 'src/components/common/PageForm';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useUser } from 'src/providers';
 import { SavableBatch, requestSaveBatch } from 'src/redux/features/batches/batchesAsyncThunks';
 import { selectBatchesRequest } from 'src/redux/features/batches/batchesSelectors';

--- a/src/scenes/InventoryRouter/InventoryForNurseryView.tsx
+++ b/src/scenes/InventoryRouter/InventoryForNurseryView.tsx
@@ -1,6 +1,5 @@
 import React, { useRef, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 
@@ -10,6 +9,7 @@ import Card from 'src/components/common/Card';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers';
 import InventorySeedlingsTableForNursery from 'src/scenes/InventoryRouter/view/InventorySeedlingsTableForNursery';
 import InventorySummaryForNursery from 'src/scenes/InventoryRouter/view/InventorySummaryForNursery';

--- a/src/scenes/InventoryRouter/InventoryForNurseryView.tsx
+++ b/src/scenes/InventoryRouter/InventoryForNurseryView.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 
@@ -20,7 +21,7 @@ import { getNurseryName } from './FilterUtils';
 
 export default function InventoryForNurseryView(): JSX.Element {
   const query = useQuery();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const pathParams = useParams<{ nurseryId: string }>();
   const { selectedOrganization } = useOrganization();
@@ -38,7 +39,7 @@ export default function InventoryForNurseryView(): JSX.Element {
     } else {
       query.set('batch', batchNum);
     }
-    void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+    navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
   };
 
   return (

--- a/src/scenes/InventoryRouter/InventoryForNurseryView.tsx
+++ b/src/scenes/InventoryRouter/InventoryForNurseryView.tsx
@@ -38,7 +38,7 @@ export default function InventoryForNurseryView(): JSX.Element {
     } else {
       query.set('batch', batchNum);
     }
-    navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+    void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
   };
 
   return (

--- a/src/scenes/InventoryRouter/InventoryForSpeciesView.tsx
+++ b/src/scenes/InventoryRouter/InventoryForSpeciesView.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 
@@ -10,6 +9,7 @@ import Card from 'src/components/common/Card';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import InventorySeedlingsTableForSpecies from 'src/scenes/InventoryRouter/view/InventorySeedlingsTableForSpecies';
 import InventorySummaryForSpecies from 'src/scenes/InventoryRouter/view/InventorySummaryForSpecies';
 import strings from 'src/strings';

--- a/src/scenes/InventoryRouter/InventoryForSpeciesView.tsx
+++ b/src/scenes/InventoryRouter/InventoryForSpeciesView.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 
@@ -22,7 +23,7 @@ interface InventoryForSpeciesViewProps {
 
 export default function InventoryForSpeciesView(props: InventoryForSpeciesViewProps): JSX.Element {
   const query = useQuery();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const openBatchNumber = (query.get('batch') || '').toLowerCase();
   const { species } = props;
@@ -54,7 +55,7 @@ export default function InventoryForSpeciesView(props: InventoryForSpeciesViewPr
     } else {
       query.set('batch', batchNum);
     }
-    void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+    navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
   };
 
   return (

--- a/src/scenes/InventoryRouter/InventoryForSpeciesView.tsx
+++ b/src/scenes/InventoryRouter/InventoryForSpeciesView.tsx
@@ -54,7 +54,7 @@ export default function InventoryForSpeciesView(props: InventoryForSpeciesViewPr
     } else {
       query.set('batch', batchNum);
     }
-    navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+    void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
   };
 
   return (

--- a/src/scenes/InventoryRouter/InventoryTable.tsx
+++ b/src/scenes/InventoryRouter/InventoryTable.tsx
@@ -97,7 +97,7 @@ export default function InventoryTable(props: InventoryTableProps): JSX.Element 
         : selectedRows.filter((r) => r.species_id).map((row) => `batchId=${row.batchId}`);
     const searchParams = origin === 'Species' ? speciesIds.join('&') : batchIds.join('&');
 
-    navigate({
+    void navigate({
       pathname: path,
       search: `?${searchParams}&source=${window.location.pathname}`,
     });

--- a/src/scenes/InventoryRouter/InventoryTable.tsx
+++ b/src/scenes/InventoryRouter/InventoryTable.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
@@ -9,6 +8,7 @@ import ProjectAssignTopBarButton from 'src/components/ProjectAssignTopBarButton'
 import Table from 'src/components/common/table';
 import { SortOrder } from 'src/components/common/table/sort';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { OriginPage } from 'src/scenes/InventoryRouter/InventoryBatchView';
 import { InventoryFiltersUnion } from 'src/scenes/InventoryRouter/InventoryFilter';
 import Search from 'src/scenes/InventoryRouter/Search';

--- a/src/scenes/InventoryRouter/InventoryTable.tsx
+++ b/src/scenes/InventoryRouter/InventoryTable.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
@@ -48,7 +48,7 @@ export default function InventoryTable(props: InventoryTableProps): JSX.Element 
   } = props;
 
   const [selectedRows, setSelectedRows] = useState<any[]>([]);
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { sessionFilters, setSessionFilters } = useSessionFilters(origin.toLowerCase());
   const [withdrawTooltip, setWithdrawTooltip] = useState<string>();
 
@@ -97,7 +97,7 @@ export default function InventoryTable(props: InventoryTableProps): JSX.Element 
         : selectedRows.filter((r) => r.species_id).map((row) => `batchId=${row.batchId}`);
     const searchParams = origin === 'Species' ? speciesIds.join('&') : batchIds.join('&');
 
-    void navigate({
+    navigate({
       pathname: path,
       search: `?${searchParams}&source=${window.location.pathname}`,
     });

--- a/src/scenes/InventoryRouter/InventoryV2View.tsx
+++ b/src/scenes/InventoryRouter/InventoryV2View.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, Grid, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem, Tabs } from '@terraware/web-components';
@@ -11,6 +10,7 @@ import OptionsMenu from 'src/components/common/OptionsMenu';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization, useUser } from 'src/providers';
 import { PreferencesService } from 'src/services';
 import NurseryInventoryService, { SearchInventoryParams } from 'src/services/NurseryInventoryService';

--- a/src/scenes/InventoryRouter/InventoryV2View.tsx
+++ b/src/scenes/InventoryRouter/InventoryV2View.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, Grid, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem, Tabs } from '@terraware/web-components';
@@ -135,7 +135,7 @@ export default function InventoryV2View(props: InventoryProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const { hasNurseries, hasSpecies } = props;
   const [importInventoryModalOpen, setImportInventoryModalOpen] = useState(false);
@@ -159,7 +159,7 @@ export default function InventoryV2View(props: InventoryProps): JSX.Element {
       await PreferencesService.updateUserPreferences({ inventoryListType: newTab });
       reloadUserPreferences();
       query.set('tab', newTab);
-      void navigate(getLocation(location.pathname, location, query.toString()));
+      navigate(getLocation(location.pathname, location, query.toString()));
     },
     [query, navigate, location, reloadUserPreferences]
   );
@@ -172,7 +172,7 @@ export default function InventoryV2View(props: InventoryProps): JSX.Element {
     const appPathLocation = {
       pathname: appPath,
     };
-    void navigate(appPathLocation);
+    navigate(appPathLocation);
   };
 
   const onCloseDownloadReportModal = () => {

--- a/src/scenes/InventoryRouter/InventoryV2View.tsx
+++ b/src/scenes/InventoryRouter/InventoryV2View.tsx
@@ -159,7 +159,7 @@ export default function InventoryV2View(props: InventoryProps): JSX.Element {
       await PreferencesService.updateUserPreferences({ inventoryListType: newTab });
       reloadUserPreferences();
       query.set('tab', newTab);
-      navigate(getLocation(location.pathname, location, query.toString()));
+      void navigate(getLocation(location.pathname, location, query.toString()));
     },
     [query, navigate, location, reloadUserPreferences]
   );
@@ -172,7 +172,7 @@ export default function InventoryV2View(props: InventoryProps): JSX.Element {
     const appPathLocation = {
       pathname: appPath,
     };
-    navigate(appPathLocation);
+    void navigate(appPathLocation);
   };
 
   const onCloseDownloadReportModal = () => {

--- a/src/scenes/InventoryRouter/SpeciesBulkWithdrawView.tsx
+++ b/src/scenes/InventoryRouter/SpeciesBulkWithdrawView.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import BatchWithdrawFlow from 'src/components/BatchWithdrawFlow';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers';
 import { NurseryBatchService } from 'src/services';
 import useQuery from 'src/utils/useQuery';

--- a/src/scenes/InventoryRouter/SpeciesBulkWithdrawView.tsx
+++ b/src/scenes/InventoryRouter/SpeciesBulkWithdrawView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import BatchWithdrawFlow from 'src/components/BatchWithdrawFlow';
 import { APP_PATHS } from 'src/constants';
@@ -16,7 +16,7 @@ export default function SpeciesBulkWithdrawView(props: SpeciesBulkWithdrawViewCo
   const [speciesIds, setSpeciesIds] = useState<string[]>();
   const [batchIds, setBatchIds] = useState<string[]>();
   const [source, setSource] = useState<string | null>();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const query = useQuery();
 
   useEffect(() => {
@@ -25,7 +25,7 @@ export default function SpeciesBulkWithdrawView(props: SpeciesBulkWithdrawViewCo
       setSource(query.get('source'));
     } else {
       // return to inventory page if we came here from some bad url (no valid species)
-      void navigate({ pathname: APP_PATHS.INVENTORY });
+      navigate({ pathname: APP_PATHS.INVENTORY });
     }
   }, [query, navigate]);
 
@@ -41,7 +41,7 @@ export default function SpeciesBulkWithdrawView(props: SpeciesBulkWithdrawViewCo
           setBatchIds(ids);
         } else {
           // return to inventory page if we came here from some bad url (no valid species)
-          void navigate({ pathname: APP_PATHS.INVENTORY });
+          navigate({ pathname: APP_PATHS.INVENTORY });
         }
       }
     };

--- a/src/scenes/InventoryRouter/SpeciesBulkWithdrawView.tsx
+++ b/src/scenes/InventoryRouter/SpeciesBulkWithdrawView.tsx
@@ -25,7 +25,7 @@ export default function SpeciesBulkWithdrawView(props: SpeciesBulkWithdrawViewCo
       setSource(query.get('source'));
     } else {
       // return to inventory page if we came here from some bad url (no valid species)
-      navigate({ pathname: APP_PATHS.INVENTORY });
+      void navigate({ pathname: APP_PATHS.INVENTORY });
     }
   }, [query, navigate]);
 
@@ -41,7 +41,7 @@ export default function SpeciesBulkWithdrawView(props: SpeciesBulkWithdrawViewCo
           setBatchIds(ids);
         } else {
           // return to inventory page if we came here from some bad url (no valid species)
-          navigate({ pathname: APP_PATHS.INVENTORY });
+          void navigate({ pathname: APP_PATHS.INVENTORY });
         }
       }
     };

--- a/src/scenes/InventoryRouter/view/InventorySeedlingsTable.tsx
+++ b/src/scenes/InventoryRouter/view/InventorySeedlingsTable.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem, TableColumnType } from '@terraware/web-components';
@@ -74,7 +74,7 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
   const { isMobile, isDesktop } = useDeviceInfo();
   const theme = useTheme();
   const snackbar = useSnackbar();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
 
   const [openExportModal, setOpenExportModal] = useState<boolean>(false);
   const [temporalSearchValue, setTemporalSearchValue] = useState<string>('');
@@ -212,14 +212,14 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
     const batch = batches.find((b) => b.batchNumber === openBatchNumber);
     if (batch) {
       if (origin === 'Nursery') {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.INVENTORY_BATCH_FOR_NURSERY.replace(':nurseryId', `${originId}`).replace(
             ':batchId',
             `${batch.id}`
           ),
         });
       } else {
-        void navigate({
+        navigate({
           pathname: APP_PATHS.INVENTORY_BATCH_FOR_SPECIES.replace(':speciesId', `${originId}`).replace(
             ':batchId',
             `${batch.id}`
@@ -261,7 +261,7 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
 
   const onBatchSelected = (batch: any, fromColumn?: string) => {
     if (fromColumn === 'withdraw') {
-      void navigate({
+      navigate({
         pathname: APP_PATHS.BATCH_WITHDRAW,
         search: `?batchId=${batch.id.toString()}&source=${window.location.pathname}`,
       });
@@ -276,7 +276,7 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
         to = APP_PATHS.INVENTORY_BATCH_FOR_SPECIES.replace(':speciesId', `${originId}`);
       }
 
-      void navigate(to.replace(':batchId', batch.id));
+      navigate(to.replace(':batchId', batch.id));
     }
   };
 
@@ -286,7 +286,7 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
   };
 
   const bulkWithdrawSelectedRows = () => {
-    void navigate({
+    navigate({
       pathname: APP_PATHS.BATCH_WITHDRAW,
       search: getSelectedRowsAsQueryParams(),
     });

--- a/src/scenes/InventoryRouter/view/InventorySeedlingsTable.tsx
+++ b/src/scenes/InventoryRouter/view/InventorySeedlingsTable.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem, TableColumnType } from '@terraware/web-components';
@@ -10,6 +9,7 @@ import OptionsMenu from 'src/components/common/OptionsMenu';
 import Table from 'src/components/common/table';
 import { SortOrder } from 'src/components/common/table/sort';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers';
 import { isBatchEmpty } from 'src/scenes/InventoryRouter/FilterUtils';
 import { InventoryFiltersUnion } from 'src/scenes/InventoryRouter/InventoryFilter';

--- a/src/scenes/InventoryRouter/view/InventorySeedlingsTable.tsx
+++ b/src/scenes/InventoryRouter/view/InventorySeedlingsTable.tsx
@@ -212,14 +212,14 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
     const batch = batches.find((b) => b.batchNumber === openBatchNumber);
     if (batch) {
       if (origin === 'Nursery') {
-        navigate({
+        void navigate({
           pathname: APP_PATHS.INVENTORY_BATCH_FOR_NURSERY.replace(':nurseryId', `${originId}`).replace(
             ':batchId',
             `${batch.id}`
           ),
         });
       } else {
-        navigate({
+        void navigate({
           pathname: APP_PATHS.INVENTORY_BATCH_FOR_SPECIES.replace(':speciesId', `${originId}`).replace(
             ':batchId',
             `${batch.id}`
@@ -261,7 +261,7 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
 
   const onBatchSelected = (batch: any, fromColumn?: string) => {
     if (fromColumn === 'withdraw') {
-      navigate({
+      void navigate({
         pathname: APP_PATHS.BATCH_WITHDRAW,
         search: `?batchId=${batch.id.toString()}&source=${window.location.pathname}`,
       });
@@ -276,7 +276,7 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
         to = APP_PATHS.INVENTORY_BATCH_FOR_SPECIES.replace(':speciesId', `${originId}`);
       }
 
-      navigate(to.replace(':batchId', batch.id));
+      void navigate(to.replace(':batchId', batch.id));
     }
   };
 
@@ -286,7 +286,7 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
   };
 
   const bulkWithdrawSelectedRows = () => {
-    navigate({
+    void navigate({
       pathname: APP_PATHS.BATCH_WITHDRAW,
       search: getSelectedRowsAsQueryParams(),
     });

--- a/src/scenes/MyAccountRouter/MyAccountForm.tsx
+++ b/src/scenes/MyAccountRouter/MyAccountForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, FormControlLabel, Grid, Radio, RadioGroup, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem } from '@terraware/web-components';
@@ -92,7 +92,7 @@ const MyAccountForm = ({
   const theme = useTheme();
   const [selectedRows, setSelectedRows] = useState<PersonOrganization[]>([]);
   const [personOrganizations, setPersonOrganizations] = useState<PersonOrganization[]>([]);
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const [record, setRecord, onChange] = useForm<User>(user);
   const [openDeleteAccountModal, setOpenDeleteAccountModal] = useState<boolean>(false);
   const [removedOrg, setRemovedOrg] = useState<Organization>();
@@ -179,7 +179,7 @@ const MyAccountForm = ({
     if (backToView) {
       backToView();
     } else {
-      void navigate(APP_PATHS.MY_ACCOUNT);
+      navigate(APP_PATHS.MY_ACCOUNT);
     }
   };
 
@@ -218,7 +218,7 @@ const MyAccountForm = ({
       if (backToView) {
         backToView();
       } else {
-        void navigate(APP_PATHS.MY_ACCOUNT);
+        navigate(APP_PATHS.MY_ACCOUNT);
       }
     }
   };
@@ -270,7 +270,7 @@ const MyAccountForm = ({
     if (backToView) {
       backToView();
     } else {
-      void navigate(APP_PATHS.MY_ACCOUNT);
+      navigate(APP_PATHS.MY_ACCOUNT);
     }
   };
 
@@ -287,7 +287,7 @@ const MyAccountForm = ({
       } else {
         snackbar.toastError();
       }
-      void navigate(APP_PATHS.HOME);
+      navigate(APP_PATHS.HOME);
     }
   };
 

--- a/src/scenes/MyAccountRouter/MyAccountForm.tsx
+++ b/src/scenes/MyAccountRouter/MyAccountForm.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, FormControlLabel, Grid, Radio, RadioGroup, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem } from '@terraware/web-components';
@@ -19,6 +18,7 @@ import Table from 'src/components/common/table';
 import { TableColumnType } from 'src/components/common/table/types';
 import { APP_PATHS } from 'src/constants';
 import { useDocLinks } from 'src/docLinks';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useTimeZones, useUser } from 'src/providers';
 import { OrganizationService, OrganizationUserService, PreferencesService, UserService } from 'src/services';
 import strings from 'src/strings';

--- a/src/scenes/MyAccountRouter/MyAccountForm.tsx
+++ b/src/scenes/MyAccountRouter/MyAccountForm.tsx
@@ -179,7 +179,7 @@ const MyAccountForm = ({
     if (backToView) {
       backToView();
     } else {
-      navigate(APP_PATHS.MY_ACCOUNT);
+      void navigate(APP_PATHS.MY_ACCOUNT);
     }
   };
 
@@ -218,7 +218,7 @@ const MyAccountForm = ({
       if (backToView) {
         backToView();
       } else {
-        navigate(APP_PATHS.MY_ACCOUNT);
+        void navigate(APP_PATHS.MY_ACCOUNT);
       }
     }
   };
@@ -270,7 +270,7 @@ const MyAccountForm = ({
     if (backToView) {
       backToView();
     } else {
-      navigate(APP_PATHS.MY_ACCOUNT);
+      void navigate(APP_PATHS.MY_ACCOUNT);
     }
   };
 
@@ -287,7 +287,7 @@ const MyAccountForm = ({
       } else {
         snackbar.toastError();
       }
-      navigate(APP_PATHS.HOME);
+      void navigate(APP_PATHS.HOME);
     }
   };
 

--- a/src/scenes/NurseriesRouter/NurseriesListView.tsx
+++ b/src/scenes/NurseriesRouter/NurseriesListView.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button, TableColumnType } from '@terraware/web-components';
@@ -13,6 +12,7 @@ import TfMain from 'src/components/common/TfMain';
 import Table from 'src/components/common/table';
 import TableSettingsButton from 'src/components/common/table/TableSettingsButton';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useTimeZones } from 'src/providers';
 import { FacilityService } from 'src/services';
 import strings from 'src/strings';

--- a/src/scenes/NurseriesRouter/NurseriesListView.tsx
+++ b/src/scenes/NurseriesRouter/NurseriesListView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button, TableColumnType } from '@terraware/web-components';
@@ -40,7 +40,7 @@ export default function NurseriesListView({ organization }: NurseriesListProps):
   const timeZones = useTimeZones();
   const defaultTimeZone = useDefaultTimeZone().get();
   const { isMobile } = useDeviceInfo();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const [temporalSearchValue, setTemporalSearchValue] = useState('');
   const debouncedSearchTerm = useDebounce(temporalSearchValue, 250);
   const [results, setResults] = useState<Facility[]>();
@@ -50,7 +50,7 @@ export default function NurseriesListView({ organization }: NurseriesListProps):
     const newNurseryLocation = {
       pathname: APP_PATHS.NURSERIES_NEW,
     };
-    void navigate(newNurseryLocation);
+    navigate(newNurseryLocation);
   };
 
   const clearSearch = () => {

--- a/src/scenes/NurseriesRouter/NurseriesListView.tsx
+++ b/src/scenes/NurseriesRouter/NurseriesListView.tsx
@@ -50,7 +50,7 @@ export default function NurseriesListView({ organization }: NurseriesListProps):
     const newNurseryLocation = {
       pathname: APP_PATHS.NURSERIES_NEW,
     };
-    navigate(newNurseryLocation);
+    void navigate(newNurseryLocation);
   };
 
   const clearSearch = () => {

--- a/src/scenes/NurseriesRouter/NurseryDetailsView.tsx
+++ b/src/scenes/NurseriesRouter/NurseryDetailsView.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 
@@ -23,7 +24,7 @@ export default function NurseryDetailsView(): JSX.Element {
   const theme = useTheme();
   const { nurseryId } = useParams<{ nurseryId: string }>();
   const [nursery, setNursery] = useState<Facility>();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const tz = useLocationTimeZone().get(nursery);
 
   useEffect(() => {
@@ -36,7 +37,7 @@ export default function NurseryDetailsView(): JSX.Element {
       if (selectedNursery) {
         setNursery(selectedNursery);
       } else {
-        void navigate(APP_PATHS.NURSERIES);
+        navigate(APP_PATHS.NURSERIES);
       }
     }
   }, [nurseryId, selectedOrganization, navigate]);
@@ -46,7 +47,7 @@ export default function NurseryDetailsView(): JSX.Element {
       const editNurseryLocation = {
         pathname: APP_PATHS.NURSERIES_EDIT.replace(':nurseryId', nurseryId),
       };
-      void navigate(editNurseryLocation);
+      navigate(editNurseryLocation);
     }
   };
 

--- a/src/scenes/NurseriesRouter/NurseryDetailsView.tsx
+++ b/src/scenes/NurseriesRouter/NurseryDetailsView.tsx
@@ -36,7 +36,7 @@ export default function NurseryDetailsView(): JSX.Element {
       if (selectedNursery) {
         setNursery(selectedNursery);
       } else {
-        navigate(APP_PATHS.NURSERIES);
+        void navigate(APP_PATHS.NURSERIES);
       }
     }
   }, [nurseryId, selectedOrganization, navigate]);
@@ -46,7 +46,7 @@ export default function NurseryDetailsView(): JSX.Element {
       const editNurseryLocation = {
         pathname: APP_PATHS.NURSERIES_EDIT.replace(':nurseryId', nurseryId),
       };
-      navigate(editNurseryLocation);
+      void navigate(editNurseryLocation);
     }
   };
 

--- a/src/scenes/NurseriesRouter/NurseryDetailsView.tsx
+++ b/src/scenes/NurseriesRouter/NurseryDetailsView.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 
 import BackToLink from 'src/components/common/BackToLink';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
 import { FacilityService } from 'src/services';
 import strings from 'src/strings';

--- a/src/scenes/NurseriesRouter/NurseryView.tsx
+++ b/src/scenes/NurseriesRouter/NurseryView.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { getDateDisplayValue } from '@terraware/web-components/utils';
@@ -9,6 +8,7 @@ import PageSnackbar from 'src/components/PageSnackbar';
 import DatePicker from 'src/components/common/DatePicker';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
 import NurserySubLocations from 'src/scenes/NurseriesRouter/NurserySubLocations';
 import { FacilityService, SubLocationService } from 'src/services';

--- a/src/scenes/NurseriesRouter/NurseryView.tsx
+++ b/src/scenes/NurseriesRouter/NurseryView.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { getDateDisplayValue } from '@terraware/web-components/utils';
@@ -48,7 +49,7 @@ export default function NurseryView(): JSX.Element {
   });
   const { nurseryId } = useParams<{ nurseryId: string }>();
   const [selectedNursery, setSelectedNursery] = useState<Facility | null>();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { isMobile } = useDeviceInfo();
   const gridSize = () => {
     if (isMobile) {
@@ -91,7 +92,7 @@ export default function NurseryView(): JSX.Element {
     const nurseriesLocation = {
       pathname: APP_PATHS.NURSERIES + (id ? `/${id}` : ''),
     };
-    void navigate(nurseriesLocation);
+    navigate(nurseriesLocation);
   };
 
   const saveNursery = async () => {

--- a/src/scenes/NurseriesRouter/NurseryView.tsx
+++ b/src/scenes/NurseriesRouter/NurseryView.tsx
@@ -91,7 +91,7 @@ export default function NurseryView(): JSX.Element {
     const nurseriesLocation = {
       pathname: APP_PATHS.NURSERIES + (id ? `/${id}` : ''),
     };
-    navigate(nurseriesLocation);
+    void navigate(nurseriesLocation);
   };
 
   const saveNursery = async () => {

--- a/src/scenes/NurseryRouter/NurseryPlantingsAndWithdrawalsView.tsx
+++ b/src/scenes/NurseryRouter/NurseryPlantingsAndWithdrawalsView.tsx
@@ -2,7 +2,6 @@
  * Nursery plantings and withdrawals
  */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Tabs } from '@terraware/web-components';
@@ -10,6 +9,7 @@ import { Tabs } from '@terraware/web-components';
 import PageSnackbar from 'src/components/PageSnackbar';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import TfMain from 'src/components/common/TfMain';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
 import { requestPlantings } from 'src/redux/features/plantings/plantingsThunks';
 import { requestPlantingSitesSearchResults } from 'src/redux/features/tracking/trackingThunks';

--- a/src/scenes/NurseryRouter/NurseryPlantingsAndWithdrawalsView.tsx
+++ b/src/scenes/NurseryRouter/NurseryPlantingsAndWithdrawalsView.tsx
@@ -41,7 +41,7 @@ export default function NurseryPlantingsAndWithdrawalsView({ reloadTracking }: N
   const onTabChange = useCallback(
     (newTab: string) => {
       query.set('tab', newTab);
-      navigate(getLocation(location.pathname, location, query.toString()));
+      void navigate(getLocation(location.pathname, location, query.toString()));
     },
     [query, navigate, location]
   );

--- a/src/scenes/NurseryRouter/NurseryPlantingsAndWithdrawalsView.tsx
+++ b/src/scenes/NurseryRouter/NurseryPlantingsAndWithdrawalsView.tsx
@@ -2,7 +2,7 @@
  * Nursery plantings and withdrawals
  */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Tabs } from '@terraware/web-components';
@@ -30,7 +30,7 @@ export default function NurseryPlantingsAndWithdrawalsView({ reloadTracking }: N
   const { selectedOrganization } = useOrganization();
   const theme = useTheme();
   const query = useQuery();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const contentRef = useRef(null);
   const dispatch = useAppDispatch();
@@ -41,7 +41,7 @@ export default function NurseryPlantingsAndWithdrawalsView({ reloadTracking }: N
   const onTabChange = useCallback(
     (newTab: string) => {
       query.set('tab', newTab);
-      void navigate(getLocation(location.pathname, location, query.toString()));
+      navigate(getLocation(location.pathname, location, query.toString()));
     },
     [query, navigate, location]
   );

--- a/src/scenes/NurseryRouter/NurseryReassignmentView.tsx
+++ b/src/scenes/NurseryRouter/NurseryReassignmentView.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, CircularProgress, Grid, useTheme } from '@mui/material';
 import { ErrorBox, TableColumnType } from '@terraware/web-components';
@@ -42,7 +43,7 @@ export default function NurseryReassignmentView(): JSX.Element {
   const numberFormatter = useNumberFormatter();
   const { selectedOrganization } = useOrganization();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { isMobile } = useDeviceInfo();
   const { deliveryId } = useParams<{ deliveryId: string }>();
   const snackbar = useSnackbar();
@@ -126,7 +127,7 @@ export default function NurseryReassignmentView(): JSX.Element {
 
   const goToWithdrawals = () => {
     const withdrawalId = query.has('fromWithdrawal') ? delivery?.withdrawalId : undefined;
-    void navigate({ pathname: APP_PATHS.NURSERY_WITHDRAWALS + (withdrawalId ? `/${withdrawalId}` : '') });
+    navigate({ pathname: APP_PATHS.NURSERY_WITHDRAWALS + (withdrawalId ? `/${withdrawalId}` : '') });
   };
 
   const reassign = async () => {

--- a/src/scenes/NurseryRouter/NurseryReassignmentView.tsx
+++ b/src/scenes/NurseryRouter/NurseryReassignmentView.tsx
@@ -126,7 +126,7 @@ export default function NurseryReassignmentView(): JSX.Element {
 
   const goToWithdrawals = () => {
     const withdrawalId = query.has('fromWithdrawal') ? delivery?.withdrawalId : undefined;
-    navigate({ pathname: APP_PATHS.NURSERY_WITHDRAWALS + (withdrawalId ? `/${withdrawalId}` : '') });
+    void navigate({ pathname: APP_PATHS.NURSERY_WITHDRAWALS + (withdrawalId ? `/${withdrawalId}` : '') });
   };
 
   const reassign = async () => {

--- a/src/scenes/NurseryRouter/NurseryReassignmentView.tsx
+++ b/src/scenes/NurseryRouter/NurseryReassignmentView.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, CircularProgress, Grid, useTheme } from '@mui/material';
 import { ErrorBox, TableColumnType } from '@terraware/web-components';
@@ -14,6 +13,7 @@ import TfMain from 'src/components/common/TfMain';
 import TitleDescription from 'src/components/common/TitleDescription';
 import Table from 'src/components/common/table';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers';
 import { useUser } from 'src/providers';
 import { SpeciesService, TrackingService } from 'src/services';

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Button, Message, Tabs } from '@terraware/web-components';
@@ -11,6 +10,7 @@ import OptionsMenu from 'src/components/common/OptionsMenu';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
 import { NurseryWithdrawalService } from 'src/services';
 import strings from 'src/strings';

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
@@ -126,7 +126,7 @@ export default function NurseryWithdrawalsDetailsView({
 
   const handleReassign = () => {
     if (delivery) {
-      navigate({
+      void navigate({
         pathname: APP_PATHS.NURSERY_REASSIGNMENT.replace(':deliveryId', delivery.id.toString()),
         search: '?fromWithdrawal',
       });

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Button, Message, Tabs } from '@terraware/web-components';
@@ -57,7 +58,7 @@ export default function NurseryWithdrawalsDetailsView({
   const contentRef = useRef(null);
   const snackbar = useSnackbar();
   const { OUTPLANT, NURSERY_TRANSFER } = NurseryWithdrawalPurposes;
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
 
   const [withdrawal, setWithdrawal] = useState<NurseryWithdrawal | undefined>(undefined);
   const [withdrawalSummary, setWithdrawalSummary] = useState<WithdrawalSummary | undefined>(undefined);
@@ -126,7 +127,7 @@ export default function NurseryWithdrawalsDetailsView({
 
   const handleReassign = () => {
     if (delivery) {
-      void navigate({
+      navigate({
         pathname: APP_PATHS.NURSERY_REASSIGNMENT.replace(':deliveryId', delivery.id.toString()),
         search: '?fromWithdrawal',
       });

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid } from '@mui/material';
 import { SortOrder } from '@terraware/web-components';
@@ -12,6 +11,7 @@ import SearchFiltersWrapper, {
 } from 'src/components/common/SearchFiltersWrapper';
 import Table from 'src/components/common/table';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
 import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
 import { useAppSelector } from 'src/redux/store';

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
@@ -144,7 +144,7 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   }, [selectedOrganization]);
 
   const onWithdrawalClicked = (withdrawal: any) => {
-    navigate({
+    void navigate({
       pathname: APP_PATHS.NURSERY_REASSIGNMENT.replace(':deliveryId', withdrawal.delivery_id),
     });
   };
@@ -242,7 +242,7 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   useEffect(() => {
     if (siteParam) {
       query.delete('siteName');
-      navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+      void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
       setFilters((curr) => ({
         ...curr,
         destinationName: {
@@ -258,7 +258,7 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   useEffect(() => {
     if (subzoneParam) {
       query.delete('subzoneName');
-      navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+      void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
       setFilters((curr) => ({
         ...curr,
         plantingSubzoneNames: {

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid } from '@mui/material';
 import { SortOrder } from '@terraware/web-components';
@@ -49,7 +49,7 @@ const columns = (): TableColumnType[] => [
 export default function NurseryWithdrawalsTable(): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const { activeLocale } = useLocalization();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
   const query = useQuery();
   const subzoneParam = query.get('subzoneName');
@@ -144,7 +144,7 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   }, [selectedOrganization]);
 
   const onWithdrawalClicked = (withdrawal: any) => {
-    void navigate({
+    navigate({
       pathname: APP_PATHS.NURSERY_REASSIGNMENT.replace(':deliveryId', withdrawal.delivery_id),
     });
   };
@@ -242,7 +242,7 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   useEffect(() => {
     if (siteParam) {
       query.delete('siteName');
-      void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+      navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
       setFilters((curr) => ({
         ...curr,
         destinationName: {
@@ -258,7 +258,7 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   useEffect(() => {
     if (subzoneParam) {
       query.delete('subzoneName');
-      void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+      navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
       setFilters((curr) => ({
         ...curr,
         plantingSubzoneNames: {

--- a/src/scenes/ObservationsRouter/ObservationsHome.tsx
+++ b/src/scenes/ObservationsRouter/ObservationsHome.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box } from '@mui/material';
 import { Tabs } from '@terraware/web-components';
@@ -33,7 +33,7 @@ export type ObservationsHomeProps = SearchProps & {
 };
 
 export default function ObservationsHome(props: ObservationsHomeProps): JSX.Element {
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const dispatch = useAppDispatch();
   const { activeLocale } = useLocalization();
   const { selectedOrganization } = useOrganization();
@@ -94,7 +94,7 @@ export default function ObservationsHome(props: ObservationsHomeProps): JSX.Elem
 
   useEffect(() => {
     if (plantingSites?.length === 0) {
-      void navigate(APP_PATHS.HOME);
+      navigate(APP_PATHS.HOME);
     }
   }, [navigate, plantingSites?.length]);
 

--- a/src/scenes/ObservationsRouter/ObservationsHome.tsx
+++ b/src/scenes/ObservationsRouter/ObservationsHome.tsx
@@ -94,7 +94,7 @@ export default function ObservationsHome(props: ObservationsHomeProps): JSX.Elem
 
   useEffect(() => {
     if (plantingSites?.length === 0) {
-      navigate(APP_PATHS.HOME);
+      void navigate(APP_PATHS.HOME);
     }
   }, [navigate, plantingSites?.length]);
 

--- a/src/scenes/ObservationsRouter/ObservationsHome.tsx
+++ b/src/scenes/ObservationsRouter/ObservationsHome.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box } from '@mui/material';
 import { Tabs } from '@terraware/web-components';
@@ -8,6 +7,7 @@ import PlantsPrimaryPage from 'src/components/PlantsPrimaryPage';
 import { ButtonProps } from 'src/components/PlantsPrimaryPage/PlantsPrimaryPageView';
 import { SearchProps } from 'src/components/common/SearchFiltersWrapper';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
 import { selectObservationsResults } from 'src/redux/features/observations/observationsSelectors';
 import {

--- a/src/scenes/ObservationsRouter/adhoc/AdHocObservationDetails.tsx
+++ b/src/scenes/ObservationsRouter/adhoc/AdHocObservationDetails.tsx
@@ -124,7 +124,7 @@ export default function AdHocObservationDetails(props: AdHocObservationDetailsPr
 
   useEffect(() => {
     if (!monitoringPlot) {
-      navigate(APP_PATHS.OBSERVATIONS);
+      void navigate(APP_PATHS.OBSERVATIONS);
     }
   }, [navigate, monitoringPlot]);
 

--- a/src/scenes/ObservationsRouter/adhoc/AdHocObservationDetails.tsx
+++ b/src/scenes/ObservationsRouter/adhoc/AdHocObservationDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Textfield } from '@terraware/web-components';
@@ -9,6 +9,7 @@ import _ from 'lodash';
 import Card from 'src/components/common/Card';
 import OptionsMenu from 'src/components/common/OptionsMenu';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
 import { selectAdHocObservationsResults } from 'src/redux/features/observations/observationsSelectors';
 import { getConditionString } from 'src/redux/features/observations/utils';
@@ -41,7 +42,7 @@ export default function AdHocObservationDetails(props: AdHocObservationDetailsPr
     monitoringPlotId: string;
   }>();
   const defaultTimeZone = useDefaultTimeZone();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
   const { activeLocale } = useLocalization();
@@ -124,7 +125,7 @@ export default function AdHocObservationDetails(props: AdHocObservationDetailsPr
 
   useEffect(() => {
     if (!monitoringPlot) {
-      void navigate(APP_PATHS.OBSERVATIONS);
+      navigate(APP_PATHS.OBSERVATIONS);
     }
   }, [navigate, monitoringPlot]);
 

--- a/src/scenes/ObservationsRouter/adhoc/index.tsx
+++ b/src/scenes/ObservationsRouter/adhoc/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Tooltip, Typography, useTheme } from '@mui/material';
 import { Icon, Textfield } from '@terraware/web-components';
@@ -8,6 +7,7 @@ import { Icon, Textfield } from '@terraware/web-components';
 import Card from 'src/components/common/Card';
 import Link from 'src/components/common/Link';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization } from 'src/providers';
 import { selectObservationMonitoringPlot } from 'src/redux/features/observations/observationMonitoringPlotSelectors';
 import { selectObservationsResults } from 'src/redux/features/observations/observationsSelectors';

--- a/src/scenes/ObservationsRouter/adhoc/index.tsx
+++ b/src/scenes/ObservationsRouter/adhoc/index.tsx
@@ -52,7 +52,7 @@ export default function ObservationMonitoringPlot(): JSX.Element {
       {
         plantingSiteId: Number(plantingSiteId),
         observationId: Number(observationId),
-        plantingZoneName: plantingZoneName,
+        plantingZoneName,
         monitoringPlotId: Number(monitoringPlotId),
       },
       defaultTimeZone.get().id
@@ -122,7 +122,7 @@ export default function ObservationMonitoringPlot(): JSX.Element {
 
   useEffect(() => {
     if (plantingZoneName && !monitoringPlot) {
-      navigate(
+      void navigate(
         APP_PATHS.OBSERVATION_PLANTING_ZONE_DETAILS.replace(':plantingSiteId', Number(plantingSiteId).toString())
           .replace(':observationId', Number(observationId).toString())
           .replace(':plantingZoneName', encodeURIComponent(plantingZoneName))

--- a/src/scenes/ObservationsRouter/adhoc/index.tsx
+++ b/src/scenes/ObservationsRouter/adhoc/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Tooltip, Typography, useTheme } from '@mui/material';
 import { Icon, Textfield } from '@terraware/web-components';
@@ -30,7 +31,7 @@ export default function ObservationMonitoringPlot(): JSX.Element {
     monitoringPlotId: string;
   }>();
   const defaultTimeZone = useDefaultTimeZone();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
   const { activeLocale } = useLocalization();
@@ -122,7 +123,7 @@ export default function ObservationMonitoringPlot(): JSX.Element {
 
   useEffect(() => {
     if (plantingZoneName && !monitoringPlot) {
-      void navigate(
+      navigate(
         APP_PATHS.OBSERVATION_PLANTING_ZONE_DETAILS.replace(':plantingSiteId', Number(plantingSiteId).toString())
           .replace(':observationId', Number(observationId).toString())
           .replace(':plantingZoneName', encodeURIComponent(plantingZoneName))

--- a/src/scenes/ObservationsRouter/details/ObservationDetailsList.tsx
+++ b/src/scenes/ObservationsRouter/details/ObservationDetailsList.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { TableColumnType } from '@terraware/web-components';
 
@@ -31,7 +32,7 @@ const ObservationDetailsList = (props: SearchProps): JSX.Element => {
   const { ...searchProps }: SearchProps = props;
 
   const defaultTimeZone = useDefaultTimeZone();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const params = useParams<{
     plantingSiteId: string;
     observationId: string;
@@ -57,7 +58,7 @@ const ObservationDetailsList = (props: SearchProps): JSX.Element => {
 
   useEffect(() => {
     if (!details) {
-      void navigate(APP_PATHS.OBSERVATIONS_SITE.replace(':plantingSiteId', `${plantingSiteId}`));
+      navigate(APP_PATHS.OBSERVATIONS_SITE.replace(':plantingSiteId', `${plantingSiteId}`));
     }
   }, [details, navigate, plantingSiteId]);
 

--- a/src/scenes/ObservationsRouter/details/ObservationDetailsList.tsx
+++ b/src/scenes/ObservationsRouter/details/ObservationDetailsList.tsx
@@ -57,7 +57,7 @@ const ObservationDetailsList = (props: SearchProps): JSX.Element => {
 
   useEffect(() => {
     if (!details) {
-      navigate(APP_PATHS.OBSERVATIONS_SITE.replace(':plantingSiteId', `${plantingSiteId}`));
+      void navigate(APP_PATHS.OBSERVATIONS_SITE.replace(':plantingSiteId', `${plantingSiteId}`));
     }
   }, [details, navigate, plantingSiteId]);
 

--- a/src/scenes/ObservationsRouter/details/ObservationDetailsList.tsx
+++ b/src/scenes/ObservationsRouter/details/ObservationDetailsList.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { TableColumnType } from '@terraware/web-components';
 
 import { SearchProps } from 'src/components/common/SearchFiltersWrapper';
 import Table from 'src/components/common/table';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import {
   searchObservationDetails,
   selectDetailsZoneNames,

--- a/src/scenes/ObservationsRouter/details/index.tsx
+++ b/src/scenes/ObservationsRouter/details/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid } from '@mui/material';
 import _ from 'lodash';
@@ -10,6 +9,7 @@ import { View } from 'src/components/common/ListMapSelector';
 import OptionsMenu from 'src/components/common/OptionsMenu';
 import Search, { SearchProps } from 'src/components/common/SearchFiltersWrapper';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
 import {
   searchObservationDetails,

--- a/src/scenes/ObservationsRouter/details/index.tsx
+++ b/src/scenes/ObservationsRouter/details/index.tsx
@@ -190,7 +190,7 @@ export default function ObservationDetails(props: ObservationDetailsProps): JSX.
 
   useEffect(() => {
     if (!details) {
-      navigate(APP_PATHS.OBSERVATIONS_SITE.replace(':plantingSiteId', `${plantingSiteId}`));
+      void navigate(APP_PATHS.OBSERVATIONS_SITE.replace(':plantingSiteId', `${plantingSiteId}`));
     }
   }, [details, navigate, plantingSiteId]);
 

--- a/src/scenes/ObservationsRouter/details/index.tsx
+++ b/src/scenes/ObservationsRouter/details/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid } from '@mui/material';
 import _ from 'lodash';
@@ -47,7 +48,7 @@ export default function ObservationDetails(props: ObservationDetailsProps): JSX.
   const { activeLocale } = useLocalization();
   const { selectedOrganization } = useOrganization();
   const defaultTimeZone = useDefaultTimeZone();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const params = useParams<{
     plantingSiteId: string;
     observationId: string;
@@ -190,7 +191,7 @@ export default function ObservationDetails(props: ObservationDetailsProps): JSX.
 
   useEffect(() => {
     if (!details) {
-      void navigate(APP_PATHS.OBSERVATIONS_SITE.replace(':plantingSiteId', `${plantingSiteId}`));
+      navigate(APP_PATHS.OBSERVATIONS_SITE.replace(':plantingSiteId', `${plantingSiteId}`));
     }
   }, [details, navigate, plantingSiteId]);
 

--- a/src/scenes/ObservationsRouter/org/OrgObservationsListView.tsx
+++ b/src/scenes/ObservationsRouter/org/OrgObservationsListView.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, useTheme } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
@@ -7,6 +6,7 @@ import sanitize from 'sanitize-filename';
 
 import Table from 'src/components/common/table';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
 import { requestAbandonObservation } from 'src/redux/features/observations/observationsAsyncThunks';
 import {

--- a/src/scenes/ObservationsRouter/org/OrgObservationsListView.tsx
+++ b/src/scenes/ObservationsRouter/org/OrgObservationsListView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, useTheme } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
@@ -107,7 +107,7 @@ export default function OrgObservationsListView({
   const { activeLocale } = useLocalization();
   const [results, setResults] = useState<any>([]);
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const scheduleObservationsEnabled = isAdmin(selectedOrganization);
   const [endObservationModalOpened, setEndObservationModalOpened] = useState(false);
   const [selectedObservation, setSelectedObservation] = useState<any>();
@@ -205,7 +205,7 @@ export default function OrgObservationsListView({
 
   const goToRescheduleObservation = useCallback(
     (observationId: number) => {
-      void navigate(APP_PATHS.RESCHEDULE_OBSERVATION.replace(':observationId', observationId.toString()));
+      navigate(APP_PATHS.RESCHEDULE_OBSERVATION.replace(':observationId', observationId.toString()));
     },
     [navigate]
   );

--- a/src/scenes/ObservationsRouter/org/OrgObservationsListView.tsx
+++ b/src/scenes/ObservationsRouter/org/OrgObservationsListView.tsx
@@ -205,7 +205,7 @@ export default function OrgObservationsListView({
 
   const goToRescheduleObservation = useCallback(
     (observationId: number) => {
-      navigate(APP_PATHS.RESCHEDULE_OBSERVATION.replace(':observationId', observationId.toString()));
+      void navigate(APP_PATHS.RESCHEDULE_OBSERVATION.replace(':observationId', observationId.toString()));
     },
     [navigate]
   );

--- a/src/scenes/ObservationsRouter/schedule/RescheduleObservation.tsx
+++ b/src/scenes/ObservationsRouter/schedule/RescheduleObservation.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
 import { useOrganization } from 'src/providers';
@@ -16,7 +17,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 import ScheduleObservationForm from './ScheduleObservationForm';
 
 export default function ScheduleObservation(): JSX.Element {
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
   const dispatch = useAppDispatch();
   const { selectedOrganization } = useOrganization();

--- a/src/scenes/ObservationsRouter/schedule/RescheduleObservation.tsx
+++ b/src/scenes/ObservationsRouter/schedule/RescheduleObservation.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers';
 import { requestRescheduleObservation } from 'src/redux/features/observations/observationsAsyncThunks';
 import { selectObservations } from 'src/redux/features/observations/observationsSelectors';

--- a/src/scenes/ObservationsRouter/schedule/ScheduleObservation.tsx
+++ b/src/scenes/ObservationsRouter/schedule/ScheduleObservation.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
 import { useOrganization } from 'src/providers';
@@ -16,7 +16,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 import ScheduleObservationForm from './ScheduleObservationForm';
 
 export default function ScheduleObservation(): JSX.Element {
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
   const dispatch = useAppDispatch();
   const { selectedOrganization } = useOrganization();

--- a/src/scenes/ObservationsRouter/schedule/ScheduleObservation.tsx
+++ b/src/scenes/ObservationsRouter/schedule/ScheduleObservation.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers';
 import { requestScheduleObservation } from 'src/redux/features/observations/observationsAsyncThunks';
 import { selectScheduleObservation } from 'src/redux/features/observations/observationsSelectors';

--- a/src/scenes/ObservationsRouter/zone/index.tsx
+++ b/src/scenes/ObservationsRouter/zone/index.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
@@ -10,6 +9,7 @@ import { FilterField } from 'src/components/common/FilterGroup';
 import Search, { SearchFiltersProps } from 'src/components/common/SearchFiltersWrapper';
 import Table from 'src/components/common/table';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
 import { searchObservationPlantingZone } from 'src/redux/features/observations/observationPlantingZoneSelectors';
 import { has25mPlots } from 'src/redux/features/observations/utils';

--- a/src/scenes/ObservationsRouter/zone/index.tsx
+++ b/src/scenes/ObservationsRouter/zone/index.tsx
@@ -126,7 +126,7 @@ export default function ObservationPlantingZone(): JSX.Element {
 
   useEffect(() => {
     if (!plantingZone) {
-      navigate(
+      void navigate(
         APP_PATHS.OBSERVATION_DETAILS.replace(':plantingSiteId', `${plantingSiteId}`).replace(
           ':observationId',
           `${observationId}`

--- a/src/scenes/ObservationsRouter/zone/index.tsx
+++ b/src/scenes/ObservationsRouter/zone/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
@@ -49,7 +50,7 @@ export default function ObservationPlantingZone(): JSX.Element {
   const { activeLocale } = useLocalization();
   const { selectedOrganization } = useOrganization();
   const defaultTimeZone = useDefaultTimeZone();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const params = useParams<{
     plantingSiteId: string;
     observationId: string;
@@ -126,7 +127,7 @@ export default function ObservationPlantingZone(): JSX.Element {
 
   useEffect(() => {
     if (!plantingZone) {
-      void navigate(
+      navigate(
         APP_PATHS.OBSERVATION_DETAILS.replace(':plantingSiteId', `${plantingSiteId}`).replace(
           ':observationId',
           `${observationId}`

--- a/src/scenes/OrgRouter/NavBar.tsx
+++ b/src/scenes/OrgRouter/NavBar.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
-import { useMatch, useNavigate } from 'react-router';
+import { useMatch } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Icon } from '@terraware/web-components';
@@ -45,7 +46,7 @@ export default function NavBar({
   const dispatch = useAppDispatch();
   const [showNurseryWithdrawals, setShowNurseryWithdrawals] = useState<boolean>(false);
   const { isDesktop, isMobile } = useDeviceInfo();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const mixpanel = useMixpanel();
   const isReportsEnabled = isEnabled('Assigning and Collecting Reports');
 
@@ -91,7 +92,7 @@ export default function NavBar({
     (path: string) => {
       closeNavBar();
       if (path) {
-        void navigate(path);
+        navigate(path);
       }
     },
     [closeNavBar, navigate]

--- a/src/scenes/OrgRouter/NavBar.tsx
+++ b/src/scenes/OrgRouter/NavBar.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
 import { useMatch } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Icon } from '@terraware/web-components';
@@ -16,6 +15,7 @@ import NewBadge from 'src/components/common/NewBadge';
 import { APP_PATHS } from 'src/constants';
 import isEnabled from 'src/features';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 import { useLocalization, useOrganization, useUser } from 'src/providers/hooks';

--- a/src/scenes/OrgRouter/NavBar.tsx
+++ b/src/scenes/OrgRouter/NavBar.tsx
@@ -91,7 +91,7 @@ export default function NavBar({
     (path: string) => {
       closeNavBar();
       if (path) {
-        navigate(path);
+        void navigate(path);
       }
     },
     [closeNavBar, navigate]

--- a/src/scenes/OrganizationRouter/EditOrganizationView.tsx
+++ b/src/scenes/OrganizationRouter/EditOrganizationView.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Dropdown } from '@terraware/web-components';
@@ -9,6 +8,7 @@ import RegionSelector from 'src/components/RegionSelector';
 import TimeZoneSelector from 'src/components/TimeZoneSelector';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useTimeZones } from 'src/providers';
 import { OrganizationService } from 'src/services';
 import strings from 'src/strings';

--- a/src/scenes/OrganizationRouter/EditOrganizationView.tsx
+++ b/src/scenes/OrganizationRouter/EditOrganizationView.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Dropdown } from '@terraware/web-components';
@@ -38,7 +38,7 @@ export default function OrganizationView({ organization, reloadOrganizationData 
   const [organizationTypeError, setOrganizationTypeError] = useState('');
   const [organizationTypeDetailsError, setOrganizationTypeDetailsError] = useState('');
   const [requireSubdivision, setRequireSubdivisions] = useState(!!organization.countrySubdivisionCode);
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
   const timeZones = useTimeZones();
   const defaultTimeZone = useUserTimeZone()?.id || getUTC(timeZones).id;
@@ -73,7 +73,7 @@ export default function OrganizationView({ organization, reloadOrganizationData 
     const organizationLocation = {
       pathname: APP_PATHS.ORGANIZATION,
     };
-    void navigate(organizationLocation);
+    navigate(organizationLocation);
   };
 
   const saveOrganization = async () => {

--- a/src/scenes/OrganizationRouter/EditOrganizationView.tsx
+++ b/src/scenes/OrganizationRouter/EditOrganizationView.tsx
@@ -73,7 +73,7 @@ export default function OrganizationView({ organization, reloadOrganizationData 
     const organizationLocation = {
       pathname: APP_PATHS.ORGANIZATION,
     };
-    navigate(organizationLocation);
+    void navigate(organizationLocation);
   };
 
   const saveOrganization = async () => {

--- a/src/scenes/OrganizationRouter/OrganizationView.tsx
+++ b/src/scenes/OrganizationRouter/OrganizationView.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { getDateDisplayValue } from '@terraware/web-components/utils';
@@ -9,6 +8,7 @@ import TextField from 'src/components/common/Textfield/Textfield';
 import TfMain from 'src/components/common/TfMain';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization, useTimeZones } from 'src/providers/hooks';
 import { OrganizationUserService } from 'src/services';
 import strings from 'src/strings';

--- a/src/scenes/OrganizationRouter/OrganizationView.tsx
+++ b/src/scenes/OrganizationRouter/OrganizationView.tsx
@@ -45,7 +45,7 @@ export default function OrganizationView(): JSX.Element {
     const editOrganizationLocation = {
       pathname: APP_PATHS.ORGANIZATION_EDIT,
     };
-    navigate(editOrganizationLocation);
+    void navigate(editOrganizationLocation);
   };
 
   const organizationState = () => {

--- a/src/scenes/OrganizationRouter/OrganizationView.tsx
+++ b/src/scenes/OrganizationRouter/OrganizationView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { getDateDisplayValue } from '@terraware/web-components/utils';
@@ -21,7 +21,7 @@ import { getUTC } from 'src/utils/useTimeZoneUtils';
 export default function OrganizationView(): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const [people, setPeople] = useState<OrganizationUser[]>();
   const { isMobile } = useDeviceInfo();
   const { countries } = useLocalization();
@@ -45,7 +45,7 @@ export default function OrganizationView(): JSX.Element {
     const editOrganizationLocation = {
       pathname: APP_PATHS.ORGANIZATION_EDIT,
     };
-    void navigate(editOrganizationLocation);
+    navigate(editOrganizationLocation);
   };
 
   const organizationState = () => {

--- a/src/scenes/PeopleRouter/NewPersonView.tsx
+++ b/src/scenes/PeopleRouter/NewPersonView.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, useTheme } from '@mui/material';
 import { Dropdown } from '@terraware/web-components';
@@ -22,7 +23,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 export default function PersonView(): JSX.Element {
   const { selectedOrganization, reloadOrganizations } = useOrganization();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const [emailError, setEmailError] = useState('');
   const snackbar = useSnackbar();
   const [repeatedEmail, setRepeatedEmail] = useState('');
@@ -70,11 +71,11 @@ export default function PersonView(): JSX.Element {
   };
 
   const goToPeople = () => {
-    void navigate({ pathname: APP_PATHS.PEOPLE });
+    navigate({ pathname: APP_PATHS.PEOPLE });
   };
 
   const goToViewPerson = (userId: string) => {
-    void navigate({ pathname: APP_PATHS.PEOPLE_VIEW.replace(':personId', userId) });
+    navigate({ pathname: APP_PATHS.PEOPLE_VIEW.replace(':personId', userId) });
   };
 
   const saveUser = async () => {
@@ -138,7 +139,7 @@ export default function PersonView(): JSX.Element {
         const profileLocation = {
           pathname: APP_PATHS.PEOPLE_VIEW.replace(':personId', profile.id.toString()),
         };
-        void navigate(profileLocation);
+        navigate(profileLocation);
       }
     }
   };

--- a/src/scenes/PeopleRouter/NewPersonView.tsx
+++ b/src/scenes/PeopleRouter/NewPersonView.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, useTheme } from '@mui/material';
 import { Dropdown } from '@terraware/web-components';
@@ -11,6 +10,7 @@ import PageForm from 'src/components/common/PageForm';
 import TextField from 'src/components/common/Textfield/Textfield';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS, EMAIL_REGEX } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
 import { OrganizationUserService } from 'src/services';
 import strings from 'src/strings';

--- a/src/scenes/PeopleRouter/NewPersonView.tsx
+++ b/src/scenes/PeopleRouter/NewPersonView.tsx
@@ -70,11 +70,11 @@ export default function PersonView(): JSX.Element {
   };
 
   const goToPeople = () => {
-    navigate({ pathname: APP_PATHS.PEOPLE });
+    void navigate({ pathname: APP_PATHS.PEOPLE });
   };
 
   const goToViewPerson = (userId: string) => {
-    navigate({ pathname: APP_PATHS.PEOPLE_VIEW.replace(':personId', userId) });
+    void navigate({ pathname: APP_PATHS.PEOPLE_VIEW.replace(':personId', userId) });
   };
 
   const saveUser = async () => {
@@ -138,7 +138,7 @@ export default function PersonView(): JSX.Element {
         const profileLocation = {
           pathname: APP_PATHS.PEOPLE_VIEW.replace(':personId', profile.id.toString()),
         };
-        navigate(profileLocation);
+        void navigate(profileLocation);
       }
     }
   };

--- a/src/scenes/PeopleRouter/PeopleListView.tsx
+++ b/src/scenes/PeopleRouter/PeopleListView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, useTheme } from '@mui/material';
 
@@ -46,7 +46,7 @@ export default function PeopleListView(): JSX.Element {
   const { selectedOrganization, reloadOrganizations } = useOrganization();
   const { user } = useUser();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const [selectedPeopleRows, setSelectedPeopleRows] = useState<OrganizationUser[]>([]);
   const [orgPeople, setOrgPeople] = useState<OrganizationUser[]>();
   const [removePeopleModalOpened, setRemovePeopleModalOpened] = useState(false);
@@ -166,7 +166,7 @@ export default function PeopleListView(): JSX.Element {
     const newPersonLocation = {
       pathname: APP_PATHS.PEOPLE_NEW,
     };
-    void navigate(newPersonLocation);
+    navigate(newPersonLocation);
   };
 
   const openDeleteOrgModal = () => {
@@ -245,7 +245,7 @@ export default function PeopleListView(): JSX.Element {
       } else {
         snackbar.toastError();
       }
-      void navigate(APP_PATHS.PEOPLE);
+      navigate(APP_PATHS.PEOPLE);
     }
   };
 
@@ -281,7 +281,7 @@ export default function PeopleListView(): JSX.Element {
       } else {
         snackbar.toastError();
       }
-      void navigate(APP_PATHS.HOME);
+      navigate(APP_PATHS.HOME);
     }
   };
 

--- a/src/scenes/PeopleRouter/PeopleListView.tsx
+++ b/src/scenes/PeopleRouter/PeopleListView.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, useTheme } from '@mui/material';
 
@@ -13,6 +12,7 @@ import Table from 'src/components/common/table';
 import TableSettingsButton from 'src/components/common/table/TableSettingsButton';
 import { TableColumnType } from 'src/components/common/table/types';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization, useUser } from 'src/providers/hooks';
 import AssignNewOwnerDialog from 'src/scenes/MyAccountRouter/AssignNewOwnerModal';
 import DeleteOrgDialog from 'src/scenes/MyAccountRouter/DeleteOrgModal';

--- a/src/scenes/PeopleRouter/PeopleListView.tsx
+++ b/src/scenes/PeopleRouter/PeopleListView.tsx
@@ -166,7 +166,7 @@ export default function PeopleListView(): JSX.Element {
     const newPersonLocation = {
       pathname: APP_PATHS.PEOPLE_NEW,
     };
-    navigate(newPersonLocation);
+    void navigate(newPersonLocation);
   };
 
   const openDeleteOrgModal = () => {
@@ -245,7 +245,7 @@ export default function PeopleListView(): JSX.Element {
       } else {
         snackbar.toastError();
       }
-      navigate(APP_PATHS.PEOPLE);
+      void navigate(APP_PATHS.PEOPLE);
     }
   };
 
@@ -281,7 +281,7 @@ export default function PeopleListView(): JSX.Element {
       } else {
         snackbar.toastError();
       }
-      navigate(APP_PATHS.HOME);
+      void navigate(APP_PATHS.HOME);
     }
   };
 

--- a/src/scenes/PeopleRouter/PersonDetailsView.tsx
+++ b/src/scenes/PeopleRouter/PersonDetailsView.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 import { getDateDisplayValue } from '@terraware/web-components/utils';
@@ -11,6 +10,7 @@ import TextField from 'src/components/common/Textfield/Textfield';
 import TfMain from 'src/components/common/TfMain';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
 import { OrganizationUserService } from 'src/services';
 import strings from 'src/strings';

--- a/src/scenes/PeopleRouter/PersonDetailsView.tsx
+++ b/src/scenes/PeopleRouter/PersonDetailsView.tsx
@@ -35,7 +35,7 @@ export default function PersonDetailsView(): JSX.Element {
           if (selectedUser) {
             setPerson(selectedUser);
           } else {
-            navigate(APP_PATHS.PEOPLE);
+            void navigate(APP_PATHS.PEOPLE);
           }
         }
       };
@@ -54,7 +54,7 @@ export default function PersonDetailsView(): JSX.Element {
       const newLocation = {
         pathname: APP_PATHS.PEOPLE_EDIT.replace(':personId', personId),
       };
-      navigate(newLocation);
+      void navigate(newLocation);
     }
   };
 

--- a/src/scenes/PeopleRouter/PersonDetailsView.tsx
+++ b/src/scenes/PeopleRouter/PersonDetailsView.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 import { getDateDisplayValue } from '@terraware/web-components/utils';
@@ -21,7 +22,7 @@ import useDeviceInfo from 'src/utils/useDeviceInfo';
 export default function PersonDetailsView(): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { personId } = useParams<{ personId: string }>();
   const [person, setPerson] = useState<OrganizationUser>();
   const { isMobile } = useDeviceInfo();
@@ -35,7 +36,7 @@ export default function PersonDetailsView(): JSX.Element {
           if (selectedUser) {
             setPerson(selectedUser);
           } else {
-            void navigate(APP_PATHS.PEOPLE);
+            navigate(APP_PATHS.PEOPLE);
           }
         }
       };
@@ -54,7 +55,7 @@ export default function PersonDetailsView(): JSX.Element {
       const newLocation = {
         pathname: APP_PATHS.PEOPLE_EDIT.replace(':personId', personId),
       };
-      void navigate(newLocation);
+      navigate(newLocation);
     }
   };
 

--- a/src/scenes/PlantingSitesRouter/edit/DeleteDraftPlantingSiteModal.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/DeleteDraftPlantingSiteModal.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Typography } from '@mui/material';
 import { BusySpinner, Button, DialogBox } from '@terraware/web-components';
 
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { selectDraftPlantingSiteEdit } from 'src/redux/features/draftPlantingSite/draftPlantingSiteSelectors';
 import { requestDeleteDraft } from 'src/redux/features/draftPlantingSite/draftPlantingSiteThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';

--- a/src/scenes/PlantingSitesRouter/edit/DeleteDraftPlantingSiteModal.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/DeleteDraftPlantingSiteModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Typography } from '@mui/material';
 import { BusySpinner, Button, DialogBox } from '@terraware/web-components';
@@ -19,7 +19,7 @@ export type Props = {
 
 export default function DeleteDraftPlantingSiteModal(props: Props): JSX.Element {
   const { onClose, plantingSite } = props;
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
   const dispatch = useAppDispatch();
   const [requestId, setRequestId] = useState<string>('');
@@ -33,7 +33,7 @@ export default function DeleteDraftPlantingSiteModal(props: Props): JSX.Element 
   useEffect(() => {
     if (result?.status === 'success') {
       snackbar.toastSuccess(strings.PLANTING_SITE_DELETED);
-      void navigate(APP_PATHS.PLANTING_SITES);
+      navigate(APP_PATHS.PLANTING_SITES);
     } else if (result?.status === 'error') {
       snackbar.toastError();
     }

--- a/src/scenes/PlantingSitesRouter/edit/DeleteDraftPlantingSiteModal.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/DeleteDraftPlantingSiteModal.tsx
@@ -33,7 +33,7 @@ export default function DeleteDraftPlantingSiteModal(props: Props): JSX.Element 
   useEffect(() => {
     if (result?.status === 'success') {
       snackbar.toastSuccess(strings.PLANTING_SITE_DELETED);
-      navigate(APP_PATHS.PLANTING_SITES);
+      void navigate(APP_PATHS.PLANTING_SITES);
     } else if (result?.status === 'error') {
       snackbar.toastError();
     }

--- a/src/scenes/PlantingSitesRouter/edit/DeletePlantingSiteModal.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/DeletePlantingSiteModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Typography } from '@mui/material';
 import { BusySpinner, Button, DialogBox } from '@terraware/web-components';
@@ -21,7 +21,7 @@ export type DeletePlantingSiteModalProps = {
 export default function DeletePlantingSiteModal(props: DeletePlantingSiteModalProps): JSX.Element {
   const { onClose, plantingSite } = props;
   const [busy, setBusy] = useState<boolean>(false);
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
   const hasPlantings = useAppSelector((state) => selectPlantingsForSite(state, plantingSite.id)).length > 0;
 
@@ -31,7 +31,7 @@ export default function DeletePlantingSiteModal(props: DeletePlantingSiteModalPr
     setBusy(false);
     if (response.requestSucceeded) {
       snackbar.toastSuccess(strings.PLANTING_SITE_DELETED);
-      void navigate(APP_PATHS.PLANTING_SITES);
+      navigate(APP_PATHS.PLANTING_SITES);
     } else {
       snackbar.toastError();
     }

--- a/src/scenes/PlantingSitesRouter/edit/DeletePlantingSiteModal.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/DeletePlantingSiteModal.tsx
@@ -31,7 +31,7 @@ export default function DeletePlantingSiteModal(props: DeletePlantingSiteModalPr
     setBusy(false);
     if (response.requestSucceeded) {
       snackbar.toastSuccess(strings.PLANTING_SITE_DELETED);
-      navigate(APP_PATHS.PLANTING_SITES);
+      void navigate(APP_PATHS.PLANTING_SITES);
     } else {
       snackbar.toastError();
     }

--- a/src/scenes/PlantingSitesRouter/edit/DeletePlantingSiteModal.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/DeletePlantingSiteModal.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Typography } from '@mui/material';
 import { BusySpinner, Button, DialogBox } from '@terraware/web-components';
 
 import TextWithLink from 'src/components/common/TextWithLink';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { selectPlantingsForSite } from 'src/redux/features/plantings/plantingsSelectors';
 import { useAppSelector } from 'src/redux/store';
 import { TrackingService } from 'src/services';

--- a/src/scenes/PlantingSitesRouter/edit/PlantingSiteCreate.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/PlantingSiteCreate.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, Grid, Typography, useTheme } from '@mui/material';
 import { MultiPolygon } from 'geojson';
@@ -33,7 +34,7 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
   const theme = useTheme();
   const { reloadPlantingSites } = props;
   const { plantingSiteId } = useParams<{ plantingSiteId: string }>();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
   const [loaded, setLoaded] = useState(false);
   const [onValidate, setOnValidate] = useState<((hasErrors: boolean) => void) | undefined>(undefined);
@@ -76,7 +77,7 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
     const plantingSitesLocation = {
       pathname: APP_PATHS.PLANTING_SITES + (id && id !== -1 ? `/${id}` : ''),
     };
-    void navigate(plantingSitesLocation);
+    navigate(plantingSitesLocation);
   };
 
   const onSave = () =>

--- a/src/scenes/PlantingSitesRouter/edit/PlantingSiteCreate.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/PlantingSiteCreate.tsx
@@ -76,7 +76,7 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
     const plantingSitesLocation = {
       pathname: APP_PATHS.PLANTING_SITES + (id && id !== -1 ? `/${id}` : ''),
     };
-    navigate(plantingSitesLocation);
+    void navigate(plantingSitesLocation);
   };
 
   const onSave = () =>

--- a/src/scenes/PlantingSitesRouter/edit/PlantingSiteCreate.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/PlantingSiteCreate.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Container, Grid, Typography, useTheme } from '@mui/material';
 import { MultiPolygon } from 'geojson';
@@ -12,6 +11,7 @@ import { View } from 'src/components/common/ListMapSelector';
 import PageForm from 'src/components/common/PageForm';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
 import { searchPlantingSiteZones } from 'src/redux/features/observations/plantingSiteDetailsSelectors';
 import { selectPlantingSite } from 'src/redux/features/tracking/trackingSelectors';

--- a/src/scenes/PlantingSitesRouter/edit/PlantingSiteTypeSelect.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/PlantingSiteTypeSelect.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { SiteType } from 'src/types/PlantingSite';
 
 import PlantingSiteSelectTypeModal2 from './PlantingSiteSelectTypeModal2';

--- a/src/scenes/PlantingSitesRouter/edit/PlantingSiteTypeSelect.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/PlantingSiteTypeSelect.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
 import { SiteType } from 'src/types/PlantingSite';
@@ -12,14 +12,14 @@ export type PlantingSiteTypeSelectProps = {
 
 export default function PlantingSiteTypeSelect(props: PlantingSiteTypeSelectProps): JSX.Element {
   const { onClose } = props;
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
 
   const goTo = (appPath: string, search?: string) => {
     const appPathLocation = {
       pathname: appPath,
       search,
     };
-    void navigate(appPathLocation);
+    navigate(appPathLocation);
   };
 
   return (

--- a/src/scenes/PlantingSitesRouter/edit/PlantingSiteTypeSelect.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/PlantingSiteTypeSelect.tsx
@@ -19,7 +19,7 @@ export default function PlantingSiteTypeSelect(props: PlantingSiteTypeSelectProp
       pathname: appPath,
       search,
     };
-    navigate(appPathLocation);
+    void navigate(appPathLocation);
   };
 
   return (

--- a/src/scenes/PlantingSitesRouter/edit/editor/Editor.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Editor.tsx
@@ -155,9 +155,9 @@ export default function Editor(props: EditorProps): JSX.Element {
 
   const goToPlantingSites = () => {
     if (plantingSite.id !== -1) {
-      navigate(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${plantingSite.id}`));
+      void navigate(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${plantingSite.id}`));
     } else {
-      navigate(APP_PATHS.PLANTING_SITES);
+      void navigate(APP_PATHS.PLANTING_SITES);
     }
   };
 

--- a/src/scenes/PlantingSitesRouter/edit/editor/Editor.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Editor.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { BusySpinner, Button, Message } from '@terraware/web-components';
@@ -67,7 +67,7 @@ export default function Editor(props: EditorProps): JSX.Element {
   const { siteEditStep, siteType } = site;
   const { activeLocale } = useLocalization();
   const contentRef = useRef(null);
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
 
@@ -155,9 +155,9 @@ export default function Editor(props: EditorProps): JSX.Element {
 
   const goToPlantingSites = () => {
     if (plantingSite.id !== -1) {
-      void navigate(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${plantingSite.id}`));
+      navigate(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${plantingSite.id}`));
     } else {
-      void navigate(APP_PATHS.PLANTING_SITES);
+      navigate(APP_PATHS.PLANTING_SITES);
     }
   };
 

--- a/src/scenes/PlantingSitesRouter/edit/editor/Editor.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Editor.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { BusySpinner, Button, Message } from '@terraware/web-components';
@@ -10,6 +9,7 @@ import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import TextWithLink from 'src/components/common/TextWithLink';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization } from 'src/providers';
 import useDraftPlantingSiteCreate from 'src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate';
 import useDraftPlantingSiteUpdate from 'src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate';

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { Statuses } from 'src/redux/features/asyncUtils';
 import { selectDraftPlantingSiteCreate } from 'src/redux/features/draftPlantingSite/draftPlantingSiteSelectors';
 import { requestCreateDraft } from 'src/redux/features/draftPlantingSite/draftPlantingSiteThunks';

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
 import { Statuses } from 'src/redux/features/asyncUtils';
@@ -37,7 +37,7 @@ export type Response = {
  */
 export default function useDraftPlantingSiteCreate(): Response {
   const dispatch = useAppDispatch();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
 
   const [createdDraft, setCreatedDraft] = useState<Data | undefined>();
@@ -66,10 +66,10 @@ export default function useDraftPlantingSiteCreate(): Response {
   useEffect(() => {
     if (draftResult?.status === 'success' && draftResult?.data && draftRequest) {
       const id = draftResult.data;
-      void navigate(APP_PATHS.PLANTING_SITES_DRAFT_EDIT.replace(':plantingSiteId', `${id}`), { replace: true });
+      navigate(APP_PATHS.PLANTING_SITES_DRAFT_EDIT.replace(':plantingSiteId', `${id}`), { replace: true });
       if (redirect) {
         snackbar.toastSuccess(strings.PLANTING_SITE_SAVED);
-        void navigate(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${id}`));
+        navigate(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${id}`));
       } else {
         setCreatedDraft({
           ...draftRequest,

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
@@ -66,10 +66,10 @@ export default function useDraftPlantingSiteCreate(): Response {
   useEffect(() => {
     if (draftResult?.status === 'success' && draftResult?.data && draftRequest) {
       const id = draftResult.data;
-      navigate(APP_PATHS.PLANTING_SITES_DRAFT_EDIT.replace(':plantingSiteId', `${id}`), { replace: true });
+      void navigate(APP_PATHS.PLANTING_SITES_DRAFT_EDIT.replace(':plantingSiteId', `${id}`), { replace: true });
       if (redirect) {
         snackbar.toastSuccess(strings.PLANTING_SITE_SAVED);
-        navigate(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${id}`));
+        void navigate(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${id}`));
       } else {
         setCreatedDraft({
           ...draftRequest,

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteGet.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteGet.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
 import { Statuses } from 'src/redux/features/asyncUtils';
@@ -25,12 +25,12 @@ export type Response = {
  */
 export default function useDraftPlantingSiteGet({ draftId }: Props): Response {
   const snackbar = useSnackbar();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const dispatch = useAppDispatch();
   const draftResult = useAppSelector(selectDraftPlantingSiteGet(draftId));
 
   const goToPlantingSites = useCallback(() => {
-    void navigate(APP_PATHS.PLANTING_SITES);
+    navigate(APP_PATHS.PLANTING_SITES);
   }, [navigate]);
 
   useEffect(() => {

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteGet.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteGet.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { Statuses } from 'src/redux/features/asyncUtils';
 import { selectDraftPlantingSiteGet } from 'src/redux/features/draftPlantingSite/draftPlantingSiteSelectors';
 import { requestGetDraft } from 'src/redux/features/draftPlantingSite/draftPlantingSiteThunks';

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteGet.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteGet.ts
@@ -30,7 +30,7 @@ export default function useDraftPlantingSiteGet({ draftId }: Props): Response {
   const draftResult = useAppSelector(selectDraftPlantingSiteGet(draftId));
 
   const goToPlantingSites = useCallback(() => {
-    navigate(APP_PATHS.PLANTING_SITES);
+    void navigate(APP_PATHS.PLANTING_SITES);
   }, [navigate]);
 
   useEffect(() => {

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
 import { Statuses } from 'src/redux/features/asyncUtils';
@@ -42,7 +42,7 @@ export type Response = {
  */
 export default function useDraftPlantingSiteUpdate(): Response {
   const dispatch = useAppDispatch();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
 
   const [draftRequest, setDraftRequest] = useState<Data>();
@@ -96,7 +96,7 @@ export default function useDraftPlantingSiteUpdate(): Response {
     if (draftResult?.status === 'success' && draftRequest) {
       if (redirect) {
         snackbar.toastSuccess(strings.PLANTING_SITE_SAVED);
-        void navigate(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${draftRequest.draft.id}`));
+        navigate(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${draftRequest.draft.id}`));
       } else {
         setUpdatedDraft(draftRequest);
       }

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { Statuses } from 'src/redux/features/asyncUtils';
 import { selectDraftPlantingSiteEdit } from 'src/redux/features/draftPlantingSite/draftPlantingSiteSelectors';
 import { requestUpdateDraft } from 'src/redux/features/draftPlantingSite/draftPlantingSiteThunks';

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
@@ -96,7 +96,7 @@ export default function useDraftPlantingSiteUpdate(): Response {
     if (draftResult?.status === 'success' && draftRequest) {
       if (redirect) {
         snackbar.toastSuccess(strings.PLANTING_SITE_SAVED);
-        navigate(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${draftRequest.draft.id}`));
+        void navigate(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${draftRequest.draft.id}`));
       } else {
         setUpdatedDraft(draftRequest);
       }

--- a/src/scenes/PlantingSitesRouter/view/GenericSiteView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/GenericSiteView.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, List, ListItem, Typography, useTheme } from '@mui/material';
 import { DropdownItem } from '@terraware/web-components';
@@ -15,6 +14,7 @@ import OptionsMenu from 'src/components/common/OptionsMenu';
 import TooltipButton from 'src/components/common/button/TooltipButton';
 import { APP_PATHS } from 'src/constants';
 import { useProjects } from 'src/hooks/useProjects';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { RootState } from 'src/redux/rootReducer';
 import { useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';

--- a/src/scenes/PlantingSitesRouter/view/GenericSiteView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/GenericSiteView.tsx
@@ -64,7 +64,7 @@ export default function GenericSiteView<T extends MinimalPlantingSite>({
       const editPlantingSiteLocation = {
         pathname: editUrl.replace(':plantingSiteId', `${plantingSite.id}`),
       };
-      navigate(editPlantingSiteLocation);
+      void navigate(editPlantingSiteLocation);
     }
   };
 

--- a/src/scenes/PlantingSitesRouter/view/GenericSiteView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/GenericSiteView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, List, ListItem, Typography, useTheme } from '@mui/material';
 import { DropdownItem } from '@terraware/web-components';
@@ -44,7 +44,7 @@ export default function GenericSiteView<T extends MinimalPlantingSite>({
 }: GenericSiteViewProps<T>): JSX.Element {
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const tz = useLocationTimeZone().get(plantingSite);
   const [plantingSeasons, setPlantingSeasons] = useState<PlantingSeason[]>([]);
   const [search, setSearch] = useState<string>('');
@@ -64,7 +64,7 @@ export default function GenericSiteView<T extends MinimalPlantingSite>({
       const editPlantingSiteLocation = {
         pathname: editUrl.replace(':plantingSiteId', `${plantingSite.id}`),
       };
-      void navigate(editPlantingSiteLocation);
+      navigate(editPlantingSiteLocation);
     }
   };
 

--- a/src/scenes/PlantingSitesRouter/view/GenericZoneView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/GenericZoneView.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
@@ -64,7 +65,7 @@ export default function GenericZoneView({
   zoneSelector,
 }: Props): JSX.Element {
   const [search, setSearch] = useState<string>('');
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { plantingSiteId, zoneId } = useParams<{ plantingSiteId: string; zoneId: string }>();
 
   const plantingSite = useAppSelector((state) => siteSelector(state, Number(plantingSiteId)));
@@ -81,11 +82,11 @@ export default function GenericZoneView({
   );
 
   if (!plantingSite) {
-    void navigate(APP_PATHS.PLANTING_SITES);
+    navigate(APP_PATHS.PLANTING_SITES);
   }
 
   if (!plantingZone && plantingSiteId) {
-    void navigate(siteViewUrl.replace(':plantingSiteId', plantingSiteId));
+    navigate(siteViewUrl.replace(':plantingSiteId', plantingSiteId));
   }
 
   const crumbs: Crumb[] = useMemo(

--- a/src/scenes/PlantingSitesRouter/view/GenericZoneView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/GenericZoneView.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
@@ -14,6 +13,7 @@ import Table from 'src/components/common/table';
 import CellRenderer, { TableRowType } from 'src/components/common/table/TableCellRenderer';
 import { RendererProps } from 'src/components/common/table/types';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { RootState } from 'src/redux/rootReducer';
 import { useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';

--- a/src/scenes/PlantingSitesRouter/view/GenericZoneView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/GenericZoneView.tsx
@@ -81,11 +81,11 @@ export default function GenericZoneView({
   );
 
   if (!plantingSite) {
-    navigate(APP_PATHS.PLANTING_SITES);
+    void navigate(APP_PATHS.PLANTING_SITES);
   }
 
   if (!plantingZone && plantingSiteId) {
-    navigate(siteViewUrl.replace(':plantingSiteId', plantingSiteId));
+    void navigate(siteViewUrl.replace(':plantingSiteId', plantingSiteId));
   }
 
   const crumbs: Crumb[] = useMemo(

--- a/src/scenes/PlantingSitesRouter/view/PlantingSiteSubzoneView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSiteSubzoneView.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
@@ -39,7 +40,7 @@ const columns = (): TableColumnType[] => [
 
 export default function PlantingSiteZoneView(): JSX.Element {
   const [search, setSearch] = useState<string>('');
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const defaultTimeZone = useDefaultTimeZone();
 
   const { plantingSiteId, zoneId, subzoneId } = useParams<{
@@ -64,15 +65,15 @@ export default function PlantingSiteZoneView(): JSX.Element {
   );
 
   if (!plantingSite) {
-    void navigate(APP_PATHS.PLANTING_SITES);
+    navigate(APP_PATHS.PLANTING_SITES);
   }
 
   if (plantingSiteId && !plantingZone) {
-    void navigate(APP_PATHS.PLANTING_SITES_VIEW.replace(':plantingSiteId', plantingSiteId));
+    navigate(APP_PATHS.PLANTING_SITES_VIEW.replace(':plantingSiteId', plantingSiteId));
   }
 
   if (zoneId && plantingSiteId && !plantingZone?.plantingSubzones.length) {
-    void navigate(
+    navigate(
       APP_PATHS.PLANTING_SITES_ZONE_VIEW.replace(':plantingSiteId', plantingSiteId).replace(':zoneId', zoneId)
     );
   }

--- a/src/scenes/PlantingSitesRouter/view/PlantingSiteSubzoneView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSiteSubzoneView.tsx
@@ -72,7 +72,9 @@ export default function PlantingSiteZoneView(): JSX.Element {
   }
 
   if (zoneId && plantingSiteId && !plantingZone?.plantingSubzones.length) {
-    void navigate(APP_PATHS.PLANTING_SITES_ZONE_VIEW.replace(':plantingSiteId', plantingSiteId).replace(':zoneId', zoneId));
+    void navigate(
+      APP_PATHS.PLANTING_SITES_ZONE_VIEW.replace(':plantingSiteId', plantingSiteId).replace(':zoneId', zoneId)
+    );
   }
 
   const crumbs: Crumb[] = useMemo(

--- a/src/scenes/PlantingSitesRouter/view/PlantingSiteSubzoneView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSiteSubzoneView.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
@@ -14,6 +13,7 @@ import Table from 'src/components/common/table';
 import CellRenderer, { TableRowType } from 'src/components/common/table/TableCellRenderer';
 import { RendererProps } from 'src/components/common/table/types';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { searchPlantingSiteMonitoringPlots } from 'src/redux/features/observations/plantingSiteDetailsSelectors';
 import { selectPlantingSite } from 'src/redux/features/tracking/trackingSelectors';
 import { useAppSelector } from 'src/redux/store';
@@ -73,9 +73,7 @@ export default function PlantingSiteZoneView(): JSX.Element {
   }
 
   if (zoneId && plantingSiteId && !plantingZone?.plantingSubzones.length) {
-    navigate(
-      APP_PATHS.PLANTING_SITES_ZONE_VIEW.replace(':plantingSiteId', plantingSiteId).replace(':zoneId', zoneId)
-    );
+    navigate(APP_PATHS.PLANTING_SITES_ZONE_VIEW.replace(':plantingSiteId', plantingSiteId).replace(':zoneId', zoneId));
   }
 
   const crumbs: Crumb[] = useMemo(

--- a/src/scenes/PlantingSitesRouter/view/PlantingSiteSubzoneView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSiteSubzoneView.tsx
@@ -64,15 +64,15 @@ export default function PlantingSiteZoneView(): JSX.Element {
   );
 
   if (!plantingSite) {
-    navigate(APP_PATHS.PLANTING_SITES);
+    void navigate(APP_PATHS.PLANTING_SITES);
   }
 
   if (plantingSiteId && !plantingZone) {
-    navigate(APP_PATHS.PLANTING_SITES_VIEW.replace(':plantingSiteId', plantingSiteId));
+    void navigate(APP_PATHS.PLANTING_SITES_VIEW.replace(':plantingSiteId', plantingSiteId));
   }
 
   if (zoneId && plantingSiteId && !plantingZone?.plantingSubzones.length) {
-    navigate(APP_PATHS.PLANTING_SITES_ZONE_VIEW.replace(':plantingSiteId', plantingSiteId).replace(':zoneId', zoneId));
+    void navigate(APP_PATHS.PLANTING_SITES_ZONE_VIEW.replace(':plantingSiteId', plantingSiteId).replace(':zoneId', zoneId));
   }
 
   const crumbs: Crumb[] = useMemo(

--- a/src/scenes/SeedBanksRouter/SeedBankDetailsView.tsx
+++ b/src/scenes/SeedBanksRouter/SeedBankDetailsView.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 
 import PageSnackbar from 'src/components/PageSnackbar';
 import BackToLink from 'src/components/common/BackToLink';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
 import SeedBankSubLocations from 'src/scenes/SeedBanksRouter/SeedBankSubLocations';
 import { FacilityService } from 'src/services';

--- a/src/scenes/SeedBanksRouter/SeedBankDetailsView.tsx
+++ b/src/scenes/SeedBanksRouter/SeedBankDetailsView.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 
@@ -23,7 +24,7 @@ export default function SeedBankDetailsView(): JSX.Element {
   const theme = useTheme();
   const { seedBankId } = useParams<{ seedBankId: string }>();
   const [seedBank, setSeedBank] = useState<Facility>();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const tz = useLocationTimeZone().get(seedBank);
 
   useEffect(() => {
@@ -36,7 +37,7 @@ export default function SeedBankDetailsView(): JSX.Element {
       if (selectedSeedBank) {
         setSeedBank(selectedSeedBank);
       } else {
-        void navigate(APP_PATHS.SEED_BANKS);
+        navigate(APP_PATHS.SEED_BANKS);
       }
     }
   }, [seedBankId, selectedOrganization, navigate]);
@@ -46,7 +47,7 @@ export default function SeedBankDetailsView(): JSX.Element {
       const editSeedBankLocation = {
         pathname: APP_PATHS.SEED_BANKS_EDIT.replace(':seedBankId', seedBankId),
       };
-      void navigate(editSeedBankLocation);
+      navigate(editSeedBankLocation);
     }
   };
 

--- a/src/scenes/SeedBanksRouter/SeedBankDetailsView.tsx
+++ b/src/scenes/SeedBanksRouter/SeedBankDetailsView.tsx
@@ -36,7 +36,7 @@ export default function SeedBankDetailsView(): JSX.Element {
       if (selectedSeedBank) {
         setSeedBank(selectedSeedBank);
       } else {
-        navigate(APP_PATHS.SEED_BANKS);
+        void navigate(APP_PATHS.SEED_BANKS);
       }
     }
   }, [seedBankId, selectedOrganization, navigate]);
@@ -46,7 +46,7 @@ export default function SeedBankDetailsView(): JSX.Element {
       const editSeedBankLocation = {
         pathname: APP_PATHS.SEED_BANKS_EDIT.replace(':seedBankId', seedBankId),
       };
-      navigate(editSeedBankLocation);
+      void navigate(editSeedBankLocation);
     }
   };
 

--- a/src/scenes/SeedBanksRouter/SeedBankView.tsx
+++ b/src/scenes/SeedBanksRouter/SeedBankView.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 
@@ -50,7 +51,7 @@ export default function SeedBankView(): JSX.Element {
   });
   const { seedBankId } = useParams<{ seedBankId: string }>();
   const [selectedSeedBank, setSelectedSeedBank] = useState<Facility | null>();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { isMobile } = useDeviceInfo();
   const gridSize = () => {
     if (isMobile) {
@@ -91,7 +92,7 @@ export default function SeedBankView(): JSX.Element {
     const sitesLocation = {
       pathname: APP_PATHS.SEED_BANKS + (id ? `/${id}` : ''),
     };
-    void navigate(sitesLocation);
+    navigate(sitesLocation);
   };
 
   const saveSeedBank = async () => {

--- a/src/scenes/SeedBanksRouter/SeedBankView.tsx
+++ b/src/scenes/SeedBanksRouter/SeedBankView.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 
@@ -8,6 +7,7 @@ import PageSnackbar from 'src/components/PageSnackbar';
 import DatePicker from 'src/components/common/DatePicker';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
 import SeedBankSubLocations from 'src/scenes/SeedBanksRouter/SeedBankSubLocations';
 import { FacilityService, SubLocationService } from 'src/services';

--- a/src/scenes/SeedBanksRouter/SeedBankView.tsx
+++ b/src/scenes/SeedBanksRouter/SeedBankView.tsx
@@ -91,7 +91,7 @@ export default function SeedBankView(): JSX.Element {
     const sitesLocation = {
       pathname: APP_PATHS.SEED_BANKS + (id ? `/${id}` : ''),
     };
-    navigate(sitesLocation);
+    void navigate(sitesLocation);
   };
 
   const saveSeedBank = async () => {

--- a/src/scenes/SeedBanksRouter/SeedBanksListView.tsx
+++ b/src/scenes/SeedBanksRouter/SeedBanksListView.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, useTheme } from '@mui/material';
 
@@ -13,6 +12,7 @@ import Table from 'src/components/common/table';
 import TableSettingsButton from 'src/components/common/table/TableSettingsButton';
 import { TableColumnType } from 'src/components/common/table/types';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useTimeZones } from 'src/providers';
 import { FacilityService } from 'src/services';
 import strings from 'src/strings';

--- a/src/scenes/SeedBanksRouter/SeedBanksListView.tsx
+++ b/src/scenes/SeedBanksRouter/SeedBanksListView.tsx
@@ -51,7 +51,7 @@ export default function SeedBanksListView({ organization }: SeedBanksListProps):
     const newSeedBankLocation = {
       pathname: APP_PATHS.SEED_BANKS_NEW,
     };
-    navigate(newSeedBankLocation);
+    void navigate(newSeedBankLocation);
   };
 
   const clearSearch = () => {

--- a/src/scenes/SeedBanksRouter/SeedBanksListView.tsx
+++ b/src/scenes/SeedBanksRouter/SeedBanksListView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Grid, useTheme } from '@mui/material';
 
@@ -40,7 +40,7 @@ export default function SeedBanksListView({ organization }: SeedBanksListProps):
   const timeZones = useTimeZones();
   const defaultTimeZone = useDefaultTimeZone().get();
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const [temporalSearchValue, setTemporalSearchValue] = useState('');
   const debouncedSearchTerm = useDebounce(temporalSearchValue, 250);
   const [results, setResults] = useState<Facility[]>([]);
@@ -51,7 +51,7 @@ export default function SeedBanksListView({ organization }: SeedBanksListProps):
     const newSeedBankLocation = {
       pathname: APP_PATHS.SEED_BANKS_NEW,
     };
-    void navigate(newSeedBankLocation);
+    navigate(newSeedBankLocation);
   };
 
   const clearSearch = () => {

--- a/src/scenes/SeedsDashboard/index.tsx
+++ b/src/scenes/SeedsDashboard/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, CircularProgress, Container, Grid, SxProps, Typography, useTheme } from '@mui/material';
 import Cookies from 'cookies-js';
@@ -26,7 +26,7 @@ Cookies.defaults = {
 
 export default function SeedSummary(): JSX.Element {
   const { selectedOrganization } = useOrganization();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
 

--- a/src/scenes/SeedsDashboard/index.tsx
+++ b/src/scenes/SeedsDashboard/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, CircularProgress, Container, Grid, SxProps, Typography, useTheme } from '@mui/material';
 import Cookies from 'cookies-js';
@@ -12,6 +11,7 @@ import Button from 'src/components/common/button/Button';
 import Icon from 'src/components/common/icon/Icon';
 import { APP_PATHS } from 'src/constants';
 import { useSeedBankSummary } from 'src/hooks/useSeedBankSummary';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
 import AccessionByStatus from 'src/scenes/SeedsDashboard/AccessionByStatus';
 import SummaryPaper from 'src/scenes/SeedsDashboard/SummaryPaper';

--- a/src/scenes/Species/SpeciesAddView.tsx
+++ b/src/scenes/Species/SpeciesAddView.tsx
@@ -56,7 +56,7 @@ export default function SpeciesAddView({ reloadData }: SpeciesAddViewProps): JSX
       if (response.requestSucceeded) {
         if (response.speciesId) {
           reloadData();
-          navigate(APP_PATHS.SPECIES_DETAILS.replace(':speciesId', response.speciesId.toString()));
+          void navigate(APP_PATHS.SPECIES_DETAILS.replace(':speciesId', response.speciesId.toString()));
         }
       } else {
         if (response.error === SpeciesRequestError.PreexistingSpecies) {

--- a/src/scenes/Species/SpeciesAddView.tsx
+++ b/src/scenes/Species/SpeciesAddView.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Container, Grid, Typography, useTheme } from '@mui/material';
 import { BusySpinner } from '@terraware/web-components';
@@ -8,6 +7,7 @@ import { DateTime } from 'luxon';
 import PageForm from 'src/components/common/PageForm';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
 import SpeciesDetailsForm from 'src/scenes/Species/SpeciesDetailsForm';
 import { SpeciesService } from 'src/services';

--- a/src/scenes/Species/SpeciesAddView.tsx
+++ b/src/scenes/Species/SpeciesAddView.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Container, Grid, Typography, useTheme } from '@mui/material';
 import { BusySpinner } from '@terraware/web-components';
@@ -37,7 +37,7 @@ export default function SpeciesAddView({ reloadData }: SpeciesAddViewProps): JSX
   const [record, setRecord, onChange] = useForm<Species>(initSpecies());
   const [nameFormatError, setNameFormatError] = useState<string | string[]>('');
   const [isBusy, setIsBusy] = useState<boolean>(false);
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
 
@@ -56,7 +56,7 @@ export default function SpeciesAddView({ reloadData }: SpeciesAddViewProps): JSX
       if (response.requestSucceeded) {
         if (response.speciesId) {
           reloadData();
-          void navigate(APP_PATHS.SPECIES_DETAILS.replace(':speciesId', response.speciesId.toString()));
+          navigate(APP_PATHS.SPECIES_DETAILS.replace(':speciesId', response.speciesId.toString()));
         }
       } else {
         if (response.error === SpeciesRequestError.PreexistingSpecies) {

--- a/src/scenes/Species/SpeciesDetailView.tsx
+++ b/src/scenes/Species/SpeciesDetailView.tsx
@@ -61,7 +61,7 @@ export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps
       if (speciesResponse.requestSucceeded) {
         setSpecies(speciesResponse.species);
       } else {
-        navigate(APP_PATHS.SPECIES);
+        void navigate(APP_PATHS.SPECIES);
       }
     };
     if (selectedOrganization && selectedOrganization.id !== -1) {
@@ -74,7 +74,7 @@ export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps
       const editSpeciesLocation = {
         pathname: APP_PATHS.SPECIES_EDIT.replace(':speciesId', speciesId),
       };
-      navigate(editSpeciesLocation);
+      void navigate(editSpeciesLocation);
     }
   };
 
@@ -95,7 +95,7 @@ export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps
         reloadData();
       }
       setDeleteSpeciesModalOpen(false);
-      navigate(APP_PATHS.SPECIES);
+      void navigate(APP_PATHS.SPECIES);
     }
   };
 

--- a/src/scenes/Species/SpeciesDetailView.tsx
+++ b/src/scenes/Species/SpeciesDetailView.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, GridProps, Typography, useTheme } from '@mui/material';
 import { BusySpinner } from '@terraware/web-components';
@@ -38,7 +39,7 @@ type SpeciesDetailViewProps = {
 export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps): JSX.Element {
   const theme = useTheme();
   const [species, setSpecies] = useState<Species>();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { isMobile } = useDeviceInfo();
   const { selectedOrganization } = useOrganization();
   const { speciesId } = useParams<{ speciesId: string }>();
@@ -61,7 +62,7 @@ export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps
       if (speciesResponse.requestSucceeded) {
         setSpecies(speciesResponse.species);
       } else {
-        void navigate(APP_PATHS.SPECIES);
+        navigate(APP_PATHS.SPECIES);
       }
     };
     if (selectedOrganization && selectedOrganization.id !== -1) {
@@ -74,7 +75,7 @@ export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps
       const editSpeciesLocation = {
         pathname: APP_PATHS.SPECIES_EDIT.replace(':speciesId', speciesId),
       };
-      void navigate(editSpeciesLocation);
+      navigate(editSpeciesLocation);
     }
   };
 
@@ -95,7 +96,7 @@ export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps
         reloadData();
       }
       setDeleteSpeciesModalOpen(false);
-      void navigate(APP_PATHS.SPECIES);
+      navigate(APP_PATHS.SPECIES);
     }
   };
 

--- a/src/scenes/Species/SpeciesDetailView.tsx
+++ b/src/scenes/Species/SpeciesDetailView.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, GridProps, Typography, useTheme } from '@mui/material';
 import { BusySpinner } from '@terraware/web-components';
@@ -11,6 +10,7 @@ import BackToLink from 'src/components/common/BackToLink';
 import Checkbox from 'src/components/common/Checkbox';
 import OptionsMenu from 'src/components/common/OptionsMenu';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 import { useOrganization } from 'src/providers/hooks';
 import { SpeciesService } from 'src/services';

--- a/src/scenes/Species/SpeciesEditView.tsx
+++ b/src/scenes/Species/SpeciesEditView.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { BusySpinner } from '@terraware/web-components';
@@ -10,6 +9,7 @@ import PageSnackbar from 'src/components/PageSnackbar';
 import PageForm from 'src/components/common/PageForm';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
 import {
   requestAddManyParticipantProjectSpecies,

--- a/src/scenes/Species/SpeciesEditView.tsx
+++ b/src/scenes/Species/SpeciesEditView.tsx
@@ -101,7 +101,7 @@ export default function SpeciesEditView(): JSX.Element {
       const speciesLocation = {
         pathname: APP_PATHS.SPECIES_DETAILS.replace(':speciesId', speciesId.toString()),
       };
-      navigate(speciesLocation);
+      void navigate(speciesLocation);
     }
   };
 
@@ -111,7 +111,7 @@ export default function SpeciesEditView(): JSX.Element {
       if (speciesResponse.requestSucceeded) {
         setSpecies(speciesResponse.species);
       } else {
-        navigate(APP_PATHS.SPECIES);
+        void navigate(APP_PATHS.SPECIES);
       }
     };
     if (selectedOrganization && selectedOrganization.id !== -1 && speciesId) {

--- a/src/scenes/Species/SpeciesEditView.tsx
+++ b/src/scenes/Species/SpeciesEditView.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { BusySpinner } from '@terraware/web-components';
@@ -45,7 +46,7 @@ function initSpecies(species?: Species): Species {
 export default function SpeciesEditView(): JSX.Element {
   const theme = useTheme();
   const [species, setSpecies] = useState<Species>();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const { isMobile } = useDeviceInfo();
   const { selectedOrganization } = useOrganization();
   const { speciesId } = useParams<{ speciesId: string }>();
@@ -101,7 +102,7 @@ export default function SpeciesEditView(): JSX.Element {
       const speciesLocation = {
         pathname: APP_PATHS.SPECIES_DETAILS.replace(':speciesId', speciesId.toString()),
       };
-      void navigate(speciesLocation);
+      navigate(speciesLocation);
     }
   };
 
@@ -111,7 +112,7 @@ export default function SpeciesEditView(): JSX.Element {
       if (speciesResponse.requestSucceeded) {
         setSpecies(speciesResponse.species);
       } else {
-        void navigate(APP_PATHS.SPECIES);
+        navigate(APP_PATHS.SPECIES);
       }
     };
     if (selectedOrganization && selectedOrganization.id !== -1 && speciesId) {

--- a/src/scenes/Species/SpeciesListView.tsx
+++ b/src/scenes/Species/SpeciesListView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, useTheme } from '@mui/material';
 import { DropdownItem, SortOrder } from '@terraware/web-components';
@@ -76,7 +76,7 @@ export default function SpeciesListView({ reloadData, species }: SpeciesListProp
   const debouncedSearchTerm = useDebounce(searchValue, 250);
   const [results, setResults] = useState<SpeciesSearchResultRow[]>();
   const query = useQuery();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const projects = useAppSelector(selectProjects);
   const { orgHasParticipants } = useParticipantData();
 
@@ -468,7 +468,7 @@ export default function SpeciesListView({ reloadData, species }: SpeciesListProp
     if (shouldCheckData) {
       query.delete('checkData');
       setCheckDataModalOpen(true);
-      void navigate({ pathname: APP_PATHS.SPECIES, search: query.toString() }, { replace: true });
+      navigate({ pathname: APP_PATHS.SPECIES, search: query.toString() }, { replace: true });
     }
   }, [query, setCheckDataModalOpen, navigate]);
 
@@ -477,7 +477,7 @@ export default function SpeciesListView({ reloadData, species }: SpeciesListProp
   }, [onApplyFilters]);
 
   const onNewSpecies = () => {
-    void navigate(APP_PATHS.SPECIES_NEW);
+    navigate(APP_PATHS.SPECIES_NEW);
   };
 
   const onChangeSearch = (id: string, value: unknown) => {

--- a/src/scenes/Species/SpeciesListView.tsx
+++ b/src/scenes/Species/SpeciesListView.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Box, Grid, useTheme } from '@mui/material';
 import { DropdownItem, SortOrder } from '@terraware/web-components';
@@ -25,6 +24,7 @@ import { OrderPreserveableTable as Table } from 'src/components/common/table';
 import TableSettingsButton from 'src/components/common/table/TableSettingsButton';
 import { TableColumnType } from 'src/components/common/table/types';
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
 import { selectProjects } from 'src/redux/features/projects/projectsSelectors';

--- a/src/scenes/Species/SpeciesListView.tsx
+++ b/src/scenes/Species/SpeciesListView.tsx
@@ -468,7 +468,7 @@ export default function SpeciesListView({ reloadData, species }: SpeciesListProp
     if (shouldCheckData) {
       query.delete('checkData');
       setCheckDataModalOpen(true);
-      navigate({ pathname: APP_PATHS.SPECIES, search: query.toString() }, { replace: true });
+      void navigate({ pathname: APP_PATHS.SPECIES, search: query.toString() }, { replace: true });
     }
   }, [query, setCheckDataModalOpen, navigate]);
 
@@ -477,7 +477,7 @@ export default function SpeciesListView({ reloadData, species }: SpeciesListProp
   }, [onApplyFilters]);
 
   const onNewSpecies = () => {
-    navigate(APP_PATHS.SPECIES_NEW);
+    void navigate(APP_PATHS.SPECIES_NEW);
   };
 
   const onChangeSearch = (id: string, value: unknown) => {

--- a/src/scenes/TerrawareRouter/index.tsx
+++ b/src/scenes/TerrawareRouter/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
-import { matchPath, useNavigate } from 'react-router';
+import { matchPath } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
 import { useOrganization, useUserFundingEntity } from 'src/providers';
@@ -35,19 +36,19 @@ const MINIMAL_FUNDER_ROUTES: string[] = [
 export default function TerrawareRouter(props: TerrawareRouterProps) {
   const { userFundingEntity } = useUserFundingEntity();
   const { organizations } = useOrganization();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const location = useStateLocation();
 
   useEffect(() => {
     if (userFundingEntity && !MINIMAL_FUNDER_ROUTES.some((path) => !!matchPath(path, location.pathname))) {
-      void navigate(APP_PATHS.FUNDER_HOME);
+      navigate(APP_PATHS.FUNDER_HOME);
     }
     if (
       organizations?.length === 0 &&
       !MINIMAL_USER_ROUTES.some((path) => !!matchPath(path, location.pathname)) &&
       !userFundingEntity
     ) {
-      void navigate(APP_PATHS.WELCOME);
+      navigate(APP_PATHS.WELCOME);
     }
   }, [navigate, location, userFundingEntity, organizations]);
 

--- a/src/scenes/TerrawareRouter/index.tsx
+++ b/src/scenes/TerrawareRouter/index.tsx
@@ -40,14 +40,14 @@ export default function TerrawareRouter(props: TerrawareRouterProps) {
 
   useEffect(() => {
     if (userFundingEntity && !MINIMAL_FUNDER_ROUTES.some((path) => !!matchPath(path, location.pathname))) {
-      navigate(APP_PATHS.FUNDER_HOME);
+      void navigate(APP_PATHS.FUNDER_HOME);
     }
     if (
       organizations?.length === 0 &&
       !MINIMAL_USER_ROUTES.some((path) => !!matchPath(path, location.pathname)) &&
       !userFundingEntity
     ) {
-      navigate(APP_PATHS.WELCOME);
+      void navigate(APP_PATHS.WELCOME);
     }
   }, [navigate, location, userFundingEntity, organizations]);
 

--- a/src/scenes/TerrawareRouter/index.tsx
+++ b/src/scenes/TerrawareRouter/index.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react';
 import { matchPath } from 'react-router';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { APP_PATHS } from 'src/constants';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization, useUserFundingEntity } from 'src/providers';
 import NoOrgRouter from 'src/scenes/NoOrgRouter';
 import OrgRouter from 'src/scenes/OrgRouter';

--- a/src/services/HttpService.ts
+++ b/src/services/HttpService.ts
@@ -108,11 +108,11 @@ const replace = (url: string, request: Request) => {
  * Service with bare bones http function calls
  */
 function RequestsHandler(url: string = '') {
-  async function get<I extends ServerData, O>(request: GetRequest, transform: (i?: I) => O): Promise<O & Response> {
+  const get = async <I extends ServerData, O>(request: GetRequest, transform: (i?: I) => O): Promise<O & Response> => {
     const { params, headers } = request;
 
     return await handleRequest(axios.get<I>(replace(url, request), { params, headers }), transform);
-  }
+  };
 
   const get2 = async <T extends ServerData>(request: GetRequest = {}): Promise<Response2<T>> => {
     const { params, headers } = request;

--- a/src/services/ProjectSpeciesService.ts
+++ b/src/services/ProjectSpeciesService.ts
@@ -50,6 +50,7 @@ const searchSpeciesDeliverables = async (projectIds: number[]): Promise<SpeciesD
   }
 
   return response.map((result: SearchResponseElement): SpeciesDeliverable => {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     const { dueDate, id, module_id, module_cohortModules_endDate, module_cohortModules_startDate, project_id } = result;
 
     return {

--- a/src/utils/filterHooks/useSessionFilters.ts
+++ b/src/utils/filterHooks/useSessionFilters.ts
@@ -30,7 +30,7 @@ export const useSessionFilters = (viewIdentifier?: string) => {
 
         resetQuery(query, viewIdentifier);
         writeFiltersToQuery(query, viewIdentifier, filters);
-        navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+        void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
       }
     },
     [navigate, location, query, viewIdentifier]
@@ -56,7 +56,7 @@ export const useSessionFilters = (viewIdentifier?: string) => {
       writeFiltersToSession(viewIdentifier, mergedFilters);
 
       writeFiltersToQuery(query, viewIdentifier, mergedFilters);
-      navigate(getLocation(location.pathname, location, query.toString()));
+      void navigate(getLocation(location.pathname, location, query.toString()));
 
       setIsInitialized(true);
     }

--- a/src/utils/filterHooks/useSessionFilters.ts
+++ b/src/utils/filterHooks/useSessionFilters.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import {
   FiltersType,
   getFiltersFromQuery,

--- a/src/utils/filterHooks/useSessionFilters.ts
+++ b/src/utils/filterHooks/useSessionFilters.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import {
   FiltersType,
@@ -14,7 +14,7 @@ import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
 
 export const useSessionFilters = (viewIdentifier?: string) => {
   const location = useStateLocation();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const query = useQuery();
 
   const [localFilters, setLocalFilters] = useState<FiltersType>();
@@ -30,7 +30,7 @@ export const useSessionFilters = (viewIdentifier?: string) => {
 
         resetQuery(query, viewIdentifier);
         writeFiltersToQuery(query, viewIdentifier, filters);
-        void navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
+        navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
       }
     },
     [navigate, location, query, viewIdentifier]
@@ -56,7 +56,7 @@ export const useSessionFilters = (viewIdentifier?: string) => {
       writeFiltersToSession(viewIdentifier, mergedFilters);
 
       writeFiltersToQuery(query, viewIdentifier, mergedFilters);
-      void navigate(getLocation(location.pathname, location, query.toString()));
+      navigate(getLocation(location.pathname, location, query.toString()));
 
       setIsInitialized(true);
     }

--- a/src/utils/useStickyTabs.ts
+++ b/src/utils/useStickyTabs.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Tab } from '@terraware/web-components';
+
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import useQuery from './useQuery';
 import useStateLocation, { getLocation } from './useStateLocation';

--- a/src/utils/useStickyTabs.ts
+++ b/src/utils/useStickyTabs.ts
@@ -43,7 +43,7 @@ const useStickyTabs = ({ defaultTab, tabs, viewIdentifier, keepQuery = true }: S
     (newTab: string) => {
       query.set('tab', newTab);
       const emptyQuery = tab === newTab ? query.toString() : new URLSearchParams(`tab=${newTab}`);
-      navigate(getLocation(location.pathname, location, keepQuery ? query.toString() : emptyQuery.toString()));
+      void navigate(getLocation(location.pathname, location, keepQuery ? query.toString() : emptyQuery.toString()));
       writeTabToSession(viewIdentifier, newTab);
     },
     [navigate, location, query, viewIdentifier, keepQuery]

--- a/src/utils/useStickyTabs.ts
+++ b/src/utils/useStickyTabs.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 
 import { Tab } from '@terraware/web-components';
 
@@ -33,7 +33,7 @@ const writeTabToSession = (viewIdentifier: string, tab: string): void => {
 
 const useStickyTabs = ({ defaultTab, tabs, viewIdentifier, keepQuery = true }: StickyTabsProps) => {
   const location = useStateLocation();
-  const navigate = useNavigate();
+  const navigate = useSyncNavigate();
   const query = useQuery();
   const tab = query.get('tab');
 
@@ -43,7 +43,7 @@ const useStickyTabs = ({ defaultTab, tabs, viewIdentifier, keepQuery = true }: S
     (newTab: string) => {
       query.set('tab', newTab);
       const emptyQuery = tab === newTab ? query.toString() : new URLSearchParams(`tab=${newTab}`);
-      void navigate(getLocation(location.pathname, location, keepQuery ? query.toString() : emptyQuery.toString()));
+      navigate(getLocation(location.pathname, location, keepQuery ? query.toString() : emptyQuery.toString()));
       writeTabToSession(viewIdentifier, newTab);
     },
     [navigate, location, query, viewIdentifier, keepQuery]


### PR DESCRIPTION
Fix react-router-v7 update to navigate being a promise (linting issue).

The update to react-router 7 caused a bunch of new linting errors because `navigate` now returns a promise. 

Unfortunately this PR has 106 files, but they should all only include the addition of `void` to calls of `navigate`.