### PR TITLE
SW-6807: Project Org Admin should be able to edit metric targets (Follow-up #4)

### DIFF
--- a/src/components/AcceleratorReports/AcceleratorReportTargetsTable.tsx
+++ b/src/components/AcceleratorReports/AcceleratorReportTargetsTable.tsx
@@ -283,7 +283,7 @@ export default function AcceleratorReportTargetsTable(): JSX.Element {
         <EditAcceleratorReportTargetsModal
           onClose={() => setEditOpenModal(false)}
           reload={reload}
-          reports={allReports}
+          reports={reports}
           row={selectedMetric}
         />
       )}

--- a/src/components/AcceleratorReports/EditAcceleratorReportTargetsModal.tsx
+++ b/src/components/AcceleratorReports/EditAcceleratorReportTargetsModal.tsx
@@ -64,6 +64,14 @@ export default function EditAcceleratorReportTargetsModal({
 
   const isAllowedReviewReportTargets = useMemo(() => isAllowed('REVIEW_REPORTS_TARGETS'), [isAllowed]);
 
+  const reportsById = useMemo(() => {
+    const reportsByIdMap: Record<number, AcceleratorReport> = {};
+    reports.forEach((report) => {
+      reportsByIdMap[report.id] = report;
+    });
+    return reportsByIdMap;
+  }, [reports]);
+
   useEffect(() => {
     if (updateReportMetricsResponse?.status === 'error') {
       snackbar.toastError();
@@ -137,7 +145,7 @@ export default function EditAcceleratorReportTargetsModal({
     } else {
       const updateManyReportsRequests = requests
         .map((request) => {
-          const report = reports.find((r) => r.id === request.reportId);
+          const report = reportsById[request.reportId];
           const reportClone = _.cloneDeep(report);
 
           ['projectMetrics', 'standardMetrics', 'systemMetrics'].forEach((metricType) => {
@@ -180,7 +188,7 @@ export default function EditAcceleratorReportTargetsModal({
           };
         })
         .filter((request) => {
-          const report = reports.find((r) => r.id === request.reportId);
+          const report = reportsById[request.reportId];
           // if request.report is unchanged, we don't need to update
           if (report && _.isEqual(report, request.report)) {
             return false;
@@ -203,14 +211,14 @@ export default function EditAcceleratorReportTargetsModal({
         return true;
       }
 
-      const report = reports.find((r) => r.id === reportId);
+      const report = reportsById[reportId];
       if (!report) {
         return true;
       }
 
       return !isAllowedReviewReportTargets && !(report.status === 'Not Submitted' || report.status === 'Needs Update');
     },
-    [reports, isAllowedReviewReportTargets]
+    [isAllowedReviewReportTargets, reports, reportsById]
   );
 
   return (

--- a/src/components/AcceleratorReports/EditAcceleratorReportTargetsModal.tsx
+++ b/src/components/AcceleratorReports/EditAcceleratorReportTargetsModal.tsx
@@ -135,54 +135,65 @@ export default function EditAcceleratorReportTargetsModal({
       const reviewRequest = dispatch(requestReviewManyAcceleratorReportMetrics(requestPayload));
       setReviewRequestId(reviewRequest.requestId);
     } else {
-      const updateManyReportsRequests = requests.map((request) => {
-        const report = reports.find((r) => r.id === request.reportId);
-        const reportClone = _.cloneDeep(report);
+      const updateManyReportsRequests = requests
+        .map((request) => {
+          const report = reports.find((r) => r.id === request.reportId);
+          const reportClone = _.cloneDeep(report);
 
-        ['projectMetrics', 'standardMetrics', 'systemMetrics'].forEach((metricType) => {
-          const reportMetrics = reportClone?.[metricType as keyof AcceleratorReport] as (
-            | ReportProjectMetricEntries
-            | ReportStandardMetricEntries
-            | ReportSystemMetricEntries
-          )[];
-          const requestMetrics = request[metricType as keyof ReviewAcceleratorReportMetricsRequest];
-          if (!Array.isArray(reportMetrics) || !Array.isArray(requestMetrics)) {
-            return;
-          }
-
-          requestMetrics.forEach((metric) => {
-            const reportMetricIndex =
-              metricType === 'systemMetrics'
-                ? reportMetrics.findIndex(
-                    (m) => (m as ReportSystemMetricEntries).metric === (metric as ReportSystemMetricEntries).metric
-                  )
-                : reportMetrics.findIndex(
-                    (m) => (m as ReportStandardMetricEntries).id === (metric as ReportStandardMetricEntries).id
-                  );
-            const reportMetric = reportMetrics[reportMetricIndex];
-            if (typeof reportMetric !== 'object' || typeof metric !== 'object') {
+          ['projectMetrics', 'standardMetrics', 'systemMetrics'].forEach((metricType) => {
+            const reportMetrics = reportClone?.[metricType as keyof AcceleratorReport] as (
+              | ReportProjectMetricEntries
+              | ReportStandardMetricEntries
+              | ReportSystemMetricEntries
+            )[];
+            const requestMetrics = request[metricType as keyof ReviewAcceleratorReportMetricsRequest];
+            if (!Array.isArray(reportMetrics) || !Array.isArray(requestMetrics)) {
               return;
             }
 
-            const reportMetricUpdate = {
-              ...reportMetric,
-              ...metric,
-            };
-            reportMetrics[reportMetricIndex] = reportMetricUpdate;
+            requestMetrics.forEach((metric) => {
+              const reportMetricIndex =
+                metricType === 'systemMetrics'
+                  ? reportMetrics.findIndex(
+                      (m) => (m as ReportSystemMetricEntries).metric === (metric as ReportSystemMetricEntries).metric
+                    )
+                  : reportMetrics.findIndex(
+                      (m) => (m as ReportStandardMetricEntries).id === (metric as ReportStandardMetricEntries).id
+                    );
+              const reportMetric = reportMetrics[reportMetricIndex];
+              if (typeof reportMetric !== 'object' || typeof metric !== 'object') {
+                return;
+              }
+
+              const reportMetricUpdate = {
+                ...reportMetric,
+                ...metric,
+              };
+              reportMetrics[reportMetricIndex] = reportMetricUpdate;
+            });
           });
+
+          return {
+            projectId,
+            report: reportClone as AcceleratorReport,
+            reportId: request.reportId,
+          };
+        })
+        .filter((request) => {
+          const report = reports.find((r) => r.id === request.reportId);
+          // if request.report is unchanged, we don't need to update
+          if (report && _.isEqual(report, request.report)) {
+            return false;
+          }
+          return true;
         });
 
-        return {
-          projectId,
-          report: reportClone as AcceleratorReport,
-          reportId: request.reportId,
-        };
-      });
-
-      const updateRequest = dispatch(
-        requestUpdateManyAcceleratorReports({ requests: updateManyReportsRequests.filter(Boolean) })
-      );
-      setUpdateRequestId(updateRequest.requestId);
+      if (!updateManyReportsRequests.length) {
+        onClose();
+      } else {
+        const updateRequest = dispatch(requestUpdateManyAcceleratorReports({ requests: updateManyReportsRequests }));
+        setUpdateRequestId(updateRequest.requestId);
+      }
     }
   };
 

--- a/src/components/AcceleratorReports/EditAcceleratorReportTargetsModal.tsx
+++ b/src/components/AcceleratorReports/EditAcceleratorReportTargetsModal.tsx
@@ -183,7 +183,7 @@ export default function EditAcceleratorReportTargetsModal({
 
           return {
             projectId,
-            report: reportClone as AcceleratorReport,
+            report: reportClone,
             reportId: request.reportId,
           };
         })


### PR DESCRIPTION
This PR includes a follow-up change to only send requests for modified reports.

Most of the diff is indentation, the only change is the addition of the `.filter` and if/else clause to handle closing the modal when there are no changes.