### PR TITLE
SW-6807: Project Org Admin should be able to edit metric targets (Follow-up #5 🫠)

### DIFF
--- a/src/components/AcceleratorReports/EditAcceleratorReportTargetsModal.tsx
+++ b/src/components/AcceleratorReports/EditAcceleratorReportTargetsModal.tsx
@@ -173,6 +173,11 @@ export default function EditAcceleratorReportTargetsModal({
                 return;
               }
 
+              // if target value is unchanged, we don't need to update
+              if (metric.target === reportMetric.target) {
+                return;
+              }
+
               const reportMetricUpdate = {
                 ...reportMetric,
                 ...metric,


### PR DESCRIPTION
This PR fixes an issue where requests were sent for unchanged targets with no previous value.

If `target` was `undefined` before and after edits, it was omitted in the API response but still set in the report copy, causing the `isEqual` check to return false despite both copies having `undefined` for `target`.
