### PR TITLE
SW-6800 Warn when scheduling observation of small site

### DIFF
--- a/src/docLinks.ts
+++ b/src/docLinks.ts
@@ -2,6 +2,7 @@ import { useLocalization } from 'src/providers';
 import { SupportedLocaleId } from 'src/strings/locales';
 
 export type DocType =
+  | 'ad_hoc_plots'
   | 'cookie_policy'
   | 'planting_site_create_boundary_instructions_video'
   | 'planting_site_create_exclusions_boundary_instructions_video'
@@ -18,6 +19,7 @@ type DocLink = Record<DocType, string>;
 
 const DOC_LINKS: Record<SupportedLocaleId, DocLink> = {
   en: {
+    ad_hoc_plots: 'https://knowledge.terraformation.com/hc/en-us/articles/36389038050708-Ad-Hoc-Plot-Observations',
     cookie_policy: 'https://www.terraformation.com/cookie-policy',
     planting_site_create_boundary_instructions_video:
       'https://player.vimeo.com/video/911493236?h=b8b5555693&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479',
@@ -37,6 +39,7 @@ const DOC_LINKS: Record<SupportedLocaleId, DocLink> = {
       'https://knowledge.terraformation.com/hc/en-us/articles/27884386873364-Strata-vs-Zones-Subzones',
   },
   es: {
+    ad_hoc_plots: 'https://knowledge.terraformation.com/hc/en-us/articles/36389038050708-Ad-Hoc-Plot-Observations',
     cookie_policy: 'https://www.terraformation.com/cookie-policy',
     planting_site_create_boundary_instructions_video:
       'https://player.vimeo.com/video/911493236?h=b8b5555693&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479',
@@ -56,6 +59,7 @@ const DOC_LINKS: Record<SupportedLocaleId, DocLink> = {
       'https://knowledge.terraformation.com/hc/en-us/articles/27884386873364-Strata-vs-Zones-Subzones',
   },
   fr: {
+    ad_hoc_plots: 'https://knowledge.terraformation.com/hc/en-us/articles/36389038050708-Ad-Hoc-Plot-Observations',
     cookie_policy: 'https://www.terraformation.com/cookie-policy',
     planting_site_create_boundary_instructions_video:
       'https://player.vimeo.com/video/911493236?h=b8b5555693&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479',

--- a/src/scenes/ObservationsRouter/schedule/ScheduleObservationForm.tsx
+++ b/src/scenes/ObservationsRouter/schedule/ScheduleObservationForm.tsx
@@ -11,11 +11,14 @@ import PageForm from 'src/components/common/PageForm';
 import TfMain from 'src/components/common/TfMain';
 import { useOrgTracking } from 'src/hooks/useOrgTracking';
 import { usePlantingSiteData } from 'src/providers/Tracking/PlantingSiteContext';
+import SmallSiteWarningDialog from 'src/scenes/ObservationsRouter/schedule/SmallSiteWarningDialog';
 import strings from 'src/strings';
 import { ScheduleObservationRequestPayload } from 'src/types/Observations';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 
 import ObservationSubzoneSelector from './ObservationSubzoneSelector';
+
+const WARN_IF_SITE_LESS_THAN_HECTARES = 3.0;
 
 export type ScheduleObservationFormProps = {
   title: string;
@@ -49,6 +52,7 @@ export default function ScheduleObservationForm({
   const [startDateError, setStartDateError] = useState<string>();
   const [endDateError, setEndDateError] = useState<string>();
   const [subzoneError, setSubzoneError] = useState<string>();
+  const [showSmallSiteWarning, setShowSmallSiteWarning] = useState<boolean>();
 
   const upcomingObservations = useMemo(() => {
     const now = Date.now();
@@ -116,12 +120,16 @@ export default function ScheduleObservationForm({
       _subzoneError = strings.SELECT_AT_LEAST_ONE_SUBZONE;
     }
 
+    const _showSmallSiteWarning =
+      plantingSite && plantingSite.areaHa !== undefined && plantingSite.areaHa < WARN_IF_SITE_LESS_THAN_HECTARES;
+
     setStartDateError(_startDateError);
     setEndDateError(_endDateError);
     setSubzoneError(_subzoneError);
+    setShowSmallSiteWarning(_showSmallSiteWarning);
 
-    return _startDateError || _endDateError || _subzoneError;
-  }, [endDate, requestedSubzoneIds, startDate]);
+    return _startDateError || _endDateError || _subzoneError || _showSmallSiteWarning;
+  }, [endDate, plantingSite, requestedSubzoneIds, setShowSmallSiteWarning, startDate]);
 
   const onSelectPlantingSite = useCallback(
     (value: string) => {
@@ -130,12 +138,18 @@ export default function ScheduleObservationForm({
     [setSelectedPlantingSite]
   );
 
-  const onSubmit = useCallback(() => {
-    setValidate(true);
-    if (!findErrors() && startDate && endDate && requestedSubzoneIds && plantingSite) {
+  const doSave = useCallback(() => {
+    if (startDate && endDate && requestedSubzoneIds && plantingSite) {
       onSave({ startDate, endDate, requestedSubzoneIds, plantingSiteId: plantingSite.id });
     }
-  }, [endDate, findErrors, onSave, plantingSite, requestedSubzoneIds, startDate]);
+  }, [endDate, onSave, plantingSite, requestedSubzoneIds, startDate]);
+
+  const onSubmit = useCallback(() => {
+    setValidate(true);
+    if (!findErrors()) {
+      doSave();
+    }
+  }, [doSave, findErrors, setValidate]);
 
   const setStartDateCallback = useCallback(
     (value: DateTime<boolean> | undefined) => setStartDate(value?.toISODate() || undefined),
@@ -220,6 +234,9 @@ export default function ScheduleObservationForm({
           </Grid>
         </Card>
       </PageForm>
+      {showSmallSiteWarning && (
+        <SmallSiteWarningDialog onSave={doSave} open={showSmallSiteWarning} setOpen={setShowSmallSiteWarning} />
+      )}
     </TfMain>
   );
 }

--- a/src/scenes/ObservationsRouter/schedule/SmallSiteWarningDialog.tsx
+++ b/src/scenes/ObservationsRouter/schedule/SmallSiteWarningDialog.tsx
@@ -1,0 +1,49 @@
+import React, { useCallback } from 'react';
+
+import { Typography } from '@mui/material';
+import { Button, DialogBox } from '@terraware/web-components';
+
+import TextWithLink from 'src/components/common/TextWithLink';
+import { useDocLinks } from 'src/docLinks';
+import strings from 'src/strings';
+
+export interface SmallSiteWarningDialogProps {
+  onSave: () => void;
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+export default function SmallSiteWarningDialog(props: SmallSiteWarningDialogProps): JSX.Element | null {
+  const docLinks = useDocLinks();
+  const { onSave, open, setOpen } = props;
+
+  const onClose = useCallback(() => setOpen(false), [setOpen]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <DialogBox
+      onClose={onClose}
+      open={open}
+      title={strings.SCHEDULE_OBSERVATION}
+      size='medium'
+      middleButtons={[
+        <Button
+          label={strings.CANCEL}
+          priority='secondary'
+          type='passive'
+          onClick={onClose}
+          size='medium'
+          key='button-1'
+        />,
+        <Button label={strings.SAVE} type='destructive' onClick={onSave} size='medium' key='button-2' />,
+      ]}
+      skrim={true}
+    >
+      <Typography>{strings.OBSERVATION_SMALL_SITE_WARNING}</Typography>
+      <TextWithLink href={docLinks.ad_hoc_plots} isExternal text={strings.LEARN_MORE} />
+    </DialogBox>
+  );
+}

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -1199,6 +1199,7 @@ OBSERVATION_PERIOD_WARN,Observation period cannot exceed two months.,
 OBSERVATION_RECENCY,Observation Recency,
 OBSERVATION_RESCHEDULED,Observation rescheduled!,
 OBSERVATION_SCHEDULED,Observation scheduled!,
+OBSERVATION_SMALL_SITE_WARNING,"You are scheduling an Observation for a site that is potentially too small for the assignment of monitoring plots. You will be notified if there are problems with assigning the monitoring plots and starting the Observation. Alternatively, you can conduct an Ad Hoc Plot Observation for this site.",
 OBSERVATION_START_DATE,Observation Start Date,
 OBSERVATION_STATUS,Observation Status,
 OBSERVATION_STATUS_OUTSTANDING,Outstanding,Remaining to be done


### PR DESCRIPTION
Observations of planting sites that are too small to fit the required
number of monitoring plots will fail. Show a warning if the user tries
to schedule an observation for a site where that's likely to happen.