### PR TITLE
SW-6840 Calculate total plants from raw numbers

### DIFF
--- a/src/scenes/ObservationsRouter/details/exportObservationResults.ts
+++ b/src/scenes/ObservationsRouter/details/exportObservationResults.ts
@@ -111,7 +111,7 @@ function makeObservationCsv(observationResults: ObservationResults): Blob {
           totalDead,
           totalExisting,
           totalLive,
-          totalPlants: monitoringPlot.totalPlants,
+          totalPlants: totalDead + totalExisting + totalLive,
           totalSpecies: monitoringPlot.totalSpecies,
           zoneName: plantingZone.name,
         };
@@ -172,7 +172,7 @@ function makePlotSpeciesCsv(observationResults: ObservationResults): Blob {
           return {
             monitoringPlot: monitoringPlot.monitoringPlotNumber,
             scientificName: speciesName,
-            totalPlants: species.totalPlants,
+            totalPlants: species.totalDead + species.totalExisting + species.totalLive,
             preExistingPlants: species.totalExisting,
             livePlants: species.totalLive,
             deadPlants: species.totalDead,


### PR DESCRIPTION
The observation results export was using the server-calculated "total plants"
value, but that total doesn't count dead plants and includes pre-existing plants
from previous observations, whereas we want the results CSV to just be the total
of the live, existing, and dead plants from the observation in question.