### PR TITLE
Add format:changed target

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint src",
     "ts": "tsc --project ./tsconfig.json",
     "format": "prettier --write .",
+    "format:changed": "git diff --name-only --diff-filter=ACMR main -- '***.js' '***.ts' '***.tsx' '***.json' '***.css' '***.scss' '***.md' | xargs -r prettier --write",
     "docker:start": "./scripts/launch_server.sh",
     "docker:stop": "docker compose down",
     "docker:remote-be:start": "docker compose -f remote-backend/docker-compose.yml up --detach",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint src",
     "ts": "tsc --project ./tsconfig.json",
     "format": "prettier --write .",
-    "format:changed": "git diff -z --name-only --diff-filter=ACMR main -- '***.js' '***.ts' '***.tsx' '***.json' '***.css' '***.scss' '***.md' | xargs -0r prettier --write",
+    "format:changed": "git diff -z --name-only --diff-filter=ACMR main -- '**.js' '**.ts' '**.tsx' '**.json' '**.css' '**.scss' '**.md' | xargs -0r prettier --write",
     "docker:start": "./scripts/launch_server.sh",
     "docker:stop": "docker compose down",
     "docker:remote-be:start": "docker compose -f remote-backend/docker-compose.yml up --detach",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint src",
     "ts": "tsc --project ./tsconfig.json",
     "format": "prettier --write .",
-    "format:changed": "git diff --name-only --diff-filter=ACMR main -- '***.js' '***.ts' '***.tsx' '***.json' '***.css' '***.scss' '***.md' | xargs -r prettier --write",
+    "format:changed": "git diff -z --name-only --diff-filter=ACMR main -- '***.js' '***.ts' '***.tsx' '***.json' '***.css' '***.scss' '***.md' | xargs -0r prettier --write",
     "docker:start": "./scripts/launch_server.sh",
     "docker:stop": "docker compose down",
     "docker:remote-be:start": "docker compose -f remote-backend/docker-compose.yml up --detach",


### PR DESCRIPTION
As the code base grows, `yarn format` takes longer and longer
to run which is annoying. Add `yarn format:changed` to reformat
only the files that differ from the main branch.