### PR TITLE
SW-6844 Rename biomass CSVs; only allow zip export

### DIFF
--- a/src/scenes/ObservationsRouter/biomass/useExportBiomassDetailsZip.ts
+++ b/src/scenes/ObservationsRouter/biomass/useExportBiomassDetailsZip.ts
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+
+import sanitize from 'sanitize-filename';
+
+import ObservationsService from 'src/services/ObservationsService';
+import strings from 'src/strings';
+import { ObservationResultsPayload } from 'src/types/Observations';
+import { PlantingSite } from 'src/types/Tracking';
+import downloadZipFile from 'src/utils/downloadZipFile';
+
+export default function useExportBiomassDetailsZip(
+  observation?: ObservationResultsPayload,
+  plantingSite?: PlantingSite
+) {
+  return useCallback(async () => {
+    if (observation && plantingSite) {
+      const fileNamePrefix = `${plantingSite.name}-${observation.startDate}-${strings.BIOMASS_OBSERVATION_FILENAME_PREFIX}`;
+      await downloadZipFile({
+        dirName: sanitize(fileNamePrefix),
+        files: [
+          {
+            fileName: `${fileNamePrefix}-${strings.PLOT}`,
+            content: () => ObservationsService.exportBiomassPlotCsv(observation.observationId),
+          },
+          {
+            fileName: `${fileNamePrefix}-${strings.QUADRAT}`,
+            content: () => ObservationsService.exportBiomassQuadratCsv(observation.observationId),
+          },
+          {
+            fileName: `${fileNamePrefix}-${strings.TREES_AND_SHRUBS}`,
+            content: () => ObservationsService.exportBiomassTreesShrubsCsv(observation.observationId),
+          },
+        ],
+        suffix: '.csv',
+      });
+    }
+  }, [observation, plantingSite]);
+}

--- a/src/services/ObservationsService.ts
+++ b/src/services/ObservationsService.ts
@@ -130,7 +130,7 @@ const exportBiomassObservationsCsv = async (organizationId: number, plantingSite
   });
 };
 
-const exportBiomassDetailsCsv = async (observationId: number): Promise<any> => {
+const exportBiomassPlotCsv = async (observationId: number): Promise<any> => {
   return SearchService.searchCsv({
     prefix: 'plantingSites.observations',
     fields: [
@@ -171,7 +171,7 @@ const exportBiomassDetailsCsv = async (observationId: number): Promise<any> => {
   });
 };
 
-const exportBiomassSpeciesCsv = async (observationId: number): Promise<any> => {
+const exportBiomassQuadratCsv = async (observationId: number): Promise<any> => {
   return SearchService.searchCsv({
     prefix: 'plantingSites.observations.observationPlots.biomassDetails.species',
     fields: ['name', 'quadratSpecies_position', 'quadratSpecies_abundancePercent', 'isInvasive', 'isThreatened'],
@@ -462,9 +462,9 @@ const listAdHocObservationResults = async (
  * Exported functions
  */
 const ObservationsService = {
-  exportBiomassDetailsCsv,
   exportBiomassObservationsCsv,
-  exportBiomassSpeciesCsv,
+  exportBiomassPlotCsv,
+  exportBiomassQuadratCsv,
   exportBiomassTreesShrubsCsv,
   exportCsv,
   exportGpx,

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -222,6 +222,7 @@ BIOMASS_EMPTY_STATE_MESSAGE_2,Observations for Biomass Monitoring can be recorde
 BIOMASS_MEASUREMENT,Biomass Measurement,
 BIOMASS_MEASUREMENTS,Biomass Measurements,
 BIOMASS_MONITORING,Biomass Monitoring,
+BIOMASS_OBSERVATION_FILENAME_PREFIX,Biomass-Observation,Included as part of the filename for data files with biomass observation data. Should not include whitespace.
 BOOLEAN_FALSE,false,
 BOOLEAN_TRUE,true,
 BOUNDARIES,Boundaries,
@@ -638,6 +639,7 @@ EXPORT_ALL_ZIP,Export All (ZIP),
 EXPORT_BIOMASS_MONITORING_DETAILS_CSV,Export Biomass Monitoring Details (CSV),
 EXPORT_LOCATIONS,Export Locations,
 EXPORT_LOCATIONS_DISABLED_TOOLTIP,Plot locations are determined at the start of the observation,
+EXPORT_OBSERVATION_DETAILS_CSV,Export Observation Details (CSV),
 EXPORT_PROJECT_BOUNDARY,Export Project Boundary,
 EXPORT_RECORDS,Export Records,
 EXPORT_RESULTS,Export Results,Menu option to export the results of an observation
@@ -1510,6 +1512,7 @@ Q1_TARGET,Q1 Target,
 Q2_TARGET,Q2 Target,
 Q3_TARGET,Q3 Target,
 Q4_TARGET,Q4 Target,
+QUADRAT,Quadrat,"Not a misspelling of ""quadrant."" A quadrat is a 1-meter-square area used for ecological surveys."
 QUALITATIVE,Qualitative,
 QUALITATIVE_INFO,Qualitative Info,
 QUANTITY,Quantity,


### PR DESCRIPTION
We can download a zip archive with all three of the biomass
observation details CSVs, so remove the options to download
the individual CSVs, which were only there initially because
we hadn't yet implemented zip downloads.

The files now have updated names, and the download logic is
moved to a helper function in anticipation of adding export
capability to the biomass observations list view.