### PR TITLE
SW-6812: Add Deliverables tab to Project Profile in Console (Follow-up #2)

### DIFF
--- a/src/components/DeliverablesTable/index.tsx
+++ b/src/components/DeliverablesTable/index.tsx
@@ -243,7 +243,9 @@ const DeliverablesTable = ({
   const dispatchSearchRequest = useCallback(
     (locale: string | null, search: SearchNodePayload, searchSortOrder: SearchSortOrder) => {
       const listRequest: ListDeliverablesRequestParams = {};
-      if (organizationId !== -1) {
+      if (projectId) {
+        listRequest.projectId = projectId;
+      } else if (organizationId !== -1) {
         listRequest.organizationId = organizationId;
       }
 
@@ -258,7 +260,7 @@ const DeliverablesTable = ({
       );
       setDeliverablesSearchRequestId(request.requestId);
     },
-    [dispatch, organizationId, searchAndSort]
+    [dispatch, organizationId, projectId, searchAndSort]
   );
 
   const _deliverables = useMemo(


### PR DESCRIPTION
This PR fixes an issue where the Deliverables Table showed zero results when `selectedOrganization.id` was set. The `selectedOrganization.id` isn't set after a refresh on a console page, but is automatically set when a non-console page is viewed.