### PR TITLE
SW-6932 Improving plants dashboard spinners

### DIFF
--- a/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
+++ b/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Box, CircularProgress, Grid, Typography, useTheme } from '@mui/material';
 import { Button, Dropdown, IconName, Message } from '@terraware/web-components';
@@ -70,6 +70,7 @@ export default function PlantsPrimaryPageView({
   const projects = useAppSelector(selectProjects);
   const dispatch = useAppDispatch();
   const { allPlantingSites, isLoading, isInitiated, plantingSite } = usePlantingSiteData();
+  const [delayedIsPlantingSiteSet, setDelayedIsPlantingSiteSet] = useState(false);
 
   const hasSites = useMemo(() => {
     return (
@@ -91,6 +92,14 @@ export default function PlantsPrimaryPageView({
       void dispatch(requestProjects(selectedOrganization.id, activeLocale || undefined));
     }
   }, [activeLocale, dispatch, selectedOrganization.id]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDelayedIsPlantingSiteSet(isPlantingSiteSet);
+    }, 1000);
+
+    return () => clearTimeout(timer); // Cancel timeout if dependencies change
+  }, [isPlantingSiteSet]);
 
   const projectsWithPlantingSites = useMemo(() => {
     if (!allPlantingSites) {
@@ -237,7 +246,7 @@ export default function PlantsPrimaryPageView({
                     </Typography>
                   </Box>
                 </Grid>
-                {!isPlantingSiteSet ? (
+                {!delayedIsPlantingSiteSet ? (
                   <CircularProgress sx={{ margin: 'auto' }} />
                 ) : (
                   <Grid item xs={isDesktop ? 6 : 12}>
@@ -249,7 +258,9 @@ export default function PlantsPrimaryPageView({
               </Grid>
             </Card>
           )}
-          {isEmptyState && !isAcceleratorRoute && !isLoading && isPlantingSiteSet && <PlantsDashboardEmptyMessage />}
+          {isEmptyState && !isAcceleratorRoute && !isLoading && delayedIsPlantingSiteSet && (
+            <PlantsDashboardEmptyMessage />
+          )}
         </>
       ) : (
         <PageHeaderWrapper nextElement={contentRef.current}>
@@ -316,7 +327,7 @@ export default function PlantsPrimaryPageView({
       <Grid item xs={12}>
         <PageSnackbar />
       </Grid>
-      {newHeader && !isPlantingSiteSet ? (
+      {newHeader && (!delayedIsPlantingSiteSet || isLoading) ? (
         <CircularProgress sx={{ margin: 'auto' }} />
       ) : (
         <Box ref={contentRef} sx={style}>

--- a/src/scenes/PlantsDashboardRouter/components/NumberOfSpeciesPlantedCard.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/NumberOfSpeciesPlantedCard.tsx
@@ -7,7 +7,7 @@ import BarChart from 'src/components/common/Chart/BarChart';
 import FormattedNumber from 'src/components/common/FormattedNumber';
 import OverviewItemCard from 'src/components/common/OverviewItemCard';
 import { useProjectPlantings } from 'src/hooks/useProjectPlantings';
-import { useUser } from 'src/providers';
+import { useLocalization, useUser } from 'src/providers';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import { usePlantingSiteData } from 'src/providers/Tracking/PlantingSiteContext';
 import { selectPlantingsForSite } from 'src/redux/features/plantings/plantingsSelectors';
@@ -41,6 +41,7 @@ export default function NumberOfSpeciesPlantedCard({
 const RolledUpCard = ({ projectId }: { projectId?: number }): JSX.Element => {
   const { reportedPlants } = useProjectPlantings(projectId);
   const { species: orgSpecies } = useSpeciesData();
+  const { activeLocale } = useLocalization();
 
   const projectTotalSpecies = useMemo(() => {
     const allSpeciesIds = new Set();
@@ -52,7 +53,7 @@ const RolledUpCard = ({ projectId }: { projectId?: number }): JSX.Element => {
     return allSpeciesIds.size;
   }, [reportedPlants]);
 
-  const labels = [strings.RARE, strings.ENDANGERED, strings.OTHER];
+  const labels = useMemo(() => (activeLocale ? [strings.RARE, strings.ENDANGERED, strings.OTHER] : []), [activeLocale]);
 
   const projectSpecies = useMemo(() => {
     const speciesMap = new Map();
@@ -160,7 +161,9 @@ const SiteWithZonesCard = ({ newVersion }: NumberOfSpeciesPlantedCardProps): JSX
   const { species: orgSpecies } = useSpeciesData();
 
   const totalSpecies = useMemo(() => plantingSiteReportedPlants?.species.length ?? 0, [plantingSiteReportedPlants]);
-  const labels = [strings.RARE, strings.ENDANGERED, strings.OTHER];
+  const { activeLocale } = useLocalization();
+
+  const labels = useMemo(() => (activeLocale ? [strings.RARE, strings.ENDANGERED, strings.OTHER] : []), [activeLocale]);
 
   const values = useMemo(() => {
     if (plantingSiteReportedPlants?.species && orgSpecies) {


### PR DESCRIPTION
Two things were done to improve spinners:

- Create a new delayedPlantingSiteSet, that is just the value of plantingSiteSet but with a second of delay, to give time to the "isLoading" flag from the provider to set to "true" when the planting site changes, and avoid showing charts for one second and disappear again when "isLoading" changes again.

- Memoize SpeciesPlanted labels to avoid re-renders on those charts