### PR TITLE
Add type guards to org membership functions

### DIFF
--- a/src/scenes/ApplicationRouter/ApplicationsList.tsx
+++ b/src/scenes/ApplicationRouter/ApplicationsList.tsx
@@ -21,7 +21,7 @@ const ApplicationListView = () => {
   const [isNewApplicationModalOpen, setIsNewApplicationModalOpen] = useState<boolean>(false);
 
   useEffect(() => {
-    if (selectedOrganization && isAdmin(selectedOrganization) && allApplications && allApplications.length === 0) {
+    if (isAdmin(selectedOrganization) && allApplications && allApplications.length === 0) {
       setIsNewApplicationModalOpen(true);
     }
   }, [allApplications, selectedOrganization, setIsNewApplicationModalOpen]);

--- a/src/scenes/Home/OnboardingHomeView/index.tsx
+++ b/src/scenes/Home/OnboardingHomeView/index.tsx
@@ -56,7 +56,7 @@ const OnboardingHomeView = () => {
 
   useEffect(() => {
     const populatePeople = async () => {
-      if (selectedOrganization && isOwner(selectedOrganization)) {
+      if (isOwner(selectedOrganization)) {
         const response = await OrganizationUserService.getOrganizationUsers(selectedOrganization.id);
         if (response.requestSucceeded) {
           setPeople(response.users);
@@ -76,7 +76,7 @@ const OnboardingHomeView = () => {
   }, [dispatch, selectedOrganization]);
 
   const isLoadingInitialData = useMemo(
-    () => allSpecies === undefined || (selectedOrganization && isOwner(selectedOrganization) && people === undefined),
+    () => allSpecies === undefined || (isOwner(selectedOrganization) && people === undefined),
     [allSpecies, people, selectedOrganization]
   );
 

--- a/src/scenes/Home/TerrawareHomeView/index.tsx
+++ b/src/scenes/Home/TerrawareHomeView/index.tsx
@@ -205,7 +205,7 @@ const TerrawareHomeView = () => {
       },
     ];
 
-    if (!plantingSites?.length && selectedOrganization && isAdmin(selectedOrganization)) {
+    if (!plantingSites?.length && isAdmin(selectedOrganization)) {
       rows.push({
         buttonProps: {
           label: strings.ADD_PLANTING_SITE,

--- a/src/scenes/Home/index.tsx
+++ b/src/scenes/Home/index.tsx
@@ -19,7 +19,7 @@ export default function Home({ selectedOrgHasSpecies }: { selectedOrgHasSpecies:
 
   useEffect(() => {
     const populatePeople = async () => {
-      if (selectedOrganization && isAdmin(selectedOrganization)) {
+      if (isAdmin(selectedOrganization)) {
         const response = await OrganizationUserService.getOrganizationUsers(selectedOrganization.id);
         if (response.requestSucceeded) {
           setPeople(response.users);

--- a/src/scenes/OrgRouter/NavBar.tsx
+++ b/src/scenes/OrgRouter/NavBar.tsx
@@ -233,7 +233,6 @@ export default function NavBar({
     () =>
       currentParticipantProject &&
       !!orgFeatures?.data?.modules?.enabled &&
-      selectedOrganization &&
       isManagerOrHigher(selectedOrganization) &&
       activeLocale ? (
         <NavItem

--- a/src/utils/organization.tsx
+++ b/src/utils/organization.tsx
@@ -20,19 +20,18 @@ export const getSeedBank = (organization: Organization, facilityId: number): Fac
   return getAllSeedBanks(organization).find((sb) => sb?.id === facilityId);
 };
 
-export const isOwner = (organization: Organization | undefined) => {
+export const isOwner = <T extends Organization>(organization: T | undefined): organization is T => {
   return organization?.role === 'Owner';
 };
 
-export const isAdmin = (organization: Organization | undefined) => {
-  return HighOrganizationRolesValues.includes(organization?.role || '');
-};
+export const isAdmin = <T extends Organization>(organization: T | undefined): organization is T =>
+  HighOrganizationRolesValues.includes(organization?.role || '');
 
-export const isManagerOrHigher = (organization: Organization | undefined) => {
+export const isManagerOrHigher = <T extends Organization>(organization: T | undefined): organization is T => {
   return organization?.role === 'Manager' || isAdmin(organization);
 };
 
-export const isMember = (organization: Organization | undefined) => {
+export const isMember = <T extends Organization>(organization: T | undefined): organization is T => {
   return !!organization;
 };
 


### PR DESCRIPTION
The helper functions to check the user's role in an organization
accept undefined organizations and return false in that case, so
there's no need for calling code to also check that the
organization is defined.