### PR TITLE
SW-7041 Console: Plants dashboard does not load

### DIFF
--- a/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
+++ b/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
@@ -74,9 +74,9 @@ export default function PlantsPrimaryPageView({
   const hasSites = useMemo(() => {
     return (
       (!isAcceleratorRoute && (allPlantingSites?.length ?? 0) > 1) ||
-      (isAcceleratorRoute && (plantingSites?.length ?? 0) > 1)
+      (isAcceleratorRoute && (plantingSites?.length ?? 0) > 0)
     );
-  }, [allPlantingSites]);
+  }, [allPlantingSites, isAcceleratorRoute, plantingSites]);
 
   const plantingSiteSelected = useMemo(() => {
     return plantingSite !== undefined;
@@ -137,7 +137,7 @@ export default function PlantsPrimaryPageView({
   if (
     !plantingSites ||
     (!isAcceleratorRoute && (allPlantingSites?.length ?? 0) > 1 && !selectedPlantingSiteId) ||
-    (isAcceleratorRoute && (plantingSites?.length ?? 0) > 1 && !selectedPlantingSiteId)
+    (isAcceleratorRoute && (plantingSites?.length ?? 0) > 0 && !selectedPlantingSiteId)
   ) {
     return (
       <TfMain>

--- a/src/components/PlantsPrimaryPage/index.tsx
+++ b/src/components/PlantsPrimaryPage/index.tsx
@@ -76,7 +76,7 @@ export default function PlantsPrimaryPage({
     const projectSitesWithAll =
       allowAllAsSiteSelection && projectSites.length > 2 ? projectSites : projectSites.filter((site) => site.id !== -1);
     return projectSitesWithAll.toSorted((a, b) => a.id - b.id);
-  }, [plantingSitesData, allowAllAsSiteSelection, selectedOrganization, projectId]);
+  }, [plantingSitesData, allowAllAsSiteSelection, projectId]);
 
   const setActivePlantingSite = useCallback(
     (site: PlantingSite | undefined) => {


### PR DESCRIPTION
For the plantingSites array that we use in PlantsPrimaryPageView, we have the "all sites" option when we have more than one planting site for that project. If the project only have one, we don't have the "all sites" option, so for the "hasSites" check we have to check lenght > 0 instead of > 1