### PR TITLE
SW-7023 Stop using organization ID -1 as sentinel

### DIFF
--- a/src/components/BatchWithdrawFlow/flow/SelectPurposeForm.tsx
+++ b/src/components/BatchWithdrawFlow/flow/SelectPurposeForm.tsx
@@ -385,11 +385,17 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
   };
 
   const onChangeFromNursery = (facilityIdSelected: string) => {
-    const foundNursery = getNurseryById(selectedOrganization, Number(facilityIdSelected));
-    setSelectedNursery(foundNursery);
+    if (selectedOrganization) {
+      const foundNursery = getNurseryById(selectedOrganization, Number(facilityIdSelected));
+      setSelectedNursery(foundNursery);
+    }
   };
 
   const nurseriesOptions = useMemo(() => {
+    if (!selectedOrganization) {
+      return [];
+    }
+
     const nurseries = batches
       .filter((batchData: SearchResponseElement) => {
         if (isOutplant) {
@@ -430,13 +436,15 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
   const gridSize = () => (isMobile ? 12 : 6);
 
   useEffect(() => {
-    const allNurseries = getAllNurseries(selectedOrganization);
-    const destinationNurseries = allNurseries.filter(
-      (nursery) => nursery.id.toString() !== selectedNursery?.id.toString()
-    );
-    setDestinationNurseriesOptions(
-      destinationNurseries.map((nursery) => ({ label: nursery.name, value: nursery.id.toString() }))
-    );
+    if (selectedOrganization) {
+      const allNurseries = getAllNurseries(selectedOrganization);
+      const destinationNurseries = allNurseries.filter(
+        (nursery) => nursery.id.toString() !== selectedNursery?.id.toString()
+      );
+      setDestinationNurseriesOptions(
+        destinationNurseries.map((nursery) => ({ label: nursery.name, value: nursery.id.toString() }))
+      );
+    }
   }, [selectedNursery, selectedOrganization, isOutplant]);
 
   useEffect(() => {

--- a/src/components/BatchWithdrawFlow/index.tsx
+++ b/src/components/BatchWithdrawFlow/index.tsx
@@ -47,7 +47,7 @@ export default function BatchWithdrawFlow(props: BatchWithdrawFlowProps): JSX.El
   const navigate = useSyncNavigate();
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const populateBatches = async () => {
         const searchResponse: SearchResponseElement[] | null = await NurseryBatchService.getBatches(
           selectedOrganization.id,
@@ -66,7 +66,7 @@ export default function BatchWithdrawFlow(props: BatchWithdrawFlowProps): JSX.El
       };
       void populateBatches();
     }
-  }, [batchIds, snackbar, selectedOrganization.id]);
+  }, [batchIds, snackbar, selectedOrganization]);
 
   const onWithdrawalConfigured = (withdrawal: NurseryWithdrawalRequest) => {
     setRecord(withdrawal);

--- a/src/components/FeatureNotification/OrganizationNotification.tsx
+++ b/src/components/FeatureNotification/OrganizationNotification.tsx
@@ -57,7 +57,7 @@ export default function OrganizationNotification(): Notification | null {
 
       let orgTz: InitializedTimeZone = {};
 
-      if (selectedOrganization.id !== -1) {
+      if (selectedOrganization) {
         orgTz = await OrganizationService.initializeTimeZone(selectedOrganization, userTz.timeZone);
       }
 
@@ -74,7 +74,7 @@ export default function OrganizationNotification(): Notification | null {
   }, [reloadOrganizations, reloadUser, selectedOrganization, user, userPreferences, timeZones]);
 
   return useMemo(() => {
-    if (timeZoneOrgNotification) {
+    if (timeZoneOrgNotification && selectedOrganization) {
       return {
         id: -2,
         notificationCriticality: 'Info',
@@ -106,11 +106,5 @@ export default function OrganizationNotification(): Notification | null {
     }
 
     return null;
-  }, [
-    timeZoneOrgNotification,
-    orgTimeZone,
-    reloadUserPreferences,
-    selectedOrganization.id,
-    timeZoneOrgNotificationRead,
-  ]);
+  }, [timeZoneOrgNotification, orgTimeZone, reloadUserPreferences, selectedOrganization, timeZoneOrgNotificationRead]);
 }

--- a/src/components/FeatureNotification/UserNotification.tsx
+++ b/src/components/FeatureNotification/UserNotification.tsx
@@ -99,7 +99,7 @@ export default function UserNotification(): Notification | null {
       return {
         id: -1,
         notificationCriticality: 'Info',
-        organizationId: selectedOrganization.id,
+        organizationId: selectedOrganization?.id || -1,
         title: strings.REVIEW_YOUR_ACCOUNT_SETTING,
         body: (
           <Box>
@@ -159,7 +159,7 @@ export default function UserNotification(): Notification | null {
     unitNotification,
     timeZoneUserNotification,
     reloadUserPreferences,
-    selectedOrganization.id,
+    selectedOrganization,
     user?.userType,
     user?.locale,
     userPreferences.preferredWeightSystem,

--- a/src/components/OrganizationsDropdown.tsx
+++ b/src/components/OrganizationsDropdown.tsx
@@ -60,7 +60,7 @@ export default function OrganizationsDropdown(): JSX.Element {
         onSuccess={(organization) => void handleSuccess(organization)}
       />
       <PopoverMenu
-        anchor={<p style={{ fontSize: '16px' }}>{selectedOrganization.name}</p>}
+        anchor={<p style={{ fontSize: '16px' }}>{selectedOrganization?.name}</p>}
         menuSections={[
           organizations?.map((organization) => ({ label: organization.name, value: organization.id.toString() })) || [],
           [{ label: strings.CREATE_NEW_ORGANIZATION, value: '0' }],

--- a/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
+++ b/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
@@ -87,10 +87,10 @@ export default function PlantsPrimaryPageView({
   }, [isInitiated, hasSites, plantingSiteSelected]);
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       void dispatch(requestProjects(selectedOrganization.id, activeLocale || undefined));
     }
-  }, [activeLocale, dispatch, selectedOrganization.id]);
+  }, [activeLocale, dispatch, selectedOrganization]);
 
   const projectsWithPlantingSites = useMemo(() => {
     if (!allPlantingSites) {

--- a/src/components/PlantsPrimaryPage/index.tsx
+++ b/src/components/PlantsPrimaryPage/index.tsx
@@ -59,7 +59,7 @@ export default function PlantsPrimaryPage({
   const navigate = useSyncNavigate();
 
   useEffect(() => {
-    if (plantsSitePreferences && selectedOrganization.id !== -1) {
+    if (plantsSitePreferences && selectedOrganization) {
       const response = CachedUserService.getUserOrgPreferences(selectedOrganization.id);
       if (!_.isEqual(response[lastVisitedPreferenceName], plantsSitePreferences)) {
         void PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
@@ -67,7 +67,7 @@ export default function PlantsPrimaryPage({
         });
       }
     }
-  }, [plantsSitePreferences, lastVisitedPreferenceName, selectedOrganization.id]);
+  }, [plantsSitePreferences, lastVisitedPreferenceName, selectedOrganization]);
 
   const plantingSitesList = useMemo((): PlantingSite[] => {
     const projectSites = projectId
@@ -96,7 +96,7 @@ export default function PlantsPrimaryPage({
     const initializePlantingSite = async () => {
       if (plantingSitesList && plantingSitesList.length) {
         let lastVisitedPlantingSite: any = {};
-        if (selectedOrganization.id !== -1 && !projectId) {
+        if (selectedOrganization && !projectId) {
           const response = CachedUserService.getUserOrgPreferences(selectedOrganization.id);
           if (response[lastVisitedPreferenceName]) {
             lastVisitedPlantingSite = response[lastVisitedPreferenceName];
@@ -110,7 +110,7 @@ export default function PlantsPrimaryPage({
           plantingSitesList.find((plantingSite) => plantingSite?.id === plantingSiteIdToUse) ?? plantingSitesList[0];
         const nextPlantingSiteId = nextPlantingSite.id;
 
-        if (selectedOrganization.id !== -1 && !projectId) {
+        if (selectedOrganization && !projectId) {
           if (nextPlantingSiteId !== lastPlantingSiteId) {
             await PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
               [lastVisitedPreferenceName]: { plantingSiteId: nextPlantingSiteId },
@@ -133,7 +133,7 @@ export default function PlantsPrimaryPage({
     plantingSitesList,
     plantingSiteId,
     setActivePlantingSite,
-    selectedOrganization.id,
+    selectedOrganization,
     lastVisitedPreferenceName,
     setPlantsSitePreferences,
     organizationId,

--- a/src/components/ProjectNewView/flow/ProjectEntitySearch.tsx
+++ b/src/components/ProjectNewView/flow/ProjectEntitySearch.tsx
@@ -90,10 +90,10 @@ export default function ProjectEntitySearch(props: ProjectEntitySearchProps): JS
   }, [entitySpecificFilterConfigs, filters, projectEntityFilterConfig]);
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       void dispatch(requestProjects(selectedOrganization.id, activeLocale || undefined));
     }
-  }, [activeLocale, dispatch, selectedOrganization.id]);
+  }, [activeLocale, dispatch, selectedOrganization]);
 
   return (
     <Grid container>

--- a/src/components/ProjectNewView/flow/SelectBatches.tsx
+++ b/src/components/ProjectNewView/flow/SelectBatches.tsx
@@ -89,7 +89,10 @@ export default function SelectBatches(props: SelectBatchesProps): JSX.Element | 
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
 
-  const nurseries = useMemo(() => getAllNurseries(selectedOrganization), [selectedOrganization]);
+  const nurseries = useMemo(
+    () => (selectedOrganization ? getAllNurseries(selectedOrganization) : []),
+    [selectedOrganization]
+  );
 
   const getSearchResults = useCallback(
     (

--- a/src/components/ProjectNewView/flow/useProjectEntitySelection.ts
+++ b/src/components/ProjectNewView/flow/useProjectEntitySelection.ts
@@ -51,7 +51,7 @@ export const useProjectEntitySelection = <T extends SearchResponseElement>({
   const debouncedSearchTerm = useDebounce(temporalSearchValue, DEFAULT_SEARCH_DEBOUNCE_MS);
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const populate = async () => {
         const searchResponse = await getSearchResults(
           selectedOrganization.id,
@@ -81,7 +81,7 @@ export const useProjectEntitySelection = <T extends SearchResponseElement>({
     debouncedSearchTerm,
     getSearchResults,
     setHasEntities,
-    selectedOrganization.id,
+    selectedOrganization,
     searchSortOrder,
     filters,
     isSearchDirty,

--- a/src/components/ProjectNewView/index.tsx
+++ b/src/components/ProjectNewView/index.tsx
@@ -36,7 +36,7 @@ export default function ProjectNewView({ reloadData }: ProjectNewViewProps): JSX
 
   const [record, setRecord] = useForm<CreateProjectRequest>({
     name: '',
-    organizationId: selectedOrganization.id,
+    organizationId: selectedOrganization?.id || -1,
   });
 
   const [flowState, setFlowState] = useState<FlowStates>('label');

--- a/src/components/ProjectView/index.tsx
+++ b/src/components/ProjectView/index.tsx
@@ -74,11 +74,11 @@ export default function ProjectView(): JSX.Element {
 
     if (projectDeleteRequest.status === 'error') {
       snackbar.toastError();
-    } else if (projectDeleteRequest.status === 'success' && selectedOrganization.id !== -1) {
+    } else if (projectDeleteRequest.status === 'success' && selectedOrganization) {
       void dispatch(requestProjects(selectedOrganization.id));
       goToProjects();
     }
-  }, [selectedOrganization.id, projectDeleteRequest, snackbar, goToProjects, dispatch]);
+  }, [selectedOrganization, projectDeleteRequest, snackbar, goToProjects, dispatch]);
 
   const rightComponent = useMemo(
     () => (

--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -42,14 +42,14 @@ export default function ProjectsList(): JSX.Element {
 
   const search = useCallback(
     async (searchTerm: string) => {
-      if (selectedOrganization.id !== -1) {
+      if (selectedOrganization) {
         const projects = await ProjectsService.searchProjects(selectedOrganization.id, searchTerm);
         if (projects) {
           return projects;
         }
       }
     },
-    [selectedOrganization.id]
+    [selectedOrganization]
   );
 
   useEffect(() => {

--- a/src/components/SeedFundReports/ReportEdit.tsx
+++ b/src/components/SeedFundReports/ReportEdit.tsx
@@ -350,7 +350,7 @@ export default function ReportEdit(): JSX.Element {
         await updateFiles();
         await updatePhotos(report.id);
         const submitResult = await SeedFundReportService.submitReport(reportIdInt);
-        if (submitResult.requestSucceeded && reportId && selectedOrganization.id !== -1) {
+        if (submitResult.requestSucceeded && reportId && selectedOrganization) {
           void reloadOrganizations(selectedOrganization.id);
           navigate({ pathname: APP_PATHS.SEED_FUND_REPORTS_VIEW.replace(':reportId', reportId) }, { replace: true });
         } else {

--- a/src/components/SeedFundReports/ReportForm.tsx
+++ b/src/components/SeedFundReports/ReportForm.tsx
@@ -105,7 +105,7 @@ export default function ReportForm(props: ReportFormProps): JSX.Element {
   );
 
   useEffect(() => {
-    if (selectedOrganization && selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       void dispatch(requestObservations(selectedOrganization.id));
       void dispatch(requestObservationsResults(selectedOrganization.id));
       void dispatch(requestPlantings(selectedOrganization.id));

--- a/src/components/SeedFundReports/ReportList.tsx
+++ b/src/components/SeedFundReports/ReportList.tsx
@@ -28,7 +28,7 @@ export default function ReportList(): JSX.Element {
   const { selectedOrganization } = useOrganization();
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const refreshSearch = async () => {
         const reportsResults = await SeedFundReportService.getReports(selectedOrganization.id);
         setResults(reportsResults.reports || []);
@@ -36,7 +36,7 @@ export default function ReportList(): JSX.Element {
 
       void refreshSearch();
     }
-  }, [selectedOrganization.id]);
+  }, [selectedOrganization]);
 
   return (
     <TfMain>

--- a/src/components/SeedFundReports/ReportSettingsEdit.tsx
+++ b/src/components/SeedFundReports/ReportSettingsEdit.tsx
@@ -17,10 +17,10 @@ const ReportSettingsEdit = () => {
   const reportsSettings = useAppSelector(selectReportsSettings);
 
   useEffect(() => {
-    if (!reportsSettings && selectedOrganization.id !== -1) {
+    if (!reportsSettings && selectedOrganization) {
       void dispatch(requestReportsSettings(selectedOrganization.id));
     }
-  }, [dispatch, reportsSettings, selectedOrganization.id]);
+  }, [dispatch, reportsSettings, selectedOrganization]);
 
   return (
     <TfMain>

--- a/src/components/SeedFundReports/ReportSettingsEditForm.tsx
+++ b/src/components/SeedFundReports/ReportSettingsEditForm.tsx
@@ -28,7 +28,7 @@ const ReportSettingsEditForm = ({ reportsSettings, isEditing }: ReportSettingsEd
   const [isBusy, setIsBusy] = useState<boolean>(false);
 
   const onSave = useCallback(async () => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       setIsBusy(true);
       const result = await ReportSettingsService.updateSettings({
         organizationId: selectedOrganization.id,
@@ -43,7 +43,7 @@ const ReportSettingsEditForm = ({ reportsSettings, isEditing }: ReportSettingsEd
 
       navigate(APP_PATHS.SEED_FUND_REPORTS_SETTINGS);
     }
-  }, [navigate, localReportsSettings, selectedOrganization.id, snackbar]);
+  }, [navigate, localReportsSettings, selectedOrganization, snackbar]);
 
   const onChange = useCallback(
     (key: string | number, value: boolean) => {

--- a/src/components/SeedFundReports/ReportSettingsEditFormFields.tsx
+++ b/src/components/SeedFundReports/ReportSettingsEditFormFields.tsx
@@ -36,10 +36,10 @@ const ReportSettingsEditFormFields = ({ isEditing, onChange, reportsSettings }: 
   const projects = useAppSelector(selectProjects);
 
   useEffect(() => {
-    if (!projects && selectedOrganization.id !== -1) {
+    if (!projects && selectedOrganization) {
       void dispatch(requestProjects(selectedOrganization.id));
     }
-  }, [dispatch, projects, selectedOrganization.id]);
+  }, [dispatch, projects, selectedOrganization]);
 
   const renderCheckbox = useCallback(
     ({ label, key, value, index }: ReportsSettingsCheckboxConfig) => {
@@ -97,7 +97,10 @@ const ReportSettingsEditFormFields = ({ isEditing, onChange, reportsSettings }: 
       </Grid>
 
       {renderCheckbox({
-        label: strings.formatString(strings.REPORTS_SETTINGS_GENERATE_FOR_ORG, selectedOrganization.name) as string,
+        label: strings.formatString(
+          strings.REPORTS_SETTINGS_GENERATE_FOR_ORG,
+          selectedOrganization?.name || ''
+        ) as string,
         key: 'organizationEnabled',
         value: reportsSettings?.organizationEnabled,
       })}

--- a/src/components/SeedFundReports/ReportsView.tsx
+++ b/src/components/SeedFundReports/ReportsView.tsx
@@ -70,13 +70,13 @@ export default function ReportsView(props: ReportsViewProps): JSX.Element {
   );
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       void dispatch(requestReportsSettings(selectedOrganization.id));
     }
-  }, [dispatch, selectedOrganization.id]);
+  }, [dispatch, selectedOrganization]);
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const refreshSearch = async () => {
         const reportsResults = await SeedFundReportService.getReports(selectedOrganization.id);
         setResults(
@@ -92,7 +92,7 @@ export default function ReportsView(props: ReportsViewProps): JSX.Element {
 
       void refreshSearch();
     }
-  }, [selectedOrganization.id, selectedOrganization.name]);
+  }, [selectedOrganization]);
 
   const reportsToComplete = useMemo(() => results.filter((report) => report.status !== 'Submitted'), [results]);
 

--- a/src/components/SeedFundReports/Router.tsx
+++ b/src/components/SeedFundReports/Router.tsx
@@ -9,7 +9,7 @@ import { useOrganization } from 'src/providers';
 const SeedFundReportsRouter = (): JSX.Element | null => {
   const { selectedOrganization } = useOrganization();
 
-  if (!selectedOrganization.canSubmitReports) {
+  if (!selectedOrganization?.canSubmitReports) {
     return null;
   }
 

--- a/src/components/SmallDeviceUserMenu.tsx
+++ b/src/components/SmallDeviceUserMenu.tsx
@@ -264,7 +264,7 @@ export default function SmallDeviceUserMenu({
                                 key={`item-${index}`}
                                 sx={[
                                   menuItemStyles,
-                                  selectedOrganization.id === org.id && {
+                                  selectedOrganization?.id === org.id && {
                                     backgroundColor: theme.palette.TwClrBgGhostActive,
                                   },
                                 ]}

--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -91,7 +91,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
           <>
             {isApplicationPortal && (
               <>
-                <p style={{ fontSize: '16px' }}>{selectedOrganization.name}</p>
+                <p style={{ fontSize: '16px' }}>{selectedOrganization?.name}</p>
               </>
             )}
             {!isAcceleratorRoute && !isApplicationPortal && !isFunderRoute && <OrganizationsDropdown />}
@@ -106,10 +106,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
 
       <Box sx={rightStyles}>
         <KnowledgeBaseLink />
-        <NotificationsDropdown
-          organizationId={selectedOrganization.id !== -1 ? selectedOrganization.id : undefined}
-          reloadOrganizationData={reloadOrganizations}
-        />
+        <NotificationsDropdown organizationId={selectedOrganization?.id} reloadOrganizationData={reloadOrganizations} />
         {userFundingEntity && <SettingsLink />}
         <div style={separatorStyles} />
         <UserMenu />
@@ -128,7 +125,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
       }}
     >
       <Grid item xs={1} sx={leftStyles}>
-        {selectedOrganization.id !== -1 && (
+        {selectedOrganization && (
           <IconButton onClick={() => setShowNavBar(true)} size='small'>
             <Icon name='iconMenu' />
           </IconButton>
@@ -150,10 +147,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
 
       <Grid item xs={5} sx={rightStyles}>
         <KnowledgeBaseLink />
-        <NotificationsDropdown
-          organizationId={selectedOrganization.id !== -1 ? selectedOrganization.id : undefined}
-          reloadOrganizationData={reloadOrganizations}
-        />
+        <NotificationsDropdown organizationId={selectedOrganization?.id} reloadOrganizationData={reloadOrganizations} />
         {userFundingEntity && <SettingsLink />}
         <SmallDeviceUserMenu onLogout={onHandleLogout} hasOrganizations={organizations && organizations.length > 0} />
       </Grid>

--- a/src/components/common/ImportModal.tsx
+++ b/src/components/common/ImportModal.tsx
@@ -237,7 +237,7 @@ export default function ImportSpeciesModal(props: ImportSpeciesModalProps): JSX.
           if (uploadApi) {
             response = await uploadApi(file, facility.id.toString());
           }
-        } else if (selectedOrganization && selectedOrganization.id !== -1) {
+        } else if (selectedOrganization) {
           if (uploadApi) {
             response = await uploadApi(file, selectedOrganization.id.toString());
           }

--- a/src/components/common/PlantingSiteSelector.tsx
+++ b/src/components/common/PlantingSiteSelector.tsx
@@ -17,7 +17,7 @@ export default function PlantingSiteSelector({ onChange, hideNoBoundary }: Plant
   // assume `requestPlantingSites` thunk has been dispatched by consumer
   const [selectedPlantingSiteId, setSelectedPlantingSiteId] = useState<number | undefined>();
   const { selectedOrganization, orgPreferences, reloadOrgPreferences } = useOrganization();
-  const plantingSites = useAppSelector(selectOrgPlantingSites(selectedOrganization.id));
+  const plantingSites = useAppSelector(selectOrgPlantingSites(selectedOrganization?.id || -1));
 
   const filteredPlantingSites = useMemo(() => {
     return plantingSites?.filter((ps) => (hideNoBoundary ? !!ps.boundary : true));
@@ -32,14 +32,14 @@ export default function PlantingSiteSelector({ onChange, hideNoBoundary }: Plant
       const id = Number(newValue);
       setSelectedPlantingSiteId(isNaN(id) ? -1 : id);
       onChange(isNaN(id) ? -1 : id);
-      if (!isNaN(id) && id !== orgPreferences.lastPlantingSiteSelected) {
+      if (!isNaN(id) && id !== orgPreferences.lastPlantingSiteSelected && selectedOrganization) {
         await PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
           ['lastPlantingSiteSelected']: id,
         });
         reloadOrgPreferences();
       }
     },
-    [onChange, orgPreferences.lastPlantingSiteSelected, selectedOrganization.id]
+    [onChange, orgPreferences.lastPlantingSiteSelected, selectedOrganization]
   );
 
   useEffect(() => {

--- a/src/components/common/SpeciesSelector/index.tsx
+++ b/src/components/common/SpeciesSelector/index.tsx
@@ -34,6 +34,7 @@ export default function SpeciesSelector<T extends { speciesId?: number } | undef
 
   const populateSpecies = useCallback(
     async (searchTerm: string) => {
+      if (!selectedOrganization) return;
       const requestId = Math.random().toString();
       setRequestId(`speciesSelectorSearch${id}`, requestId);
       const response: SuggestedSpecies[] | null = await SpeciesService.suggestSpecies(
@@ -44,11 +45,11 @@ export default function SpeciesSelector<T extends { speciesId?: number } | undef
         setSpeciesList(response.sort((a, b) => a.scientificName.localeCompare(b.scientificName)));
       }
     },
-    [selectedOrganization.id]
+    [selectedOrganization, id]
   );
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       void populateSpecies(debouncedSearchTerm);
     }
   }, [populateSpecies, debouncedSearchTerm]);

--- a/src/components/common/table/index.tsx
+++ b/src/components/common/table/index.tsx
@@ -114,15 +114,17 @@ export function OrderPreserveableTable<T extends TableRowType>(
   );
 
   const reorderHandler = async (reorderedColumns: string[]) => {
-    await PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
-      [getPreferenceName()]: reorderedColumns,
-    });
-    reloadOrgPreferences();
-    const columnsToSet = getTableColumns(reorderedColumns);
-    setColumns(columnsToSet);
+    if (selectedOrganization) {
+      await PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
+        [getPreferenceName()]: reorderedColumns,
+      });
+      reloadOrgPreferences();
+      const columnsToSet = getTableColumns(reorderedColumns);
+      setColumns(columnsToSet);
 
-    if (onReorderEnd) {
-      onReorderEnd(reorderedColumns);
+      if (onReorderEnd) {
+        onReorderEnd(reorderedColumns);
+      }
     }
   };
 

--- a/src/components/emptyStatePages/EmptyStatePage.tsx
+++ b/src/components/emptyStatePages/EmptyStatePage.tsx
@@ -195,7 +195,7 @@ export default function EmptyStatePage({ pageName, reloadData }: EmptyStatePageP
   };
 
   const pageContent = (): PageContent => {
-    const contributor = selectedOrganization && isContributor(selectedOrganization);
+    const contributor = isContributor(selectedOrganization);
 
     switch (pageName) {
       case 'Species':

--- a/src/components/seeds/database/DownloadReportModal.tsx
+++ b/src/components/seeds/database/DownloadReportModal.tsx
@@ -18,6 +18,8 @@ export default function DownloadReportModal(props: DownloadReportModalProps): JS
   const { searchCriteria, searchSortOrder, searchColumns, open, onClose } = props;
 
   const onExport = async () => {
+    if (!selectedOrganization) return null;
+
     return await SearchService.searchCsv({
       prefix: 'facilities.accessions',
       fields: [...searchColumns],

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -153,10 +153,10 @@ export default function Database(props: DatabaseProps): JSX.Element {
   const closeMessageSelector = useAppSelector(selectMessage(`seeds.${SNACKBAR_PAGE_CLOSE_KEY}.ackWeightSystem`));
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       void dispatch(requestProjects(selectedOrganization.id, activeLocale || undefined));
     }
-  }, [activeLocale, dispatch, selectedOrganization.id]);
+  }, [activeLocale, dispatch, selectedOrganization]);
 
   useEffect(() => {
     const updatePreferences = async () => {
@@ -229,12 +229,12 @@ export default function Database(props: DatabaseProps): JSX.Element {
 
   const saveSearchColumns = useCallback(
     async (columnNames?: string[]) => {
-      if (selectedOrganization.id !== -1) {
+      if (selectedOrganization) {
         await PreferencesService.updateUserOrgPreferences(selectedOrganization.id, { accessionsColumns: columnNames });
         reloadOrgPreferences();
       }
     },
-    [selectedOrganization.id, reloadOrgPreferences]
+    [selectedOrganization, reloadOrgPreferences]
   );
 
   const saveUpdateSearchColumns = useCallback(
@@ -282,7 +282,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
     }
 
     if ((facilityId || query.has('facilityId')) && selectedOrganization) {
-      const seedBanks = getAllSeedBanks(selectedOrganization);
+      const seedBanks = selectedOrganization ? getAllSeedBanks(selectedOrganization) : [];
       delete newSearchCriteria.facility_name;
       if (seedBanks && facilityId) {
         const facility = seedBanks.find((seedBank) => seedBank?.id === parseInt(facilityId, 10));
@@ -331,7 +331,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
   ]);
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const populateUnfilteredResults = async () => {
         const apiResponse: SearchResponseElementWithId[] | null = await SeedBankService.searchAccessions({
           organizationId: selectedOrganization.id,
@@ -351,7 +351,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
       void populateUnfilteredResults();
       void populatePendingAccessions();
     }
-  }, [selectedOrganization.id]);
+  }, [selectedOrganization]);
 
   const initAccessions = useCallback(() => {
     const getFieldsFromSearchColumns = () => {
@@ -365,7 +365,7 @@ export default function Database(props: DatabaseProps): JSX.Element {
       return columnsNamesToSearch;
     };
 
-    if (selectedOrganization && selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const requestId = setRequestId('accessions_search');
 
       const populateSearchResults = async () => {

--- a/src/hooks/useOrgNurserySummary.ts
+++ b/src/hooks/useOrgNurserySummary.ts
@@ -12,7 +12,7 @@ export const useOrgNurserySummary = () => {
   const [orgNurserySummary, setOrgNurserySummary] = useState<OrganizationNurserySummaryResponse>();
 
   useEffect(() => {
-    if (selectedOrganization && selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const populateSummary = async () => {
         const response = await NurserySummaryService.getOrganizationNurserySummary(selectedOrganization.id);
         setOrgNurserySummary(response);

--- a/src/hooks/useOrgTracking.ts
+++ b/src/hooks/useOrgTracking.ts
@@ -54,6 +54,8 @@ export const useOrgTracking = () => {
   const reportedPlantsResponse = useAppSelector(selectOrganizationReportedPlants(reportedPlantsRequestId));
 
   const reload = useCallback(() => {
+    if (!selectedOrganization) return;
+
     const plantingSitesRequest = dispatch(requestListPlantingSites(selectedOrganization.id));
     const observationsRequest = dispatch(requestOrganizationObservations({ organizationId: selectedOrganization.id }));
     const resultsRequest = dispatch(requestOrganizationObservationResults({ organizationId: selectedOrganization.id }));

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -31,10 +31,10 @@ export const useProjects = (record?: { projectId?: number }) => {
   }, [availableProjects, record?.projectId]);
 
   useEffect(() => {
-    if (!availableProjects && selectedOrganization.id !== -1) {
+    if (!availableProjects && selectedOrganization) {
       void dispatch(requestProjects(selectedOrganization.id));
     }
-  }, [availableProjects, dispatch, selectedOrganization.id]);
+  }, [availableProjects, dispatch, selectedOrganization]);
 
   // fetch all projects in the accelerator route
   useEffect(() => {

--- a/src/hooks/useSeedBankSummary.ts
+++ b/src/hooks/useSeedBankSummary.ts
@@ -12,7 +12,7 @@ export const useSeedBankSummary = () => {
   const [seedBankSummary, setSeedBankSummary] = useState<SummaryResponse>();
 
   useEffect(() => {
-    if (selectedOrganization && selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const populateSummary = async () => {
         const response = await SeedBankService.getSummary(selectedOrganization.id);
         setSeedBankSummary(response);

--- a/src/providers/Application/index.tsx
+++ b/src/providers/Application/index.tsx
@@ -66,7 +66,7 @@ const ApplicationProvider = ({ children }: Props) => {
     if (isAcceleratorRoute && isAllowedAllApplications) {
       const listAll = dispatch(requestListApplications({ listAll: true }));
       setListApplicationRequest(listAll.requestId);
-    } else if (selectedOrganization && selectedOrganization.id !== -1) {
+    } else if (selectedOrganization) {
       const listOrg = dispatch(requestListApplications({ organizationId: selectedOrganization.id }));
       setListApplicationRequest(listOrg.requestId);
     }

--- a/src/providers/DataTypes.ts
+++ b/src/providers/DataTypes.ts
@@ -21,7 +21,7 @@ export type ProvidedUserData = {
 };
 
 export type ProvidedOrganizationData = {
-  selectedOrganization: Organization;
+  selectedOrganization: Organization | undefined;
   setSelectedOrganization: React.Dispatch<React.SetStateAction<Organization | undefined>>;
   organizations: Organization[];
   orgPreferences: PreferencesType;

--- a/src/providers/OrganizationProvider.tsx
+++ b/src/providers/OrganizationProvider.tsx
@@ -12,7 +12,7 @@ import useQuery from 'src/utils/useQuery';
 import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
 
 import { PreferencesType, ProvidedOrganizationData } from './DataTypes';
-import { OrganizationContext, defaultSelectedOrg } from './contexts';
+import { OrganizationContext } from './contexts';
 import { useUser } from './hooks';
 
 export type OrganizationProviderProps = {
@@ -30,7 +30,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
   const [bootstrapped, setBootstrapped] = useState<boolean>(false);
   const [selectedOrganization, setSelectedOrganization] = useState<Organization>();
   const [orgPreferences, setOrgPreferences] = useState<PreferencesType>({});
-  const [orgPreferenceForId, setOrgPreferenceForId] = useState<number>(defaultSelectedOrg.id);
+  const [orgPreferenceForId, setOrgPreferenceForId] = useState<number>(-1);
   const [orgAPIRequestStatus, setOrgAPIRequestStatus] = useState<APIRequestStatus>(APIRequestStatus.AWAITING);
   const [organizations, setOrganizations] = useState<Organization[]>();
   const navigate = useSyncNavigate();
@@ -70,7 +70,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
 
   const reloadOrgPreferences = useCallback(() => {
     const getOrgPreferences = async () => {
-      if (selectedOrganization && selectedOrganization.id !== -1) {
+      if (selectedOrganization) {
         const response = await PreferencesService.getUserOrgPreferences(selectedOrganization.id);
         if (response.requestSucceeded && response.preferences) {
           setOrgPreferences(response.preferences);
@@ -96,7 +96,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
     setOrganizationData((prev) => ({
       ...prev,
       redirectAndNotify,
-      selectedOrganization: selectedOrganization || defaultSelectedOrg,
+      selectedOrganization,
       organizations: organizations ?? [],
       orgPreferences,
       bootstrapped,
@@ -176,7 +176,7 @@ export default function OrganizationProvider({ children }: OrganizationProviderP
   }, [orgAPIRequestStatus]);
 
   const [organizationData, setOrganizationData] = useState<ProvidedOrganizationData>({
-    selectedOrganization: selectedOrganization || defaultSelectedOrg,
+    selectedOrganization,
     setSelectedOrganization,
     organizations: organizations ?? [],
     orgPreferences,

--- a/src/providers/Participant/ParticipantProvider.tsx
+++ b/src/providers/Participant/ParticipantProvider.tsx
@@ -57,7 +57,7 @@ const ParticipantProvider = ({ children }: Props) => {
   });
 
   useEffect(() => {
-    if (selectedOrganization && selectedOrganization.id !== -1 && activeLocale) {
+    if (selectedOrganization && activeLocale) {
       setCurrentParticipantProject(undefined);
       setModuleProjects([]);
       setOrgHasModules(undefined);
@@ -74,7 +74,7 @@ const ParticipantProvider = ({ children }: Props) => {
   }, [projects]);
 
   useEffect(() => {
-    if (selectedOrganization && selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const request = dispatch(requestListModuleProjects(selectedOrganization.id));
       setListModuleProjectsRequestId(request.requestId);
     }

--- a/src/providers/Species/SpeciesProvider.tsx
+++ b/src/providers/Species/SpeciesProvider.tsx
@@ -30,8 +30,8 @@ const SpeciesProvider = ({ children }: Props) => {
   const { acceleratorOrganizationId } = usePlantingSiteData();
 
   const reload = useCallback(() => {
-    const orgId = isAcceleratorRoute ? acceleratorOrganizationId ?? selectedOrganization.id : selectedOrganization.id;
-    if (orgId > 0) {
+    const orgId = (isAcceleratorRoute ? acceleratorOrganizationId : undefined) ?? selectedOrganization?.id;
+    if (orgId && orgId > 0) {
       const speciesRequest = dispatch(requestListSpecies(orgId));
       const inUseSpeciesRequest = dispatch(requestListInUseSpecies(orgId));
 

--- a/src/providers/Tracking/PlantingSiteProvider.tsx
+++ b/src/providers/Tracking/PlantingSiteProvider.tsx
@@ -76,7 +76,7 @@ const PlantingSiteProvider = ({ children }: Props) => {
   const reportedPlantsResponse = useAppSelector(selectPlantingSiteReportedPlants(reportedPlantsRequestId));
 
   const allSitesOption = useMemo(() => {
-    const orgId = isAcceleratorRoute ? acceleratorOrganizationId : selectedOrganization.id;
+    const orgId = isAcceleratorRoute ? acceleratorOrganizationId : selectedOrganization?.id;
     if (activeLocale && orgId) {
       return {
         name: strings.ALL_PLANTING_SITES,
@@ -89,13 +89,13 @@ const PlantingSiteProvider = ({ children }: Props) => {
   }, [activeLocale, isAcceleratorRoute, acceleratorOrganizationId, selectedOrganization]);
 
   const reload = useCallback(() => {
-    const orgId = isAcceleratorRoute ? acceleratorOrganizationId : selectedOrganization.id;
+    const orgId = isAcceleratorRoute ? acceleratorOrganizationId : selectedOrganization?.id;
     if (orgId) {
       const request = dispatch(requestListPlantingSites(orgId));
       setPlantingSitesRequestId(request.requestId);
       _setSelectedPlantingSite(undefined);
     }
-  }, [acceleratorOrganizationId, dispatch, isAcceleratorRoute, selectedOrganization.id]);
+  }, [acceleratorOrganizationId, dispatch, isAcceleratorRoute, selectedOrganization?.id]);
 
   useEffect(() => {
     reload();

--- a/src/providers/contexts.ts
+++ b/src/providers/contexts.ts
@@ -28,13 +28,6 @@ export const UserContext = createContext<ProvidedUserData>({
   isAllowed: (_: GlobalRolePermission, __?: unknown) => false,
 });
 
-export const defaultSelectedOrg: Organization = {
-  id: -1,
-  name: '',
-  role: 'Contributor',
-  totalUsers: 0,
-};
-
 export const OrganizationContext = createContext<ProvidedOrganizationData>({
   organizations: [],
   orgPreferences: {},
@@ -59,7 +52,7 @@ export const OrganizationContext = createContext<ProvidedOrganizationData>({
     return;
   },
 
-  selectedOrganization: defaultSelectedOrg,
+  selectedOrganization: undefined,
   bootstrapped: false,
   orgPreferenceForId: -1,
 });

--- a/src/scenes/AcceleratorRouter/Species/SpeciesEditView.tsx
+++ b/src/scenes/AcceleratorRouter/Species/SpeciesEditView.tsx
@@ -100,10 +100,13 @@ export default function SpeciesEditView(): JSX.Element {
           </Box>
           <Box marginBottom={4}>
             <Message
-              title={strings.formatString(strings.EDITING_SPECIES_DATA_FOR_ORGANIZATION, selectedOrganization.name)}
+              title={strings.formatString(
+                strings.EDITING_SPECIES_DATA_FOR_ORGANIZATION,
+                selectedOrganization?.name || ''
+              )}
               body={strings.formatString(
                 strings.EDITING_SPECIES_DATA_FOR_ORGANIZATION_WARNING,
-                selectedOrganization.name
+                selectedOrganization?.name || ''
               )}
               type='page'
               priority='warning'

--- a/src/scenes/AccessionsRouter/Accession2CreateView.tsx
+++ b/src/scenes/AccessionsRouter/Accession2CreateView.tsx
@@ -101,7 +101,7 @@ export default function CreateAccession(): JSX.Element | null {
   }, [record, availableProjects, setRecord]);
 
   useEffect(() => {
-    if (record.facilityId) {
+    if (record.facilityId && selectedOrganization) {
       const accessionSeedBank = getSeedBank(selectedOrganization, record.facilityId);
       setSelectedSeedBank(accessionSeedBank);
     }

--- a/src/scenes/AccessionsRouter/Accession2View.tsx
+++ b/src/scenes/AccessionsRouter/Accession2View.tsx
@@ -95,7 +95,7 @@ export default function Accession2View(): JSX.Element {
   const seedBankTimeZone = useMemo(() => {
     const facility = accession?.facilityId
       ? FacilityService.getFacility({
-          organization: selectedOrganization,
+          organization: selectedOrganization!,
           facilityId: accession.facilityId,
           type: 'Seed Bank',
         })
@@ -595,7 +595,7 @@ export default function Accession2View(): JSX.Element {
               title={strings.LOCATION}
               contents={
                 <Box>
-                  {getSeedBank(selectedOrganization, accession.facilityId)?.name}
+                  {selectedOrganization ? getSeedBank(selectedOrganization, accession.facilityId)?.name : undefined}
                   {accession.subLocation ? ` / ${accession.subLocation}` : ''}
                 </Box>
               }

--- a/src/scenes/AccessionsRouter/AccessionsView.tsx
+++ b/src/scenes/AccessionsRouter/AccessionsView.tsx
@@ -36,12 +36,12 @@ const AccessionsView = () => {
   );
 
   const setDefaults = useCallback(() => {
-    if (!isPlaceholderOrg(selectedOrganization.id)) {
+    if (!isPlaceholderOrg(selectedOrganization?.id)) {
       const savedColumns = orgPreferences.accessionsColumns ? (orgPreferences.accessionsColumns as string[]) : [];
       const defaultColumns = savedColumns.length ? savedColumns : DefaultColumns(preferredWeightSystem).fields;
       setAccessionsDisplayColumns(defaultColumns);
     }
-  }, [orgPreferences.accessionsColumns, preferredWeightSystem, selectedOrganization.id]);
+  }, [orgPreferences.accessionsColumns, preferredWeightSystem, selectedOrganization]);
 
   useEffect(() => {
     setDefaults();
@@ -57,7 +57,7 @@ const AccessionsView = () => {
       setSearchColumns={setSeedSearchColumns}
       displayColumnNames={accessionsDisplayColumns}
       setDisplayColumnNames={setAccessionsDisplayColumns}
-      hasSeedBanks={selectedOrgHasFacilityType(selectedOrganization, 'Seed Bank')}
+      hasSeedBanks={selectedOrganization ? selectedOrgHasFacilityType(selectedOrganization, 'Seed Bank') : false}
       hasSpecies={species.length > 0}
       reloadData={() => void reloadOrganizations()}
     />

--- a/src/scenes/AccessionsRouter/edit/Accession2EditModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/Accession2EditModal.tsx
@@ -47,7 +47,7 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
   const [validateFields, setValidateFields] = useState<boolean>(false);
   const snackbar = useSnackbar();
   const { selectedOrganization } = useOrganization();
-  const selectedSeedBank = getSeedBank(selectedOrganization, record.facilityId);
+  const selectedSeedBank = selectedOrganization ? getSeedBank(selectedOrganization, record.facilityId) : undefined;
   const tz = useLocationTimeZone().get(selectedSeedBank);
   const timeZone = tz.id;
   const [collectedDateError, setCollectedDateError] = useState<string>();

--- a/src/scenes/AccessionsRouter/edit/EditLocationModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/EditLocationModal.tsx
@@ -28,7 +28,11 @@ export default function EditLocationModal(props: EditLocationModalProps): JSX.El
   const { selectedOrganization } = useOrganization();
   const { activeLocale } = useLocalization();
   const { onClose, open, accession, reload } = props;
-  const seedBanks: Facility[] = getAllSeedBanks(selectedOrganization).filter((sb) => !!sb) || [];
+  const seedBanks: Facility[] = selectedOrganization
+    ? selectedOrganization
+      ? getAllSeedBanks(selectedOrganization)
+      : [].filter((sb) => !!sb)
+    : [];
   const [subLocations, setSubLocations] = useState<SubLocation[]>([]);
   const snackbar = useSnackbar();
 

--- a/src/scenes/AccessionsRouter/edit/EndDryingReminderModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/EndDryingReminderModal.tsx
@@ -29,7 +29,9 @@ export default function EndDryingReminderModal(props: EndDryingReminderModalProp
   const [record, setRecord, onChange] = useForm(accession);
   const snackbar = useSnackbar();
   const { selectedOrganization } = useOrganization();
-  const timeZoneId = useLocationTimeZone().get(getSeedBank(selectedOrganization, accession.facilityId))?.id;
+  const timeZoneId = useLocationTimeZone().get(
+    selectedOrganization ? getSeedBank(selectedOrganization, accession.facilityId) : undefined
+  )?.id;
 
   useEffect(() => {
     setRecord(accession);

--- a/src/scenes/AccessionsRouter/properties/CollectionSiteName.tsx
+++ b/src/scenes/AccessionsRouter/properties/CollectionSiteName.tsx
@@ -18,7 +18,7 @@ export default function CollectionSiteName({ collectionSiteName = '', onChange }
   const [options, setOptions] = useState<string[]>();
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const populateCollectionSiteNames = async () => {
         setOptions(await SeedBankService.getCollectionSiteNames(selectedOrganization.id));
       };

--- a/src/scenes/AccessionsRouter/properties/Collectors2.tsx
+++ b/src/scenes/AccessionsRouter/properties/Collectors2.tsx
@@ -22,7 +22,7 @@ export default function Collectors2({ collectors = [''], onChange }: Props): JSX
   const theme = useTheme();
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const populateCollectors = async () => {
         setCollectorsOpt(await SeedBankService.getCollectors(selectedOrganization.id));
       };

--- a/src/scenes/AccessionsRouter/properties/SeedBank2Selector.tsx
+++ b/src/scenes/AccessionsRouter/properties/SeedBank2Selector.tsx
@@ -25,7 +25,7 @@ export default function SeedBank2Selector(props: SeedBank2SelectorProps): JSX.El
   const [subLocations, setSubLocations] = useState<SubLocation[]>([]);
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
-  const seedBanks: Facility[] = getAllSeedBanks(selectedOrganization).filter((sb) => !!sb) || [];
+  const seedBanks: Facility[] = selectedOrganization ? getAllSeedBanks(selectedOrganization) : [];
 
   const gridSize = () => (isMobile ? 12 : 6);
 

--- a/src/scenes/AccessionsRouter/viabilityTesting/NewViabilityTestModal.tsx
+++ b/src/scenes/AccessionsRouter/viabilityTesting/NewViabilityTestModal.tsx
@@ -78,13 +78,15 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
 
   useEffect(() => {
     if (accession.facilityId) {
-      const accessionSeedBank = getSeedBank(selectedOrganization, accession.facilityId);
+      const accessionSeedBank = selectedOrganization
+        ? getSeedBank(selectedOrganization, accession.facilityId)
+        : undefined;
       setSelectedSeedBank(accessionSeedBank);
     }
   }, [selectedOrganization, accession.facilityId]);
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const getOrgUsers = async () => {
         const response = await OrganizationUserService.getOrganizationUsers(selectedOrganization.id);
         if (response.requestSucceeded) {

--- a/src/scenes/AccessionsRouter/withdraw/WithdrawModal.tsx
+++ b/src/scenes/AccessionsRouter/withdraw/WithdrawModal.tsx
@@ -86,7 +86,9 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
 
   useEffect(() => {
     if (accession.facilityId) {
-      const accessionSeedBank = getSeedBank(selectedOrganization, accession.facilityId);
+      const accessionSeedBank = selectedOrganization
+        ? getSeedBank(selectedOrganization, accession.facilityId)
+        : undefined;
       setSelectedSeedBank(accessionSeedBank);
     }
   }, [selectedOrganization, accession.facilityId]);
@@ -107,7 +109,7 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
   }, [timeZone, setRecord]);
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const getOrgUsers = async () => {
         const response = await OrganizationUserService.getOrganizationUsers(selectedOrganization.id);
         if (response.requestSucceeded) {
@@ -290,7 +292,7 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
                 id='destinationFacilityId'
                 label={strings.DESTINATION_REQUIRED}
                 selectedValue={nurseryTransferRecord.destinationFacilityId.toString()}
-                options={getAllNurseries(selectedOrganization).map((nursery) => ({
+                options={(selectedOrganization ? getAllNurseries(selectedOrganization) : []).map((nursery) => ({
                   label: nursery.name,
                   value: nursery.id.toString(),
                 }))}

--- a/src/scenes/ApplicationRouter/ApplicationsList.tsx
+++ b/src/scenes/ApplicationRouter/ApplicationsList.tsx
@@ -21,7 +21,7 @@ const ApplicationListView = () => {
   const [isNewApplicationModalOpen, setIsNewApplicationModalOpen] = useState<boolean>(false);
 
   useEffect(() => {
-    if (isAdmin(selectedOrganization) && allApplications && allApplications.length === 0) {
+    if (selectedOrganization && isAdmin(selectedOrganization) && allApplications && allApplications.length === 0) {
       setIsNewApplicationModalOpen(true);
     }
   }, [allApplications, selectedOrganization, setIsNewApplicationModalOpen]);

--- a/src/scenes/ApplicationRouter/NewApplicationModal.tsx
+++ b/src/scenes/ApplicationRouter/NewApplicationModal.tsx
@@ -119,7 +119,7 @@ const NewApplicationModal = ({ open, onClose }: NewApplicationModalProps): JSX.E
   }, [onClose]);
 
   const onSave = useCallback(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization?.id) {
       let error = '';
       if (newApplication.projectType === 'New') {
         if ((error = validateProjectName(newApplication.projectName ?? ''))) {
@@ -130,7 +130,7 @@ const NewApplicationModal = ({ open, onClose }: NewApplicationModalProps): JSX.E
         const createProjectApplicationRequest = dispatch(
           requestCreateProjectApplication({
             projectName: newApplication.projectName ?? '',
-            organizationId: selectedOrganization.id,
+            organizationId: selectedOrganization?.id,
           })
         );
         setCreateProjectApplicationRequestId(createProjectApplicationRequest.requestId);

--- a/src/scenes/CheckIn/index.tsx
+++ b/src/scenes/CheckIn/index.tsx
@@ -38,7 +38,7 @@ export default function CheckIn(): JSX.Element {
 
   const reloadData = useCallback(() => {
     const populatePendingAccessions = async () => {
-      if (selectedOrganization && selectedOrganization.id !== -1) {
+      if (selectedOrganization) {
         setPendingAccessions(await SeedBankService.getPendingAccessions(selectedOrganization.id));
       }
     };
@@ -47,7 +47,7 @@ export default function CheckIn(): JSX.Element {
 
   useEffect(() => {
     reloadData();
-  }, [selectedOrganization, reloadData]);
+  }, [reloadData]);
 
   const checkInAccession = async (accession: Accession) => {
     if (accession) {

--- a/src/scenes/DeliverablesRouter/DeliverablesList.tsx
+++ b/src/scenes/DeliverablesRouter/DeliverablesList.tsx
@@ -177,14 +177,16 @@ const DeliverablesList = ({ projectId }: DeliverablesListProps): JSX.Element => 
         </PageHeaderWrapper>
       )}
 
-      <DeliverablesTable
-        extraTableFilters={extraTableFilters}
-        filterModifiers={filterModifiers}
-        organizationId={selectedOrganization.id}
-        searchAndSort={searchAndSort}
-        tableId={'participantDeliverablesTable'}
-        projectId={projectId}
-      />
+      {selectedOrganization && (
+        <DeliverablesTable
+          extraTableFilters={extraTableFilters}
+          filterModifiers={filterModifiers}
+          organizationId={selectedOrganization.id}
+          searchAndSort={searchAndSort}
+          tableId={'participantDeliverablesTable'}
+          projectId={projectId}
+        />
+      )}
     </Wrapper>
   );
 };

--- a/src/scenes/Home/OnboardingHomeView/index.tsx
+++ b/src/scenes/Home/OnboardingHomeView/index.tsx
@@ -56,7 +56,7 @@ const OnboardingHomeView = () => {
 
   useEffect(() => {
     const populatePeople = async () => {
-      if (isOwner(selectedOrganization)) {
+      if (selectedOrganization && isOwner(selectedOrganization)) {
         const response = await OrganizationUserService.getOrganizationUsers(selectedOrganization.id);
         if (response.requestSucceeded) {
           setPeople(response.users);
@@ -69,27 +69,33 @@ const OnboardingHomeView = () => {
   const [isNewApplicationModalOpen, setIsNewApplicationModalOpen] = useState<boolean>(false);
 
   useEffect(() => {
-    void dispatch(requestObservations(selectedOrganization.id));
-    void dispatch(requestObservationsResults(selectedOrganization.id));
-  }, [dispatch, selectedOrganization.id]);
+    if (selectedOrganization) {
+      void dispatch(requestObservations(selectedOrganization.id));
+      void dispatch(requestObservationsResults(selectedOrganization.id));
+    }
+  }, [dispatch, selectedOrganization]);
 
   const isLoadingInitialData = useMemo(
-    () => allSpecies === undefined || (isOwner(selectedOrganization) && people === undefined),
+    () => allSpecies === undefined || (selectedOrganization && isOwner(selectedOrganization) && people === undefined),
     [allSpecies, people, selectedOrganization]
   );
 
   const dismissAcceleratorCard = async () => {
-    await PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
-      ['showAcceleratorCard']: false,
-    });
-    reloadOrgPreferences();
+    if (selectedOrganization) {
+      await PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
+        ['showAcceleratorCard']: false,
+      });
+      reloadOrgPreferences();
+    }
   };
 
   const markAsComplete = async () => {
-    await PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
-      ['singlePersonOrg']: true,
-    });
-    reloadOrgPreferences();
+    if (selectedOrganization) {
+      await PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
+        ['singlePersonOrg']: true,
+      });
+      reloadOrgPreferences();
+    }
   };
 
   const onboardingCardRows: OnboardingCardRow[] = useMemo(() => {

--- a/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
+++ b/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
@@ -209,7 +209,9 @@ export const PlantingSiteStats = () => {
               {strings.VIEW_FULL_DASHBOARD}
             </Link>
             <Box>
-              {isAdmin(selectedOrganization) ? (
+              {selectedOrganization ? (
+                isAdmin(selectedOrganization)
+              ) : false ? (
                 <AddLink
                   disabled={false}
                   id='add-planting-site'

--- a/src/scenes/Home/TerrawareHomeView/index.tsx
+++ b/src/scenes/Home/TerrawareHomeView/index.tsx
@@ -55,11 +55,11 @@ const TerrawareHomeView = () => {
   }, [orgPreferences]);
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       void dispatch(requestObservations(selectedOrganization.id));
       void dispatch(requestObservationsResults(selectedOrganization.id));
     }
-  }, [dispatch, selectedOrganization.id]);
+  }, [dispatch, selectedOrganization]);
 
   const isLoadingInitialData = useMemo(
     () => orgNurserySummary?.requestSucceeded === undefined || seedBankSummary?.requestSucceeded === undefined,
@@ -93,10 +93,12 @@ const TerrawareHomeView = () => {
   }, [isMobile, isTablet]);
 
   const dismissAcceleratorCard = async () => {
-    await PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
-      ['showAcceleratorCard']: false,
-    });
-    reloadOrgPreferences();
+    if (selectedOrganization) {
+      await PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
+        ['showAcceleratorCard']: false,
+      });
+      reloadOrgPreferences();
+    }
   };
 
   const organizationStatsCardRows: OrganizationStatsCardRow[] = useMemo(() => {
@@ -132,18 +134,19 @@ const TerrawareHomeView = () => {
       {
         buttonProps: isAdmin(selectedOrganization)
           ? {
-              label: selectedOrgHasFacilityType(selectedOrganization, 'Seed Bank')
-                ? strings.ADD_AN_ACCESSION
-                : strings.SET_UP_SEED_BANK,
+              label:
+                selectedOrganization && selectedOrgHasFacilityType(selectedOrganization, 'Seed Bank')
+                  ? strings.ADD_AN_ACCESSION
+                  : strings.SET_UP_SEED_BANK,
               onClick: () =>
-                selectedOrgHasFacilityType(selectedOrganization, 'Seed Bank')
+                selectedOrganization && selectedOrgHasFacilityType(selectedOrganization, 'Seed Bank')
                   ? navigate(APP_PATHS.ACCESSIONS2_NEW)
                   : navigate(APP_PATHS.SEED_BANKS_NEW),
             }
           : {
               label: strings.ADD_AN_ACCESSION,
               onClick: () =>
-                selectedOrgHasFacilityType(selectedOrganization, 'Seed Bank')
+                selectedOrganization && selectedOrgHasFacilityType(selectedOrganization, 'Seed Bank')
                   ? goToNewAccession()
                   : navigate(APP_PATHS.ACCESSIONS),
             },
@@ -167,18 +170,19 @@ const TerrawareHomeView = () => {
       {
         buttonProps: isAdmin(selectedOrganization)
           ? {
-              label: selectedOrgHasFacilityType(selectedOrganization, 'Nursery')
-                ? strings.ADD_INVENTORY
-                : strings.SET_UP_NURSERY,
+              label:
+                selectedOrganization && selectedOrgHasFacilityType(selectedOrganization, 'Nursery')
+                  ? strings.ADD_INVENTORY
+                  : strings.SET_UP_NURSERY,
               onClick: () =>
-                selectedOrgHasFacilityType(selectedOrganization, 'Nursery')
+                selectedOrganization && selectedOrgHasFacilityType(selectedOrganization, 'Nursery')
                   ? navigate(APP_PATHS.INVENTORY_NEW)
                   : navigate(APP_PATHS.NURSERIES_NEW),
             }
           : {
               label: strings.ADD_INVENTORY,
               onClick: () =>
-                selectedOrgHasFacilityType(selectedOrganization, 'Nursery')
+                selectedOrganization && selectedOrgHasFacilityType(selectedOrganization, 'Nursery')
                   ? navigate(APP_PATHS.INVENTORY_NEW)
                   : navigate(APP_PATHS.INVENTORY),
             },
@@ -201,7 +205,7 @@ const TerrawareHomeView = () => {
       },
     ];
 
-    if (!plantingSites?.length && isAdmin(selectedOrganization)) {
+    if (!plantingSites?.length && selectedOrganization && isAdmin(selectedOrganization)) {
       rows.push({
         buttonProps: {
           label: strings.ADD_PLANTING_SITE,

--- a/src/scenes/Home/index.tsx
+++ b/src/scenes/Home/index.tsx
@@ -19,7 +19,7 @@ export default function Home({ selectedOrgHasSpecies }: { selectedOrgHasSpecies:
 
   useEffect(() => {
     const populatePeople = async () => {
-      if (isAdmin(selectedOrganization)) {
+      if (selectedOrganization && isAdmin(selectedOrganization)) {
         const response = await OrganizationUserService.getOrganizationUsers(selectedOrganization.id);
         if (response.requestSucceeded) {
           setPeople(response.users);

--- a/src/scenes/InventoryRouter/BatchDetailsModal.tsx
+++ b/src/scenes/InventoryRouter/BatchDetailsModal.tsx
@@ -107,7 +107,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
   }, [record, selectedOrganization]);
 
   useEffect(() => {
-    if (record?.facilityId) {
+    if (record?.facilityId && selectedOrganization) {
       const newFacility = getNurseryById(selectedOrganization, record.facilityId);
       if (newFacility.id.toString() !== facility?.id.toString()) {
         setFacility(newFacility);
@@ -122,11 +122,13 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
   }, [tz.id, timeZone]);
 
   useEffect(() => {
-    const foundFacility = selectedOrganization.facilities?.find(
-      (f) => f.id.toString() === batch?.facilityId.toString()
-    );
-    if (foundFacility) {
-      setFacility(foundFacility);
+    if (selectedOrganization) {
+      const foundFacility = selectedOrganization.facilities?.find(
+        (f) => f.id.toString() === batch?.facilityId.toString()
+      );
+      if (foundFacility) {
+        setFacility(foundFacility);
+      }
     }
   }, [batch, setRecord, selectedOrganization]);
 

--- a/src/scenes/InventoryRouter/BatchHistory.tsx
+++ b/src/scenes/InventoryRouter/BatchHistory.tsx
@@ -110,7 +110,7 @@ export default function BatchHistory({ batchId, nurseryName }: BatchHistoryProps
   );
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const fetchUsers = async () => {
         const response = await OrganizationUserService.getOrganizationUsers(selectedOrganization.id);
         if (response.requestSucceeded) {
@@ -123,7 +123,7 @@ export default function BatchHistory({ batchId, nurseryName }: BatchHistoryProps
       };
       void fetchUsers();
     }
-  }, [selectedOrganization.id]);
+  }, [selectedOrganization]);
 
   const findPreviousEvent = useCallback(
     (batch: BatchHistoryItem, allItems: BatchHistoryItem[] | null): BatchHistoryItem | undefined => {

--- a/src/scenes/InventoryRouter/EventDetailsModal.tsx
+++ b/src/scenes/InventoryRouter/EventDetailsModal.tsx
@@ -304,7 +304,9 @@ export default function EventDetailsModal(props: EventDetailsModalProps): JSX.El
             <Grid item xs={gridSize()} sx={marginTop} paddingRight={paddingSeparator}>
               <Textfield
                 id='fromNursery'
-                value={getNurseryById(selectedOrganization, relatedBatch.facilityId).name || ''}
+                value={
+                  selectedOrganization ? getNurseryById(selectedOrganization, relatedBatch.facilityId).name || '' : ''
+                }
                 type='text'
                 label={strings.FROM_NURSERY}
                 display={true}

--- a/src/scenes/InventoryRouter/ImportInventoryModal.tsx
+++ b/src/scenes/InventoryRouter/ImportInventoryModal.tsx
@@ -33,7 +33,7 @@ export default function ImportInventoryModal(props: ImportInventoryModalProps): 
   const [validate, setValidate] = useState<boolean>(false);
 
   useEffect(() => {
-    if (record && record.facilityId) {
+    if (record && record.facilityId && selectedOrganization) {
       const found = selectedOrganization.facilities?.find((fac) => fac.id.toString() === record.facilityId.toString());
       setSelectedFacility(found);
     }

--- a/src/scenes/InventoryRouter/InventoryBatchView.tsx
+++ b/src/scenes/InventoryRouter/InventoryBatchView.tsx
@@ -70,12 +70,14 @@ export default function InventoryBatchView({ origin, species }: InventoryBatchPr
   }, [speciesId, species, batch]);
 
   useEffect(() => {
-    if (nurseryId) {
-      const nursery = getNurseryById(selectedOrganization, Number(nurseryId));
-      setInventoryNursery(nursery);
-    } else if (batch?.facilityId) {
-      const nursery = getNurseryById(selectedOrganization, Number(batch.facilityId));
-      setInventoryNursery(nursery);
+    if (selectedOrganization) {
+      if (nurseryId) {
+        const nursery = getNurseryById(selectedOrganization, Number(nurseryId));
+        setInventoryNursery(nursery);
+      } else if (batch?.facilityId) {
+        const nursery = getNurseryById(selectedOrganization, Number(batch.facilityId));
+        setInventoryNursery(nursery);
+      }
     }
   }, [nurseryId, batch, selectedOrganization]);
 

--- a/src/scenes/InventoryRouter/InventoryForNurseryView.tsx
+++ b/src/scenes/InventoryRouter/InventoryForNurseryView.tsx
@@ -61,7 +61,10 @@ export default function InventoryForNurseryView(): JSX.Element {
               fontStyle: 'bold',
             }}
           >
-            {strings.formatString(strings.BATCHES_AT, getNurseryName(nurseryId, selectedOrganization))}
+            {strings.formatString(
+              strings.BATCHES_AT,
+              selectedOrganization ? getNurseryName(nurseryId, selectedOrganization) : ''
+            )}
           </Typography>
           <Grid item xs={12}>
             <PageSnackbar />

--- a/src/scenes/InventoryRouter/InventoryListByBatch.tsx
+++ b/src/scenes/InventoryRouter/InventoryListByBatch.tsx
@@ -94,7 +94,7 @@ export default function InventoryListByBatch({ setReportData }: InventoryListByB
   };
 
   const onApplyFilters = useCallback(async () => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const requestId = Math.random().toString();
       setRequestId('searchInventory', requestId);
 

--- a/src/scenes/InventoryRouter/InventoryListByNursery.tsx
+++ b/src/scenes/InventoryRouter/InventoryListByNursery.tsx
@@ -75,7 +75,7 @@ export default function InventoryListByNursery({ setReportData }: InventoryListB
   };
 
   const onApplyFilters = useCallback(async () => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const requestId = Math.random().toString();
       setRequestId('searchInventory', requestId);
 

--- a/src/scenes/InventoryRouter/InventoryListBySpecies.tsx
+++ b/src/scenes/InventoryRouter/InventoryListBySpecies.tsx
@@ -88,7 +88,7 @@ export default function InventoryListBySpecies({ setReportData }: InventoryListB
   };
 
   const onApplyFilters = useCallback(async () => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const requestId = Math.random().toString();
       setRequestId('searchInventory', requestId);
       setReportData({

--- a/src/scenes/InventoryRouter/InventoryV2View.tsx
+++ b/src/scenes/InventoryRouter/InventoryV2View.tsx
@@ -335,7 +335,9 @@ export default function InventoryV2View(props: InventoryProps): JSX.Element {
         ) : (
           <Container maxWidth={false} sx={{ padding: '32px 0' }}>
             {!isMobile && <Grid item xs={12} padding={theme.spacing(3)} />}
-            {isAdmin(selectedOrganization) ? (
+            {selectedOrganization ? (
+              isAdmin(selectedOrganization)
+            ) : false ? (
               <EmptyMessage title={strings.ONBOARDING_ADMIN_TITLE} rowItems={getEmptyState()} sx={messageStyles} />
             ) : (
               <EmptyMessage

--- a/src/scenes/InventoryRouter/NurseryDropdown.tsx
+++ b/src/scenes/InventoryRouter/NurseryDropdown.tsx
@@ -37,10 +37,14 @@ export default function NurseryDropdown<T extends AccessionPostRequestBody>(
       id='facilityId'
       label={label}
       selectedValue={record.facilityId?.toString()}
-      options={getAllNurseries(selectedOrganization).map((nursery) => ({
-        label: nursery.name,
-        value: nursery.id.toString(),
-      }))}
+      options={
+        selectedOrganization
+          ? getAllNurseries(selectedOrganization).map((nursery) => ({
+              label: nursery.name,
+              value: nursery.id.toString(),
+            }))
+          : []
+      }
       onChange={onChangeHandler}
       errorText={validate && !isSelectionValid(record) ? strings.REQUIRED_FIELD : ''}
       fullWidth={true}

--- a/src/scenes/InventoryRouter/Search.tsx
+++ b/src/scenes/InventoryRouter/Search.tsx
@@ -73,7 +73,7 @@ export default function Search(props: SearchProps): JSX.Element | null {
   const [availableSpecies, setAvailableSpecies] = useState<Species[]>([]);
 
   useEffect(() => {
-    setNurseries(getAllNurseries(selectedOrganization));
+    setNurseries(selectedOrganization ? getAllNurseries(selectedOrganization) : []);
   }, [selectedOrganization]);
 
   useEffect(() => {
@@ -81,10 +81,10 @@ export default function Search(props: SearchProps): JSX.Element | null {
   }, [filters.facilityIds, dispatch]);
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       void dispatch(requestProjects(selectedOrganization.id, activeLocale || undefined));
     }
-  }, [dispatch, selectedOrganization.id, activeLocale]);
+  }, [dispatch, selectedOrganization?.id, activeLocale]);
 
   useEffect(() => {
     if (origin !== 'Nursery' || !species.length) {
@@ -147,7 +147,9 @@ export default function Search(props: SearchProps): JSX.Element | null {
         data.push({
           id: 'facilityIds',
           label: strings.NURSERY,
-          value: filters.facilityIds?.map((id) => getNurseryName(id, selectedOrganization)).join(', ') ?? '',
+          value: selectedOrganization
+            ? filters.facilityIds?.map((id) => getNurseryName(id, selectedOrganization))?.join(', ') ?? ''
+            : '',
           emptyValue: [],
         });
       }

--- a/src/scenes/InventoryRouter/SpeciesBulkWithdrawView.tsx
+++ b/src/scenes/InventoryRouter/SpeciesBulkWithdrawView.tsx
@@ -31,7 +31,7 @@ export default function SpeciesBulkWithdrawView(props: SpeciesBulkWithdrawViewCo
 
   useEffect(() => {
     const populateResults = async () => {
-      if (speciesIds && selectedOrganization.id !== -1) {
+      if (speciesIds && selectedOrganization) {
         const searchResponse = await NurseryBatchService.getBatchIdsForSpecies(
           selectedOrganization.id,
           speciesIds.map((id) => Number(id))
@@ -47,7 +47,7 @@ export default function SpeciesBulkWithdrawView(props: SpeciesBulkWithdrawViewCo
     };
 
     void populateResults();
-  }, [speciesIds, navigate, selectedOrganization.id]);
+  }, [speciesIds, navigate, selectedOrganization?.id]);
 
   return batchIds ? (
     <BatchWithdrawFlow

--- a/src/scenes/InventoryRouter/form/BatchDetailsForm.tsx
+++ b/src/scenes/InventoryRouter/form/BatchDetailsForm.tsx
@@ -105,7 +105,7 @@ export default function BatchDetailsForm(props: BatchDetailsFormProps): JSX.Elem
 
   const handleBatchValidation = useCallback(
     (savableRecord: SavableFormRecord) => {
-      if (selectedOrganization.id !== -1) {
+      if (selectedOrganization) {
         if (hasErrors()) {
           setValidateFields(true);
           onBatchValidated(false);
@@ -114,12 +114,12 @@ export default function BatchDetailsForm(props: BatchDetailsFormProps): JSX.Elem
 
         onBatchValidated({
           batch: savableRecord as SavableBatch,
-          organizationId: selectedOrganization.id,
+          organizationId: selectedOrganization?.id || -1,
           timezone: timeZone,
         });
       }
     },
-    [hasErrors, onBatchValidated, selectedOrganization.id, timeZone]
+    [hasErrors, onBatchValidated, selectedOrganization?.id, timeZone]
   );
 
   const accessionQuantity = useMemo<{ value: number; display?: string } | undefined>(() => {
@@ -146,7 +146,7 @@ export default function BatchDetailsForm(props: BatchDetailsFormProps): JSX.Elem
     }
 
     const facility = FacilityService.getFacility({
-      organization: selectedOrganization,
+      organization: selectedOrganization!,
       facilityId,
       type: 'Nursery',
     });

--- a/src/scenes/InventoryRouter/form/useAccessions.ts
+++ b/src/scenes/InventoryRouter/form/useAccessions.ts
@@ -11,7 +11,7 @@ export const useAccessions = (record?: { accessionId?: number }, speciesId?: num
   const dispatch = useAppDispatch();
   const { selectedOrganization } = useOrganization();
 
-  const accessionsResponseData = useAppSelector(selectAccessions(selectedOrganization.id, speciesId));
+  const accessionsResponseData = useAppSelector(selectAccessions(selectedOrganization?.id || -1, speciesId));
   const availableAccessions = useMemo(
     () =>
       (accessionsResponseData &&
@@ -36,7 +36,7 @@ export const useAccessions = (record?: { accessionId?: number }, speciesId?: num
   }, [availableAccessions, record?.accessionId]);
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       void dispatch(requestAccessions(selectedOrganization.id, speciesId));
     }
   }, [dispatch, selectedOrganization, speciesId]);

--- a/src/scenes/InventoryRouter/form/useNurseries.ts
+++ b/src/scenes/InventoryRouter/form/useNurseries.ts
@@ -11,7 +11,7 @@ export const useNurseries = (record?: { facilityId?: number }) => {
   const [selectedNursery, setSelectedNursery] = useState<Facility>();
 
   const initNurseries = useCallback(() => {
-    setAvailableNurseries(getAllNurseries(selectedOrganization));
+    setAvailableNurseries(selectedOrganization ? getAllNurseries(selectedOrganization) : []);
   }, [selectedOrganization]);
 
   useEffect(() => {

--- a/src/scenes/InventoryRouter/index.tsx
+++ b/src/scenes/InventoryRouter/index.tsx
@@ -25,7 +25,7 @@ const InventoryRouter = ({ setWithdrawalCreated }: InventoryRouterProps) => {
         path={'/*'}
         element={
           <InventoryV2View
-            hasNurseries={selectedOrgHasFacilityType(selectedOrganization, 'Nursery')}
+            hasNurseries={selectedOrganization ? selectedOrgHasFacilityType(selectedOrganization, 'Nursery') : false}
             hasSpecies={species.length > 0}
           />
         }

--- a/src/scenes/InventoryRouter/view/InventorySeedlingsTable.tsx
+++ b/src/scenes/InventoryRouter/view/InventorySeedlingsTable.tsx
@@ -150,7 +150,7 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
     const requestId = setRequestId('inventory-seedlings');
 
     const populateResults = async () => {
-      if (!originId || selectedOrganization.id === -1) {
+      if (!originId || !selectedOrganization) {
         return;
       }
 
@@ -179,7 +179,7 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
     const requestId = setRequestId('inventory-seedlings-species-unfiltered');
 
     const populateSpeciesUnfilteredResults = async () => {
-      if (!originId || selectedOrganization.id === -1) {
+      if (!originId || !selectedOrganization) {
         return;
       }
 
@@ -356,12 +356,12 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
   };
 
   const batchesExport = useCallback(() => {
-    if (!originId || !getBatchesExport || selectedOrganization.id === -1) {
+    if (!originId || !getBatchesExport || !selectedOrganization) {
       return Promise.resolve([] as SearchResponseElement[]);
     }
 
     return getBatchesExport(selectedOrganization.id, originId, getSearchFields(), searchSortOrder);
-  }, [getBatchesExport, selectedOrganization.id, originId, getSearchFields, searchSortOrder]);
+  }, [getBatchesExport, selectedOrganization, originId, getSearchFields, searchSortOrder]);
 
   const getResultsSpeciesNames = useCallback(
     (): string[] => speciesUnfilteredBatches.map((s) => s.species_scientificName as string),

--- a/src/scenes/InventoryRouter/view/InventorySummaryForSpecies.tsx
+++ b/src/scenes/InventoryRouter/view/InventorySummaryForSpecies.tsx
@@ -40,13 +40,13 @@ export default function InventorySummaryForSpecies(props: InventorySummaryProps)
       }
     };
 
-    if (speciesId !== undefined && selectedOrganization.id !== -1) {
+    if (speciesId !== undefined && selectedOrganization) {
       void populateSummary();
-      void dispatch(requestSpeciesProjects(selectedOrganization.id, speciesId));
+      void dispatch(requestSpeciesProjects(selectedOrganization?.id, speciesId));
     } else {
       setSummary(undefined);
     }
-  }, [speciesId, summary, snackbar, dispatch, selectedOrganization.id]);
+  }, [speciesId, summary, snackbar, dispatch, selectedOrganization?.id]);
 
   useEffect(() => {
     reloadData();

--- a/src/scenes/InventoryRouter/view/OverviewItemCardSubLocations.tsx
+++ b/src/scenes/InventoryRouter/view/OverviewItemCardSubLocations.tsx
@@ -42,12 +42,12 @@ const OverviewItemCardSubLocations = (props: OverviewItemCardSubLocationsProps) 
 
   const syncSubLocations = useCallback(
     (_batch: Batch) => {
-      if (!_.isEqual(props.batch.subLocationIds, _batch.subLocationIds) && selectedOrganization.id !== -1) {
+      if (!_.isEqual(props.batch.subLocationIds, _batch.subLocationIds) && selectedOrganization) {
         const request = dispatch(requestSaveBatch({ batch: _batch, organizationId: selectedOrganization.id }));
         setRequestId(request.requestId);
       }
     },
-    [dispatch, props.batch.subLocationIds, selectedOrganization.id]
+    [dispatch, props.batch.subLocationIds, selectedOrganization?.id]
   );
 
   const toggleSubLocationEdit = useCallback(() => {

--- a/src/scenes/NurseriesRouter/NurseryView.tsx
+++ b/src/scenes/NurseriesRouter/NurseryView.tsx
@@ -44,7 +44,7 @@ export default function NurseryView(): JSX.Element {
     name: '',
     id: -1,
     type: 'Nursery',
-    organizationId: selectedOrganization.id,
+    organizationId: selectedOrganization?.id || -1,
     connectionState: 'Not Connected',
   });
   const { nurseryId } = useParams<{ nurseryId: string }>();
@@ -61,7 +61,7 @@ export default function NurseryView(): JSX.Element {
 
   useEffect(() => {
     if (nurseryId) {
-      const seedBanks = getAllNurseries(selectedOrganization);
+      const seedBanks = selectedOrganization ? getAllNurseries(selectedOrganization) : [];
       setSelectedNursery(seedBanks?.find((sb) => sb?.id === parseInt(nurseryId, 10)));
     }
   }, [nurseryId, selectedOrganization]);
@@ -77,7 +77,7 @@ export default function NurseryView(): JSX.Element {
       name: selectedNursery?.name || '',
       description: selectedNursery?.description,
       id: selectedNursery?.id ?? -1,
-      organizationId: selectedOrganization.id,
+      organizationId: selectedOrganization?.id || -1,
       type: 'Nursery',
       connectionState: 'Not Connected',
       timeZone: selectedNursery?.timeZone,
@@ -128,7 +128,7 @@ export default function NurseryView(): JSX.Element {
           subLocationNames: editedSubLocations?.map((l) => l.name as string),
         });
 
-    if (response.requestSucceeded && selectedOrganization.id !== -1) {
+    if (response.requestSucceeded && selectedOrganization) {
       if (selectedNursery && editedSubLocations) {
         await SubLocationService.saveEditedSubLocations(id as number, editedSubLocations);
       }

--- a/src/scenes/NurseriesRouter/index.tsx
+++ b/src/scenes/NurseriesRouter/index.tsx
@@ -12,7 +12,11 @@ const NurseriesRouter = () => {
   const { selectedOrganization } = useOrganization();
 
   const getNurseriesView = useCallback((): JSX.Element => {
-    if (!isPlaceholderOrg(selectedOrganization.id) && selectedOrgHasFacilityType(selectedOrganization, 'Nursery')) {
+    if (
+      selectedOrganization &&
+      !isPlaceholderOrg(selectedOrganization.id) &&
+      selectedOrgHasFacilityType(selectedOrganization, 'Nursery')
+    ) {
       return <NurseriesListView organization={selectedOrganization} />;
     }
     return <EmptyStatePage pageName={'Nurseries'} />;

--- a/src/scenes/NurseryRouter/NurseryPlantingsAndWithdrawalsView.tsx
+++ b/src/scenes/NurseryRouter/NurseryPlantingsAndWithdrawalsView.tsx
@@ -43,11 +43,11 @@ export default function NurseryPlantingsAndWithdrawalsView(): JSX.Element {
   );
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       void dispatch(requestPlantings(selectedOrganization.id));
       void dispatch(requestPlantingSitesSearchResults(selectedOrganization.id));
     }
-  }, [dispatch, selectedOrganization.id]);
+  }, [dispatch, selectedOrganization?.id]);
 
   useEffect(() => {
     if (activeLocale) {

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
@@ -85,7 +85,7 @@ export default function NurseryWithdrawalsDetailsView({
         setBatches(withdrawalResponse.batches);
       }
       // get summary information
-      if (withdrawalId && selectedOrganization.id !== -1) {
+      if (withdrawalId && selectedOrganization) {
         const apiSearchResults = await NurseryWithdrawalService.listNurseryWithdrawals(selectedOrganization.id, [
           {
             operation: 'field',

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
@@ -136,7 +136,7 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   );
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const getApiSearchResults = async () => {
         setFilterOptions(await NurseryWithdrawalService.getFilterOptions(selectedOrganization.id));
       };
@@ -216,7 +216,7 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   }, [filters, debouncedSearchTerm]);
 
   const onApplyFilters = useCallback(async () => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const searchChildren: SearchNodePayload[] = getSearchChildren();
       const requestId = Math.random().toString();
       setRequestId('searchWithdrawals', requestId);

--- a/src/scenes/NurseryRouter/PlantingProgressList.tsx
+++ b/src/scenes/NurseryRouter/PlantingProgressList.tsx
@@ -103,7 +103,7 @@ export default function PlantingProgressList({
   const [selectedZoneIdsBySiteId, setSelectedZoneIdsBySiteId] = useState<Record<number, Set<number>>>();
   const updatePlantingResult = useAppSelector((state) => selectUpdatePlantingsCompleted(state, requestId));
   const subzonesStatisticsResult = useAppSelector((state) =>
-    selectZonesHaveStatistics(state, selectedOrganization.id, selectedZoneIdsBySiteId, defaultTimeZone.get().id)
+    selectZonesHaveStatistics(state, selectedOrganization?.id || -1, selectedZoneIdsBySiteId, defaultTimeZone.get().id)
   );
   const snackbar = useSnackbar();
   const [showWarningModal, setShowWarningModal] = useState(false);

--- a/src/scenes/NurseryRouter/PlantingProgressMap.tsx
+++ b/src/scenes/NurseryRouter/PlantingProgressMap.tsx
@@ -44,7 +44,7 @@ export default function PlantingProgressMap({ plantingSiteId, reloadTracking }: 
   const selectedZoneHasStats = useAppSelector((state) =>
     selectZonesHaveStatistics(
       state,
-      selectedOrganization.id,
+      selectedOrganization?.id || -1,
       { [plantingSiteId]: new Set([zoneIdSelected]) },
       defaultTimeZone.get().id
     )

--- a/src/scenes/NurseryRouter/PlantingProgressTabContent.tsx
+++ b/src/scenes/NurseryRouter/PlantingProgressTabContent.tsx
@@ -77,10 +77,10 @@ export default function PlantingProgress(): JSX.Element {
   );
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       void dispatch(requestObservationsResults(selectedOrganization.id));
     }
-  }, [dispatch, selectedOrganization.id]);
+  }, [dispatch, selectedOrganization?.id]);
 
   const filterColumns = useMemo<FilterField[]>(
     () =>
@@ -108,10 +108,10 @@ export default function PlantingProgress(): JSX.Element {
   );
 
   const reloadTrackingAndObservations = useCallback(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       void dispatch(requestObservationsResults(selectedOrganization.id));
     }
-  }, [selectedOrganization.id, dispatch]);
+  }, [selectedOrganization?.id, dispatch]);
 
   const plantingSitesNames = useAppSelector((state) => selectPlantingSitesNames(state));
 

--- a/src/scenes/NurseryRouter/WithdrawalDetails/WithdrawalOverview.tsx
+++ b/src/scenes/NurseryRouter/WithdrawalDetails/WithdrawalOverview.tsx
@@ -18,7 +18,7 @@ export default function WithdrawalOverview({ withdrawal, withdrawalSummary }: Wi
   const { selectedOrganization } = useOrganization();
   const { isMobile } = useDeviceInfo();
 
-  const facilityName = selectedOrganization.facilities?.find((f) => f.id === withdrawal?.facilityId)?.name;
+  const facilityName = selectedOrganization?.facilities?.find((f) => f.id === withdrawal?.facilityId)?.name;
   const overviewCardData = [
     {
       title: strings.DATE,

--- a/src/scenes/ObservationsRouter/ObservationsDataView.tsx
+++ b/src/scenes/ObservationsRouter/ObservationsDataView.tsx
@@ -49,7 +49,7 @@ export default function ObservationsDataView(props: ObservationsDataViewProps): 
     searchObservations(
       state,
       selectedPlantingSiteId,
-      selectedOrganization.id,
+      selectedOrganization?.id || -1,
       defaultTimeZone.get().id,
       searchProps.search,
       searchProps.filtersProps?.filters.zone?.values ?? [],

--- a/src/scenes/ObservationsRouter/ObservationsHome.tsx
+++ b/src/scenes/ObservationsRouter/ObservationsHome.tsx
@@ -116,10 +116,10 @@ export default function ObservationsHome(props: ObservationsHomeProps): JSX.Elem
   }, [navigate, allPlantingSites?.length]);
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       void dispatch(requestPlantings(selectedOrganization.id));
     }
-  }, [dispatch, selectedOrganization.id]);
+  }, [dispatch, selectedOrganization]);
 
   const actionButton = useMemo<ButtonProps | undefined>(() => {
     if (!activeLocale || !newObservationsSchedulable || !scheduleObservationsEnabled) {

--- a/src/scenes/ObservationsRouter/biomass/BiomassMeasurement.tsx
+++ b/src/scenes/ObservationsRouter/biomass/BiomassMeasurement.tsx
@@ -65,12 +65,12 @@ export default function BiomassMeasurement(props: BiomassMeasurementProps): JSX.
 
   const exportObservationsList = useCallback(async () => {
     const content = await ObservationsService.exportBiomassObservationsCsv(
-      organization.selectedOrganization.id,
+      organization.selectedOrganization?.id || -1,
       selectedPlantingSite?.id
     );
 
     if (content !== null) {
-      const siteName = selectedPlantingSite?.name ?? organization.selectedOrganization.name;
+      const siteName = selectedPlantingSite?.name ?? organization.selectedOrganization?.name ?? 'Unknown';
       const fileName = sanitize(`${siteName}-${strings.BIOMASS_MONITORING}.csv`);
 
       const encodedUri = 'data:text/csv;charset=utf-8,' + encodeURIComponent(content);

--- a/src/scenes/ObservationsRouter/details/ObservationDetailsList.tsx
+++ b/src/scenes/ObservationsRouter/details/ObservationDetailsList.tsx
@@ -49,7 +49,7 @@ const ObservationDetailsList = (props: SearchProps): JSX.Element => {
       {
         plantingSiteId,
         observationId,
-        orgId: selectedOrganization.id,
+        orgId: selectedOrganization?.id || -1,
         search: searchProps.search,
         zoneNames: searchProps.filtersProps?.filters.zone?.values ?? [],
       },
@@ -58,7 +58,7 @@ const ObservationDetailsList = (props: SearchProps): JSX.Element => {
   );
 
   const zoneNames = useAppSelector((state) =>
-    selectDetailsZoneNames(state, plantingSiteId, observationId, selectedOrganization.id)
+    selectDetailsZoneNames(state, plantingSiteId, observationId, selectedOrganization?.id || -1)
   );
 
   useEffect(() => {

--- a/src/scenes/ObservationsRouter/details/index.tsx
+++ b/src/scenes/ObservationsRouter/details/index.tsx
@@ -75,7 +75,7 @@ export default function ObservationDetails(props: ObservationDetailsProps): JSX.
     searchObservations(
       state,
       plantingSiteId,
-      selectedOrganization.id,
+      selectedOrganization,
       defaultTimeZone.get().id,
       searchProps.search,
       searchProps.filtersProps?.filters?.zone?.values ?? [],
@@ -97,7 +97,7 @@ export default function ObservationDetails(props: ObservationDetailsProps): JSX.
       {
         plantingSiteId,
         observationId,
-        orgId: selectedOrganization.id,
+        orgId: selectedOrganization?.id || -1,
         search: searchProps.search,
         zoneNames: searchProps.filtersProps?.filters.zone?.values ?? [],
       },
@@ -132,7 +132,7 @@ export default function ObservationDetails(props: ObservationDetailsProps): JSX.
   const plantingSite = useAppSelector((state) => selectPlantingSite(state, plantingSiteId));
   const observation = useAppSelector((state) => selectObservation(state, plantingSiteId, observationId));
   const zoneNames = useAppSelector((state) =>
-    selectDetailsZoneNames(state, plantingSiteId, observationId, selectedOrganization.id)
+    selectDetailsZoneNames(state, plantingSiteId, observationId, selectedOrganization)
   );
 
   const title = useMemo(() => {

--- a/src/scenes/ObservationsRouter/index.tsx
+++ b/src/scenes/ObservationsRouter/index.tsx
@@ -55,14 +55,14 @@ export default function ObservationsRouter(): JSX.Element {
   const plantingSites = useAppSelector(selectPlantingSites);
 
   useEffect(() => {
-    if (plantingSites !== undefined && !dispatched && selectedOrganization.id !== -1) {
+    if (plantingSites !== undefined && !dispatched && selectedOrganization) {
       setDispatched(true);
-      void dispatch(requestObservationsResults(selectedOrganization.id));
+      void dispatch(requestObservationsResults(selectedOrganization?.id));
       void dispatch(requestAdHocObservationResults(selectedOrganization.id));
       void dispatch(requestObservations(selectedOrganization.id));
       void dispatch(requestObservations(selectedOrganization.id, true));
     }
-  }, [dispatch, selectedOrganization.id, plantingSites, dispatched]);
+  }, [dispatch, selectedOrganization?.id, plantingSites, dispatched]);
 
   useEffect(() => {
     if (observationsResultsError || plantingSitesError) {

--- a/src/scenes/ObservationsRouter/replacePlot/ReplaceObservationPlotModal.tsx
+++ b/src/scenes/ObservationsRouter/replacePlot/ReplaceObservationPlotModal.tsx
@@ -79,12 +79,12 @@ export default function ReplaceObservationPlotModal(props: ReplaceObservationPlo
 
     if (result.status === 'error') {
       snackbar.toastError();
-    } else if (result.status === 'success' && selectedOrganization.id !== -1) {
+    } else if (result.status === 'success' && selectedOrganization) {
       const { addedMonitoringPlotIds, removedMonitoringPlotIds } = result.data as ReplaceObservationPlotResponsePayload;
       setAddedPlotIds(addedMonitoringPlotIds);
       setRemovedPlotIds(removedMonitoringPlotIds);
       snackbar.toastSuccess(strings.REASSIGNMENT_REQUEST_SENT);
-      void dispatch(requestObservationsResults(selectedOrganization.id));
+      void dispatch(requestObservationsResults(selectedOrganization?.id || -1));
       const dispatched = dispatch(
         requestMonitoringPlots({
           plantingSiteId,
@@ -93,7 +93,7 @@ export default function ReplaceObservationPlotModal(props: ReplaceObservationPlo
       );
       setMonitoringPlotsRequestId(dispatched.requestId);
     }
-  }, [dispatch, result, selectedOrganization.id, snackbar, plantingSiteId]);
+  }, [dispatch, result, selectedOrganization, snackbar, plantingSiteId]);
 
   useEffect(() => {
     if (plots?.status === 'pending') {

--- a/src/scenes/ObservationsRouter/zone/index.tsx
+++ b/src/scenes/ObservationsRouter/zone/index.tsx
@@ -113,7 +113,7 @@ export default function ObservationPlantingZone(): JSX.Element {
       {
         plantingSiteId,
         observationId,
-        orgId: selectedOrganization.id,
+        orgId: selectedOrganization?.id || -1,
         plantingZoneName,
         search,
         plotType: filters.plotType === undefined ? undefined : filters.plotType.values[0] === strings.PERMANENT,

--- a/src/scenes/OrgRouter/NavBar.tsx
+++ b/src/scenes/OrgRouter/NavBar.tsx
@@ -99,12 +99,12 @@ export default function NavBar({
   );
 
   const checkNurseryWithdrawals = useCallback(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       void NurseryWithdrawalService.hasNurseryWithdrawals(selectedOrganization.id).then((result: boolean) => {
         setShowNurseryWithdrawals(result);
       });
     }
-  }, [selectedOrganization.id]);
+  }, [selectedOrganization]);
 
   useEffect(() => {
     setShowNurseryWithdrawals(false);
@@ -120,7 +120,7 @@ export default function NavBar({
   }, [withdrawalCreated, checkNurseryWithdrawals, showNurseryWithdrawals]);
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1 && !isContributor(selectedOrganization)) {
+    if (selectedOrganization && !isContributor(selectedOrganization)) {
       const request = dispatch(requestOrganizationFeatures({ organizationId: selectedOrganization.id }));
       setOrgFeaturesRequestId(request.requestId);
     }
@@ -213,7 +213,7 @@ export default function NavBar({
 
   const seedFundReportsMenu = useMemo<JSX.Element | null>(
     () =>
-      selectedOrganization.canSubmitReports && !!orgFeatures?.data?.seedFundReports?.enabled && activeLocale ? (
+      selectedOrganization?.canSubmitReports && !!orgFeatures?.data?.seedFundReports?.enabled && activeLocale ? (
         <NavItem
           icon='iconGraphReport'
           label={strings.SEED_FUND_REPORTS}
@@ -229,7 +229,7 @@ export default function NavBar({
       closeAndNavigateTo,
       isSeedFundReportsRoute,
       orgFeatures?.data?.seedFundReports?.enabled,
-      selectedOrganization.canSubmitReports,
+      selectedOrganization?.canSubmitReports,
     ]
   );
 
@@ -237,6 +237,7 @@ export default function NavBar({
     () =>
       currentParticipantProject &&
       !!orgFeatures?.data?.modules?.enabled &&
+      selectedOrganization &&
       isManagerOrHigher(selectedOrganization) &&
       activeLocale ? (
         <NavItem

--- a/src/scenes/OrgRouter/index.tsx
+++ b/src/scenes/OrgRouter/index.tsx
@@ -67,7 +67,9 @@ const OrgRouter = ({ showNavBar, setShowNavBar }: OrgRouterProps) => {
 
   const { species } = useSpeciesData();
   const hasObservationsResults: boolean = useAppSelector(selectHasObservationsResults);
-  const plantingSites: PlantingSite[] | undefined = useAppSelector(selectOrgPlantingSites(selectedOrganization.id));
+  const plantingSites: PlantingSite[] | undefined = useAppSelector(
+    selectOrgPlantingSites(selectedOrganization?.id || -1)
+  );
   const projects: Project[] | undefined = useAppSelector(selectProjects);
 
   const contentStyles = {
@@ -99,27 +101,27 @@ const OrgRouter = ({ showNavBar, setShowNavBar }: OrgRouterProps) => {
 
   const reloadProjects = useCallback(() => {
     const populateProjects = () => {
-      if (!isPlaceholderOrg(selectedOrganization.id)) {
+      if (selectedOrganization && !isPlaceholderOrg(selectedOrganization.id)) {
         void dispatch(requestProjects(selectedOrganization.id, activeLocale || undefined));
       }
     };
     populateProjects();
-  }, [selectedOrganization.id, dispatch, activeLocale]);
+  }, [selectedOrganization?.id, dispatch, activeLocale]);
 
   const reloadPlantingSites = useCallback(() => {
     const populatePlantingSites = () => {
-      if (!isPlaceholderOrg(selectedOrganization.id)) {
+      if (selectedOrganization && !isPlaceholderOrg(selectedOrganization.id)) {
         void dispatch(requestPlantingSites(selectedOrganization.id));
       }
     };
     populatePlantingSites();
-  }, [dispatch, selectedOrganization.id, activeLocale]);
+  }, [dispatch, selectedOrganization, activeLocale]);
 
   const setDefaults = useCallback(() => {
-    if (!isPlaceholderOrg(selectedOrganization.id)) {
+    if (selectedOrganization && !isPlaceholderOrg(selectedOrganization.id)) {
       setWithdrawalCreated(false);
     }
-  }, [selectedOrganization.id]);
+  }, [selectedOrganization]);
 
   useEffect(() => {
     reloadProjects();
@@ -136,12 +138,12 @@ const OrgRouter = ({ showNavBar, setShowNavBar }: OrgRouterProps) => {
   const selectedOrgHasSpecies = useCallback((): boolean => species.length > 0, [species]);
 
   const selectedOrgHasSeedBanks = useCallback(
-    (): boolean => selectedOrgHasFacilityType(selectedOrganization, 'Seed Bank'),
+    (): boolean => (selectedOrganization ? selectedOrgHasFacilityType(selectedOrganization, 'Seed Bank') : false),
     [selectedOrganization]
   );
 
   const selectedOrgHasNurseries = useCallback(
-    (): boolean => selectedOrgHasFacilityType(selectedOrganization, 'Nursery'),
+    (): boolean => (selectedOrganization ? selectedOrgHasFacilityType(selectedOrganization, 'Nursery') : false),
     [selectedOrganization]
   );
 
@@ -217,7 +219,7 @@ const OrgRouter = ({ showNavBar, setShowNavBar }: OrgRouterProps) => {
               element={
                 <ProjectsRouter
                   reloadProjects={reloadProjects}
-                  isPlaceholderOrg={() => isPlaceholderOrg(selectedOrganization.id)}
+                  isPlaceholderOrg={() => (selectedOrganization ? isPlaceholderOrg(selectedOrganization.id) : true)}
                   selectedOrgHasProjects={selectedOrgHasProjects}
                 />
               }

--- a/src/scenes/OrganizationRouter/OrganizationView.tsx
+++ b/src/scenes/OrganizationRouter/OrganizationView.tsx
@@ -27,10 +27,10 @@ export default function OrganizationView(): JSX.Element {
   const { countries } = useLocalization();
   const timeZones = useTimeZones();
   const utcTimeZone = getUTC(timeZones);
-  const currentTimeZone = timeZones.find((tz) => tz.id === selectedOrganization.timeZone)?.longName;
+  const currentTimeZone = timeZones.find((tz) => tz.id === selectedOrganization?.timeZone)?.longName;
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const populatePeople = async () => {
         const response = await OrganizationUserService.getOrganizationUsers(selectedOrganization.id);
         if (response.requestSucceeded) {
@@ -49,7 +49,7 @@ export default function OrganizationView(): JSX.Element {
   };
 
   const organizationState = () => {
-    if (countries && selectedOrganization.countryCode && selectedOrganization.countrySubdivisionCode) {
+    if (countries && selectedOrganization?.countryCode && selectedOrganization?.countrySubdivisionCode) {
       return getSubdivisionByCode(
         countries,
         selectedOrganization.countryCode,
@@ -59,7 +59,7 @@ export default function OrganizationView(): JSX.Element {
   };
 
   const getDateAdded = () => {
-    if (selectedOrganization.createdTime) {
+    if (selectedOrganization?.createdTime) {
       return getDateDisplayValue(selectedOrganization.createdTime);
     }
   };
@@ -105,7 +105,7 @@ export default function OrganizationView(): JSX.Element {
             label={strings.ORGANIZATION_NAME}
             id='name'
             type='text'
-            value={selectedOrganization.name}
+            value={selectedOrganization?.name || ''}
             display={true}
           />
         </Grid>
@@ -114,7 +114,7 @@ export default function OrganizationView(): JSX.Element {
             label={strings.DESCRIPTION}
             id='description'
             type='text'
-            value={selectedOrganization.description}
+            value={selectedOrganization?.description || ''}
             display={true}
           />
         </Grid>
@@ -127,14 +127,14 @@ export default function OrganizationView(): JSX.Element {
             id='country'
             type='text'
             value={
-              countries && selectedOrganization.countryCode
+              countries && selectedOrganization?.countryCode
                 ? getCountryByCode(countries, selectedOrganization.countryCode)?.name
                 : ''
             }
             display={true}
           />
         </Grid>
-        {selectedOrganization.countrySubdivisionCode && (
+        {selectedOrganization?.countrySubdivisionCode && (
           <Grid item xs={gridSize()} paddingBottom={theme.spacing(4)}>
             <TextField label={strings.STATE} id='state' type='text' value={organizationState()} display={true} />
           </Grid>
@@ -163,11 +163,13 @@ export default function OrganizationView(): JSX.Element {
             label={strings.ORGANIZATION_TYPE}
             id='org-type'
             type='text'
-            value={organizationTypeLabel(selectedOrganization.organizationType)}
+            value={
+              selectedOrganization?.organizationType ? organizationTypeLabel(selectedOrganization.organizationType) : ''
+            }
             display={true}
           />
         </Grid>
-        {selectedOrganization.organizationType === 'Other' && (
+        {selectedOrganization?.organizationType === 'Other' && (
           <Grid item xs={gridSize()} paddingBottom={isMobile ? theme.spacing(4) : 0}>
             <TextField
               label={strings.ORGANIZATION_TYPE_DESCRIPTION}
@@ -183,7 +185,7 @@ export default function OrganizationView(): JSX.Element {
             label={strings.ORGANIZATION_WEBSITE}
             id='org-website'
             type='text'
-            value={selectedOrganization.website}
+            value={selectedOrganization?.website || ''}
             display={true}
           />
         </Grid>

--- a/src/scenes/OrganizationRouter/index.tsx
+++ b/src/scenes/OrganizationRouter/index.tsx
@@ -13,7 +13,11 @@ const OrganizationRouter = () => {
       <Route
         path={'/edit'}
         element={
-          <EditOrganizationView organization={selectedOrganization} reloadOrganizationData={reloadOrganizations} />
+          selectedOrganization ? (
+            <EditOrganizationView organization={selectedOrganization} reloadOrganizationData={reloadOrganizations} />
+          ) : (
+            <div>No organization selected</div>
+          )
         }
       />
       <Route path={'/*'} element={<OrganizationView />} />

--- a/src/scenes/PeopleRouter/NewPersonView.tsx
+++ b/src/scenes/PeopleRouter/NewPersonView.tsx
@@ -54,7 +54,7 @@ export default function PersonView(): JSX.Element {
   }, [selectedOrganization, personSelectedToEdit, setNewPerson]);
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const populatePeople = async () => {
         const response = await OrganizationUserService.getOrganizationUsers(selectedOrganization.id);
         if (personId && response.requestSucceeded) {
@@ -94,7 +94,7 @@ export default function PersonView(): JSX.Element {
     let successMessage: string | null = null;
     let userId = -1;
 
-    if (!!personSelectedToEdit && selectedOrganization.id !== -1) {
+    if (!!personSelectedToEdit && selectedOrganization) {
       const response = await OrganizationUserService.updateOrganizationUser(
         selectedOrganization.id,
         newPerson.id,
@@ -103,7 +103,9 @@ export default function PersonView(): JSX.Element {
       successMessage = response.requestSucceeded ? strings.CHANGES_SAVED : null;
       userId = newPerson.id;
     } else {
-      const response = await OrganizationUserService.createOrganizationUser(selectedOrganization.id, { ...newPerson });
+      const response = await OrganizationUserService.createOrganizationUser(selectedOrganization?.id || -1, {
+        ...newPerson,
+      });
       if (!response.requestSucceeded) {
         if (response.errorDetails === 'PRE_EXISTING_USER') {
           setRepeatedEmail(newPerson.email);

--- a/src/scenes/PeopleRouter/PersonDetailsView.tsx
+++ b/src/scenes/PeopleRouter/PersonDetailsView.tsx
@@ -28,7 +28,7 @@ export default function PersonDetailsView(): JSX.Element {
   const { isMobile } = useDeviceInfo();
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       const populatePersonData = async () => {
         const response = await OrganizationUserService.getOrganizationUsers(selectedOrganization.id);
         if (response.requestSucceeded) {
@@ -101,25 +101,27 @@ export default function PersonDetailsView(): JSX.Element {
             </Typography>
           </Grid>
           <Grid item xs={3}>
-            {isAdmin(selectedOrganization) &&
-              (isMobile ? (
-                <Button
-                  icon='iconEdit'
-                  priority='primary'
-                  size='medium'
-                  onClick={goToEditPerson}
-                  style={{ float: 'right' }}
-                />
-              ) : (
-                <Button
-                  label={strings.EDIT_PERSON}
-                  icon='iconEdit'
-                  priority='primary'
-                  size='medium'
-                  onClick={goToEditPerson}
-                  style={{ float: 'right' }}
-                />
-              ))}
+            {selectedOrganization
+              ? isAdmin(selectedOrganization)
+              : false &&
+                (isMobile ? (
+                  <Button
+                    icon='iconEdit'
+                    priority='primary'
+                    size='medium'
+                    onClick={goToEditPerson}
+                    style={{ float: 'right' }}
+                  />
+                ) : (
+                  <Button
+                    label={strings.EDIT_PERSON}
+                    icon='iconEdit'
+                    priority='primary'
+                    size='medium'
+                    onClick={goToEditPerson}
+                    style={{ float: 'right' }}
+                  />
+                ))}
           </Grid>
         </Grid>
         <Grid item xs={12}>

--- a/src/scenes/PlantingSitesRouter/edit/DetailsInputForm.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/DetailsInputForm.tsx
@@ -49,7 +49,7 @@ export default function DetailsInputForm<T extends MinimalPlantingSite>({
   const { selectedOrganization } = useOrganization();
   const dispatch = useAppDispatch();
   const plantingSites = useAppSelector(selectPlantingSites);
-  const draftSites = useAppSelector(selectDraftPlantingSites(selectedOrganization.id));
+  const draftSites = useAppSelector(selectDraftPlantingSites(selectedOrganization?.id || -1));
 
   const checkErrors = useCallback(() => {
     let hasNameError = true;
@@ -75,16 +75,16 @@ export default function DetailsInputForm<T extends MinimalPlantingSite>({
   }, [plantingSeasonsValid, record.name, usedNames]);
 
   useEffect(() => {
-    if (!plantingSites && selectedOrganization.id !== -1) {
+    if (!plantingSites && selectedOrganization) {
       void dispatch(requestPlantingSites(selectedOrganization.id));
     }
-  }, [activeLocale, dispatch, plantingSites, selectedOrganization.id]);
+  }, [activeLocale, dispatch, plantingSites, selectedOrganization]);
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       void dispatch(requestSearchDrafts(selectedOrganization.id));
     }
-  }, [dispatch, selectedOrganization.id]);
+  }, [dispatch, selectedOrganization]);
 
   useEffect(() => {
     const allSites = [...(plantingSites || []), ...(draftSites?.data || [])];

--- a/src/scenes/PlantingSitesRouter/edit/PlantingSiteCreate.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/PlantingSiteCreate.tsx
@@ -37,7 +37,7 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
     id: -1,
     adHocPlots: [],
     name: '',
-    organizationId: selectedOrganization.id,
+    organizationId: selectedOrganization?.id || -1,
     plantingSeasons: [],
   });
 
@@ -50,13 +50,13 @@ export default function CreatePlantingSite(props: CreatePlantingSiteProps): JSX.
       description: plantingSite?.description,
       id: plantingSite?.id || -1,
       name: plantingSite?.name || '',
-      organizationId: selectedOrganization.id,
+      organizationId: selectedOrganization?.id || -1,
       plantingSeasons: plantingSite?.plantingSeasons || [],
       plantingZones: plantingSite?.plantingZones,
       projectId: plantingSite?.projectId,
       timeZone: plantingSite?.timeZone,
     });
-  }, [plantingSite, setRecord, selectedOrganization.id]);
+  }, [plantingSite, setRecord, selectedOrganization]);
 
   const goToPlantingSite = useCallback(
     (id?: number) => {

--- a/src/scenes/PlantingSitesRouter/edit/PlantingSiteDraftCreate.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/PlantingSiteDraftCreate.tsx
@@ -16,12 +16,12 @@ export default function PlantingSiteDraftCreate(): JSX.Element {
       createdBy: -1,
       id: -1,
       name: '',
-      organizationId: selectedOrganization.id,
+      organizationId: selectedOrganization?.id || -1,
       plantingSeasons: [],
       siteEditStep: 'details',
       siteType,
     }),
-    [selectedOrganization.id, siteType]
+    [selectedOrganization, siteType]
   );
 
   return <PlantingSiteEditor site={site} />;

--- a/src/scenes/PlantingSitesRouter/index.tsx
+++ b/src/scenes/PlantingSitesRouter/index.tsx
@@ -45,14 +45,14 @@ export function PlantingSitesRouter({ reloadTracking }: PlantingSitesProps): JSX
 
   useEffect(() => {
     const siteId = Number(plantingSiteId);
-    if (!isNaN(siteId) && selectedOrganization.id !== -1) {
+    if (!isNaN(siteId) && selectedOrganization) {
       setSelectedPlantingSite(siteId);
 
       // This dispatch is required for a hasPlantings attribute for deleting a site
       // TODO: move plantings into usePlantingSite hook
       void dispatch(requestPlantings(selectedOrganization.id));
     }
-  }, [dispatch, selectedOrganization.id, plantingSiteId, setSelectedPlantingSite]);
+  }, [dispatch, selectedOrganization, plantingSiteId, setSelectedPlantingSite]);
 
   // show spinner while initializing data
   if (allPlantingSites === undefined) {

--- a/src/scenes/PlantingSitesRouter/view/PlantingSitesList.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSitesList.tsx
@@ -57,13 +57,13 @@ export default function PlantingSitesList(): JSX.Element {
    */
   const searchData = useCallback(
     async (searchFields: SearchNodePayload[]) => {
-      if (selectedOrganization.id !== -1) {
+      if (selectedOrganization) {
         const searchRequests = [
-          TrackingService.searchPlantingSites(selectedOrganization.id, searchFields, searchSortOrder),
+          TrackingService.searchPlantingSites(selectedOrganization?.id, searchFields, searchSortOrder),
         ];
 
         searchRequests.push(
-          DraftPlantingSiteService.searchDraftPlantingSites(selectedOrganization.id, searchFields, searchSortOrder)
+          DraftPlantingSiteService.searchDraftPlantingSites(selectedOrganization?.id, searchFields, searchSortOrder)
         );
 
         // batch the search requests
@@ -102,7 +102,7 @@ export default function PlantingSitesList(): JSX.Element {
         return sites;
       }
     },
-    [activeLocale, defaultTimeZone, searchSortOrder, selectedOrganization.id, timeZones]
+    [activeLocale, defaultTimeZone, searchSortOrder, selectedOrganization, timeZones]
   );
 
   const onSearch = useCallback(async () => {

--- a/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
+++ b/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
@@ -74,9 +74,9 @@ export default function PlantsDashboardView({
   }, [latestResult, plantingSite]);
 
   useEffect(() => {
-    const orgId = organizationId ?? selectedOrganization.id;
+    const orgId = organizationId ?? selectedOrganization?.id ?? -1;
     setAcceleratorOrganizationId(orgId);
-  }, [dispatch, organizationId, selectedOrganization, setAcceleratorOrganizationId]);
+  }, [dispatch, organizationId, selectedOrganization?.id, setAcceleratorOrganizationId]);
 
   const sectionHeader = (title: string) => (
     <Grid item xs={12}>
@@ -349,17 +349,17 @@ export default function PlantsDashboardView({
               gap: theme.spacing(3),
             }}
           >
-            {(organizationId || selectedOrganization.id) && (
+            {(organizationId || selectedOrganization?.id) && (
               <MultiplePlantingSiteMap
                 projectId={projectId!}
-                organizationId={organizationId ?? selectedOrganization.id}
+                organizationId={organizationId ?? selectedOrganization?.id ?? -1}
               />
             )}
           </Box>
         </Grid>
       </>
     );
-  }, [theme, organizationId, selectedOrganization.id, projectId]);
+  }, [theme, organizationId, selectedOrganization?.id, projectId]);
 
   return (
     <PlantsPrimaryPage

--- a/src/scenes/SeedBanksRouter/SeedBankView.tsx
+++ b/src/scenes/SeedBanksRouter/SeedBankView.tsx
@@ -46,7 +46,7 @@ export default function SeedBankView(): JSX.Element {
     name: '',
     id: -1,
     type: 'Seed Bank',
-    organizationId: selectedOrganization.id,
+    organizationId: selectedOrganization?.id || -1,
     connectionState: 'Not Connected',
   });
   const { seedBankId } = useParams<{ seedBankId: string }>();
@@ -68,7 +68,7 @@ export default function SeedBankView(): JSX.Element {
 
   useEffect(() => {
     if (seedBankId) {
-      const seedBanks = getAllSeedBanks(selectedOrganization);
+      const seedBanks = selectedOrganization ? getAllSeedBanks(selectedOrganization) : [];
       setSelectedSeedBank(seedBanks?.find((sb) => sb?.id === parseInt(seedBankId, 10)));
     }
   }, [seedBankId, selectedOrganization]);
@@ -78,7 +78,7 @@ export default function SeedBankView(): JSX.Element {
       name: selectedSeedBank?.name || '',
       description: selectedSeedBank?.description,
       id: selectedSeedBank?.id ?? -1,
-      organizationId: selectedOrganization.id,
+      organizationId: selectedOrganization?.id || -1,
       type: 'Seed Bank',
       connectionState: 'Not Connected',
       timeZone: selectedSeedBank?.timeZone,
@@ -96,7 +96,7 @@ export default function SeedBankView(): JSX.Element {
   };
 
   const saveSeedBank = async () => {
-    if (selectedOrganization.id === -1) {
+    if (!selectedOrganization) {
       return;
     }
     let id = selectedSeedBank?.id;
@@ -130,7 +130,7 @@ export default function SeedBankView(): JSX.Element {
         if (editedSubLocations) {
           await SubLocationService.saveEditedSubLocations(selectedSeedBank.id, editedSubLocations);
         }
-        void reloadOrganizations(selectedOrganization.id);
+        void reloadOrganizations(selectedOrganization?.id);
         snackbar.toastSuccess(strings.CHANGES_SAVED);
       } else {
         snackbar.toastError();
@@ -141,7 +141,7 @@ export default function SeedBankView(): JSX.Element {
         subLocationNames: editedSubLocations?.map((l) => l.name as string),
       });
       if (response.requestSucceeded) {
-        await reloadOrganizations(selectedOrganization.id);
+        await reloadOrganizations(selectedOrganization?.id);
         snackbar.toastSuccess(strings.SEED_BANK_ADDED);
         id = response.facilityId || undefined;
       } else {

--- a/src/scenes/SeedBanksRouter/SelectSeedBankModal.tsx
+++ b/src/scenes/SeedBanksRouter/SelectSeedBankModal.tsx
@@ -22,7 +22,7 @@ export default function SelectSeedBankModal(props: SelectSeedBankProps): JSX.Ele
   const { open, onClose } = props;
   const [selectedFacility, setSelectedFacility] = useState<Facility | undefined>();
 
-  const availableFacilities = getAllSeedBanks(selectedOrganization) || [];
+  const availableFacilities = selectedOrganization ? getAllSeedBanks(selectedOrganization) : [];
 
   const onChange = (facilityName: string) => {
     setSelectedFacility(availableFacilities.find((facility) => facility?.name === facilityName));

--- a/src/scenes/SeedBanksRouter/index.tsx
+++ b/src/scenes/SeedBanksRouter/index.tsx
@@ -12,7 +12,11 @@ const SeedBanksRouter = () => {
   const { selectedOrganization } = useOrganization();
 
   const getSeedBanksView = useCallback((): JSX.Element => {
-    if (!isPlaceholderOrg(selectedOrganization.id) && selectedOrgHasFacilityType(selectedOrganization, 'Seed Bank')) {
+    if (
+      selectedOrganization &&
+      !isPlaceholderOrg(selectedOrganization.id) &&
+      selectedOrgHasFacilityType(selectedOrganization, 'Seed Bank')
+    ) {
       return <SeedBanksListView organization={selectedOrganization} />;
     }
     return <EmptyStatePage pageName={'SeedBanks'} />;

--- a/src/scenes/Species/SpeciesAddView.tsx
+++ b/src/scenes/Species/SpeciesAddView.tsx
@@ -34,7 +34,7 @@ type SpeciesAddViewProps = {
 
 export default function SpeciesAddView({ reloadData }: SpeciesAddViewProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
-  const organizationId = selectedOrganization.id;
+  const organizationId = selectedOrganization?.id || -1; // TODO: Add null check for selectedOrganization
   const [record, setRecord, onChange] = useForm<Species>(initSpecies());
   const [nameFormatError, setNameFormatError] = useState<string | string[]>('');
   const [isBusy, setIsBusy] = useState<boolean>(false);

--- a/src/scenes/Species/SpeciesDetailView.tsx
+++ b/src/scenes/Species/SpeciesDetailView.tsx
@@ -57,15 +57,15 @@ export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps
   }, [isMobile]);
 
   useEffect(() => {
-    const getSpecies = async () => {
-      const speciesResponse = await SpeciesService.getSpecies(Number(speciesId), selectedOrganization.id);
-      if (speciesResponse.requestSucceeded) {
-        setSpecies(speciesResponse.species);
-      } else {
-        navigate(APP_PATHS.SPECIES);
-      }
-    };
-    if (selectedOrganization && selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
+      const getSpecies = async () => {
+        const speciesResponse = await SpeciesService.getSpecies(Number(speciesId), selectedOrganization.id);
+        if (speciesResponse.requestSucceeded) {
+          setSpecies(speciesResponse.species);
+        } else {
+          navigate(APP_PATHS.SPECIES);
+        }
+      };
       void getSpecies();
     }
   }, [speciesId, selectedOrganization, navigate]);
@@ -86,7 +86,7 @@ export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps
   };
 
   const deleteSelectedSpecies = async (id: number) => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       setIsBusy(true);
       const success = await SpeciesService.deleteSpecies(id, selectedOrganization.id);
       setIsBusy(false);

--- a/src/scenes/Species/SpeciesEditView.tsx
+++ b/src/scenes/Species/SpeciesEditView.tsx
@@ -108,17 +108,17 @@ export default function SpeciesEditView(): JSX.Element {
 
   useEffect(() => {
     const getSpecies = async () => {
-      const speciesResponse = await SpeciesService.getSpecies(Number(speciesId), selectedOrganization.id);
+      const speciesResponse = await SpeciesService.getSpecies(Number(speciesId), selectedOrganization?.id || -1);
       if (speciesResponse.requestSucceeded) {
         setSpecies(speciesResponse.species);
       } else {
         navigate(APP_PATHS.SPECIES);
       }
     };
-    if (selectedOrganization && selectedOrganization.id !== -1 && speciesId) {
+    if (selectedOrganization && speciesId) {
       void getSpecies();
     }
-  }, [speciesId, selectedOrganization, navigate]);
+  }, [speciesId, selectedOrganization?.id, navigate]);
 
   useEffect(() => {
     const now = DateTime.now().toISO();
@@ -138,7 +138,7 @@ export default function SpeciesEditView(): JSX.Element {
   }, [species, setRecord, selectedOrganization]);
 
   const saveSpecies = async () => {
-    if (selectedOrganization.id === -1) {
+    if (!selectedOrganization) {
       return;
     }
     if (!record.scientificName) {

--- a/src/scenes/Species/SpeciesListView.tsx
+++ b/src/scenes/Species/SpeciesListView.tsx
@@ -253,6 +253,8 @@ export default function SpeciesListView({ reloadData, species }: SpeciesListProp
   }, [activeLocale, filterColumns, filterOptions]);
 
   useEffect(() => {
+    if (!selectedOrganization) return;
+
     const getApiSearchResults = async () => {
       const searchParams: SearchRequestPayload = {
         prefix: 'species',
@@ -312,6 +314,16 @@ export default function SpeciesListView({ reloadData, species }: SpeciesListProp
   const { isMobile } = useDeviceInfo();
 
   const getParams = useCallback(() => {
+    if (!selectedOrganization) {
+      // Return empty params if no organization is selected
+      return {
+        prefix: 'species',
+        fields: [],
+        search: { operation: 'and', children: [] },
+        count: 0,
+      } as SearchRequestPayload;
+    }
+
     const params: SearchRequestPayload = {
       prefix: 'species',
       fields: [

--- a/src/scenes/Species/SpeciesProjectsTable.tsx
+++ b/src/scenes/Species/SpeciesProjectsTable.tsx
@@ -73,7 +73,7 @@ export default function SpeciesProjectsTable({
   const [selectableProjects, setSelectableProjects] = useState<Project[]>([]);
 
   useEffect(() => {
-    if (selectedOrganization.id !== -1) {
+    if (selectedOrganization) {
       void dispatch(requestProjects(selectedOrganization.id));
     }
   }, [dispatch, selectedOrganization]);

--- a/src/utils/organization.tsx
+++ b/src/utils/organization.tsx
@@ -1,4 +1,3 @@
-import { defaultSelectedOrg } from 'src/providers/contexts';
 import { Facility, FacilityType } from 'src/types/Facility';
 import { HighOrganizationRolesValues, Organization, OrganizationRole } from 'src/types/Organization';
 import { OrganizationUser } from 'src/types/User';
@@ -53,7 +52,7 @@ export const getNurseryById = (organization: Organization, id: number): Facility
   return found[0];
 };
 
-export const isPlaceholderOrg = (id: number | undefined) => !id || id === defaultSelectedOrg.id;
+export const isPlaceholderOrg = (id: number | undefined) => !id;
 
 export const selectedOrgHasFacilityType = (organization: Organization, facilityType: FacilityType): boolean => {
   if (!isPlaceholderOrg(organization?.id) && organization?.facilities) {

--- a/src/utils/useTimeZoneUtils.ts
+++ b/src/utils/useTimeZoneUtils.ts
@@ -50,7 +50,7 @@ export const useDefaultTimeZone = () => {
   return useMemo(
     () => ({
       get: (forEdit?: boolean) => {
-        const orgTimeZone = getTimeZone(timeZones, selectedOrganization.timeZone);
+        const orgTimeZone = getTimeZone(timeZones, selectedOrganization?.timeZone);
         if (orgTimeZone) {
           return orgTimeZone;
         }


### PR DESCRIPTION
Currently, when there's no organization selected, the
OrganizationProvider sets the selected organization to a dummy one
with an organization ID of -1, which is treated as a sentinel value
in the code. But sometimes we forget to check for it and the -1
value ends up in API requests, which then sometimes cause server
errors.

* Change the provider's context to make the selected organization
  object optional; it will be undefined when there's no organization
  selected.
* Update all the places where we were checking for organization -1
  to instead check whether the selected organization object exists.
* Fix the TypeScript errors that indicated where we were using the
  organization ID without checking whether it was valid.

There may still be places where we're missing a required check, but
there should at least be fewer of them than before.