### PR TITLE
SW-7036 Use raw enum values for searches

### DIFF
--- a/src/services/FacilityService.ts
+++ b/src/services/FacilityService.ts
@@ -1,5 +1,4 @@
 import { paths } from 'src/api/types/generated-schema';
-import strings from 'src/strings';
 import { Facility, FacilityType } from 'src/types/Facility';
 import { Organization } from 'src/types/Organization';
 import { OrNodePayload, SearchRequestPayload } from 'src/types/Search';
@@ -113,7 +112,6 @@ const updateFacility = async (facility: Facility): Promise<Response> => {
  * Search facilities by parameters
  */
 const getFacilities = async ({ type, organizationId, query }: FacilitySearchParams): Promise<Facilities> => {
-  const typeVal = type === 'Seed Bank' ? strings.SEED_BANK : strings.NURSERY;
   const searchField: OrNodePayload | null = query
     ? (() => {
         const { type: searchType, values } = parseSearchTerm(query);
@@ -154,7 +152,7 @@ const getFacilities = async ({ type, organizationId, query }: FacilitySearchPara
     search: {
       operation: 'and',
       children: [
-        { operation: 'field', field: 'type', type: 'Exact', values: [typeVal] },
+        { operation: 'field', field: 'type(raw)', type: 'Exact', values: [type] },
         {
           operation: 'field',
           field: 'organization_id',

--- a/src/services/SeedBankService.ts
+++ b/src/services/SeedBankService.ts
@@ -1,5 +1,4 @@
 import { paths } from 'src/api/types/generated-schema';
-import strings from 'src/strings';
 import { AccessionState } from 'src/types/Accession';
 import { GetUploadStatusResponsePayload, UploadFileResponse } from 'src/types/File';
 import {
@@ -199,9 +198,9 @@ const getPendingAccessions = async (organizationId: number): Promise<SearchRespo
       [
         {
           operation: 'field',
-          field: 'state',
+          field: 'state(raw)',
           type: 'Exact',
-          values: [strings.AWAITING_CHECK_IN],
+          values: ['Awaiting Check-In'],
         },
       ],
       organizationId
@@ -314,9 +313,9 @@ const getAccessionForSpecies = (
     operation: 'not',
     child: {
       operation: 'field',
-      field: 'state',
+      field: 'state(raw)',
       type: 'Exact',
-      values: [strings.USED_UP],
+      values: ['Used Up'],
     },
   };
 


### PR DESCRIPTION
If you load the Nurseries or Seed Banks page and switch locales,
a new search request is triggered to refresh the table view with
the new locale. But it's possible for that request to be sent
before the new locale's strings have finished loading, in which
case we were using the old locale's strings to construct the
search API requests. This was resulting in a server error because
the server expects searches of enum fields to use the localized
enum values.

Change the searches to filter on the "raw" search fields instead;
they don't get localized so there's no issue if strings haven't
loaded yet when the search request is constructed.