### PR TITLE
Add organization existence check to BatchDetailsForm

### DIFF
--- a/src/scenes/InventoryRouter/form/BatchDetailsForm.tsx
+++ b/src/scenes/InventoryRouter/form/BatchDetailsForm.tsx
@@ -141,12 +141,12 @@ export default function BatchDetailsForm(props: BatchDetailsFormProps): JSX.Elem
   }, [selectedAccession]);
 
   useEffect(() => {
-    if (!facilityId) {
+    if (!facilityId || !selectedOrganization) {
       return;
     }
 
     const facility = FacilityService.getFacility({
-      organization: selectedOrganization!,
+      organization: selectedOrganization,
       facilityId,
       type: 'Nursery',
     });


### PR DESCRIPTION
The non-null assertion was causing a TypeScript warning,
and it was potentially a real bug that we could try to
load the facility details before the organization was
loaded.