### PR TITLE
Remove decimal when total planted under 999 in project profile

### DIFF
--- a/src/scenes/AcceleratorRouter/ParticipantProjects/ProjectProfileView.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/ProjectProfileView.tsx
@@ -309,7 +309,7 @@ const ProjectProfileView = ({
               metrics={lastSubmittedReport.systemMetrics}
               metricName={'Trees Planted'}
               units={strings.PLANTS}
-              formatter={(value) => formatNumberScale(value, 1)}
+              formatter={(value) => (value ? formatNumberScale(value, value < 999 ? 0 : 1) : '0')}
             />
             <ReportMetricCard
               label={strings.TOTAL_PLANTED}
@@ -334,7 +334,7 @@ const ProjectProfileView = ({
               publishedMetrics={lastPublishedReport.systemMetrics}
               metricName={'Trees Planted'}
               units={strings.PLANTS}
-              formatter={(value) => formatNumberScale(value, 1)}
+              formatter={(value) => (value ? formatNumberScale(value, value < 999 ? 0 : 1) : '0')}
             />
             <ReportMetricCard
               label={strings.TOTAL_PLANTED}


### PR DESCRIPTION
We previously had a decimal count of 1 for Total Planted because I assumed it would be over 1000 most of the time, and chose to display that as 1.2k, 2.4m, etc. Remove the decimal when count is under 999 but leave it for 1000+. 