### PR TITLE
Disable template expression rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -206,6 +206,9 @@ export default fixupConfigRules([
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',
 
+      '@typescript-eslint/no-base-to-string': 'off',
+      '@typescript-eslint/restrict-template-expressions': 'off',
+
       'arrow-parens': ['error', 'always'],
       'brace-style': ['off', 'off'],
       complexity: 'off',

--- a/src/scenes/PlantsDashboardRouter/components/PlantingDensityPerZoneCard.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/PlantingDensityPerZoneCard.tsx
@@ -100,7 +100,6 @@ export default function PlantingDensityPerZoneCard(): JSX.Element {
           }}
           customTooltipLabel={(tooltipItem) => {
             const v = tooltipItem.dataset.data[tooltipItem.dataIndex];
-            // eslint-disable-next-line @typescript-eslint/no-base-to-string
             return Array.isArray(v) ? v[0].toString() : v ? v.toString() : '';
           }}
           customLegend

--- a/src/utils/searchAndSort.ts
+++ b/src/utils/searchAndSort.ts
@@ -196,7 +196,6 @@ export const sortResults = <T extends Record<string, unknown>>(
   if (isNumberField) {
     results = results.sort((a, b) => Number(getRawField(a, field)) - Number(getRawField(b, field)));
   } else {
-    // eslint-disable-next-line  @typescript-eslint/no-base-to-string
     results = results.sort((a, b) => `${a[field] || ''}`.localeCompare(`${b[field] || ''}`, locale || undefined));
   }
 


### PR DESCRIPTION
The rules `no-base-to-string` and `restrict-template-expressions` are disabled in `package.json`'s `eslintConfig` property, so disabling them in eslint's config too. This brings the failure count from ~181 to ~142