### PR TITLE
Fix 2 console warnings during playwright tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@mui/styled-engine-sc": "^5.14.12",
     "@mui/styles": "^6.2.0",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^3.4.23",
+    "@terraware/web-components": "^3.4.24",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/src/components/BatchWithdrawFlow/flow/SelectPurposeForm.tsx
+++ b/src/components/BatchWithdrawFlow/flow/SelectPurposeForm.tsx
@@ -561,7 +561,7 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
               {strings.WITHDRAWAL_DETAILS}
             </Typography>
             <Typography>{strings.WITHDRAW_INSTRUCTIONS}</Typography>
-            <Grid xs={12} padding={theme.spacing(4, 0, 0)}>
+            <Grid padding={theme.spacing(4, 0, 0)}>
               <Typography fontSize='14px' fontWeight={400} lineHeight='20px'>
                 {strings.SPECIES_SELECTED}
               </Typography>
@@ -569,7 +569,7 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
                 {batchSpeciesNames.join(', ')}
               </Typography>
             </Grid>
-            <Grid xs={12} padding={theme.spacing(4, 0, 0)}>
+            <Grid padding={theme.spacing(4, 0, 0)}>
               <FormControl>
                 <FormLabel
                   sx={{
@@ -657,7 +657,7 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
             {isOutplant && (
               <>
                 <Divisor mt={3} />
-                <Grid xs={12}>
+                <Grid>
                   <Dropdown
                     id='plantingSiteId'
                     placeholder={strings.SELECT}

--- a/src/scenes/InventoryRouter/InventoryCellRenderer.tsx
+++ b/src/scenes/InventoryRouter/InventoryCellRenderer.tsx
@@ -54,11 +54,29 @@ export default function InventoryCellRenderer(props: RendererProps<TableRowType>
     createLinkWithQuery(APP_PATHS.INVENTORY_BATCH.replace(':batchId', row.batchId.toString()), iValue);
 
   if (column.key === 'facilityInventories' && typeof value === 'string') {
-    return <CellRenderer index={index} column={column} value={getNamesList(value)} row={row} sx={textStyles} />;
+    return (
+      <CellRenderer
+        component={'span'}
+        index={index}
+        column={column}
+        value={getNamesList(value)}
+        row={row}
+        sx={textStyles}
+      />
+    );
   }
 
   if (column.key === 'subLocations' && typeof value === 'string') {
-    return <CellRenderer index={index} column={column} value={getNamesList(value)} row={row} sx={textStyles} />;
+    return (
+      <CellRenderer
+        component={'span'}
+        index={index}
+        column={column}
+        value={getNamesList(value)}
+        row={row}
+        sx={textStyles}
+      />
+    );
   }
 
   if (column.key === 'species_scientificName') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4104,10 +4104,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^3.4.23":
-  version "3.4.23"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.4.23.tgz#da1ace05d973d3b284382227359757804ec53f65"
-  integrity sha512-qmvjus/1nnjfrIVVXZwu6Sxqj6PgzYFCqPVe8LyXP6KbP+DDR+YSqh/L514s/zSFH1CS55f8Q6xacNlO2KHapg==
+"@terraware/web-components@^3.4.24":
+  version "3.4.24"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.4.24.tgz#743408a1fee28060fabc967430ff7c4ae6152f2c"
+  integrity sha512-u95bgLSvAm/+Qz/hMHT1Lxtx9sNrTM6I66NC4dK2RRW369yI24vcxDc4NU/buhe8UlmYiatrYVQrnifd5EjmNQ==
   dependencies:
     "@dnd-kit/core" "^6.0.7"
     "@dnd-kit/sortable" "^7.0.2"


### PR DESCRIPTION
Some console errors were making playwright output harder to parse. Fix them.

The 2 console warnings:
- Nested `<p>` under `<p>`
- Grid element cannot have `xs` without `item`