### PR TITLE
SW-6967 Fix mobile funder logo

### DIFF
--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -121,7 +121,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
       sx={{
         background:
           isFunderRoute || user?.userType === 'Funder'
-            ? 'url(/assets/funder-logo-mobile.svg) no-repeat 0/199px'
+            ? 'url(/assets/funder-logo-mobile.svg) no-repeat 0/145px'
             : 'url(/assets/terraware-logo-mobile.svg) no-repeat 32px/105px',
         display: 'flex',
         alignItems: 'center',


### PR DESCRIPTION
Funder portal's mobile logo was too large and overlapping with other items in the header. Make the logo smaller to be closer to designs.