### PR TITLE
SW-6873 Update handling of deleting model use types

### DIFF
--- a/src/components/Units/Co2HectareYear.tsx
+++ b/src/components/Units/Co2HectareYear.tsx
@@ -1,11 +1,21 @@
 import React from 'react';
 
-const Co2HectareYear = () => {
-  return (
-    <>
-      tCO<sub>2</sub>/ha/yr
-    </>
-  );
-};
+const Co2HectareYear = () => (
+  <span style={{ display: 'inline-flex', alignItems: 'baseline' }}>
+    tCO
+    <span
+      style={{
+        display: 'inline-block',
+        position: 'relative',
+        fontSize: '65%',
+        bottom: '-0.2em',
+        lineHeight: 0,
+      }}
+    >
+      2
+    </span>
+    /ha/yr
+  </span>
+);
 
 export default Co2HectareYear;

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/EditView/ProjectProfileEdit.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/EditView/ProjectProfileEdit.tsx
@@ -33,7 +33,7 @@ import { requestUpdateParticipantProject } from 'src/redux/features/participantP
 import { selectParticipantProjectUpdateRequest } from 'src/redux/features/participantProjects/participantProjectsSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
-import { LAND_USE_MODEL_TYPES } from 'src/types/ParticipantProject';
+import { LAND_USE_MODEL_TYPES, ParticipantProject } from 'src/types/ParticipantProject';
 import { OrganizationUser } from 'src/types/User';
 import { SelectVariable, VariableWithValues } from 'src/types/documentProducer/Variable';
 import { getImagePath } from 'src/utils/images';
@@ -228,8 +228,18 @@ const ProjectProfileEdit = () => {
       uploadImages: false,
     };
 
+    const updatedRecord = { ...participantProjectRecord } as ParticipantProject;
+    const typesToRemove = Object.keys(participantProjectRecord?.landUseModelHectares || {}).filter(
+      (type) => !(updatedRecord.landUseModelTypes as string[]).includes(type)
+    );
+    const updatedModelHectares = { ...(participantProjectRecord?.landUseModelHectares || {}) };
+    typesToRemove.forEach((type) => {
+      delete updatedModelHectares[type];
+    });
+    updatedRecord.landUseModelHectares = updatedModelHectares;
+
     if (participantProjectRecord) {
-      const dispatched = dispatch(requestUpdateParticipantProject(participantProjectRecord));
+      const dispatched = dispatch(requestUpdateParticipantProject(updatedRecord));
       setParticipantProjectRequestId(dispatched.requestId);
       newInitiatedRequests.participantProject = true;
     }
@@ -304,18 +314,6 @@ const ProjectProfileEdit = () => {
       delete updated[type];
     }
     onChangeParticipantProject('landUseModelHectares', updated);
-  };
-
-  const onChangeLandUseTypes = (_: string, types: string[]) => {
-    const typesToRemove = Object.keys(participantProjectRecord?.landUseModelHectares || {}).filter(
-      (type) => !types.includes(type)
-    );
-    const updatedModelHectares = { ...(participantProjectRecord?.landUseModelHectares || {}) };
-    typesToRemove.forEach((type) => {
-      delete updatedModelHectares[type];
-    });
-    onChangeParticipantProject('landUseModelHectares', updatedModelHectares);
-    onChangeParticipantProject('landUseModelTypes', types);
   };
 
   const onChangeSdgList = (id: string, newList: string[]) => {
@@ -415,7 +413,7 @@ const ProjectProfileEdit = () => {
                 id={'landUseModelTypes'}
                 md={6}
                 label={strings.LAND_USE_MODEL_TYPE}
-                onChange={onChangeLandUseTypes}
+                onChange={onChangeParticipantProject}
                 value={sortedSelectedModelTypes}
               />
             </Grid>

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/ProjectProfileView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/ProjectProfileView.tsx
@@ -235,6 +235,7 @@ const ProjectProfileView = ({
             label={strings.ACCUMULATION_RATE}
             value={participantProject?.accumulationRate}
             backgroundColor={theme.palette.TwClrBaseGray050}
+            units={<Co2HectareYear />}
           />
         )}
         <InvertedCard
@@ -282,29 +283,36 @@ const ProjectProfileView = ({
           </Grid>
         </>
       )}
-      {projectReports?.length > 0 && (
-        <Grid container marginY={theme.spacing(2)} marginLeft={theme.spacing(1)}>
-          {lastSubmittedReport && lastSubmittedReport.submittedTime && (
-            <Grid item marginRight={theme.spacing(3)}>
-              <Typography fontWeight={500}>
-                {strings.formatString(
-                  strings.LAST_REPORT_SUBMITTED,
-                  getDateDisplayValue(lastSubmittedReport.submittedTime)
-                )}
-              </Typography>
-            </Grid>
-          )}
+      <Grid container marginY={theme.spacing(2)} marginLeft={theme.spacing(1)}>
+        {projectReports?.length > 0 && (
+          <>
+            {lastSubmittedReport && lastSubmittedReport.submittedTime && (
+              <Grid item marginRight={theme.spacing(3)} marginLeft={theme.spacing(1)}>
+                <Typography fontWeight={500}>
+                  {strings.formatString(
+                    strings.LAST_REPORT_SUBMITTED,
+                    getDateDisplayValue(lastSubmittedReport.submittedTime)
+                  )}
+                </Typography>
+              </Grid>
+            )}
 
-          <Grid item>
-            <Link to={APP_PATHS.ACCELERATOR_PROJECT_REPORTS.replace(':projectId', (project?.id || '').toString())}>
-              {strings.VIEW_REPORTS}
-            </Link>
-          </Grid>
-        </Grid>
-      )}
+            <Grid item>
+              <Link to={APP_PATHS.ACCELERATOR_PROJECT_REPORTS.replace(':projectId', (project?.id || '').toString())}>
+                {strings.VIEW_REPORTS}
+              </Link>
+            </Grid>
+          </>
+        )}
+      </Grid>
 
       <Grid container>
-        <Box marginX={theme.spacing(2)} borderTop={`1px solid ${theme.palette.TwClrBrdrTertiary}`} width={'100%'}>
+        <Box
+          marginX={theme.spacing(1)}
+          paddingX={theme.spacing(1)}
+          borderTop={`1px solid ${theme.palette.TwClrBrdrTertiary}`}
+          width={'100%'}
+        >
           <Grid item xs={12} marginTop={theme.spacing(2)}>
             <Typography fontSize='20px' fontWeight={600} lineHeight='28px'>
               {strings.LAND_DATA}
@@ -433,7 +441,7 @@ const ProjectProfileView = ({
               label={strings.DELIVERABLES}
             />
           )}
-          {project && projectReports?.length > 0 && (
+          {project && (
             <ProjectFieldLink
               value={APP_PATHS.ACCELERATOR_PROJECT_REPORTS.replace(':projectId', project.id.toString())}
               label={strings.REPORTS}


### PR DESCRIPTION
If a land-use model type is deleted but there was a hectares value for it, don't delete model hectares until save. This allows the user to add it back in and still have the value from before.

Always display reports link.

Adjust spacing of "Last Submitted Report" and divider.