### PR TITLE
Convert strings CSV files for all locales on edit

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,7 +1,7 @@
 const chokidar = require('chokidar');
-const { convertCsvFile } = require('./src/strings/export');
 const fs = require('fs');
 const { whenDev } = require('@craco/craco');
+const { convertAllLocales } = require('./src/strings/export');
 
 module.exports = {
   devServer: (devServerConfig, { paths }) => ({
@@ -16,7 +16,7 @@ module.exports = {
       // change; the JS edits will be picked up by Webpack. The "add" event is fired when Chokidar
       // first discovers each file, which will cause JS to be generated as part of server
       // initialization.
-      const convert = (path) => convertCsvFile(path, 'src/strings');
+      const convert = () => convertAllLocales('src/strings/csv', 'src/strings');
       chokidar.watch('src/strings/csv/*.csv').on('add', convert).on('change', convert);
 
       if (fs.existsSync(paths.proxySetup)) {

--- a/scripts/generate-strings.js
+++ b/scripts/generate-strings.js
@@ -3,23 +3,9 @@
  *
  * This is run as part of the CI build process; you usually shouldn't need to run it by hand.
  */
-const fs = require('fs/promises');
-const { convertCsvFile } = require('../src/strings/export');
+const { convertAllLocales } = require('../src/strings/export');
 
 const csvDir = 'src/strings/csv';
 const stringsDir = 'src/strings';
 
-async function convertAll() {
-  const files = await fs.readdir(csvDir);
-  const conversions = files.map(async (filename) => {
-    if (filename.endsWith('.csv')) {
-      // eslint-disable no-console
-      console.log(`Converting ${filename} to JavaScript`);
-      await convertCsvFile(`${csvDir}/${filename}`, stringsDir);
-    }
-  });
-
-  await Promise.resolve(Promise.all(conversions));
-}
-
-convertAll();
+convertAllLocales(csvDir, stringsDir);

--- a/src/strings/export.js
+++ b/src/strings/export.js
@@ -165,4 +165,21 @@ function generateGibberish(english) {
   return { ...gibberish, ...overrides };
 }
 
-module.exports = { convertCsvFile, generateGibberish };
+/**
+ * Converts the CSV files for all locales to JavaScript source files that export a symbol
+ * "strings." The list of locales is determined by the presence of CSV files.
+ */
+async function convertAllLocales(csvDir, stringsDir) {
+  const files = await fs.readdir(csvDir);
+  const conversions = files.map(async (filename) => {
+    if (filename.endsWith('.csv')) {
+      // eslint-disable no-console
+      console.log(`Converting ${filename} to JavaScript`);
+      await convertCsvFile(`${csvDir}/${filename}`, stringsDir);
+    }
+  });
+
+  await Promise.resolve(Promise.all(conversions));
+}
+
+module.exports = { convertAllLocales };


### PR DESCRIPTION
When a strings CSV file changes while the dev server is running,
we automatically regenerate its JavaScript file to avoid having to
restart the server. Unfortunately, we still have to restart the
server if strings are being added to the English CSV, because the
other locales' JavaScript files are missing those strings and
thus the TypeScript types don't match.

Change the regeneration code to always regenerate all the JS
files if any of the CSV files change. Then we can freely edit
the English strings file (or switch between git branches that have
different edits to the strings file) without restarting the dev
server.