### PR TITLE
SW-7020 Add tooltip icon to live-plants titles

### DIFF
--- a/src/scenes/ObservationsRouter/adhoc/AdHocObservationDetails.tsx
+++ b/src/scenes/ObservationsRouter/adhoc/AdHocObservationDetails.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { ReactNode, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 
 import { Box, Grid, Tooltip, Typography, useTheme } from '@mui/material';
-import { Textfield } from '@terraware/web-components';
+import { Icon, Textfield } from '@terraware/web-components';
 import { getDateDisplayValue } from '@terraware/web-components/utils';
 import _ from 'lodash';
 
@@ -105,14 +105,13 @@ export default function AdHocObservationDetails(props: AdHocObservationDetailsPr
     ];
   }, [activeLocale, defaultTimeZone, monitoringPlot, plantingSite]);
 
-  const title = (text: string, marginTop?: number, marginBottom?: number) => (
+  const title = (text: string | ReactNode, marginTop?: number, marginBottom?: number) => (
     <Typography
       fontSize='20px'
       lineHeight='28px'
       fontWeight={600}
       color={theme.palette.TwClrTxt}
       margin={theme.spacing(marginTop ?? 3, 0, marginBottom ?? 2)}
-      width='fit-content'
     >
       {text}
     </Typography>
@@ -194,9 +193,16 @@ export default function AdHocObservationDetails(props: AdHocObservationDetailsPr
                 </Grid>
               ))}
             </Grid>
-            <Tooltip title={strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES_TOOLTIP}>
-              {title(strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES)}
-            </Tooltip>
+            {title(
+              <Box display={'flex'}>
+                {strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES}
+                <Tooltip title={strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES_TOOLTIP}>
+                  <Box display='flex' marginLeft={1}>
+                    <Icon fillColor={theme.palette.TwClrIcnInfo} name='info' size='small' />
+                  </Box>
+                </Tooltip>
+              </Box>
+            )}
             <Box height='360px'>
               <SpeciesTotalPlantsChart minHeight='360px' species={monitoringPlot?.species} />
             </Box>

