### PR TITLE
Fix infinite render on challenges

### DIFF
--- a/src/components/AcceleratorReports/ChallengesMitigationBox.tsx
+++ b/src/components/AcceleratorReports/ChallengesMitigationBox.tsx
@@ -138,7 +138,7 @@ const ChallengesMitigationBox = (props: ReportBoxProps) => {
   }, [challengeMitigations]);
 
   const areFilteredChallengesDifferent = useMemo(() => {
-    return nonEmptyChallenges && JSON.stringify(nonEmptyChallenges) !== JSON.stringify(report?.challenges);
+    return nonEmptyChallenges.length > 0 && JSON.stringify(nonEmptyChallenges) !== JSON.stringify(report?.challenges);
   }, [report?.challenges, nonEmptyChallenges]);
 
   useEffect(() => {

--- a/src/components/AcceleratorReports/ChallengesMitigationBox.tsx
+++ b/src/components/AcceleratorReports/ChallengesMitigationBox.tsx
@@ -133,13 +133,13 @@ const ChallengesMitigationBox = (props: ReportBoxProps) => {
   const updateReportResponse = useAppSelector(selectReviewAcceleratorReport(requestId));
   const snackbar = useSnackbar();
 
-  const getNonEmptyChallenges = (challengesList: ChallengeMitigation[]) =>
-    challengesList.filter((s) => !!s.challenge || !!s.mitigationPlan);
+  const nonEmptyChallenges = useMemo(() => {
+    return challengeMitigations.filter((s) => !!s.challenge || !!s.mitigationPlan);
+  }, [challengeMitigations]);
 
   const areFilteredChallengesDifferent = useMemo(() => {
-    const filteredChallenges = getNonEmptyChallenges(challengeMitigations);
-    return filteredChallenges && JSON.stringify(filteredChallenges) !== JSON.stringify(report?.challenges);
-  }, [report?.challenges, challengeMitigations]);
+    return nonEmptyChallenges && JSON.stringify(nonEmptyChallenges) !== JSON.stringify(report?.challenges);
+  }, [report?.challenges, nonEmptyChallenges]);
 
   useEffect(() => {
     if (!editing) {
@@ -181,8 +181,7 @@ const ChallengesMitigationBox = (props: ReportBoxProps) => {
   const onSave = useCallback(() => {
     if (isAcceleratorReport(report)) {
       setValidateFields(false);
-      const filteredChallenges = getNonEmptyChallenges(challengeMitigations);
-      if (filteredChallenges.some((c) => !c.challenge || !c.mitigationPlan)) {
+      if (nonEmptyChallenges.some((c) => !c.challenge || !c.mitigationPlan)) {
         setValidateFields(true);
         return;
       }
@@ -192,7 +191,7 @@ const ChallengesMitigationBox = (props: ReportBoxProps) => {
           review: {
             ...report,
             achievements: report?.achievements || [],
-            challenges: filteredChallenges,
+            challenges: nonEmptyChallenges,
             status: report?.status || 'Not Submitted',
           },
           projectId: Number(projectId),
@@ -201,7 +200,7 @@ const ChallengesMitigationBox = (props: ReportBoxProps) => {
       );
       setRequestId(request.requestId);
     }
-  }, [report, challengeMitigations, dispatch, projectId]);
+  }, [report, nonEmptyChallenges, dispatch, projectId]);
 
   const onCancel = useCallback(() => {
     setInternalEditing(false);

--- a/src/components/AcceleratorReports/ChallengesMitigationBox.tsx
+++ b/src/components/AcceleratorReports/ChallengesMitigationBox.tsx
@@ -133,26 +133,19 @@ const ChallengesMitigationBox = (props: ReportBoxProps) => {
   const updateReportResponse = useAppSelector(selectReviewAcceleratorReport(requestId));
   const snackbar = useSnackbar();
 
-  const getNonEmptyChallenges = useCallback(() => {
-    return challengeMitigations.filter((s) => !!s.challenge || !!s.mitigationPlan);
-  }, [challengeMitigations]);
+  const getNonEmptyChallenges = (challengesList: ChallengeMitigation[]) =>
+    challengesList.filter((s) => !!s.challenge || !!s.mitigationPlan);
 
   const areFilteredChallengesDifferent = useMemo(() => {
-    const filteredChallenges = getNonEmptyChallenges();
+    const filteredChallenges = getNonEmptyChallenges(challengeMitigations);
     return filteredChallenges && JSON.stringify(filteredChallenges) !== JSON.stringify(report?.challenges);
-  }, [getNonEmptyChallenges, report?.challenges]);
+  }, [report?.challenges, challengeMitigations]);
 
   useEffect(() => {
     if (!editing) {
       setChallengeMitigations(report?.challenges || []);
     }
-    // For participant editing, react can't keep up with setting challengeMitigations, then calling onChange on the
-    // report, and having this useEffect update challengeMitigations again. This check ensures we're only setting it
-    // from report when needed
-    if (((editing && !getNonEmptyChallenges()) || getNonEmptyChallenges().length === 0) && report?.challenges) {
-      setChallengeMitigations(report?.challenges ?? []);
-    }
-  }, [editing, getNonEmptyChallenges, report?.challenges]);
+  }, [editing, report?.challenges]);
 
   useEffect(() => onEditChange?.(internalEditing), [internalEditing, onEditChange]);
 
@@ -188,7 +181,7 @@ const ChallengesMitigationBox = (props: ReportBoxProps) => {
   const onSave = useCallback(() => {
     if (isAcceleratorReport(report)) {
       setValidateFields(false);
-      const filteredChallenges = getNonEmptyChallenges();
+      const filteredChallenges = getNonEmptyChallenges(challengeMitigations);
       if (filteredChallenges.some((c) => !c.challenge || !c.mitigationPlan)) {
         setValidateFields(true);
         return;
@@ -208,7 +201,7 @@ const ChallengesMitigationBox = (props: ReportBoxProps) => {
       );
       setRequestId(request.requestId);
     }
-  }, [report, getNonEmptyChallenges, dispatch, projectId]);
+  }, [report, challengeMitigations, dispatch, projectId]);
 
   const onCancel = useCallback(() => {
     setInternalEditing(false);


### PR DESCRIPTION
Fixing the exhaustive-deps linting issue caused an infinite render on the challenges/mitigations in reports. Fix the infinite render.