### PR TITLE
SW-6918 Fix order of sdg list

### DIFF
--- a/src/components/ProjectField/ProjectSdgDisplay.tsx
+++ b/src/components/ProjectField/ProjectSdgDisplay.tsx
@@ -13,11 +13,13 @@ const ProjectSdgDisplay = ({ sdgList }: { sdgList?: SustainableDevelopmentGoal[]
     return <Typography>{strings.NONE_SELECTED}</Typography>;
   }
 
-  return sdgList.map((sdg, i) => (
-    <Grid item md={1} key={`sdg-${i}`} paddingRight={theme.spacing(1)} component={'span'}>
-      <SdgIcon goal={sdg} size={128} />
-    </Grid>
-  ));
+  return sdgList
+    .toSorted((a, b) => Number(a) - Number(b))
+    .map((sdg, i) => (
+      <Grid item md={1} key={`sdg-${i}`} paddingRight={theme.spacing(1)} component={'span'}>
+        <SdgIcon goal={sdg} size={128} />
+      </Grid>
+    ));
 };
 
 export default ProjectSdgDisplay;


### PR DESCRIPTION
Previous order was non-deterministic because the server represented the list with a set.

Before:
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Gd93CNnCsYqInZuuYUOX/274bc392-7c60-4c93-a107-c26b82ec12a6.png)

After:
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Gd93CNnCsYqInZuuYUOX/dd04be45-7a8a-49d0-abd1-a4d96a698195.png)

