### PR TITLE
SW-6955: Browser back button doesn't work on some pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@mui/styled-engine-sc": "^5.14.12",
     "@mui/styles": "^6.2.0",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^3.4.24",
+    "@terraware/web-components": "^3.4.25",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/playwright/e2e/suites/inventory.spec.ts
+++ b/playwright/e2e/suites/inventory.spec.ts
@@ -128,6 +128,7 @@ export default function InventoryTests() {
     await waitFor(page, '#home');
     await page.getByRole('button', { name: 'Seedlings' }).click();
     await page.getByRole('button', { name: 'Inventory' }).click();
+    await page.getByRole('tab', { name: 'By Batch' }).click();
     await page.getByRole('link', { name: '-2-2-004' }).click();
     await page.getByLabel('Details').getByRole('button').nth(1).click();
     await page.getByRole('spinbutton').click();
@@ -175,6 +176,7 @@ export default function InventoryTests() {
     await waitFor(page, '#home');
     await page.getByRole('button', { name: 'Seedlings' }).click();
     await page.getByRole('button', { name: 'Inventory' }).click();
+    await page.getByRole('tab', { name: 'By Batch' }).click();
     await page.getByRole('link', { name: '-2-2-003' }).click();
     await page.getByRole('button', { name: 'Withdraw', exact: true }).click();
     await page.waitForTimeout(1000); //Wait for modal to load

--- a/src/components/SeedFundReports/ReportsView.tsx
+++ b/src/components/SeedFundReports/ReportsView.tsx
@@ -52,7 +52,7 @@ export default function ReportsView(props: ReportsViewProps): JSX.Element {
   const [activeTab, setActiveTab] = useState<string>(tab);
   const [results, setResults] = useState<(ListReport & { organizationName?: string })[]>([]);
 
-  const onTabChange = useCallback(
+  const onChangeTab = useCallback(
     (newTab: string) => {
       setActiveTab(newTab);
 
@@ -131,7 +131,7 @@ export default function ReportsView(props: ReportsViewProps): JSX.Element {
 
       <Tabs
         activeTab={activeTab}
-        onTabChange={onTabChange}
+        onChangeTab={onChangeTab}
         tabs={[
           {
             id: 'reports',

--- a/src/scenes/AcceleratorRouter/Applications/ApplicationListView.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationListView.tsx
@@ -32,7 +32,7 @@ const ApplicationListView = () => {
     ];
   }, [activeLocale]);
 
-  const { activeTab, onTabChange } = useStickyTabs({
+  const { activeTab, onChangeTab } = useStickyTabs({
     defaultTab: 'applications',
     tabs,
     viewIdentifier: 'accelerator-applications',
@@ -60,7 +60,7 @@ const ApplicationListView = () => {
           },
         }}
       >
-        <Tabs activeTab={activeTab} onTabChange={onTabChange} tabs={tabs} />
+        <Tabs activeTab={activeTab} onChangeTab={onChangeTab} tabs={tabs} />
       </Box>
     </Page>
   );

--- a/src/scenes/AcceleratorRouter/Applications/ApplicationListView.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationListView.tsx
@@ -17,6 +17,7 @@ const ApplicationListView = () => {
     if (!activeLocale) {
       return [];
     }
+
     return [
       {
         id: 'applications',
@@ -34,8 +35,7 @@ const ApplicationListView = () => {
   const { activeTab, onTabChange } = useStickyTabs({
     defaultTab: 'applications',
     tabs,
-    viewIdentifier: 'accelerator-application-list',
-    keepQuery: false,
+    viewIdentifier: 'accelerator-applications',
   });
 
   return (

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
@@ -95,7 +95,6 @@ const tableCellRenderer = (props: RendererProps<any>): JSX.Element => {
 
 export type DocumentVariablesProps = {
   projectId?: number;
-  setSelectedTab?: (tab: string) => void;
 };
 
 const filterSearch =
@@ -112,7 +111,7 @@ const filterSearch =
     );
   };
 
-const DocumentVariablesTab = ({ projectId: projectIdProp, setSelectedTab }: DocumentVariablesProps): JSX.Element => {
+const DocumentVariablesTab = ({ projectId: projectIdProp }: DocumentVariablesProps): JSX.Element => {
   const activeLocale = useLocalization();
   const { isAllowed } = useUser();
   const { allVariables, documentSectionVariables, getUsedSections, projectId, reload } = useDocumentProducerData();
@@ -159,22 +158,21 @@ const DocumentVariablesTab = ({ projectId: projectIdProp, setSelectedTab }: Docu
     );
   }, [documentSectionVariables, getUsedSections, variables]);
 
-  const onSectionClicked = useCallback(
-    (sectionNumber: string) => {
-      setOpenEditVariableModal(false);
-      setSelectedVariable(undefined);
+  const onSectionClicked = useCallback((sectionNumber: string) => {
+    setOpenEditVariableModal(false);
+    setSelectedVariable(undefined);
 
-      if (setSelectedTab) {
-        setSelectedTab(strings.DOCUMENT);
-        setTimeout(() => {
-          // do find and scroll async to allow tab-switching to occur first
-          const relevantSection = document.getElementById(sectionNumber);
-          relevantSection?.scrollIntoView({ behavior: 'smooth' });
-        }, 0);
-      }
-    },
-    [setSelectedTab]
-  );
+    const documentTabElement: HTMLButtonElement | null = document.querySelector('button[role="tab"]:first-child');
+    if (documentTabElement) {
+      documentTabElement.click();
+
+      setTimeout(() => {
+        // do find and scroll async after timeout to allow tab-switching to occur first
+        const relevantSection = document.getElementById(sectionNumber);
+        relevantSection?.scrollIntoView({ behavior: 'smooth' });
+      }, 400);
+    }
+  }, []);
 
   const onSearch = (str: string) => setSearchValue(str);
 

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
@@ -162,7 +162,7 @@ const DocumentVariablesTab = ({ projectId: projectIdProp }: DocumentVariablesPro
     setOpenEditVariableModal(false);
     setSelectedVariable(undefined);
 
-    const documentTabElement: HTMLButtonElement | null = document.querySelector('button[role="tab"]:first-child');
+    const documentTabElement: HTMLButtonElement | null = document.querySelector('button[role="tab"]');
     if (documentTabElement) {
       documentTabElement.click();
 

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/index.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/index.tsx
@@ -98,7 +98,7 @@ export default function DocumentView(): JSX.Element {
     ];
   }, [activeLocale, document]);
 
-  const { activeTab, onTabChange } = useStickyTabs({
+  const { activeTab, onChangeTab } = useStickyTabs({
     defaultTab: 'document',
     tabs,
     viewIdentifier: 'accelerator-documents',
@@ -142,7 +142,7 @@ export default function DocumentView(): JSX.Element {
       </Box>
       <Box marginTop={3} display='flex' flexDirection='row' flexGrow={1}>
         <Box display='flex' flexGrow={1}>
-          <Tabs activeTab={activeTab} onTabChange={onTabChange} tabs={tabs} />
+          <Tabs activeTab={activeTab} onChangeTab={onChangeTab} tabs={tabs} />
         </Box>
         <Box>
           {activeTab === 'document' && <DocumentOutlinePanel open={outlinePanelOpen} setOpen={setOutlinePanelOpen} />}

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/index.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/index.tsx
@@ -71,36 +71,32 @@ export default function DocumentView(): JSX.Element {
     [activeLocale]
   );
 
-  const setSelectedTab = useCallback((tab: string) => {
-    onTabChange(tab);
-  }, []);
+  const tabs: Tab[] = useMemo(() => {
+    if (!activeLocale || !document) {
+      return [];
+    }
 
-  const tabs: Tab[] = useMemo(
-    () =>
-      activeLocale && document
-        ? [
-            {
-              id: 'document',
-              label: strings.DOCUMENT,
-              icon: 'iconParchment',
-              children: <DocumentTab />,
-            },
-            {
-              id: 'variables',
-              label: strings.VARIABLES,
-              icon: 'iconModule',
-              children: <DocumentVariablesTab setSelectedTab={setSelectedTab} />,
-            },
-            {
-              id: 'history',
-              label: strings.HISTORY,
-              icon: 'iconHistory',
-              children: <DocumentHistoryTab />,
-            },
-          ]
-        : [],
-    [activeLocale, document]
-  );
+    return [
+      {
+        id: 'document',
+        label: strings.DOCUMENT,
+        icon: 'iconParchment',
+        children: <DocumentTab />,
+      },
+      {
+        id: 'variables',
+        label: strings.VARIABLES,
+        icon: 'iconModule',
+        children: <DocumentVariablesTab />,
+      },
+      {
+        id: 'history',
+        label: strings.HISTORY,
+        icon: 'iconHistory',
+        children: <DocumentHistoryTab />,
+      },
+    ];
+  }, [activeLocale, document]);
 
   const { activeTab, onTabChange } = useStickyTabs({
     defaultTab: 'document',
@@ -146,7 +142,7 @@ export default function DocumentView(): JSX.Element {
       </Box>
       <Box marginTop={3} display='flex' flexDirection='row' flexGrow={1}>
         <Box display='flex' flexGrow={1}>
-          <Tabs tabs={tabs} activeTab={activeTab} onTabChange={onTabChange} />
+          <Tabs activeTab={activeTab} onTabChange={onTabChange} tabs={tabs} />
         </Box>
         <Box>
           {activeTab === 'document' && <DocumentOutlinePanel open={outlinePanelOpen} setOpen={setOutlinePanelOpen} />}

--- a/src/scenes/AcceleratorRouter/Modules/ModuleView.tsx
+++ b/src/scenes/AcceleratorRouter/Modules/ModuleView.tsx
@@ -66,7 +66,7 @@ export default function ModuleView(): JSX.Element {
       ]
     : [];
 
-  const { activeTab, onTabChange } = useStickyTabs({
+  const { activeTab, onChangeTab } = useStickyTabs({
     defaultTab: 'details',
     tabs,
     viewIdentifier: 'accelerator-module',
@@ -121,7 +121,7 @@ export default function ModuleView(): JSX.Element {
           },
         }}
       >
-        {moduleId && <Tabs activeTab={activeTab} onTabChange={onTabChange} tabs={tabs} />}
+        {moduleId && <Tabs activeTab={activeTab} onChangeTab={onChangeTab} tabs={tabs} />}
       </Box>
     </TfMain>
   );

--- a/src/scenes/AcceleratorRouter/Modules/ModuleView.tsx
+++ b/src/scenes/AcceleratorRouter/Modules/ModuleView.tsx
@@ -69,7 +69,7 @@ export default function ModuleView(): JSX.Element {
   const { activeTab, onTabChange } = useStickyTabs({
     defaultTab: 'details',
     tabs,
-    viewIdentifier: 'accelerator-module-view',
+    viewIdentifier: 'accelerator-module',
   });
 
   useEffect(() => {

--- a/src/scenes/AcceleratorRouter/Overview/index.tsx
+++ b/src/scenes/AcceleratorRouter/Overview/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
 
 import { Box } from '@mui/material';
@@ -22,7 +22,9 @@ const OverviewView = () => {
     if (!activeLocale) {
       return [];
     }
+
     const canReadParticipants = isAllowed('READ_PARTICIPANTS');
+
     return [
       {
         id: 'projects',
@@ -50,17 +52,19 @@ const OverviewView = () => {
     defaultTab: 'projects',
     tabs,
     viewIdentifier: 'accelerator-overview',
-    keepQuery: false,
   });
 
-  const onTabChangeHandler = (tab: string) => {
-    if (tab !== 'projects') {
-      mixpanel?.track(MIXPANEL_EVENTS.CONSOLE_OVERVIEW_TAB, {
-        tab,
-      });
-    }
-    onTabChange(tab);
-  };
+  const onTabChangeHandler = useCallback(
+    (tab: string) => {
+      if (tab !== 'projects') {
+        mixpanel?.track(MIXPANEL_EVENTS.CONSOLE_OVERVIEW_TAB, {
+          tab,
+        });
+      }
+      onTabChange(tab);
+    },
+    [mixpanel, onTabChange]
+  );
 
   return (
     <Page title={strings.OVERVIEW} contentStyle={{ display: 'block' }}>

--- a/src/scenes/AcceleratorRouter/Overview/index.tsx
+++ b/src/scenes/AcceleratorRouter/Overview/index.tsx
@@ -48,22 +48,22 @@ const OverviewView = () => {
     ];
   }, [activeLocale, isAllowed]);
 
-  const { activeTab, onTabChange } = useStickyTabs({
+  const { activeTab, onChangeTab } = useStickyTabs({
     defaultTab: 'projects',
     tabs,
     viewIdentifier: 'accelerator-overview',
   });
 
-  const onTabChangeHandler = useCallback(
+  const onChangeTabHandler = useCallback(
     (tab: string) => {
       if (tab !== 'projects') {
         mixpanel?.track(MIXPANEL_EVENTS.CONSOLE_OVERVIEW_TAB, {
           tab,
         });
       }
-      onTabChange(tab);
+      onChangeTab(tab);
     },
-    [mixpanel, onTabChange]
+    [mixpanel, onChangeTab]
   );
 
   return (
@@ -88,7 +88,7 @@ const OverviewView = () => {
           },
         }}
       >
-        <Tabs activeTab={activeTab} onTabChange={onTabChangeHandler} tabs={tabs} />
+        <Tabs activeTab={activeTab} onChangeTab={onChangeTabHandler} tabs={tabs} />
       </Box>
     </Page>
   );

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/ProjectPage.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/ProjectPage.tsx
@@ -99,8 +99,7 @@ const ProjectPage = () => {
   const { activeTab, onTabChange } = useStickyTabs({
     defaultTab: 'projectProfile',
     tabs,
-    viewIdentifier: 'funder-home',
-    keepQuery: false,
+    viewIdentifier: 'project-profile',
   });
 
   const goToProjectEdit = useCallback(

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/ProjectPage.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/ProjectPage.tsx
@@ -96,7 +96,7 @@ const ProjectPage = () => {
     ];
   }, [activeLocale, projectData, projectApplication, projectScore, phaseVotes]);
 
-  const { activeTab, onTabChange } = useStickyTabs({
+  const { activeTab, onChangeTab } = useStickyTabs({
     defaultTab: 'projectProfile',
     tabs,
     viewIdentifier: 'project-profile',
@@ -200,7 +200,7 @@ const ProjectPage = () => {
       >
         {projectData.status === 'pending' && <BusySpinner />}
 
-        <Tabs activeTab={activeTab} onTabChange={onTabChange} tabs={tabs} />
+        <Tabs activeTab={activeTab} onChangeTab={onChangeTab} tabs={tabs} />
       </Page>
     </>
   );

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportsView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportsView.tsx
@@ -46,7 +46,6 @@ const ReportsView = () => {
     defaultTab: 'reports',
     tabs,
     viewIdentifier: 'project-reports',
-    keepQuery: true,
   });
 
   return (

--- a/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportsView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/Reports/ReportsView.tsx
@@ -42,7 +42,7 @@ const ReportsView = () => {
     ];
   }, [activeLocale]);
 
-  const { activeTab, onTabChange } = useStickyTabs({
+  const { activeTab, onChangeTab } = useStickyTabs({
     defaultTab: 'reports',
     tabs,
     viewIdentifier: 'project-reports',
@@ -62,7 +62,7 @@ const ReportsView = () => {
       titleStyle={{ paddingTop: '16px' }}
     >
       <Box display='flex' flexDirection='column' flexGrow={1}>
-        <Tabs activeTab={activeTab} onTabChange={onTabChange} tabs={tabs} />
+        <Tabs activeTab={activeTab} onChangeTab={onChangeTab} tabs={tabs} />
       </Box>
     </Page>
   );

--- a/src/scenes/AccessionsRouter/Accession2View.tsx
+++ b/src/scenes/AccessionsRouter/Accession2View.tsx
@@ -388,7 +388,7 @@ export default function Accession2View(): JSX.Element {
     ];
   }, [accession, reloadData, activeLocale, themeObj, viabilityEditable, isMobile, hasPendingTests]);
 
-  const { activeTab, onTabChange, setActiveTab } = useStickyTabs({
+  const { activeTab, onChangeTab, setActiveTab } = useStickyTabs({
     defaultTab: 'detail',
     tabs,
     viewIdentifier: 'accession',
@@ -705,7 +705,7 @@ export default function Accession2View(): JSX.Element {
             : {},
         }}
       >
-        <Tabs activeTab={activeTab} onTabChange={onTabChange} tabs={tabs} />
+        <Tabs activeTab={activeTab} onChangeTab={onChangeTab} tabs={tabs} />
       </Box>
     </TfMain>
   );

--- a/src/scenes/AccessionsRouter/Accession2View.tsx
+++ b/src/scenes/AccessionsRouter/Accession2View.tsx
@@ -15,7 +15,6 @@ import OverviewItemCard from 'src/components/common/OverviewItemCard';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useUser } from 'src/providers';
 import { useOrganization } from 'src/providers/hooks';
 import { AccessionService, FacilityService } from 'src/services';
@@ -26,9 +25,7 @@ import { stateName } from 'src/types/Accession';
 import { getUnitName, isUnitInPreferredSystem } from 'src/units';
 import { getSeedBank, isContributor } from 'src/utils/organization';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
-import useQuery from 'src/utils/useQuery';
 import useSnackbar from 'src/utils/useSnackbar';
-import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
 import useStickyTabs from 'src/utils/useStickyTabs';
 import { useLocationTimeZone } from 'src/utils/useTimeZoneUtils';
 
@@ -49,9 +46,6 @@ export default function Accession2View(): JSX.Element {
   const { user } = useUser();
   const { selectedOrganization } = useOrganization();
   const { userPreferences } = useUser();
-  const query = useQuery();
-  const navigate = useSyncNavigate();
-  const location = useStateLocation();
   const { accessionId } = useParams<{ accessionId: string }>();
   const [accession, setAccession] = useState<Accession>();
   const [openEditLocationModal, setOpenEditLocationModal] = useState(false);
@@ -177,11 +171,6 @@ export default function Accession2View(): JSX.Element {
       }
     }
   }, [accession, activeLocale, seedBankTimeZone]);
-
-  const handleChange = (newValue: string) => {
-    query.set('tab', newValue);
-    navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
-  };
 
   const linkStyle = {
     color: themeObj.palette.TwClrTxtBrand,
@@ -399,11 +388,10 @@ export default function Accession2View(): JSX.Element {
     ];
   }, [accession, reloadData, activeLocale, themeObj, viabilityEditable, isMobile, hasPendingTests]);
 
-  const { activeTab, onTabChange } = useStickyTabs({
+  const { activeTab, onTabChange, setActiveTab } = useStickyTabs({
     defaultTab: 'detail',
     tabs,
-    viewIdentifier: 'accession-view',
-    tabsAreNewPages: false,
+    viewIdentifier: 'accession',
   });
 
   return (
@@ -493,7 +481,7 @@ export default function Accession2View(): JSX.Element {
               accession={accession}
               reload={reloadData}
               setNewViabilityTestOpened={setOpenNewViabilityTest}
-              changeTab={handleChange}
+              changeTab={setActiveTab}
               title={accession?.viabilityPercent?.toString() ? strings.EDIT_VIABILITY : strings.ADD_VIABILITY}
             />
           )}

--- a/src/scenes/FunderHome/index.tsx
+++ b/src/scenes/FunderHome/index.tsx
@@ -107,7 +107,7 @@ export default function FunderHome() {
     ];
   }, [activeLocale, projectDetails, selectedProjectId, publishedReports, selectedReport]);
 
-  const { activeTab, onTabChange } = useStickyTabs({
+  const { activeTab, onChangeTab } = useStickyTabs({
     defaultTab: 'projectProfile',
     tabs,
     viewIdentifier: 'funder-home',
@@ -159,7 +159,7 @@ export default function FunderHome() {
               />
             )}
           </Box>
-          <Tabs activeTab={activeTab} onTabChange={onTabChange} tabs={tabs} />
+          <Tabs activeTab={activeTab} onChangeTab={onChangeTab} tabs={tabs} />
         </Box>
       </Box>
     </TfMain>

--- a/src/scenes/FunderHome/index.tsx
+++ b/src/scenes/FunderHome/index.tsx
@@ -90,6 +90,7 @@ export default function FunderHome() {
     if (!activeLocale) {
       return [];
     }
+
     return [
       {
         id: 'projectProfile',
@@ -110,7 +111,6 @@ export default function FunderHome() {
     defaultTab: 'projectProfile',
     tabs,
     viewIdentifier: 'funder-home',
-    keepQuery: false,
   });
 
   const strippedDealName = useMemo(() => {

--- a/src/scenes/InventoryRouter/InventoryBatchView.tsx
+++ b/src/scenes/InventoryRouter/InventoryBatchView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
@@ -19,8 +19,7 @@ import { Facility } from 'src/types/Facility';
 import { Species } from 'src/types/Species';
 import { getNurseryById } from 'src/utils/organization';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
-import useQuery from 'src/utils/useQuery';
-import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
+import useStickyTabs from 'src/utils/useStickyTabs';
 
 import BatchDetails from './BatchDetails';
 import BatchHistory from './BatchHistory';
@@ -33,26 +32,15 @@ type InventoryBatchProps = {
   species: Species[];
 };
 
-const initializeTab = (tab: string | null): 'details' | 'history' => {
-  if (tab === 'history') {
-    return 'history';
-  }
-  return 'details';
-};
-
 export default function InventoryBatchView({ origin, species }: InventoryBatchProps) {
   const dispatch = useAppDispatch();
   const contentRef = useRef(null);
   const theme = useTheme();
-  const query = useQuery();
   const { batchId } = useParams<{ batchId: string }>();
   const { speciesId } = useParams<{ speciesId: string }>();
   const { nurseryId } = useParams<{ nurseryId: string }>();
   const batch = useAppSelector(selectBatch(batchId || -1));
-  const tab = initializeTab(query.get('tab'));
-  const [activeTab, setActiveTab] = useState<string>(tab);
   const navigate = useSyncNavigate();
-  const location = useStateLocation();
   const [inventorySpecies, setInventorySpecies] = useState<Species>();
   const [inventoryNursery, setInventoryNursery] = useState<Facility>();
   const { selectedOrganization } = useOrganization();
@@ -81,10 +69,6 @@ export default function InventoryBatchView({ origin, species }: InventoryBatchPr
     }
   }, [nurseryId, batch, selectedOrganization]);
 
-  useEffect(() => {
-    setActiveTab(tab);
-  }, [tab]);
-
   const getSpeciesLabel = () => {
     const { scientificName, commonName } = inventorySpecies || {};
 
@@ -101,14 +85,6 @@ export default function InventoryBatchView({ origin, species }: InventoryBatchPr
     return inventoryNursery?.name || '';
   };
 
-  const onTabChange = useCallback(
-    (newTab: string) => {
-      query.set('tab', newTab);
-      navigate(getLocation(location.pathname, location, query.toString()));
-    },
-    [query, navigate, location]
-  );
-
   const fetchBatch = useCallback(() => {
     if (batchId) {
       void dispatch(requestFetchBatch({ batchId }));
@@ -118,6 +94,31 @@ export default function InventoryBatchView({ origin, species }: InventoryBatchPr
   useEffect(() => {
     fetchBatch();
   }, [batchId, fetchBatch]);
+
+  const tabs = useMemo(() => {
+    if (!batch) {
+      return [];
+    }
+
+    return [
+      {
+        id: 'details',
+        label: strings.DETAILS,
+        children: <BatchDetails batch={batch} onUpdate={fetchBatch} />,
+      },
+      {
+        id: 'history',
+        label: strings.HISTORY,
+        children: <BatchHistory batchId={batch.id} nurseryName={inventoryNursery?.name} />,
+      },
+    ];
+  }, [batch, fetchBatch, inventoryNursery]);
+
+  const { activeTab, onTabChange } = useStickyTabs({
+    defaultTab: 'details',
+    tabs,
+    viewIdentifier: 'inventory-batch-details',
+  });
 
   return (
     <TfMain>
@@ -220,22 +221,7 @@ export default function InventoryBatchView({ origin, species }: InventoryBatchPr
                 },
               }}
             >
-              <Tabs
-                activeTab={activeTab}
-                onTabChange={onTabChange}
-                tabs={[
-                  {
-                    id: 'details',
-                    label: strings.DETAILS,
-                    children: <BatchDetails batch={batch} onUpdate={fetchBatch} />,
-                  },
-                  {
-                    id: 'history',
-                    label: strings.HISTORY,
-                    children: <BatchHistory batchId={batch.id} nurseryName={inventoryNursery?.name} />,
-                  },
-                ]}
-              />
+              <Tabs activeTab={activeTab} onTabChange={onTabChange} tabs={tabs} />
             </Box>
           </Grid>
         )}

--- a/src/scenes/InventoryRouter/InventoryBatchView.tsx
+++ b/src/scenes/InventoryRouter/InventoryBatchView.tsx
@@ -114,7 +114,7 @@ export default function InventoryBatchView({ origin, species }: InventoryBatchPr
     ];
   }, [batch, fetchBatch, inventoryNursery]);
 
-  const { activeTab, onTabChange } = useStickyTabs({
+  const { activeTab, onChangeTab } = useStickyTabs({
     defaultTab: 'details',
     tabs,
     viewIdentifier: 'inventory-batch-details',
@@ -221,7 +221,7 @@ export default function InventoryBatchView({ origin, species }: InventoryBatchPr
                 },
               }}
             >
-              <Tabs activeTab={activeTab} onTabChange={onTabChange} tabs={tabs} />
+              <Tabs activeTab={activeTab} onChangeTab={onChangeTab} tabs={tabs} />
             </Box>
           </Grid>
         )}

--- a/src/scenes/InventoryRouter/InventoryCellRenderer.tsx
+++ b/src/scenes/InventoryRouter/InventoryCellRenderer.tsx
@@ -29,7 +29,6 @@ export default function InventoryCellRenderer(props: RendererProps<TableRowType>
   };
 
   const createLinkWithQuery = (path: string, iValue: React.ReactNode | unknown[]) => {
-    query.delete('tab');
     const queryString = query.toString();
 
     let to = path;

--- a/src/scenes/InventoryRouter/InventoryV2View.tsx
+++ b/src/scenes/InventoryRouter/InventoryV2View.tsx
@@ -222,7 +222,7 @@ export default function InventoryV2View(props: InventoryProps): JSX.Element {
     ];
   }, [activeLocale, isOnboarded]);
 
-  const { activeTab, onTabChange } = useStickyTabs({
+  const { activeTab, onChangeTab } = useStickyTabs({
     defaultTab: InventoryListTypes.BATCHES_BY_SPECIES,
     tabs,
     viewIdentifier: 'inventory',
@@ -309,7 +309,7 @@ export default function InventoryV2View(props: InventoryProps): JSX.Element {
         }}
       >
         {isOnboarded ? (
-          <Tabs activeTab={activeTab} onTabChange={onTabChange} tabs={tabs} />
+          <Tabs activeTab={activeTab} onChangeTab={onChangeTab} tabs={tabs} />
         ) : (
           <Container maxWidth={false} sx={{ padding: '32px 0' }}>
             {!isMobile && <Grid item xs={12} padding={theme.spacing(3)} />}

--- a/src/scenes/InventoryRouter/InventoryV2View.tsx
+++ b/src/scenes/InventoryRouter/InventoryV2View.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 
 import { Box, Container, Grid, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem, Tabs } from '@terraware/web-components';
@@ -11,14 +11,12 @@ import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
-import { useOrganization, useUser } from 'src/providers';
-import { PreferencesService } from 'src/services';
+import { useLocalization, useOrganization } from 'src/providers';
 import NurseryInventoryService, { SearchInventoryParams } from 'src/services/NurseryInventoryService';
 import strings from 'src/strings';
 import { isAdmin } from 'src/utils/organization';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
-import useQuery from 'src/utils/useQuery';
-import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
+import useStickyTabs from 'src/utils/useStickyTabs';
 
 import DownloadReportModal from './DownloadReportModal';
 import ImportInventoryModal from './ImportInventoryModal';
@@ -119,31 +117,15 @@ type InventoryProps = {
   hasSpecies: boolean;
 };
 
-const initializeTab = (queryTab: string | null, userPrefValue: string | undefined): InventoryListType => {
-  if (Object.values(InventoryListTypes).some((val: InventoryListType) => val === queryTab)) {
-    return queryTab as InventoryListType;
-  }
-
-  if (Object.values(InventoryListTypes).some((val: InventoryListType) => val === userPrefValue)) {
-    return userPrefValue as InventoryListType;
-  }
-
-  return InventoryListTypes.BATCHES_BY_SPECIES;
-};
-
 export default function InventoryV2View(props: InventoryProps): JSX.Element {
+  const { activeLocale } = useLocalization();
   const { selectedOrganization } = useOrganization();
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
   const navigate = useSyncNavigate();
-  const location = useStateLocation();
   const { hasNurseries, hasSpecies } = props;
   const [importInventoryModalOpen, setImportInventoryModalOpen] = useState(false);
   const contentRef = useRef(null);
-  const { userPreferences, reloadUserPreferences } = useUser();
-  const query = useQuery();
-  const tab = initializeTab(query.get('tab'), userPreferences.inventoryListType as string);
-  const [activeTab, setActiveTab] = useState<InventoryListType>(tab);
   const [reportModalOpen, setReportModalOpen] = useState(false);
   const [reportData, setReportData] = useState<SearchInventoryParams>();
 
@@ -153,20 +135,6 @@ export default function InventoryV2View(props: InventoryProps): JSX.Element {
     padding: '48px',
     width: isMobile ? 'auto' : '800px',
   };
-
-  const onTabChange = useCallback(
-    async (newTab: string) => {
-      await PreferencesService.updateUserPreferences({ inventoryListType: newTab });
-      reloadUserPreferences();
-      query.set('tab', newTab);
-      navigate(getLocation(location.pathname, location, query.toString()));
-    },
-    [query, navigate, location, reloadUserPreferences]
-  );
-
-  useEffect(() => {
-    setActiveTab(tab);
-  }, [tab]);
 
   const goTo = (appPath: string) => {
     const appPathLocation = {
@@ -229,6 +197,36 @@ export default function InventoryV2View(props: InventoryProps): JSX.Element {
 
     return emptyState;
   };
+
+  const tabs = useMemo(() => {
+    if (!activeLocale || !isOnboarded) {
+      return [];
+    }
+
+    return [
+      {
+        id: InventoryListTypes.BATCHES_BY_SPECIES,
+        label: strings.BY_SPECIES,
+        children: <InventoryListBySpecies setReportData={setReportData} />,
+      },
+      {
+        id: InventoryListTypes.BATCHES_BY_NURSERY,
+        label: strings.BY_NURSERY,
+        children: <InventoryListByNursery setReportData={setReportData} />,
+      },
+      {
+        id: InventoryListTypes.BATCHES_BY_BATCH,
+        label: strings.BY_BATCH,
+        children: <InventoryListByBatch setReportData={setReportData} />,
+      },
+    ];
+  }, [activeLocale, isOnboarded]);
+
+  const { activeTab, onTabChange } = useStickyTabs({
+    defaultTab: InventoryListTypes.BATCHES_BY_SPECIES,
+    tabs,
+    viewIdentifier: 'inventory',
+  });
 
   return (
     <TfMain>
@@ -311,27 +309,7 @@ export default function InventoryV2View(props: InventoryProps): JSX.Element {
         }}
       >
         {isOnboarded ? (
-          <Tabs
-            activeTab={activeTab}
-            onTabChange={(newTab) => void onTabChange(newTab)}
-            tabs={[
-              {
-                id: InventoryListTypes.BATCHES_BY_SPECIES,
-                label: strings.BY_SPECIES,
-                children: <InventoryListBySpecies setReportData={setReportData} />,
-              },
-              {
-                id: InventoryListTypes.BATCHES_BY_NURSERY,
-                label: strings.BY_NURSERY,
-                children: <InventoryListByNursery setReportData={setReportData} />,
-              },
-              {
-                id: InventoryListTypes.BATCHES_BY_BATCH,
-                label: strings.BY_BATCH,
-                children: <InventoryListByBatch setReportData={setReportData} />,
-              },
-            ]}
-          />
+          <Tabs activeTab={activeTab} onTabChange={onTabChange} tabs={tabs} />
         ) : (
           <Container maxWidth={false} sx={{ padding: '32px 0' }}>
             {!isMobile && <Grid item xs={12} padding={theme.spacing(3)} />}

--- a/src/scenes/NurseryRouter/NurseryPlantingsAndWithdrawalsView.tsx
+++ b/src/scenes/NurseryRouter/NurseryPlantingsAndWithdrawalsView.tsx
@@ -1,7 +1,7 @@
 /**
  * Nursery plantings and withdrawals
  */
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Tabs } from '@terraware/web-components';
@@ -9,14 +9,12 @@ import { Tabs } from '@terraware/web-components';
 import PageSnackbar from 'src/components/PageSnackbar';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import TfMain from 'src/components/common/TfMain';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
 import { requestPlantings } from 'src/redux/features/plantings/plantingsThunks';
 import { requestPlantingSitesSearchResults } from 'src/redux/features/tracking/trackingThunks';
 import { useAppDispatch } from 'src/redux/store';
 import strings from 'src/strings';
-import useQuery from 'src/utils/useQuery';
-import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
+import useStickyTabs from 'src/utils/useStickyTabs';
 
 import NurseryWithdrawals from './NurseryWithdrawalsTabContent';
 import PlantingProgress from './PlantingProgressTabContent';
@@ -25,35 +23,36 @@ export default function NurseryPlantingsAndWithdrawalsView(): JSX.Element {
   const { activeLocale } = useLocalization();
   const { selectedOrganization } = useOrganization();
   const theme = useTheme();
-  const query = useQuery();
-  const navigate = useSyncNavigate();
-  const location = useStateLocation();
   const contentRef = useRef(null);
   const dispatch = useAppDispatch();
-  const tab = query.get('tab') || 'planting_progress';
 
-  const [activeTab, setActiveTab] = useState<string>(tab);
+  const tabs = useMemo(() => {
+    if (!activeLocale) {
+      return [];
+    }
 
-  const onTabChange = useCallback(
-    (newTab: string) => {
-      query.set('tab', newTab);
-      navigate(getLocation(location.pathname, location, query.toString()));
-    },
-    [query, navigate, location]
-  );
+    return [
+      {
+        id: 'planting_progress',
+        label: strings.PLANTING_PROGRESS,
+        children: <PlantingProgress />,
+      },
+      { id: 'withdrawal_history', label: strings.WITHDRAWAL_HISTORY, children: <NurseryWithdrawals /> },
+    ];
+  }, [activeLocale]);
+
+  const { activeTab, onTabChange } = useStickyTabs({
+    defaultTab: 'planting_progress',
+    tabs,
+    viewIdentifier: 'nursery-plantings-and-withdrawals',
+  });
 
   useEffect(() => {
     if (selectedOrganization) {
       void dispatch(requestPlantings(selectedOrganization.id));
       void dispatch(requestPlantingSitesSearchResults(selectedOrganization.id));
     }
-  }, [dispatch, selectedOrganization?.id]);
-
-  useEffect(() => {
-    if (activeLocale) {
-      setActiveTab(tab);
-    }
-  }, [tab, activeLocale]);
+  }, [dispatch, selectedOrganization, selectedOrganization?.id]);
 
   return (
     <TfMain>
@@ -93,18 +92,7 @@ export default function NurseryPlantingsAndWithdrawalsView(): JSX.Element {
               },
             }}
           >
-            <Tabs
-              activeTab={activeTab}
-              onTabChange={onTabChange}
-              tabs={[
-                {
-                  id: 'planting_progress',
-                  label: strings.PLANTING_PROGRESS,
-                  children: <PlantingProgress />,
-                },
-                { id: 'withdrawal_history', label: strings.WITHDRAWAL_HISTORY, children: <NurseryWithdrawals /> },
-              ]}
-            />
+            <Tabs activeTab={activeTab} onTabChange={onTabChange} tabs={tabs} />
           </Box>
         </Grid>
       </Box>

--- a/src/scenes/NurseryRouter/NurseryPlantingsAndWithdrawalsView.tsx
+++ b/src/scenes/NurseryRouter/NurseryPlantingsAndWithdrawalsView.tsx
@@ -41,7 +41,7 @@ export default function NurseryPlantingsAndWithdrawalsView(): JSX.Element {
     ];
   }, [activeLocale]);
 
-  const { activeTab, onTabChange } = useStickyTabs({
+  const { activeTab, onChangeTab } = useStickyTabs({
     defaultTab: 'planting_progress',
     tabs,
     viewIdentifier: 'nursery-plantings-and-withdrawals',
@@ -92,7 +92,7 @@ export default function NurseryPlantingsAndWithdrawalsView(): JSX.Element {
               },
             }}
           >
-            <Tabs activeTab={activeTab} onTabChange={onTabChange} tabs={tabs} />
+            <Tabs activeTab={activeTab} onChangeTab={onChangeTab} tabs={tabs} />
           </Box>
         </Grid>
       </Box>

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
@@ -189,7 +189,7 @@ export default function NurseryWithdrawalsDetailsView({
   const { activeTab, onTabChange } = useStickyTabs({
     defaultTab: 'withdrawal',
     tabs,
-    viewIdentifier: 'nursery-withdrawal-details',
+    viewIdentifier: 'nursery-withdrawal',
   });
 
   return (

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
@@ -186,7 +186,7 @@ export default function NurseryWithdrawalsDetailsView({
     ];
   }, [species, plantingSubzoneNames, withdrawal, withdrawalSummary, delivery, batches, activeLocale]);
 
-  const { activeTab, onTabChange } = useStickyTabs({
+  const { activeTab, onChangeTab } = useStickyTabs({
     defaultTab: 'withdrawal',
     tabs,
     viewIdentifier: 'nursery-withdrawal',
@@ -261,7 +261,7 @@ export default function NurseryWithdrawalsDetailsView({
           </Box>
         )}
         {withdrawal?.purpose === OUTPLANT && withdrawalSummary?.hasReassignments && (
-          <Tabs activeTab={activeTab} onTabChange={onTabChange} tabs={tabs} />
+          <Tabs activeTab={activeTab} onChangeTab={onChangeTab} tabs={tabs} />
         )}
         {withdrawal?.purpose === OUTPLANT && !withdrawalSummary?.hasReassignments && (
           <Box sx={contentPanelProps}>

--- a/src/scenes/ObservationsRouter/ObservationsHome.tsx
+++ b/src/scenes/ObservationsRouter/ObservationsHome.tsx
@@ -92,7 +92,7 @@ export default function ObservationsHome(props: ObservationsHomeProps): JSX.Elem
     ];
   }, [activeLocale, plantingSite, props]);
 
-  const { activeTab, onTabChange } = useStickyTabs({
+  const { activeTab, onChangeTab } = useStickyTabs({
     defaultTab: 'plantMonitoring',
     tabs,
     viewIdentifier: 'observations',
@@ -147,7 +147,7 @@ export default function ObservationsHome(props: ObservationsHomeProps): JSX.Elem
     >
       <Box display='flex' flexGrow={1} flexDirection='column'>
         <ObservationsEventsNotification events={upcomingObservations} />
-        <Tabs activeTab={activeTab} onTabChange={onTabChange} tabs={tabs} />
+        <Tabs activeTab={activeTab} onChangeTab={onChangeTab} tabs={tabs} />
       </Box>
     </PlantsPrimaryPage>
   );

--- a/src/scenes/ObservationsRouter/ObservationsHome.tsx
+++ b/src/scenes/ObservationsRouter/ObservationsHome.tsx
@@ -77,6 +77,7 @@ export default function ObservationsHome(props: ObservationsHomeProps): JSX.Elem
     if (!activeLocale) {
       return [];
     }
+
     return [
       {
         id: 'plantMonitoring',
@@ -94,8 +95,7 @@ export default function ObservationsHome(props: ObservationsHomeProps): JSX.Elem
   const { activeTab, onTabChange } = useStickyTabs({
     defaultTab: 'plantMonitoring',
     tabs,
-    viewIdentifier: 'accelerator-overview',
-    keepQuery: false,
+    viewIdentifier: 'observations',
   });
 
   const newObservationsSchedulable = useMemo(() => {

--- a/src/scenes/Reports/AcceleratorReportsView.tsx
+++ b/src/scenes/Reports/AcceleratorReportsView.tsx
@@ -55,7 +55,7 @@ const AcceleratorReportsView = () => {
     ];
   }, [activeLocale, projectFilter?.projectId]);
 
-  const { activeTab, onTabChange } = useStickyTabs({
+  const { activeTab, onChangeTab } = useStickyTabs({
     defaultTab: 'reports',
     tabs,
     viewIdentifier: 'accelerator-reports',
@@ -97,7 +97,7 @@ const AcceleratorReportsView = () => {
   return (
     <Page hierarchicalCrumbs={false} leftComponent={PageHeaderLeftComponent} title={strings.REPORTS}>
       <Box display='flex' flexDirection='column' flexGrow={1}>
-        <Tabs activeTab={activeTab} onTabChange={onTabChange} tabs={tabs} />
+        <Tabs activeTab={activeTab} onChangeTab={onChangeTab} tabs={tabs} />
       </Box>
     </Page>
   );

--- a/src/scenes/Reports/AcceleratorReportsView.tsx
+++ b/src/scenes/Reports/AcceleratorReportsView.tsx
@@ -59,7 +59,6 @@ const AcceleratorReportsView = () => {
     defaultTab: 'reports',
     tabs,
     viewIdentifier: 'accelerator-reports',
-    keepQuery: true,
   });
 
   const PageHeaderLeftComponent = useMemo(

--- a/src/scenes/Settings/SettingsPage.tsx
+++ b/src/scenes/Settings/SettingsPage.tsx
@@ -53,13 +53,13 @@ const SettingsPage = () => {
     ];
   }, [activeLocale, user, reloadUser, isEditingAccount, isDeleteModalOpen]);
 
-  const { activeTab, onTabChange } = useStickyTabs({
+  const { activeTab, onChangeTab } = useStickyTabs({
     defaultTab: 'my-account',
     tabs,
     viewIdentifier: 'settings',
   });
 
-  const onTabChangeHandler = useCallback(
+  const onChangeTabHandler = useCallback(
     (tab: string) => {
       if (tab !== 'my-account') {
         mixpanel?.track(MIXPANEL_EVENTS.SETTINGS_TAB, {
@@ -67,9 +67,9 @@ const SettingsPage = () => {
         });
       }
       setIsEditingAccount(false);
-      onTabChange(tab);
+      onChangeTab(tab);
     },
-    [mixpanel, onTabChange]
+    [mixpanel, onChangeTab]
   );
 
   const onOptionItemClick = (optionItem: DropdownItem) => {
@@ -131,7 +131,7 @@ const SettingsPage = () => {
           </Box>
         </PageHeaderWrapper>
         <Box ref={contentRef}>
-          <Tabs activeTab={activeTab} onTabChange={onTabChangeHandler} tabs={tabs} />
+          <Tabs activeTab={activeTab} onChangeTab={onChangeTabHandler} tabs={tabs} />
         </Box>
       </Box>
     </Page>

--- a/src/scenes/Settings/SettingsPage.tsx
+++ b/src/scenes/Settings/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useMixpanel } from 'react-mixpanel-browser';
 
 import { Box, useTheme } from '@mui/material';
@@ -57,18 +57,20 @@ const SettingsPage = () => {
     defaultTab: 'my-account',
     tabs,
     viewIdentifier: 'settings',
-    keepQuery: false,
   });
 
-  const onTabChangeHandler = (tab: string) => {
-    if (tab !== 'my-account') {
-      mixpanel?.track(MIXPANEL_EVENTS.SETTINGS_TAB, {
-        tab,
-      });
-    }
-    setIsEditingAccount(false);
-    onTabChange(tab);
-  };
+  const onTabChangeHandler = useCallback(
+    (tab: string) => {
+      if (tab !== 'my-account') {
+        mixpanel?.track(MIXPANEL_EVENTS.SETTINGS_TAB, {
+          tab,
+        });
+      }
+      setIsEditingAccount(false);
+      onTabChange(tab);
+    },
+    [mixpanel, onTabChange]
+  );
 
   const onOptionItemClick = (optionItem: DropdownItem) => {
     if (optionItem.value === 'delete-account') {

--- a/src/utils/filterHooks/useSessionFilters.ts
+++ b/src/utils/filterHooks/useSessionFilters.ts
@@ -55,8 +55,10 @@ export const useSessionFilters = (viewIdentifier?: string) => {
 
       writeFiltersToSession(viewIdentifier, mergedFilters);
 
-      writeFiltersToQuery(query, viewIdentifier, mergedFilters);
-      navigate(getLocation(location.pathname, location, query.toString()));
+      if (Object.keys(mergedFilters).length) {
+        writeFiltersToQuery(query, viewIdentifier, mergedFilters);
+        navigate(getLocation(location.pathname, location, query.toString()));
+      }
 
       setIsInitialized(true);
     }

--- a/src/utils/useStickyTabs.ts
+++ b/src/utils/useStickyTabs.ts
@@ -56,8 +56,6 @@ const useStickyTabs = ({ defaultTab, tabs, viewIdentifier }: StickyTabsProps) =>
       const sessionTab = getTabFromSession(viewIdentifier);
       if (sessionTab) {
         onTabChange(sessionTab);
-      } else {
-        // onTabChange(defaultTab);
       }
       return;
     }

--- a/src/utils/useStickyTabs.ts
+++ b/src/utils/useStickyTabs.ts
@@ -11,8 +11,6 @@ interface StickyTabsProps {
   defaultTab: string;
   tabs: Tab[];
   viewIdentifier: string;
-  keepQuery?: boolean;
-  tabsAreNewPages?: boolean;
 }
 
 const makeTabSessionKey = (viewIdentifier: string) => `tab-${viewIdentifier}`;
@@ -33,55 +31,49 @@ const writeTabToSession = (viewIdentifier: string, tab: string): void => {
   }
 };
 
-const useStickyTabs = ({
-  defaultTab,
-  tabs,
-  viewIdentifier,
-  keepQuery = true,
-  tabsAreNewPages = true,
-}: StickyTabsProps) => {
+const useStickyTabs = ({ defaultTab, tabs, viewIdentifier }: StickyTabsProps) => {
   const location = useStateLocation();
   const navigate = useSyncNavigate();
   const query = useQuery();
-  const tab = query.get('tab');
+  const queryTab = query.get('tab');
 
   const [activeTab, setActiveTab] = useState<string>(defaultTab);
 
   const onTabChange = useCallback(
     (newTab: string) => {
-      query.set('tab', newTab);
-      const emptyQuery = tab === newTab ? query.toString() : new URLSearchParams(`tab=${newTab}`);
-      navigate(getLocation(location.pathname, location, keepQuery ? query.toString() : emptyQuery.toString()), {
-        replace: !tabsAreNewPages,
-      });
+      if (queryTab) {
+        navigate(getLocation(location.pathname, location), { replace: true });
+      }
+      setActiveTab(newTab);
       writeTabToSession(viewIdentifier, newTab);
     },
-    [navigate, location, query, viewIdentifier, keepQuery, tab, tabsAreNewPages]
+    [navigate, location, viewIdentifier, queryTab, defaultTab]
   );
 
   useEffect(() => {
-    if (!tab) {
+    if (!queryTab) {
       // If there is a "last viewed" tab in the session, use that, otherwise send to default
       const sessionTab = getTabFromSession(viewIdentifier);
       if (sessionTab) {
         onTabChange(sessionTab);
       } else {
-        onTabChange(defaultTab);
+        // onTabChange(defaultTab);
       }
       return;
     }
 
-    if (tabs.some((data) => data.id === tab)) {
-      setActiveTab(tab);
+    if (tabs.some((data) => data.id === queryTab)) {
+      setActiveTab(queryTab);
     } else if (tabs.length) {
       setActiveTab(tabs[0].id);
     }
-  }, [defaultTab, onTabChange, tab, tabs, viewIdentifier]);
+  }, [defaultTab, onTabChange, queryTab, tabs, viewIdentifier]);
 
   return {
     activeTab,
     onTabChange,
-    tab,
+    setActiveTab,
+    tab: queryTab,
   };
 };
 

--- a/src/utils/useStickyTabs.ts
+++ b/src/utils/useStickyTabs.ts
@@ -39,7 +39,7 @@ const useStickyTabs = ({ defaultTab, tabs, viewIdentifier }: StickyTabsProps) =>
 
   const [activeTab, setActiveTab] = useState<string>(defaultTab);
 
-  const onTabChange = useCallback(
+  const onChangeTab = useCallback(
     (newTab: string) => {
       if (queryTab) {
         navigate(getLocation(location.pathname, location), { replace: true });
@@ -55,8 +55,9 @@ const useStickyTabs = ({ defaultTab, tabs, viewIdentifier }: StickyTabsProps) =>
       // If there is a "last viewed" tab in the session, use that, otherwise send to default
       const sessionTab = getTabFromSession(viewIdentifier);
       if (sessionTab) {
-        onTabChange(sessionTab);
+        onChangeTab(sessionTab);
       }
+
       return;
     }
 
@@ -65,11 +66,11 @@ const useStickyTabs = ({ defaultTab, tabs, viewIdentifier }: StickyTabsProps) =>
     } else if (tabs.length) {
       setActiveTab(tabs[0].id);
     }
-  }, [defaultTab, onTabChange, queryTab, tabs, viewIdentifier]);
+  }, [defaultTab, onChangeTab, queryTab, tabs, viewIdentifier]);
 
   return {
     activeTab,
-    onTabChange,
+    onChangeTab,
     setActiveTab,
     tab: queryTab,
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4112,10 +4112,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^3.4.24":
-  version "3.4.24"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.4.24.tgz#743408a1fee28060fabc967430ff7c4ae6152f2c"
-  integrity sha512-u95bgLSvAm/+Qz/hMHT1Lxtx9sNrTM6I66NC4dK2RRW369yI24vcxDc4NU/buhe8UlmYiatrYVQrnifd5EjmNQ==
+"@terraware/web-components@^3.4.25":
+  version "3.4.25"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.4.25.tgz#10057c74e0f726a64085e9b2f05d5e90bd2fb08b"
+  integrity sha512-urvjwpw1fjoRRjRztLFM7pu9oXbOsaw944WnbRT8hkfzh+i7XBHCXFhC8DSc6yJs9e1+fafAyAXb+hmqyspMdQ==
   dependencies:
     "@dnd-kit/core" "^6.0.7"
     "@dnd-kit/sortable" "^7.0.2"


### PR DESCRIPTION
This PR fixes an issue where the back button failed in some scenarios.

Previously, active tab state was managed by both React state and query params. When navigating back to a page with sticky tabs, replacing the URL triggered a new history stack, causing the previous history to be lost.

Note: The `tab` query param can still  beused to indicate a tab to load and if set, will override the tab stored from the previous session.