### PR TITLE
SW-7055 Fix Last Report used for data

### DIFF
--- a/src/scenes/AcceleratorRouter/ParticipantProjects/ProjectProfileView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/ProjectProfileView.tsx
@@ -118,10 +118,10 @@ const ProjectProfileView = ({
   const lastSubmittedReport = useMemo(() => {
     if (acceleratorReports?.length > 0) {
       const submittedReports = acceleratorReports
-        .filter((r) => ['Submitted', 'Approved'].includes(r.status) && !!r.submittedTime)
+        .filter((r) => ['Submitted', 'Approved'].includes(r.status) && !!r.submittedTime && !!r.endDate)
         .toSorted((a, b) => {
-          const timeA = a.submittedTime ? new Date(a.submittedTime).getTime() : 0;
-          const timeB = b.submittedTime ? new Date(b.submittedTime).getTime() : 0;
+          const timeA = a.endDate ? new Date(a.endDate).getTime() : 0;
+          const timeB = b.endDate ? new Date(b.endDate).getTime() : 0;
           return timeB - timeA;
         });
       if (submittedReports.length > 0) {
@@ -133,8 +133,8 @@ const ProjectProfileView = ({
   const lastPublishedReport = useMemo(() => {
     if (publishedReports?.length > 0) {
       const sortedReports = publishedReports.toSorted((a, b) => {
-        const timeA = a.publishedTime ? new Date(a.publishedTime).getTime() : 0;
-        const timeB = b.publishedTime ? new Date(b.publishedTime).getTime() : 0;
+        const timeA = a.endDate ? new Date(a.endDate).getTime() : 0;
+        const timeB = b.endDate ? new Date(b.endDate).getTime() : 0;
         return timeB - timeA;
       });
       if (sortedReports.length > 0) {


### PR DESCRIPTION
Previously the data displayed for the most recent report on the project profile page was determined by the time the report was submitted (console) or published (funder). 
This caused issues in situations like this:
- Q1 published
- Q2 published
- Q1 re-published because of updates

In this situation, the data displayed should have been from Q2 but was instead displaying Q1's data because it was published most recently.

Change to using endDate for both console and funder portal.