### PR TITLE
SW-7006 Spinner doesn't go after creating planting site

### DIFF
--- a/src/providers/Tracking/PlantingSiteContext.tsx
+++ b/src/providers/Tracking/PlantingSiteContext.tsx
@@ -28,6 +28,7 @@ export type PlantingSiteData = {
 
   isLoading: boolean;
   isInitiated: boolean;
+  reload: () => void;
 };
 
 // default values pointing to nothing
@@ -38,6 +39,8 @@ export const PlantingSiteContext = createContext<PlantingSiteData>({
   setSelectedPlantingSite: () => {},
   isLoading: true,
   isInitiated: false,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  reload: () => {},
 });
 
 export const usePlantingSiteData = () => useContext(PlantingSiteContext);

--- a/src/providers/Tracking/PlantingSiteProvider.tsx
+++ b/src/providers/Tracking/PlantingSiteProvider.tsx
@@ -85,13 +85,17 @@ const PlantingSiteProvider = ({ children }: Props) => {
     }
   }, [activeLocale, isAcceleratorRoute, acceleratorOrganizationId, selectedOrganization]);
 
-  useEffect(() => {
+  const reload = useCallback(() => {
     const orgId = isAcceleratorRoute ? acceleratorOrganizationId : selectedOrganization.id;
     if (orgId) {
       void dispatch(requestPlantingSites(orgId));
       _setSelectedPlantingSite(undefined);
     }
-  }, [dispatch, isAcceleratorRoute, acceleratorOrganizationId, selectedOrganization, _setSelectedPlantingSite]);
+  }, [acceleratorOrganizationId, dispatch, isAcceleratorRoute, selectedOrganization.id]);
+
+  useEffect(() => {
+    reload();
+  }, [dispatch, isAcceleratorRoute, acceleratorOrganizationId, selectedOrganization, _setSelectedPlantingSite, reload]);
 
   const allPlantingSites = useMemo(
     () => (plantingSitesResults && allSitesOption ? [...plantingSitesResults, allSitesOption] : []),
@@ -253,6 +257,7 @@ const PlantingSiteProvider = ({ children }: Props) => {
       latestResult,
       isLoading,
       isInitiated: plantingSitesResults !== undefined,
+      reload,
     }),
     [
       acceleratorOrganizationId,
@@ -273,6 +278,7 @@ const PlantingSiteProvider = ({ children }: Props) => {
       latestResult,
       isLoading,
       plantingSitesResults,
+      reload,
     ]
   );
 

--- a/src/scenes/PlantingSitesRouter/hooks/usePlantingSiteCreate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/usePlantingSiteCreate.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import useNavigateTo from 'src/hooks/useNavigateTo';
+import { usePlantingSiteData } from 'src/providers/Tracking/PlantingSiteContext';
 import { Statuses } from 'src/redux/features/asyncUtils';
 import { selectDraftPlantingSiteEdit } from 'src/redux/features/draftPlantingSite/draftPlantingSiteSelectors';
 import { requestDeleteDraft } from 'src/redux/features/draftPlantingSite/draftPlantingSiteThunks';
@@ -38,6 +39,7 @@ export default function usePlantingSiteCreate(): Response {
   const deleteDraftResult = useAppSelector(selectDraftPlantingSiteEdit(deleteDraftRequestId));
 
   const { validateDraft, validateSite, validateSiteStatus, isValid, problems } = usePlantingSiteValidate();
+  const { reload } = usePlantingSiteData();
 
   const _validateDraft = useCallback(
     (draft: DraftPlantingSite) => {
@@ -95,10 +97,11 @@ export default function usePlantingSiteCreate(): Response {
 
   useEffect(() => {
     if (deleteDraftResult?.status === 'success' && createResult.data) {
+      reload();
       snackbar.toastSuccess(strings.PLANTING_SITE_SAVED);
       goToPlantingSiteView(createResult.data);
     }
-  }, [deleteDraftResult, createResult, dispatch, goToPlantingSiteView, snackbar]);
+  }, [deleteDraftResult, createResult, dispatch, goToPlantingSiteView, snackbar, reload]);
 
   return useMemo<Response>(
     () => ({


### PR DESCRIPTION
After creating a planting site, we need to reload the allPlantingSites in the provider before redirecting to the planting site page