### PR TITLE
SW-7082 Plants Dashboard in Console does not load correctly if I viewed another project's plants dashboard in the same session

### DIFF
--- a/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
+++ b/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
@@ -75,12 +75,10 @@ export default function PlantsDashboardView({
   }, [latestResult, plantingSite]);
 
   useEffect(() => {
-    if (!acceleratorOrganizationId) {
-      if (organizationId) {
-        setAcceleratorOrganizationId(organizationId);
-      } else if (selectedOrganization?.id) {
-        setAcceleratorOrganizationId(selectedOrganization?.id);
-      }
+    if (organizationId) {
+      setAcceleratorOrganizationId(organizationId);
+    } else if (!isAcceleratorRoute && selectedOrganization?.id) {
+      setAcceleratorOrganizationId(selectedOrganization?.id);
     }
   }, [
     acceleratorOrganizationId,


### PR DESCRIPTION
With the old condition we were not updating the acceleratorOrganizationId when the organizationId changed.