### PR TITLE
SW-6872 Add Empty State for Land Use Model Hectares

### DIFF
--- a/src/components/ProjectField/LandUseModelTypeCard.tsx
+++ b/src/components/ProjectField/LandUseModelTypeCard.tsx
@@ -3,16 +3,17 @@ import React, { useMemo } from 'react';
 import { useTheme } from '@mui/material';
 
 import strings from 'src/strings';
-import { LAND_USE_MODEL_TYPES } from 'src/types/ParticipantProject';
+import { LAND_USE_MODEL_TYPES, LandUseModelType } from 'src/types/ParticipantProject';
 
 import InvertedCard from './InvertedCard';
 
 type LandUseModelTypeCardProps = {
+  selectedTypes?: LandUseModelType[];
   modelHectares?: { [key: string]: number };
   numericFormatter?: any;
 };
 
-const LandUseModelTypeCard = ({ modelHectares, numericFormatter }: LandUseModelTypeCardProps) => {
+const LandUseModelTypeCard = ({ selectedTypes, modelHectares, numericFormatter }: LandUseModelTypeCardProps) => {
   const theme = useTheme();
 
   const value = useMemo(() => {
@@ -21,11 +22,14 @@ const LandUseModelTypeCard = ({ modelHectares, numericFormatter }: LandUseModelT
     }
     const output: string[] = [];
     for (const type of LAND_USE_MODEL_TYPES) {
-      if (modelHectares[type] > 0) {
-        output.push(
-          `${type} (${strings.formatString(strings.X_HA, numericFormatter.format(modelHectares[type]))?.toString()})`
-        );
+      if (!selectedTypes?.includes(type)) {
+        continue;
       }
+      let hectaresString = '--';
+      if (modelHectares[type] >= 0) {
+        hectaresString = strings.formatString(strings.X_HA, numericFormatter.format(modelHectares[type]))?.toString();
+      }
+      output.push(`${type} (${hectaresString})`);
     }
     return output.join('/');
   }, [modelHectares]);

--- a/src/components/ProjectField/Textfield.tsx
+++ b/src/components/ProjectField/Textfield.tsx
@@ -20,7 +20,7 @@ const ProjectFieldTextfield = ({ height, id, label, onChange, type, value, md, t
   );
 
   useEffect(() => {
-    if (value) {
+    if (value !== undefined) {
       setLocalValue(`${value}`);
     }
   }, [value]);

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/EditView/ProjectProfileEdit.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/EditView/ProjectProfileEdit.tsx
@@ -300,6 +300,9 @@ const ProjectProfileEdit = () => {
 
   const onChangeLandUseHectares = (type: string, hectares: string) => {
     const updated = { ...participantProjectRecord?.landUseModelHectares, [type]: Number(hectares) };
+    if (hectares === '') {
+      delete updated[type];
+    }
     onChangeParticipantProject('landUseModelHectares', updated);
   };
 

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/ProjectProfileView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/ProjectProfileView.tsx
@@ -209,6 +209,7 @@ const ProjectProfileView = ({
 
       <Grid container>
         <LandUseModelTypeCard
+          selectedTypes={participantProject?.landUseModelTypes}
           modelHectares={participantProject?.landUseModelHectares}
           numericFormatter={numericFormatter}
         />


### PR DESCRIPTION
Add display of land-use model hectares when the type is selected but there was no value input for that land-use type.

Also allow setting of hectare value to 0.