### PR TITLE
SW-7016 Include unknown species in observation CSVs

### DIFF
--- a/src/redux/features/observations/utils.ts
+++ b/src/redux/features/observations/utils.ts
@@ -231,7 +231,9 @@ const mergeSpecies = (
   return speciesObservations
     .filter(
       (speciesObservation: ObservationSpeciesResultsPayload) =>
-        species[speciesObservation.speciesId ?? -1] || speciesObservation.speciesName
+        species[speciesObservation.speciesId ?? -1] ||
+        speciesObservation.speciesName ||
+        speciesObservation.certainty === 'Unknown'
     )
     .map(
       (speciesObservation: ObservationSpeciesResultsPayload): ObservationSpeciesResults => ({

--- a/src/scenes/ObservationsRouter/details/index.tsx
+++ b/src/scenes/ObservationsRouter/details/index.tsx
@@ -11,6 +11,7 @@ import Search, { SearchProps } from 'src/components/common/SearchFiltersWrapper'
 import { APP_PATHS } from 'src/constants';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
+import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import {
   searchObservationDetails,
   selectDetailsZoneNames,
@@ -47,6 +48,7 @@ export default function ObservationDetails(props: ObservationDetailsProps): JSX.
   const { activeLocale } = useLocalization();
   const { selectedOrganization } = useOrganization();
   const defaultTimeZone = useDefaultTimeZone();
+  const speciesData = useSpeciesData();
   const navigate = useSyncNavigate();
   const params = useParams<{
     plantingSiteId: string;
@@ -205,10 +207,15 @@ export default function ObservationDetails(props: ObservationDetailsProps): JSX.
   const onSaveMergedSpecies = useOnSaveMergedSpecies({ observationId, reload, setShowMatchSpeciesModal });
 
   const onExportObservationResults = useCallback(() => {
-    if (selectedObservationResults && selectedObservationResults.length > 0) {
-      void exportObservationResults({ observationResults: selectedObservationResults[0] });
+    if (plantingSite && selectedObservationResults && selectedObservationResults.length > 0) {
+      void exportObservationResults({
+        observationId: selectedObservationResults[0].observationId,
+        defaultTimeZone: defaultTimeZone.get().id,
+        plantingSites: [plantingSite],
+        species: speciesData.species,
+      });
     }
-  }, [selectedObservationResults]);
+  }, [defaultTimeZone, plantingSite, selectedObservationResults, speciesData]);
 
   return (
     <DetailsPage

--- a/src/scenes/ObservationsRouter/org/OrgObservationsListView.tsx
+++ b/src/scenes/ObservationsRouter/org/OrgObservationsListView.tsx
@@ -8,6 +8,8 @@ import Table from 'src/components/common/table';
 import { APP_PATHS } from 'src/constants';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
+import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
+import { usePlantingSiteData } from 'src/providers/Tracking/PlantingSiteContext';
 import { requestAbandonObservation } from 'src/redux/features/observations/observationsAsyncThunks';
 import {
   selectAbandonObservation,
@@ -105,6 +107,8 @@ export default function OrgObservationsListView({
   timeZone,
 }: OrgObservationsListViewProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
+  const speciesData = useSpeciesData();
+  const plantingSiteData = usePlantingSiteData();
   const { activeLocale } = useLocalization();
   const [results, setResults] = useState<any>([]);
   const theme = useTheme();
@@ -206,12 +210,16 @@ export default function OrgObservationsListView({
 
   const onExportObservationResults = useCallback(
     (observationId: number) => {
-      const observation = (observationsResults ?? []).find((item) => item.observationId === observationId);
-      if (observation !== undefined) {
-        void exportObservationResults({ observationResults: observation });
+      if (speciesData.species && plantingSiteData.allPlantingSites) {
+        void exportObservationResults({
+          observationId,
+          defaultTimeZone: timeZone,
+          species: speciesData.species,
+          plantingSites: plantingSiteData.allPlantingSites,
+        });
       }
     },
-    [observationsResults]
+    [timeZone, speciesData, plantingSiteData]
   );
 
   const goToRescheduleObservation = useCallback(

--- a/src/services/ObservationsService.ts
+++ b/src/services/ObservationsService.ts
@@ -19,6 +19,7 @@ import SearchService from './SearchService';
 const AD_HOC_OBSERVATIONS_ENDPOINT = '/api/v1/tracking/observations/adHoc';
 const AD_HOC_OBSERVATION_RESULTS_ENDPOINT = '/api/v1/tracking/observations/adHoc/results';
 const OBSERVATIONS_ENDPOINT = '/api/v1/tracking/observations';
+const OBSERVATION_RESULTS_SINGLE_ENDPOINT = '/api/v1/tracking/observations/{observationId}/results';
 const OBSERVATION_RESULTS_ENDPOINT = '/api/v1/tracking/observations/results';
 const OBSERVATION_ENDPOINT = '/api/v1/tracking/observations/{observationId}';
 const OBSERVATION_EXPORT_ENDPOINT = '/api/v1/tracking/observations/{observationId}/plots';
@@ -34,6 +35,9 @@ type AdHocObservationResultsPayload =
 
 type ObservationResultsResponsePayload =
   paths[typeof OBSERVATION_RESULTS_ENDPOINT]['get']['responses'][200]['content']['application/json'];
+
+type ObservationResultsSingleResponsePayload =
+  paths[typeof OBSERVATION_RESULTS_SINGLE_ENDPOINT]['get']['responses'][200]['content']['application/json'];
 
 type ObservationsResponsePayload =
   paths[typeof OBSERVATIONS_ENDPOINT]['get']['responses'][200]['content']['application/json'];
@@ -55,6 +59,7 @@ export type ObservationsData = {
 const httpAdHocObservations = HttpService.root(AD_HOC_OBSERVATIONS_ENDPOINT);
 const httpAdHocObservationResults = HttpService.root(AD_HOC_OBSERVATION_RESULTS_ENDPOINT);
 const httpObservationResults = HttpService.root(OBSERVATION_RESULTS_ENDPOINT);
+const httpObservationResultsSingle = HttpService.root(OBSERVATION_RESULTS_SINGLE_ENDPOINT);
 const httpObservations = HttpService.root(OBSERVATIONS_ENDPOINT);
 const httpObservation = HttpService.root(OBSERVATION_ENDPOINT);
 const httpObservationExport = HttpService.root(OBSERVATION_EXPORT_ENDPOINT);
@@ -229,6 +234,18 @@ const exportGpx = async (observationId: number): Promise<any> => {
   } catch {
     return null;
   }
+};
+
+const getSingleObservationResults = async (
+  observationId: number,
+  includeUnknown: boolean = false
+): Promise<Response2<ObservationResultsSingleResponsePayload>> => {
+  const response = await httpObservationResultsSingle.get2<ObservationResultsSingleResponsePayload>({
+    params: { includeUnknown: includeUnknown.toString() },
+    urlReplacements: { '{observationId}': observationId.toString() },
+  });
+
+  return response;
 };
 
 /**
@@ -474,6 +491,7 @@ const ObservationsService = {
   replaceObservationPlot,
   rescheduleObservation,
   scheduleObservation,
+  getSingleObservationResults,
   getPlantingSiteObservationsSummaries,
   abandonObservation,
   listAdHocObservationResults,


### PR DESCRIPTION
By default, observation results don't include "species"-level data for plants of
unknown species, which is fine since we don't want them to appear anywhere in the
UI. However, they need to be included in exported CSV files.

Make the CSV export code fetch a version of the results that includes the unknown
species, and use that to generate the CSVs for export.