### PR TITLE
Disable project map zoom for country map only

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -88,6 +88,7 @@ export default function Map(props: MapProps): JSX.Element {
     topRightMapControl,
     bottomLeftMapControl,
     hideAllControls,
+    disableZoom,
     mapViewStyle: initialMapViewStyle,
   } = props;
   const theme = useTheme();
@@ -464,6 +465,8 @@ export default function Map(props: MapProps): JSX.Element {
               event.target.resize();
             }
           }}
+          scrollZoom={!disableZoom}
+          doubleClickZoom={!disableZoom}
         >
           {mapSources}
           {!hideAllControls && (

--- a/src/components/ProjectField/ProjectMap.tsx
+++ b/src/components/ProjectField/ProjectMap.tsx
@@ -91,6 +91,7 @@ const ProjectMap = ({ application, countryCode, md }: ProjectMapProps) => {
           mapViewStyle={'Light'}
           style={style}
           hideAllControls={true}
+          disableZoom={true}
           bottomRightLabel={<ProjectFigureLabel labelText={strings.COUNTRY_ONLY} />}
         />
       );

--- a/src/types/Map.ts
+++ b/src/types/Map.ts
@@ -155,6 +155,7 @@ export type MapControl = {
   topRightMapControl?: React.ReactNode;
   bottomLeftMapControl?: React.ReactNode;
   hideAllControls?: boolean;
+  disableZoom?: boolean;
 };
 
 /**


### PR DESCRIPTION
Add ability to disable zoom on Map component.

There's no need to be able to zoom the map when the project's country map is displaying, so disable the zoom for it.