### PR TITLE
Fixed dispatches in useOrganization hook

### DIFF
--- a/src/hooks/useOrgTracking.ts
+++ b/src/hooks/useOrgTracking.ts
@@ -10,6 +10,7 @@ import {
 import {
   requestOrganizationAdHocObservationResults,
   requestOrganizationAdHocObservations,
+  requestOrganizationObservationResults,
   requestOrganizationObservations,
 } from 'src/redux/features/observations/observationsThunks';
 import {
@@ -55,14 +56,12 @@ export const useOrgTracking = () => {
   const reload = useCallback(() => {
     const plantingSitesRequest = dispatch(requestListPlantingSites(selectedOrganization.id));
     const observationsRequest = dispatch(requestOrganizationObservations({ organizationId: selectedOrganization.id }));
-    const resultsRequest = dispatch(
-      requestOrganizationAdHocObservationResults({ organizationId: selectedOrganization.id })
-    );
+    const resultsRequest = dispatch(requestOrganizationObservationResults({ organizationId: selectedOrganization.id }));
     const adHocObservationsRequest = dispatch(
       requestOrganizationAdHocObservations({ organizationId: selectedOrganization.id })
     );
     const adHocResultsRequest = dispatch(
-      requestOrganizationAdHocObservations({ organizationId: selectedOrganization.id })
+      requestOrganizationAdHocObservationResults({ organizationId: selectedOrganization.id })
     );
     const reportedPlantsRequest = dispatch(requestOrganizationReportedPlants(selectedOrganization.id));
 


### PR DESCRIPTION
This hook isn't used by anything yet, but it was merged early to unblock PlantDashboard development. Found a bug to patch.