### PR TITLE
SW-7009 If multiple species have the same mortality rate, we incorrectly show only one species with mortality

### DIFF
--- a/src/scenes/PlantsDashboardRouter/components/HighestAndLowestMortalityRateSpeciesCard.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/HighestAndLowestMortalityRateSpeciesCard.tsx
@@ -42,7 +42,7 @@ export default function HighestAndLowestMortalityRateSpeciesCard(): JSX.Element 
           _highestMortalityRate = observationSpecies.mortalityRate;
           _highestSpeciesName = speciesName;
         }
-        if (observationSpecies.mortalityRate <= _lowestMortalityRate) {
+        if (observationSpecies.mortalityRate < _lowestMortalityRate) {
           _lowestMortalityRate = observationSpecies.mortalityRate;
           _lowestSpeciesName = speciesName;
         }

--- a/src/scenes/PlantsDashboardRouter/components/HighestAndLowestMortalityRateZonesCard.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/HighestAndLowestMortalityRateZonesCard.tsx
@@ -27,7 +27,7 @@ export default function TotalMortalityRateCard(): JSX.Element {
           _highestMortalityRate = zone.mortalityRate;
           _highestZoneId = zone.plantingZoneId;
         }
-        if (zone.mortalityRate <= _lowestMortalityRate) {
+        if (zone.mortalityRate < _lowestMortalityRate) {
           _lowestMortalityRate = zone.mortalityRate;
           _lowestZoneId = zone.plantingZoneId;
         }


### PR DESCRIPTION
We only mark a species as lowest mortality rate if its value is lower than the previous (not equal). If it is equal we don't mark it, so in case we have 2 species with same value, the last one can be set a highest, and the first one as lowest