### PR TITLE
SW-6955: Browser back button doesn't work on some pages

### DIFF
--- a/src/utils/filterHooks/useSessionFilters.ts
+++ b/src/utils/filterHooks/useSessionFilters.ts
@@ -6,7 +6,6 @@ import {
   getFiltersFromQuery,
   getFiltersFromSession,
   resetQuery,
-  writeFiltersToQuery,
   writeFiltersToSession,
 } from 'src/utils/filterHooks';
 import useQuery from 'src/utils/useQuery';
@@ -29,7 +28,6 @@ export const useSessionFilters = (viewIdentifier?: string) => {
         writeFiltersToSession(viewIdentifier, filters);
 
         resetQuery(query, viewIdentifier);
-        writeFiltersToQuery(query, viewIdentifier, filters);
         navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
       }
     },
@@ -55,9 +53,9 @@ export const useSessionFilters = (viewIdentifier?: string) => {
 
       writeFiltersToSession(viewIdentifier, mergedFilters);
 
-      if (Object.keys(mergedFilters).length) {
-        writeFiltersToQuery(query, viewIdentifier, mergedFilters);
-        navigate(getLocation(location.pathname, location, query.toString()));
+      if (Object.keys(currentQueryFilters).length) {
+        resetQuery(query, viewIdentifier);
+        navigate(getLocation(location.pathname, location, query.toString()), { replace: true });
       }
 
       setIsInitialized(true);


### PR DESCRIPTION
This PR includes a follow-up change to fix broken back button behavior in the Nursery Inventory View when table filters are set.

- Do not write filters to query
- Only navigate on init to remove query param, if set