### PR TITLE
Enable jsx-no-bind linting rule, prepare to remove it in CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -63,9 +63,9 @@ jobs:
       - name: Generate strings
         run: yarn generate-strings
 
-      # Disable the linter since it will not pass in its current state
+      # Disable the linter since it will not pass in its current state. Remove the jsx-no-bind rule because it has lots of errors currently
       # - name: Run linter
-      #   run: yarn lint
+      #   run: yarn lint --rule "react/jsx-no-bind: 0"
 
       - name: Do typescript check
         run: yarn ts

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,7 +29,7 @@ export default fixupConfigRules([
       'plugin:react/recommended',
       'plugin:jest-react/recommended',
       // 'plugin:storybook/recommended',
-      'prettier'
+      'prettier',
     )
     .map((config) => ({
       ...config,
@@ -347,7 +347,7 @@ export default fixupConfigRules([
       'react/display-name': 'error',
       'react/jsx-boolean-value': 'off',
       'react/jsx-key': 'error',
-      'react/jsx-no-bind': 'off',
+      'react/jsx-no-bind': 'error',
       'react/jsx-no-comment-textnodes': 'error',
       'react/jsx-no-duplicate-props': 'error',
       'react/jsx-no-target-blank': 'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,7 +29,7 @@ export default fixupConfigRules([
       'plugin:react/recommended',
       'plugin:jest-react/recommended',
       // 'plugin:storybook/recommended',
-      'prettier',
+      'prettier'
     )
     .map((config) => ({
       ...config,


### PR DESCRIPTION
This rule currently adds over 1500 new errors. We want to start moving away from lambdas in jsx props, so enabling this rule to help us not use them moving forward. 
Also disable the rule in the github actions workflow comment, so that when we do enable linting in CI this rule doesn't keep us from seeing the rest of the issues.