### PR TITLE
SW-6813: Add Variables tab to Project Profile in Console (Follow-up #1)

### DIFF
--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
@@ -15,9 +15,11 @@ import { SelectOptionPayload, VariableWithValues } from 'src/types/documentProdu
 import {
   VariableValueDateValue,
   VariableValueEmailValue,
+  VariableValueImageValue,
   VariableValueLinkValue,
   VariableValueNumberValue,
   VariableValueSelectValue,
+  VariableValueTableValue,
   VariableValueTextValue,
 } from 'src/types/documentProducer/VariableValue';
 import { fuzzyMatch } from 'src/utils/searchAndSort';
@@ -72,6 +74,16 @@ const tableCellRenderer = (props: RendererProps<any>): JSX.Element => {
       if (row.type === 'Link') {
         const variableLinkValue = props.value[0] as VariableValueLinkValue;
         return <CellRenderer {...props} value={variableLinkValue.url} />;
+      }
+      if (row.type === 'Image') {
+        const variableImageValues = props.value as VariableValueImageValue[];
+        const imageCount = variableImageValues.length;
+        return <CellRenderer {...props} value={`${imageCount} image${imageCount > 1 ? 's' : ''}`} />;
+      }
+      if (row.type === 'Table') {
+        const variableTableValues = props.value as VariableValueTableValue[];
+        const rowCount = variableTableValues.length;
+        return <CellRenderer {...props} value={`${rowCount} row${rowCount > 1 ? 's' : ''}`} />;
       }
     }
     // Default (type not found): Render an empty cell

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
@@ -30,7 +30,13 @@ const tableCellRenderer = (props: RendererProps<any>): JSX.Element => {
 
   if (column.key === 'name') {
     if (props.value) {
-      return <CellRenderer {...props} value={<Link>{value?.toString()}</Link>} />;
+      return <CellRenderer {...props} title={value?.toString()} value={<Link>{value?.toString()}</Link>} />;
+    }
+  }
+
+  if (column.key === 'deliverableQuestion') {
+    if (props.value) {
+      return <CellRenderer {...props} title={value?.toString()} />;
     }
   }
 


### PR DESCRIPTION
This PR includes some follow-up enhancements in the Variables tab in the new Project Profile Page:

- Show full value on hover for Name & Question columns (add tooltip)
- Render a text label value for Image & Table variables ('N images' or 'N rows')