### PR TITLE
SW-6820 Make Project Map be the same height as the Project Image

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -112,7 +112,8 @@ export default function Map(props: MapProps): JSX.Element {
     // `firstVisible` detects when the box containing the map is first visible in the viewport. The map should only be
     // rendered if `firstVisible` is true. This accounts for cases in which the map is initially rendered hidden, and
     // is improperly resized when it first becomes visible.
-    setFirstVisible((fv) => fv || visible);
+    // A timeout was added to fix non-static height maps, which were also improperly resized on initial render.
+    setTimeout(() => setFirstVisible((fv) => fv || visible), 200);
   }, [visible]);
 
   const loadImages = useCallback(

--- a/src/components/ProjectField/ProjectMap.tsx
+++ b/src/components/ProjectField/ProjectMap.tsx
@@ -73,12 +73,13 @@ const ProjectMap = ({ application, countryCode, md }: ProjectMapProps) => {
   }, [application, getRenderAttributes]);
 
   const mapElement = useMemo(() => {
+    const style = { height: '100%', width: '100%', borderRadius: theme.spacing(1) };
     if (application?.boundary) {
       return (
         <GenericMap
           options={appBoundaryMapOptions}
           mapViewStyle={'Satellite'}
-          style={{ height: '100%', width: '100%', borderRadius: theme.spacing(1) }}
+          style={style}
           hideAllControls={true}
           bottomRightLabel={<ProjectFigureLabel labelText={strings.APPLICATION_SITE_BOUNDARY} />}
         />
@@ -88,7 +89,7 @@ const ProjectMap = ({ application, countryCode, md }: ProjectMapProps) => {
         <GenericMap
           options={countryMapOptions}
           mapViewStyle={'Light'}
-          style={{ height: '100%', width: '100%', borderRadius: theme.spacing(1) }}
+          style={style}
           hideAllControls={true}
           bottomRightLabel={<ProjectFigureLabel labelText={strings.COUNTRY_ONLY} />}
         />
@@ -98,7 +99,7 @@ const ProjectMap = ({ application, countryCode, md }: ProjectMapProps) => {
 
   return (
     <Grid item md={md || 12} paddingX={theme.spacing(1)}>
-      <Box display='flex' minHeight={'400px'} justifyContent={'center'} alignContent={'center'}>
+      <Box sx={{ display: 'flex', width: '100%', height: '100%', justifyContent: 'center', alignContent: 'center' }}>
         {mapElement}
       </Box>
     </Grid>


### PR DESCRIPTION
This required adding a `setTimeout` on the initial render of Map, which is only used in a few places:
- Application Map Card
- Planting Site Map

The timeout was only 200ms, which seemed minimal since it takes longer to retrieve the satellite images inside the map.