### PR TITLE
Don't install Playwright if we aren't running it

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -83,6 +83,7 @@ jobs:
           TERRAWARE_MAPBOX_API_TOKEN: ${{ secrets.REACT_APP_MAPBOX_TOKEN }}
 
       - name: Install Playwright Browsers
+        if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
         run: yarn playwright install --with-deps
 
       - name: Run end-to-end playwright tests


### PR DESCRIPTION
We only run Playwright tests on PRs, but we install its
dependencies including browsers no matter what. Skip the
install step if we're not going to run it.