--- a/src/scenes/ObservationsRouter/adhoc/AdHocObservationDetails.tsx
+++ b/src/scenes/ObservationsRouter/adhoc/AdHocObservationDetails.tsx
@@ -1,8 +1,8 @@
 import React, { ReactNode, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 
-import { Box, Grid, Tooltip, Typography, useTheme } from '@mui/material';
-import { Icon, Textfield } from '@terraware/web-components';
+import { Box, Grid, Typography, useTheme } from '@mui/material';
+import { IconTooltip, Textfield } from '@terraware/web-components';
 import { getDateDisplayValue } from '@terraware/web-components/utils';
 import _ from 'lodash';
 
@@ -196,11 +196,7 @@ export default function AdHocObservationDetails(props: AdHocObservationDetailsPr
             {title(
               <Box display={'flex'}>
                 {strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES}
-                <Tooltip title={strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES_TOOLTIP}>
-                  <Box display='flex' marginLeft={1}>
-                    <Icon fillColor={theme.palette.TwClrIcnInfo} name='info' size='small' />
-                  </Box>
-                </Tooltip>
+                <IconTooltip title={strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES_TOOLTIP} />
               </Box>
             )}
             <Box height='360px'>

--- a/src/scenes/ObservationsRouter/adhoc/index.tsx
+++ b/src/scenes/ObservationsRouter/adhoc/index.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 
 import { Box, Grid, Tooltip, Typography, useTheme } from '@mui/material';
-import { Icon, Textfield } from '@terraware/web-components';
+import { Icon, IconTooltip, Textfield } from '@terraware/web-components';
 import getDateDisplayValue from '@terraware/web-components/utils/date';
 
 import Card from 'src/components/common/Card';
@@ -281,11 +281,7 @@ export default function ObservationMonitoringPlot(): JSX.Element | undefined {
             {title(
               <Box display='flex'>
                 {strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES}
-                <Tooltip title={strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES_TOOLTIP}>
-                  <Box display='flex' marginLeft={1}>
-                    <Icon fillColor={theme.palette.TwClrIcnInfo} name='info' size='medium' />
-                  </Box>
-                </Tooltip>
+                <IconTooltip title={strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES_TOOLTIP} />
               </Box>
             )}
             <Box height='360px'>

--- a/src/scenes/ObservationsRouter/adhoc/index.tsx
+++ b/src/scenes/ObservationsRouter/adhoc/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { ReactNode, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 
 import { Box, Grid, Tooltip, Typography, useTheme } from '@mui/material';
@@ -167,14 +167,13 @@ export default function ObservationMonitoringPlot(): JSX.Element | undefined {
     ];
   }, [activeLocale, defaultTimeZone, monitoringPlotResult, plantingSite, plantingZone, plantingSubzone]);
 
-  const title = (text: string, marginTop?: number, marginBottom?: number) => (
+  const title = (text: string | ReactNode, marginTop?: number, marginBottom?: number) => (
     <Typography
       fontSize='20px'
       lineHeight='28px'
       fontWeight={600}
       color={theme.palette.TwClrTxt}
       margin={theme.spacing(marginTop ?? 3, 0, marginBottom ?? 2)}
-      width='fit-content'
     >
       {text}
     </Typography>
@@ -279,9 +278,16 @@ export default function ObservationMonitoringPlot(): JSX.Element | undefined {
                 </Grid>
               )}
             </Grid>
-            <Tooltip title={strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES_TOOLTIP}>
-              {title(strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES)}
-            </Tooltip>
+            {title(
+              <Box display='flex'>
+                {strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES}
+                <Tooltip title={strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES_TOOLTIP}>
+                  <Box display='flex' marginLeft={1}>
+                    <Icon fillColor={theme.palette.TwClrIcnInfo} name='info' size='medium' />
+                  </Box>
+                </Tooltip>
+              </Box>
+            )}
             <Box height='360px'>
               <SpeciesTotalPlantsChart minHeight='360px' species={monitoringPlotSpecies} />
             </Box>

--- a/src/scenes/ObservationsRouter/common/AggregatedPlantsStats.tsx
+++ b/src/scenes/ObservationsRouter/common/AggregatedPlantsStats.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
-import { Icon, Tooltip } from '@terraware/web-components';
+import { IconTooltip } from '@terraware/web-components';
 
 import Card from 'src/components/common/Card';
 import OverviewItemCard from 'src/components/common/OverviewItemCard';
@@ -34,7 +34,6 @@ export default function AggregatedPlantsStats({
   const { isMobile } = useDeviceInfo();
   const infoCardGridSize = isMobile ? 12 : 3;
   const chartGridSize = isMobile ? 12 : 6;
-  const theme = useTheme();
 
   const handleMissingData = (num?: number) => (!completedTime && !num ? '' : num);
 
@@ -69,11 +68,7 @@ export default function AggregatedPlantsStats({
             title={
               <Box display='flex'>
                 {strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES}
-                <Tooltip title={strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES_TOOLTIP}>
-                  <Box display='flex' marginLeft={1}>
-                    <Icon fillColor={theme.palette.TwClrIcnInfo} name='info' size='small' />
-                  </Box>
-                </Tooltip>
+                <IconTooltip title={strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES_TOOLTIP} />
               </Box>
             }
           >

--- a/src/scenes/ObservationsRouter/common/AggregatedPlantsStats.tsx
+++ b/src/scenes/ObservationsRouter/common/AggregatedPlantsStats.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
-import { Tooltip } from '@terraware/web-components';
+import { Icon, Tooltip } from '@terraware/web-components';
 
 import Card from 'src/components/common/Card';
 import OverviewItemCard from 'src/components/common/OverviewItemCard';
@@ -34,6 +34,7 @@ export default function AggregatedPlantsStats({
   const { isMobile } = useDeviceInfo();
   const infoCardGridSize = isMobile ? 12 : 3;
   const chartGridSize = isMobile ? 12 : 6;
+  const theme = useTheme();
 
   const handleMissingData = (num?: number) => (!completedTime && !num ? '' : num);
 
@@ -66,9 +67,14 @@ export default function AggregatedPlantsStats({
         <Grid item xs={chartGridSize}>
           <ChartWrapper
             title={
-              <Tooltip title={strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES_TOOLTIP}>
-                <>{strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES}</>
-              </Tooltip>
+              <Box display='flex'>
+                {strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES}
+                <Tooltip title={strings.NUMBER_OF_LIVE_PLANTS_PER_SPECIES_TOOLTIP}>
+                  <Box display='flex' marginLeft={1}>
+                    <Icon fillColor={theme.palette.TwClrIcnInfo} name='info' size='small' />
+                  </Box>
+                </Tooltip>
+              </Box>
             }
           >
             <SpeciesTotalPlantsChart species={species} minHeight='170px' />


### PR DESCRIPTION
Commit 6bacecb9 added a tooltip to the titles of the live
plants graphs in observation detail views, but it should have
put the tooltip on an icon, not on the text of the titles.