### PR TITLE
Disabled no-unsafe-* linting rules and removed manual disabling of them for lines

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -199,6 +199,13 @@ export default fixupConfigRules([
 
       '@typescript-eslint/typedef': 'off',
       '@typescript-eslint/unified-signatures': 'error',
+
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+
       'arrow-parens': ['error', 'always'],
       'brace-style': ['off', 'off'],
       complexity: 'off',

--- a/src/components/PlantsPrimaryPage/index.tsx
+++ b/src/components/PlantsPrimaryPage/index.tsx
@@ -98,11 +98,9 @@ export default function PlantsPrimaryPage({
         if (selectedOrganization.id !== -1) {
           const response = CachedUserService.getUserOrgPreferences(selectedOrganization.id);
           if (response[lastVisitedPreferenceName]) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             lastVisitedPlantingSite = response[lastVisitedPreferenceName];
           }
         }
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         const lastPlantingSiteId = Number(lastVisitedPlantingSite.plantingSiteId);
         const paramPlantingSiteId = plantingSiteId ? Number(plantingSiteId) : undefined;
 

--- a/src/scenes/AcceleratorRouter/Cohorts/CohortForm.tsx
+++ b/src/scenes/AcceleratorRouter/Cohorts/CohortForm.tsx
@@ -72,7 +72,6 @@ export default function CohortForm<T extends CreateCohortRequestPayload | Update
   const updateField = (field: keyof T, value: any) => {
     setLocalRecord((prev) => ({
       ...prev,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       [field]: value,
     }));
   };

--- a/src/scenes/Home/TerrawareHomeView/index.tsx
+++ b/src/scenes/Home/TerrawareHomeView/index.tsx
@@ -36,7 +36,6 @@ const TerrawareHomeView = () => {
   const { user } = useUser();
   const { selectedOrganization, orgPreferences, reloadOrgPreferences } = useOrganization();
   const { isTablet, isMobile, isDesktop } = useDeviceInfo();
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const mixpanel = useMixpanel();
   const navigate = useSyncNavigate();
   const dispatch = useAppDispatch();

--- a/src/scenes/ObservationsRouter/adhoc/AdHocObservationDetails.tsx
+++ b/src/scenes/ObservationsRouter/adhoc/AdHocObservationDetails.tsx
@@ -196,9 +196,7 @@ export default function AdHocObservationDetails(props: AdHocObservationDetailsPr
                 <Grid key={index} item xs={gridSize} marginTop={2}>
                   <Textfield
                     id={`plot-observation-${index}`}
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                     label={datum.label}
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                     value={datum.value}
                     type={datum.text ? 'textarea' : 'text'}
                     preserveNewlines={true}

--- a/src/scenes/ObservationsRouter/adhoc/index.tsx
+++ b/src/scenes/ObservationsRouter/adhoc/index.tsx
@@ -187,9 +187,7 @@ export default function ObservationMonitoringPlot(): JSX.Element | undefined {
                 <Grid key={index} item xs={gridSize} marginTop={2}>
                   <Textfield
                     id={`plot-observation-${index}`}
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                     label={datum.label}
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                     value={datum.value}
                     type={datum.text ? 'textarea' : 'text'}
                     preserveNewlines={true}

--- a/src/scenes/PlantsDashboardRouter/components/ZoneLevelDataMap.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/ZoneLevelDataMap.tsx
@@ -234,7 +234,6 @@ export default function ZoneLevelDataMap({ plantingSiteId }: ZoneLevelDataMapPro
 
         return (
           <MapTooltip
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             title={zoneObservation?.name ?? entity.name}
             subtitle={''} // TODO calculate latest observation per zone
             properties={properties}


### PR DESCRIPTION
This drops the lint problem count from 1971 errors to 184 errors.