### PR TITLE
Disable no-console

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -249,7 +249,7 @@ export default fixupConfigRules([
       'no-class-assign': 'error',
       'no-compare-neg-zero': 'error',
       'no-cond-assign': 'error',
-      'no-console': 'off',
+      'no-console': 'warn',
       'no-const-assign': 'error',
       'no-constant-binary-expression': 'error',
       'no-constant-condition': 'error',


### PR DESCRIPTION
I'd like to disable the `no-console` rule for now. We should catch console statements in CI or commit hooks instead of showing editor errors. I use `console.log` heavily during development and would prefer to not deal with constant red squiggles or repeatedly disabling the rule.