### PR TITLE
Declare cached selector types; fix missing parameter

### DIFF
--- a/src/redux/features/observations/observationDetailsSelectors.ts
+++ b/src/redux/features/observations/observationDetailsSelectors.ts
@@ -35,7 +35,11 @@ export const selectObservationDetails = createSelector(
     observationsResults?.find((observation: ObservationResults) => observation.observationId === params.observationId)
 );
 
-export const searchObservationDetails = createCachedSelector(
+export const searchObservationDetails: (
+  state: RootState,
+  params: DetailsSearchParams,
+  defaultTimeZone: string
+) => ObservationResults | undefined = createCachedSelector(
   selectObservationDetails,
   (state: RootState, params: DetailsSearchParams, defaultTimeZone: string) => params,
   (observation, params) => searchResultZones(params.search, params.zoneNames, observation)
@@ -47,7 +51,12 @@ export const searchObservationDetails = createCachedSelector(
 );
 
 // get zone names in observation result
-export const selectDetailsZoneNames = createCachedSelector(
+export const selectDetailsZoneNames: (
+  state: RootState,
+  plantingSiteId: number,
+  observationId: number,
+  organizationId: number
+) => string[] = createCachedSelector(
   (state: RootState, plantingSiteId: number, observationId: number, orgId: number) =>
     selectObservationDetails(state, { plantingSiteId, observationId, orgId, search: '', zoneNames: [] }, ''),
   (details) =>

--- a/src/redux/features/observations/observationPlantingZoneSelectors.ts
+++ b/src/redux/features/observations/observationPlantingZoneSelectors.ts
@@ -23,7 +23,11 @@ export const selectObservationPlantingZone = createSelector(
   }
 );
 
-export const searchObservationPlantingZone = createCachedSelector(
+export const searchObservationPlantingZone: (
+  state: RootState,
+  params: ZoneSearchParams,
+  defaultTimeZone: string
+) => ObservationPlantingZoneResults | undefined = createCachedSelector(
   selectObservationPlantingZone,
   (state: RootState, params: ZoneSearchParams, defaultTimeZone: string) => params,
   (plantingZone, params) => searchResultPlots(params.search, params.plotType, plantingZone)

--- a/src/redux/features/observations/observationsSelectors.ts
+++ b/src/redux/features/observations/observationsSelectors.ts
@@ -5,9 +5,11 @@ import { selectSpeciesList } from 'src/redux/features/species/speciesSelectors';
 import { selectPlantingSites } from 'src/redux/features/tracking/trackingSelectors';
 import { RootState } from 'src/redux/rootReducer';
 import {
+  AdHocObservationResults,
   Observation,
   ObservationPlantingZoneResults,
   ObservationResults,
+  ObservationResultsPayload,
   ObservationState,
 } from 'src/types/Observations';
 
@@ -38,7 +40,12 @@ export const selectHasCompletedObservations = (state: RootState, plantingSiteId:
  * Select observations results, filtered down by planting site and/or observation state.
  * Preserves order of results.
  */
-export const selectPlantingSiteObservationsResults = createCachedSelector(
+export const selectPlantingSiteObservationsResults: (
+  state: RootState,
+  plantingSiteId: number,
+  status?: ObservationState[],
+  orgId?: number
+) => ObservationResultsPayload[] | undefined = createCachedSelector(
   (state: RootState, plantingSiteId: number, status?: ObservationState[], orgId?: number) =>
     orgId && orgId !== -1 ? selectOrgObservationsResults(orgId)(state) : selectObservationsResults(state),
   (state: RootState, plantingSiteId: number, status?: ObservationState[], orgId?: number) => plantingSiteId,
@@ -58,7 +65,10 @@ export const selectPlantingSiteObservationsResults = createCachedSelector(
   }
 )((state, plantingSiteId: number, status?: ObservationState[]) => `${plantingSiteId}_${status?.join(',')}`);
 
-export const selectPlantingSiteAdHocObservationResults = createCachedSelector(
+export const selectPlantingSiteAdHocObservationResults: (
+  state: RootState,
+  plantingSiteId: number
+) => ObservationResultsPayload[] | undefined = createCachedSelector(
   (state: RootState, plantingSiteId: number) => selectAdHocObservationResults(state),
   (state: RootState, plantingSiteId: number) => plantingSiteId,
   (observationsResults, plantingSiteId) => {
@@ -76,7 +86,13 @@ export const selectPlantingSiteAdHocObservationResults = createCachedSelector(
  * Merge named entity information with observation results.
  * Preserves order of results.
  */
-export const selectMergedPlantingSiteObservations = createCachedSelector(
+export const selectMergedPlantingSiteObservations: (
+  state: RootState,
+  plantingSiteId: number,
+  orgId: number,
+  defaultTimeZone: string,
+  status?: ObservationState[]
+) => ObservationResults[] | undefined = createCachedSelector(
   (state: RootState, plantingSiteId: number, orgId: number, defaultTimeZone: string, status?: ObservationState[]) =>
     selectPlantingSiteObservationsResults(state, plantingSiteId, status, orgId),
   (state: RootState, plantingSiteId: number, orgId: number, defaultTimeZone: string, status?: ObservationState[]) =>
@@ -100,7 +116,11 @@ export const selectMergedPlantingSiteObservations = createCachedSelector(
     `${plantingSiteId}_${orgId}_${defaultTimeZone}_${status?.join(',')}`
 );
 
-export const selectMergedPlantingSiteAdHocObservations = createCachedSelector(
+export const selectMergedPlantingSiteAdHocObservations: (
+  state: RootState,
+  plantingSiteId: number,
+  defaultTimeZone: string
+) => AdHocObservationResults[] | undefined = createCachedSelector(
   (state: RootState, plantingSiteId: number, defaultTimeZone: string) =>
     selectPlantingSiteAdHocObservationResults(state, plantingSiteId),
   (state: RootState, plantingSiteId: number, defaultTimeZone: string) => selectPlantingSites(state),
@@ -121,7 +141,15 @@ export const selectMergedPlantingSiteAdHocObservations = createCachedSelector(
  * Search observations (search planting zone name only at this time).
  * Preserves order of results.
  */
-export const searchObservations = createCachedSelector(
+export const searchObservations: (
+  state: RootState,
+  plantingSiteId: number,
+  orgId: number,
+  defaultTimeZone: string,
+  search: string,
+  zoneNames: string[],
+  status?: ObservationState[]
+) => ObservationResults[] | undefined = createCachedSelector(
   (
     state: RootState,
     plantingSiteId: number,
@@ -164,8 +192,13 @@ export const searchObservations = createCachedSelector(
 );
 
 // get zone names in observations
-export const selectObservationsZoneNames = createCachedSelector(
-  (state: RootState, plantingSiteId: number, orgId: number, status?: ObservationState[]) =>
+export const selectObservationsZoneNames: (
+  state: RootState,
+  plantingSiteId: number,
+  orgId: number,
+  status: ObservationState[]
+) => string[] = createCachedSelector(
+  (state: RootState, plantingSiteId: number, orgId: number, status: ObservationState[]) =>
     selectMergedPlantingSiteObservations(state, plantingSiteId, orgId, '', status),
   (observations) =>
     Array.from(
@@ -176,7 +209,7 @@ export const selectObservationsZoneNames = createCachedSelector(
       )
     )
 )(
-  (state: RootState, plantingSiteId: number, status?: ObservationState[]) =>
+  (state: RootState, plantingSiteId: number, orgId: number, status: ObservationState[]) =>
     `${plantingSiteId.toString()}_${status?.join(',')}`
 );
 
@@ -195,7 +228,11 @@ export const selectObservation = (state: RootState, plantingSiteId: number, obse
   );
 
 // get observations specific to a planting site, by optional status
-export const selectPlantingSiteObservations = createCachedSelector(
+export const selectPlantingSiteObservations: (
+  state: RootState,
+  plantingSiteId: number,
+  status?: ObservationState
+) => Observation[] = createCachedSelector(
   (state: RootState, plantingSiteId: number, status?: ObservationState) => selectObservations(state),
   (state: RootState, plantingSiteId: number, status?: ObservationState) => plantingSiteId,
   (state: RootState, plantingSiteId: number, status?: ObservationState) => status,
@@ -211,7 +248,11 @@ export const selectPlantingSiteObservations = createCachedSelector(
 )((state: RootState, plantingSiteId: number, status?: ObservationState) => `${plantingSiteId.toString()}_${status}`);
 
 // get ad hoc observations specific to a planting site, by optional status
-export const selectPlantingSiteAdHocObservations = createCachedSelector(
+export const selectPlantingSiteAdHocObservations: (
+  state: RootState,
+  plantingSiteId: number,
+  status?: ObservationState
+) => Observation[] = createCachedSelector(
   (state: RootState, plantingSiteId: number, status?: ObservationState) => selectObservations(state, true),
   (state: RootState, plantingSiteId: number, status?: ObservationState) => plantingSiteId,
   (state: RootState, plantingSiteId: number, status?: ObservationState) => status,
@@ -227,7 +268,12 @@ export const selectPlantingSiteAdHocObservations = createCachedSelector(
 )((state: RootState, plantingSiteId: number, status?: ObservationState) => `${plantingSiteId.toString()}_${status}`);
 
 // get the latest observation for a planting site
-export const selectLatestObservation = createCachedSelector(
+export const selectLatestObservation: (
+  state: RootState,
+  plantingSiteId: number,
+  orgId: number,
+  defaultTimeZoneId: string
+) => ObservationResults | undefined = createCachedSelector(
   (state: RootState, plantingSiteId: number, orgId: number, defaultTimeZoneId: string) =>
     searchObservations(state, plantingSiteId, orgId, defaultTimeZoneId, '', [], []),
   (observationsResults: ObservationResults[] | undefined) =>
@@ -280,7 +326,12 @@ export const selectOrganizationAdHocObservationsRequest = (requestId: string) =>
 export const selectOrganizationAdHocObservationResultsRequest = (requestId: string) => (state: RootState) =>
   state.organizationAdHocObservationResults[requestId];
 
-export const searchAdHocObservations = createCachedSelector(
+export const searchAdHocObservations: (
+  state: RootState,
+  plantingSiteId: number,
+  defaultTimeZone: string,
+  search: string
+) => AdHocObservationResults[] | undefined = createCachedSelector(
   (state: RootState, plantingSiteId: number, defaultTimeZone: string, search: string) => search,
   (state: RootState, plantingSiteId: number, defaultTimeZone: string, search: string) => plantingSiteId,
   (state: RootState, plantingSiteId: number, defaultTimeZone: string, search: string) =>

--- a/src/scenes/ObservationsRouter/ObservationsDataView.tsx
+++ b/src/scenes/ObservationsRouter/ObservationsDataView.tsx
@@ -73,20 +73,29 @@ export default function ObservationsDataView(props: ObservationsDataViewProps): 
   }, [allAdHocObservationResults, selectedPlantingSite]);
 
   const zoneNames = useAppSelector((state) =>
-    selectObservationsZoneNames(state, selectedPlantingSiteId, searchProps.filtersProps?.filters.status?.values)
+    selectedOrganization
+      ? selectObservationsZoneNames(
+          state,
+          selectedPlantingSiteId,
+          selectedOrganization.id,
+          searchProps.filtersProps?.filters.status?.values
+        )
+      : undefined
   );
 
   useEffect(() => {
-    setFilterOptions({
-      zone: {
-        partial: false,
-        values: zoneNames,
-      },
-      status: {
-        partial: false,
-        values: ['Abandoned', 'Completed', 'InProgress', 'Overdue'],
-      },
-    });
+    if (zoneNames !== undefined) {
+      setFilterOptions({
+        zone: {
+          partial: false,
+          values: zoneNames,
+        },
+        status: {
+          partial: false,
+          values: ['Abandoned', 'Completed', 'InProgress', 'Overdue'],
+        },
+      });
+    }
   }, [setFilterOptions, zoneNames]);
 
   return (


### PR DESCRIPTION
`createCachedSelector` doesn't appear to reliably have a type signature
that allows TypeScript to verify that callers are passing the correct
types of arguments. Add explicit type signatures to all the cached
selectors in the observations code and fix a missing argument that was
flagged as a result.