### PR TITLE
SW-6933 If Accelerator project does not have any species, accelerator home page does not show

### DIFF
--- a/src/scenes/Home/index.tsx
+++ b/src/scenes/Home/index.tsx
@@ -34,7 +34,7 @@ export default function Home({ selectedOrgHasSpecies }: { selectedOrgHasSpecies:
       return <Page isLoading={true} />;
     }
 
-    if ((people?.length === 1 && !orgPreferences.singlePersonOrg) || !selectedOrgHasSpecies()) {
+    if ((people?.length === 1 && !orgPreferences.singlePersonOrg) || (!orgHasModules && !selectedOrgHasSpecies())) {
       return <OnboardingHomeView />;
     } else {
       return orgHasModules && isManagerOrHigher(selectedOrganization) ? <ParticipantHomeView /> : <TerrawareHomeView />;


### PR DESCRIPTION
If the org has modules, we don't need to check the org has species condition