### PR TITLE
SW-7038 Updated planting site edit and create to use hooks

### DIFF
--- a/src/components/common/PlantingSiteSelector.tsx
+++ b/src/components/common/PlantingSiteSelector.tsx
@@ -3,8 +3,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Dropdown } from '@terraware/web-components';
 
 import { useOrganization } from 'src/providers';
-import { selectOrgPlantingSites } from 'src/redux/features/tracking/trackingSelectors';
-import { useAppSelector } from 'src/redux/store';
+import { usePlantingSiteData } from 'src/providers/Tracking/PlantingSiteContext';
 import { PreferencesService } from 'src/services';
 import strings from 'src/strings';
 
@@ -17,21 +16,18 @@ export default function PlantingSiteSelector({ onChange, hideNoBoundary }: Plant
   // assume `requestPlantingSites` thunk has been dispatched by consumer
   const [selectedPlantingSiteId, setSelectedPlantingSiteId] = useState<number | undefined>();
   const { selectedOrganization, orgPreferences, reloadOrgPreferences } = useOrganization();
-  const plantingSites = useAppSelector(selectOrgPlantingSites(selectedOrganization?.id || -1));
+  const { allPlantingSites } = usePlantingSiteData();
 
   const filteredPlantingSites = useMemo(() => {
-    return plantingSites?.filter((ps) => (hideNoBoundary ? !!ps.boundary : true));
-  }, [plantingSites, hideNoBoundary]);
+    return allPlantingSites?.filter((ps) => (hideNoBoundary ? !!ps.boundary : true));
+  }, [allPlantingSites, hideNoBoundary]);
 
   const options = useMemo(() => {
     return filteredPlantingSites?.map((site) => ({ label: site.name, value: site.id })) ?? [];
   }, [filteredPlantingSites]);
 
-  const updateSelection = useCallback(
-    async (newValue: any) => {
-      const id = Number(newValue);
-      setSelectedPlantingSiteId(isNaN(id) ? -1 : id);
-      onChange(isNaN(id) ? -1 : id);
+  const updateAndReloadLastSelectedSite = useCallback(
+    async (id: number) => {
       if (!isNaN(id) && id !== orgPreferences.lastPlantingSiteSelected && selectedOrganization) {
         await PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
           ['lastPlantingSiteSelected']: id,
@@ -39,23 +35,33 @@ export default function PlantingSiteSelector({ onChange, hideNoBoundary }: Plant
         reloadOrgPreferences();
       }
     },
-    [onChange, orgPreferences.lastPlantingSiteSelected, reloadOrgPreferences, selectedOrganization]
+    [orgPreferences.lastPlantingSiteSelected, reloadOrgPreferences, selectedOrganization]
+  );
+
+  const updateSelection = useCallback(
+    (newValue: any) => {
+      const id = Number(newValue);
+      setSelectedPlantingSiteId(isNaN(id) ? -1 : id);
+      onChange(isNaN(id) ? -1 : id);
+      void updateAndReloadLastSelectedSite(id);
+    },
+    [onChange, updateAndReloadLastSelectedSite]
   );
 
   useEffect(() => {
-    if (plantingSites && (selectedPlantingSiteId === undefined || selectedPlantingSiteId === -1)) {
+    if (allPlantingSites && (selectedPlantingSiteId === undefined || selectedPlantingSiteId === -1)) {
       if (orgPreferences.lastPlantingSiteSelected) {
-        void updateSelection(orgPreferences.lastPlantingSiteSelected);
+        updateSelection(orgPreferences.lastPlantingSiteSelected);
       } else {
-        void updateSelection(plantingSites[0]?.id);
+        updateSelection(allPlantingSites[0]?.id);
       }
     }
-  }, [plantingSites, selectedPlantingSiteId, updateSelection, orgPreferences.lastPlantingSiteSelected]);
+  }, [selectedPlantingSiteId, updateSelection, orgPreferences.lastPlantingSiteSelected, allPlantingSites]);
 
   return (
     <Dropdown
       placeholder={strings.SELECT}
-      onChange={(newValue) => void updateSelection(newValue)}
+      onChange={updateSelection}
       options={options}
       selectedValue={selectedPlantingSiteId}
     />

--- a/src/providers/Tracking/PlantingSiteContext.tsx
+++ b/src/providers/Tracking/PlantingSiteContext.tsx
@@ -12,7 +12,7 @@ export type PlantingSiteData = {
   plantingSite?: PlantingSite;
   plantingSiteReportedPlants?: PlantingSiteReportedPlants;
   plantingSiteHistories?: PlantingSiteHistory[];
-  setSelectedPlantingSite: (plantingSiteId: number) => void;
+  setSelectedPlantingSite: (plantingSiteId?: number) => void;
 
   adHocObservations?: Observation[];
   adHocObservationResults?: ObservationResultsPayload[];

--- a/src/providers/Tracking/PlantingSiteProvider.tsx
+++ b/src/providers/Tracking/PlantingSiteProvider.tsx
@@ -44,7 +44,7 @@ const PlantingSiteProvider = ({ children }: Props) => {
 
   const { selectedOrganization } = useOrganization();
   const [acceleratorOrganizationId, setAcceleratorOrganizationId] = useState<number>();
-  const [plantingSite, _setSelectedPlantingSite] = useState<PlantingSite>();
+  const [plantingSite, setPlantingSite] = useState<PlantingSite>();
 
   const [plantingSitesRequestId, setPlantingSitesRequestId] = useState<string>('');
   const [observationsRequestId, setObservationsRequestId] = useState<string>('');
@@ -93,7 +93,6 @@ const PlantingSiteProvider = ({ children }: Props) => {
     if (orgId) {
       const request = dispatch(requestListPlantingSites(orgId));
       setPlantingSitesRequestId(request.requestId);
-      _setSelectedPlantingSite(undefined);
     }
   }, [acceleratorOrganizationId, dispatch, isAcceleratorRoute, selectedOrganization?.id]);
 
@@ -103,13 +102,13 @@ const PlantingSiteProvider = ({ children }: Props) => {
 
   // Function to select a planting site
   const setSelectedPlantingSite = useCallback(
-    (plantingSiteId: number) => {
+    (plantingSiteId?: number) => {
       let foundSite = plantingSites?.find((site) => site.id === plantingSiteId);
       if (plantingSiteId === -1) {
         foundSite = allSitesOption;
       }
       if (plantingSite !== foundSite) {
-        _setSelectedPlantingSite(foundSite);
+        setPlantingSite(foundSite);
         setObservations(undefined);
         setObservationResults(undefined);
         setObservationSummaries(undefined);
@@ -148,8 +147,13 @@ const PlantingSiteProvider = ({ children }: Props) => {
   useEffect(() => {
     if (plantingSitesResponse?.status === 'success' && plantingSitesResponse.data) {
       setPlantingSites(plantingSitesResponse.data);
+
+      // Look up already selected planting site
+      if (plantingSite) {
+        setSelectedPlantingSite(plantingSite?.id);
+      }
     }
-  }, [plantingSitesResponse]);
+  }, [plantingSite, plantingSitesResponse, setSelectedPlantingSite]);
 
   useEffect(() => {
     if (observationsResponse?.status === 'success') {
@@ -200,6 +204,7 @@ const PlantingSiteProvider = ({ children }: Props) => {
 
   const isLoading = useMemo(() => {
     return (
+      plantingSitesResponse?.status === 'pending' ||
       observationsResponse?.status === 'pending' ||
       resultsResponse?.status === 'pending' ||
       adHocObservationsResponse?.status === 'pending' ||
@@ -213,6 +218,7 @@ const PlantingSiteProvider = ({ children }: Props) => {
     adHocResultsResponse?.status,
     historiesResponse?.status,
     observationsResponse?.status,
+    plantingSitesResponse?.status,
     reportedPlantsResponse?.status,
     resultsResponse?.status,
     summariesResponse?.status,

--- a/src/redux/features/observations/observationsSelectors.ts
+++ b/src/redux/features/observations/observationsSelectors.ts
@@ -24,10 +24,6 @@ export const selectObservationsResults = (state: RootState) => state.observation
 export const selectOrgObservationsResults = (orgId: number) => (state: RootState) =>
   state.observationsResults?.[orgId]?.data?.observations;
 export const selectObservationsResultsError = (state: RootState) => state.observationsResults?.error;
-export const selectHasObservationsResults = (state: RootState) => {
-  const results = selectObservationsResults(state);
-  return results !== undefined && results.filter((result) => result.state !== 'Upcoming').length > 0;
-};
 export const selectHasCompletedObservations = (state: RootState, plantingSiteId: number) => {
   const results = selectObservationsResults(state);
   return (

--- a/src/redux/features/plantingSite/plantingSiteThunks.ts
+++ b/src/redux/features/plantingSite/plantingSiteThunks.ts
@@ -3,14 +3,12 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { TrackingService } from 'src/services';
 import { PlantingSitePutRequestBody } from 'src/services/TrackingService';
 import strings from 'src/strings';
-import { DraftPlantingSite } from 'src/types/PlantingSite';
-import { fromDraftToCreate } from 'src/utils/draftPlantingSiteUtils';
+import { CreatePlantingSiteRequestPayload } from 'src/types/PlantingSite';
 
 export const createPlantingSite = createAsyncThunk(
   'createPlantingSite',
-  async (draft: DraftPlantingSite, { rejectWithValue }) => {
-    const payload = fromDraftToCreate(draft);
-    const response = await TrackingService.createPlantingSite(payload);
+  async (site: CreatePlantingSiteRequestPayload, { rejectWithValue }) => {
+    const response = await TrackingService.createPlantingSite(site);
 
     if (response && response.requestSucceeded && response.data) {
       return response.data.id;
@@ -22,9 +20,8 @@ export const createPlantingSite = createAsyncThunk(
 
 export const validatePlantingSite = createAsyncThunk(
   'validatePlantingSite',
-  async (draft: DraftPlantingSite, { rejectWithValue }) => {
-    const payload = fromDraftToCreate(draft);
-    const response = await TrackingService.validatePlantingSite(payload);
+  async (site: CreatePlantingSiteRequestPayload, { rejectWithValue }) => {
+    const response = await TrackingService.validatePlantingSite(site);
 
     if (response && response.requestSucceeded && response.data) {
       return response.data;

--- a/src/redux/features/tracking/trackingSelectors.ts
+++ b/src/redux/features/tracking/trackingSelectors.ts
@@ -5,9 +5,6 @@ import { PlantingSite } from 'src/types/Tracking';
 
 export const selectPlantingSites = (state: RootState) => state.tracking?.plantingSites;
 
-export const selectOrgPlantingSites = (organizationId: number) => (state: RootState) =>
-  state.tracking?.[organizationId]?.data?.plantingSites;
-
 export const selectPlantingSitesNames = createCachedSelector(
   (state: RootState) => selectPlantingSites(state),
   (plantingSites) => {

--- a/src/scenes/Home/TerrawareHomeView/index.tsx
+++ b/src/scenes/Home/TerrawareHomeView/index.tsx
@@ -17,9 +17,7 @@ import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useLocalization, useOrganization, useUser } from 'src/providers';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
-import { requestObservations, requestObservationsResults } from 'src/redux/features/observations/observationsThunks';
-import { selectPlantingSites } from 'src/redux/features/tracking/trackingSelectors';
-import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import { usePlantingSiteData } from 'src/providers/Tracking/PlantingSiteContext';
 import NewApplicationModal from 'src/scenes/ApplicationRouter/NewApplicationModal';
 import CTACard from 'src/scenes/Home/CTACard';
 import MobileAppCard from 'src/scenes/Home/MobileAppCard';
@@ -38,28 +36,20 @@ const TerrawareHomeView = () => {
   const { isTablet, isMobile, isDesktop } = useDeviceInfo();
   const mixpanel = useMixpanel();
   const navigate = useSyncNavigate();
-  const dispatch = useAppDispatch();
   const { goToNewAccession } = useNavigateTo();
-  const plantingSites = useAppSelector(selectPlantingSites);
   const { species } = useSpeciesData();
   const seedBankSummary = useSeedBankSummary();
   const orgNurserySummary = useOrgNurserySummary();
   const [showAcceleratorCard, setShowAcceleratorCard] = useState(true);
 
   const [isNewApplicationModalOpen, setIsNewApplicationModalOpen] = useState<boolean>(false);
+  const { allPlantingSites } = usePlantingSiteData();
 
   useEffect(() => {
     if (orgPreferences.showAcceleratorCard === false && showAcceleratorCard) {
       setShowAcceleratorCard(false);
     }
   }, [orgPreferences, showAcceleratorCard]);
-
-  useEffect(() => {
-    if (selectedOrganization) {
-      void dispatch(requestObservations(selectedOrganization.id));
-      void dispatch(requestObservationsResults(selectedOrganization.id));
-    }
-  }, [dispatch, selectedOrganization]);
 
   const isLoadingInitialData = useMemo(
     () => orgNurserySummary?.requestSucceeded === undefined || seedBankSummary?.requestSucceeded === undefined,
@@ -205,7 +195,7 @@ const TerrawareHomeView = () => {
       },
     ];
 
-    if (!plantingSites?.length && isAdmin(selectedOrganization)) {
+    if (!allPlantingSites?.length && isAdmin(selectedOrganization)) {
       rows.push({
         buttonProps: {
           label: strings.ADD_PLANTING_SITE,
@@ -225,12 +215,12 @@ const TerrawareHomeView = () => {
     navigate,
     numberFormatter,
     activeLocale,
-    species,
-    orgNurserySummary,
-    plantingSites,
-    seedBankSummary,
     selectedOrganization,
+    species.length,
     speciesLastModifiedDate,
+    seedBankSummary,
+    orgNurserySummary,
+    allPlantingSites,
   ]);
 
   return (

--- a/src/scenes/NurseryRouter/PlantingProgressList.tsx
+++ b/src/scenes/NurseryRouter/PlantingProgressList.tsx
@@ -131,6 +131,10 @@ export default function PlantingProgressList({
   }, [selectedRows]);
 
   useEffect(() => {
+    reloadTracking();
+  }, [reloadTracking]);
+
+  useEffect(() => {
     if (updatePlantingResult?.status === 'success') {
       reloadTracking();
       setRequestId('');

--- a/src/scenes/NurseryRouter/PlantingProgressTabContent.tsx
+++ b/src/scenes/NurseryRouter/PlantingProgressTabContent.tsx
@@ -10,8 +10,10 @@ import PlantingSiteSelector from 'src/components/common/PlantingSiteSelector';
 import Search, { FeaturedFilterConfig, SearchProps } from 'src/components/common/SearchFiltersWrapper';
 import { useLocalization, useOrganization } from 'src/providers';
 import { requestObservationsResults } from 'src/redux/features/observations/observationsThunks';
+import { requestPlantings } from 'src/redux/features/plantings/plantingsThunks';
 import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
 import { selectPlantingSite, selectPlantingSitesNames } from 'src/redux/features/tracking/trackingSelectors';
+import { requestPlantingSites } from 'src/redux/features/tracking/trackingThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 import { Project } from 'src/types/Project';
@@ -109,7 +111,9 @@ export default function PlantingProgress(): JSX.Element {
 
   const reloadTrackingAndObservations = useCallback(() => {
     if (selectedOrganization) {
+      void dispatch(requestPlantingSites(selectedOrganization.id));
       void dispatch(requestObservationsResults(selectedOrganization.id));
+      void dispatch(requestPlantings(selectedOrganization.id));
     }
   }, [selectedOrganization, dispatch]);
 

--- a/src/scenes/ObservationsRouter/index.tsx
+++ b/src/scenes/ObservationsRouter/index.tsx
@@ -17,7 +17,6 @@ import {
   requestObservations,
   requestObservationsResults,
 } from 'src/redux/features/observations/observationsThunks';
-import { selectPlantingSites, selectPlantingSitesError } from 'src/redux/features/tracking/trackingSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import BiomassMeasurementsDetails from 'src/scenes/ObservationsRouter/biomass/BiomassMeasurementsDetails';
 import strings from 'src/strings';
@@ -32,6 +31,7 @@ import AdHocObservationDetails from './adhoc/AdHocObservationDetails';
 import ObservationDetails from './details';
 import { RescheduleObservation, ScheduleObservation } from './schedule';
 import ObservationPlantingZoneDetails from './zone';
+import { requestPlantingSites } from 'src/redux/features/tracking/trackingThunks';
 
 /**
  * This page will route to the correct component based on url params
@@ -49,26 +49,25 @@ export default function ObservationsRouter(): JSX.Element {
 
   // listen for error
   const observationsResultsError = useAppSelector(selectObservationsResultsError);
-  const plantingSitesError = useAppSelector(selectPlantingSitesError);
   // listen for data
   const observationsResults = useAppSelector(selectObservationsResults);
-  const plantingSites = useAppSelector(selectPlantingSites);
 
   useEffect(() => {
-    if (plantingSites !== undefined && !dispatched && selectedOrganization) {
+    if (!dispatched && selectedOrganization) {
       setDispatched(true);
-      void dispatch(requestObservationsResults(selectedOrganization?.id));
+      void dispatch(requestPlantingSites(selectedOrganization.id));
+      void dispatch(requestObservationsResults(selectedOrganization.id));
       void dispatch(requestAdHocObservationResults(selectedOrganization.id));
       void dispatch(requestObservations(selectedOrganization.id));
       void dispatch(requestObservations(selectedOrganization.id, true));
     }
-  }, [dispatch, selectedOrganization, plantingSites, dispatched]);
+  }, [dispatch, dispatched, selectedOrganization]);
 
   useEffect(() => {
-    if (observationsResultsError || plantingSitesError) {
+    if (observationsResultsError) {
       snackbar.toastError();
     }
-  }, [snackbar, observationsResultsError, plantingSitesError]);
+  }, [snackbar, observationsResultsError]);
 
   const reload = useCallback(() => {
     reloadSpecies();
@@ -76,7 +75,7 @@ export default function ObservationsRouter(): JSX.Element {
   }, [reloadSpecies]);
 
   // show spinner while initializing data
-  if (observationsResults === undefined && !(observationsResultsError || plantingSitesError)) {
+  if (observationsResults === undefined && !(observationsResultsError)) {
     return <CircularProgress sx={{ margin: 'auto' }} />;
   }
 

--- a/src/scenes/ObservationsRouter/index.tsx
+++ b/src/scenes/ObservationsRouter/index.tsx
@@ -17,6 +17,7 @@ import {
   requestObservations,
   requestObservationsResults,
 } from 'src/redux/features/observations/observationsThunks';
+import { requestPlantingSites } from 'src/redux/features/tracking/trackingThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import BiomassMeasurementsDetails from 'src/scenes/ObservationsRouter/biomass/BiomassMeasurementsDetails';
 import strings from 'src/strings';
@@ -31,7 +32,6 @@ import AdHocObservationDetails from './adhoc/AdHocObservationDetails';
 import ObservationDetails from './details';
 import { RescheduleObservation, ScheduleObservation } from './schedule';
 import ObservationPlantingZoneDetails from './zone';
-import { requestPlantingSites } from 'src/redux/features/tracking/trackingThunks';
 
 /**
  * This page will route to the correct component based on url params
@@ -75,7 +75,7 @@ export default function ObservationsRouter(): JSX.Element {
   }, [reloadSpecies]);
 
   // show spinner while initializing data
-  if (observationsResults === undefined && !(observationsResultsError)) {
+  if (observationsResults === undefined && !observationsResultsError) {
     return <CircularProgress sx={{ margin: 'auto' }} />;
   }
 

--- a/src/scenes/OrgRouter/index.tsx
+++ b/src/scenes/OrgRouter/index.tsx
@@ -17,7 +17,6 @@ import { selectHasObservationsResults } from 'src/redux/features/observations/ob
 import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
 import { requestProjects } from 'src/redux/features/projects/projectsThunks';
 import { selectOrgPlantingSites } from 'src/redux/features/tracking/trackingSelectors';
-import { requestPlantingSites } from 'src/redux/features/tracking/trackingThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import AccessionsRouter from 'src/scenes/AccessionsRouter';
 import ApplicationRouter from 'src/scenes/ApplicationRouter';
@@ -108,15 +107,6 @@ const OrgRouter = ({ showNavBar, setShowNavBar }: OrgRouterProps) => {
     populateProjects();
   }, [selectedOrganization, dispatch, activeLocale]);
 
-  const reloadPlantingSites = useCallback(() => {
-    const populatePlantingSites = () => {
-      if (selectedOrganization && !isPlaceholderOrg(selectedOrganization.id)) {
-        void dispatch(requestPlantingSites(selectedOrganization.id));
-      }
-    };
-    populatePlantingSites();
-  }, [dispatch, selectedOrganization]);
-
   const setDefaults = useCallback(() => {
     if (selectedOrganization && !isPlaceholderOrg(selectedOrganization.id)) {
       setWithdrawalCreated(false);
@@ -126,10 +116,6 @@ const OrgRouter = ({ showNavBar, setShowNavBar }: OrgRouterProps) => {
   useEffect(() => {
     reloadProjects();
   }, [reloadProjects]);
-
-  useEffect(() => {
-    reloadPlantingSites();
-  }, [reloadPlantingSites]);
 
   useEffect(() => {
     setDefaults();
@@ -235,10 +221,7 @@ const OrgRouter = ({ showNavBar, setShowNavBar }: OrgRouterProps) => {
               path={APP_PATHS.BATCH_WITHDRAW}
               element={<BatchBulkWithdrawView withdrawalCreatedCallback={() => setWithdrawalCreated(true)} />}
             />
-            <Route
-              path={APP_PATHS.PLANTING_SITES + '/*'}
-              element={<PlantingSites reloadTracking={reloadPlantingSites} />}
-            />
+            <Route path={APP_PATHS.PLANTING_SITES + '/*'} element={<PlantingSites />} />
             <Route path={APP_PATHS.NURSERY + '/*'} element={<NurseryRouter />} />
             <Route path={APP_PATHS.HELP_SUPPORT + '/*'} element={<HelpSupportRouter />} />
             <Route path={APP_PATHS.MY_ACCOUNT + '/*'} element={<MyAccountRouter />} />

--- a/src/scenes/OrgRouter/index.tsx
+++ b/src/scenes/OrgRouter/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Navigate, Route, Routes } from 'react-router';
 
 import { Box, Slide, useTheme } from '@mui/material';
@@ -7,16 +7,15 @@ import ErrorBoundary from 'src/ErrorBoundary';
 import ProjectsRouter from 'src/components/Projects/Router';
 import SeedFundReportsRouter from 'src/components/SeedFundReports/Router';
 import { APP_PATHS } from 'src/constants';
+import { useOrgTracking } from 'src/hooks/useOrgTracking';
 import { useLocalization, useOrganization, useUser } from 'src/providers';
 import ApplicationProvider from 'src/providers/Application';
 import ParticipantProvider from 'src/providers/Participant/ParticipantProvider';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import SpeciesProvider from 'src/providers/Species/SpeciesProvider';
 import PlantingSiteProvider from 'src/providers/Tracking/PlantingSiteProvider';
-import { selectHasObservationsResults } from 'src/redux/features/observations/observationsSelectors';
 import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
 import { requestProjects } from 'src/redux/features/projects/projectsThunks';
-import { selectOrgPlantingSites } from 'src/redux/features/tracking/trackingSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import AccessionsRouter from 'src/scenes/AccessionsRouter';
 import ApplicationRouter from 'src/scenes/ApplicationRouter';
@@ -42,7 +41,6 @@ import SeedBanksRouter from 'src/scenes/SeedBanksRouter';
 import SeedsDashboard from 'src/scenes/SeedsDashboard';
 import SpeciesRouter from 'src/scenes/Species';
 import { Project } from 'src/types/Project';
-import { PlantingSite } from 'src/types/Tracking';
 import { getRgbaFromHex } from 'src/utils/color';
 import { isPlaceholderOrg, selectedOrgHasFacilityType } from 'src/utils/organization';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
@@ -65,11 +63,12 @@ const OrgRouter = ({ showNavBar, setShowNavBar }: OrgRouterProps) => {
   const theme = useTheme();
 
   const { species } = useSpeciesData();
-  const hasObservationsResults: boolean = useAppSelector(selectHasObservationsResults);
-  const plantingSites: PlantingSite[] | undefined = useAppSelector(
-    selectOrgPlantingSites(selectedOrganization?.id || -1)
-  );
+  const { plantingSites, observationResults } = useOrgTracking();
   const projects: Project[] | undefined = useAppSelector(selectProjects);
+
+  const hasObservationsResults = useMemo(() => {
+    return observationResults.length > 0;
+  }, [observationResults.length]);
 
   const contentStyles = {
     height: '100%',

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
@@ -14,9 +14,9 @@ import useSnackbar from 'src/utils/useSnackbar';
  * Data type for request and response in hook functions.
  * Also is a container to pass state data back to client.
  * @param draft
- *  The draft planting site to be created
+ * The draft planting site to be created
  * @param nextStep
- *  Next step to use in the flow if create was successful.
+ * Next step to use in the flow if create was successful.
  */
 export type Data = {
   draft: DraftPlantingSite;

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteFinalize.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteFinalize.ts
@@ -77,13 +77,11 @@ export default function useDraftPlantingSiteFinalize(
   }, [_createFromDraft, draft, onError, snackbar, validateResult]);
 
   useEffect(() => {
-    if (createResult) {
-      if (createResult.status === 'error') {
-        snackbar.toastError(strings.GENERIC_ERROR);
-      } else if (createResult.status === 'success') {
-        if (draft) {
-          _deleteDraft(draft);
-        }
+    if (createResult?.status === 'error') {
+      snackbar.toastError(strings.GENERIC_ERROR);
+    } else if (createResult?.status === 'success') {
+      if (draft) {
+        _deleteDraft(draft);
       }
     }
   }, [_createFromDraft, draft, onError, createResult, _deleteDraft, snackbar]);

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteFinalize.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteFinalize.ts
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { selectDraftPlantingSiteEdit } from 'src/redux/features/draftPlantingSite/draftPlantingSiteSelectors';
+import { requestDeleteDraft } from 'src/redux/features/draftPlantingSite/draftPlantingSiteThunks';
+import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import strings from 'src/strings';
+import { DraftPlantingSite, PlantingSiteProblem } from 'src/types/PlantingSite';
+import { fromDraftToCreate } from 'src/utils/draftPlantingSiteUtils';
+import useSnackbar from 'src/utils/useSnackbar';
+
+import usePlantingSiteCreate from './usePlantingSiteCreate';
+import usePlantingSiteValidate from './usePlantingSiteValidate';
+
+export type Response = {
+  finalize: (draft: DraftPlantingSite) => void;
+  isPending: boolean;
+};
+
+/**
+ * Hook to create a planting site from a draft.
+ * Deletes draft if create is successful.
+ * Redirects user to created planting site.
+ * Returns create function and status on request.
+ */
+export default function useDraftPlantingSiteFinalize(
+  onSuccess?: (plantingSiteId: number) => void,
+  onError?: (problems?: PlantingSiteProblem[]) => void
+): Response {
+  const dispatch = useAppDispatch();
+  const [draft, setDraft] = useState<DraftPlantingSite>();
+  const snackbar = useSnackbar();
+
+  const { create, result: createResult } = usePlantingSiteCreate();
+
+  const { validate, result: validateResult } = usePlantingSiteValidate();
+  const [deleteDraftRequestId, setDeleteDraftRequestId] = useState<string>('');
+  const deleteDraftResult = useAppSelector(selectDraftPlantingSiteEdit(deleteDraftRequestId));
+
+  const _createFromDraft = useCallback(
+    (_draft: DraftPlantingSite) => {
+      const site = fromDraftToCreate(_draft);
+      create(site);
+    },
+    [create]
+  );
+
+  const _validateDraft = useCallback(
+    (_draft: DraftPlantingSite) => {
+      const site = fromDraftToCreate(_draft);
+      validate(site);
+    },
+    [validate]
+  );
+
+  const _deleteDraft = useCallback(
+    (_draft: DraftPlantingSite) => {
+      const dispatched = dispatch(requestDeleteDraft(_draft.id));
+      setDeleteDraftRequestId(dispatched.requestId);
+    },
+    [dispatch]
+  );
+
+  useEffect(() => {
+    if (validateResult) {
+      if (validateResult.status === 'error') {
+        snackbar.toastError(strings.GENERIC_ERROR);
+      } else if (validateResult.status === 'success') {
+        if (validateResult.data?.isValid) {
+          if (draft) {
+            _createFromDraft(draft);
+          }
+        } else {
+          onError?.(validateResult.data?.problems);
+        }
+      }
+    }
+  }, [_createFromDraft, draft, onError, snackbar, validateResult]);
+
+  useEffect(() => {
+    if (createResult) {
+      if (createResult.status === 'error') {
+        snackbar.toastError(strings.GENERIC_ERROR);
+      } else if (createResult.status === 'success') {
+        if (draft) {
+          _deleteDraft(draft);
+        }
+      }
+    }
+  }, [_createFromDraft, draft, onError, createResult, _deleteDraft, snackbar]);
+
+  useEffect(() => {
+    if (deleteDraftResult?.status === 'success') {
+      if (createResult?.data) {
+        onSuccess?.(createResult.data);
+      }
+    }
+  }, [deleteDraftResult, createResult, dispatch, onSuccess]);
+
+  const finalize = useCallback(
+    (_draft: DraftPlantingSite) => {
+      setDraft(_draft);
+      _validateDraft(_draft);
+    },
+    [_validateDraft]
+  );
+
+  const isPending = useMemo(() => {
+    return (
+      validateResult?.status === 'pending' ||
+      createResult?.status === 'pending' ||
+      deleteDraftResult?.status === 'pending'
+    );
+  }, [createResult?.status, deleteDraftResult?.status, validateResult?.status]);
+
+  return useMemo<Response>(
+    () => ({
+      finalize,
+      isPending,
+    }),
+    [finalize, isPending]
+  );
+}

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
@@ -8,6 +8,7 @@ import { requestUpdateDraft } from 'src/redux/features/draftPlantingSite/draftPl
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 import { DraftPlantingSite, OptionalSiteEditStep, SiteEditStep } from 'src/types/PlantingSite';
+import { fromDraftToCreate } from 'src/utils/draftPlantingSiteUtils';
 import useSnackbar from 'src/utils/useSnackbar';
 
 import usePlantingSiteValidate from './usePlantingSiteValidate';
@@ -16,11 +17,11 @@ import usePlantingSiteValidate from './usePlantingSiteValidate';
  * Data type for request and response in hook functions.
  * Also is a container to pass state data back to client.
  * @param draft
- *  The draft planting site to be created
+ * The draft planting site to be created
  * @param nextStep
- *  Next step to use in the flow if update was successful.
+ * Next step to use in the flow if update was successful.
  * @param optionalSteps
- *  Dictionary of optional steps that were completed if update was successful.
+ * Dictionary of optional steps that were completed if update was successful.
  */
 export type Data = {
   draft: DraftPlantingSite;
@@ -52,14 +53,7 @@ export default function useDraftPlantingSiteUpdate(): Response {
   const [requestId, setRequestId] = useState<string>('');
   const draftResult = useAppSelector(selectDraftPlantingSiteEdit(requestId));
 
-  const { validateDraft, validateSite, validateSiteStatus, isValid, problems } = usePlantingSiteValidate();
-
-  const _validateDraft = useCallback(
-    (request: Data) => {
-      validateSite(request.draft);
-    },
-    [validateSite]
-  );
+  const { validate, result: validateResult } = usePlantingSiteValidate();
 
   const _updateDraft = useCallback(
     (request: Data) => {
@@ -69,22 +63,19 @@ export default function useDraftPlantingSiteUpdate(): Response {
     [dispatch]
   );
 
+  const _validateDraft = useCallback(
+    (request: Data) => {
+      const site = fromDraftToCreate(request.draft);
+      validate(site);
+    },
+    [validate]
+  );
+
   useEffect(() => {
-    if (draftRequest && validateDraft === draftRequest.draft) {
-      if (validateSiteStatus === 'success') {
-        if (isValid) {
-          _updateDraft(draftRequest);
-        } else {
-          // TODO: Show detailed erros on map according to designs
-          snackbar.toastError('Failed to validate planting site.');
-          // TODO: Remove debug logs
-          console.log('Server responded with problems during validation: ', problems);
-        }
-      } else if (validateSiteStatus === 'error') {
-        snackbar.toastError(strings.GENERIC_ERROR);
-      }
+    if (validateResult?.status === 'success' && draftRequest) {
+      _updateDraft(draftRequest);
     }
-  }, [_updateDraft, draftRequest, validateDraft, validateSiteStatus, isValid, snackbar, problems]);
+  }, [draftRequest, _updateDraft, validateResult]);
 
   useEffect(() => {
     if (draftResult?.status === 'error') {
@@ -93,15 +84,19 @@ export default function useDraftPlantingSiteUpdate(): Response {
   }, [draftResult?.status, snackbar]);
 
   useEffect(() => {
-    if (draftResult?.status === 'success' && draftRequest) {
-      if (redirect) {
-        snackbar.toastSuccess(strings.PLANTING_SITE_SAVED);
-        navigate(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${draftRequest.draft.id}`));
-      } else {
-        setUpdatedDraft(draftRequest);
+    if (draftResult) {
+      if (draftResult.status === 'error') {
+        snackbar.toastError(strings.GENERIC_ERROR);
+      } else if (draftResult?.status === 'success' && draftRequest) {
+        if (redirect) {
+          snackbar.toastSuccess(strings.PLANTING_SITE_SAVED);
+          navigate(APP_PATHS.PLANTING_SITES_DRAFT_VIEW.replace(':plantingSiteId', `${draftRequest.draft.id}`));
+        } else {
+          setUpdatedDraft(draftRequest);
+        }
       }
     }
-  }, [draftRequest, draftResult?.status, navigate, redirect, snackbar]);
+  }, [draftRequest, draftResult, navigate, redirect, snackbar]);
 
   const updateDraft = useCallback(
     (request: Data, redirectToDraft: boolean) => {

--- a/src/scenes/PlantingSitesRouter/hooks/usePlantingSiteCreate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/usePlantingSiteCreate.ts
@@ -1,114 +1,37 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
-import useNavigateTo from 'src/hooks/useNavigateTo';
-import { usePlantingSiteData } from 'src/providers/Tracking/PlantingSiteContext';
-import { Statuses } from 'src/redux/features/asyncUtils';
-import { selectDraftPlantingSiteEdit } from 'src/redux/features/draftPlantingSite/draftPlantingSiteSelectors';
-import { requestDeleteDraft } from 'src/redux/features/draftPlantingSite/draftPlantingSiteThunks';
+import { StatusT } from 'src/redux/features/asyncUtils';
 import { selectPlantingSiteCreate } from 'src/redux/features/plantingSite/plantingSiteSelectors';
 import { createPlantingSite } from 'src/redux/features/plantingSite/plantingSiteThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
-import strings from 'src/strings';
-import { DraftPlantingSite } from 'src/types/PlantingSite';
-import useSnackbar from 'src/utils/useSnackbar';
-
-import usePlantingSiteValidate from './usePlantingSiteValidate';
+import { CreatePlantingSiteRequestPayload } from 'src/types/PlantingSite';
 
 export type Response = {
-  createPlantingSite: (draft: DraftPlantingSite) => void;
-  createPlantingSiteStatus?: Statuses;
-  createPlantingSiteId?: number;
+  create: (site: CreatePlantingSiteRequestPayload) => void;
+  result: StatusT<number>;
 };
 
 /**
- * Hook to create a planting site from a draft.
- * Deletes draft if create is successful.
- * Redirects user to created planting site.
- * Returns create function and status on request.
+ * Hook to create a planting site
  */
 export default function usePlantingSiteCreate(): Response {
   const dispatch = useAppDispatch();
-  const { goToPlantingSiteView } = useNavigateTo();
-  const snackbar = useSnackbar();
-
-  const [createRequest, setCreateRequest] = useState<DraftPlantingSite>();
   const [requestId, setRequestId] = useState<string>('');
-  const createResult = useAppSelector(selectPlantingSiteCreate(requestId));
+  const result = useAppSelector(selectPlantingSiteCreate(requestId));
 
-  const [deleteDraftRequestId, setDeleteDraftRequestId] = useState<string>('');
-  const deleteDraftResult = useAppSelector(selectDraftPlantingSiteEdit(deleteDraftRequestId));
-
-  const { validateDraft, validateSite, validateSiteStatus, isValid, problems } = usePlantingSiteValidate();
-  const { reload } = usePlantingSiteData();
-
-  const _validateDraft = useCallback(
-    (draft: DraftPlantingSite) => {
-      validateSite(draft);
-    },
-    [validateSite]
-  );
-
-  const _createSite = useCallback(
-    (draft: DraftPlantingSite) => {
-      const dispatched = dispatch(createPlantingSite(draft));
-      setCreateRequest(draft);
+  const create = useCallback(
+    (site: CreatePlantingSiteRequestPayload) => {
+      const dispatched = dispatch(createPlantingSite(site));
       setRequestId(dispatched.requestId);
     },
     [dispatch]
   );
 
-  useEffect(() => {
-    if (createRequest && validateDraft === createRequest) {
-      if (validateSiteStatus === 'success') {
-        if (isValid) {
-          _createSite(createRequest);
-        } else {
-          // TODO: Show detailed erros on map according to designs
-          snackbar.toastError('Failed to validate planting site.');
-          // TODO: Remove debug logs
-          console.log('Server responded with problems during validation: ', problems);
-        }
-      } else if (validateSiteStatus === 'error') {
-        snackbar.toastError(strings.GENERIC_ERROR);
-      }
-    }
-  }, [_createSite, createRequest, validateDraft, validateSiteStatus, isValid, snackbar, problems]);
-
-  const createSite = useCallback(
-    (draft: DraftPlantingSite) => {
-      setCreateRequest(draft);
-      _validateDraft(draft);
-    },
-    [_validateDraft]
-  );
-
-  useEffect(() => {
-    if (createResult?.status === 'error' || deleteDraftResult?.status === 'error') {
-      snackbar.toastError(strings.GENERIC_ERROR);
-    }
-  }, [createResult?.status, deleteDraftResult?.status, snackbar]);
-
-  useEffect(() => {
-    if (createResult?.status === 'success' && createRequest) {
-      const dispatched = dispatch(requestDeleteDraft(createRequest.id));
-      setDeleteDraftRequestId(dispatched.requestId);
-    }
-  }, [createRequest, createResult?.status, dispatch]);
-
-  useEffect(() => {
-    if (deleteDraftResult?.status === 'success' && createResult.data) {
-      reload();
-      snackbar.toastSuccess(strings.PLANTING_SITE_SAVED);
-      goToPlantingSiteView(createResult.data);
-    }
-  }, [deleteDraftResult, createResult, dispatch, goToPlantingSiteView, snackbar, reload]);
-
   return useMemo<Response>(
     () => ({
-      createPlantingSite: createSite,
-      createPlantingSiteStatus: createResult?.status,
-      createPlantingSiteId: createResult?.data,
+      create,
+      result,
     }),
-    [createSite, createResult]
+    [create, result]
   );
 }

--- a/src/scenes/PlantingSitesRouter/hooks/usePlantingSiteUpdate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/usePlantingSiteUpdate.ts
@@ -12,7 +12,7 @@ export type Response = {
 };
 
 /**
- * Hook to create a planting site
+ * Hook to update a planting site
  */
 export default function usePlantingSiteUpdate(): Response {
   const dispatch = useAppDispatch();

--- a/src/scenes/PlantingSitesRouter/hooks/usePlantingSiteUpdate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/usePlantingSiteUpdate.ts
@@ -1,0 +1,37 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { StatusT } from 'src/redux/features/asyncUtils';
+import { selectPlantingSiteUpdate } from 'src/redux/features/plantingSite/plantingSiteSelectors';
+import { updatePlantingSite } from 'src/redux/features/plantingSite/plantingSiteThunks';
+import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import { PlantingSitePutRequestBody } from 'src/services/TrackingService';
+
+export type Response = {
+  update: (id: number, request: PlantingSitePutRequestBody) => void;
+  result: StatusT<boolean>;
+};
+
+/**
+ * Hook to create a planting site
+ */
+export default function usePlantingSiteCreate(): Response {
+  const dispatch = useAppDispatch();
+  const [requestId, setRequestId] = useState<string>('');
+  const result = useAppSelector(selectPlantingSiteUpdate(requestId));
+
+  const update = useCallback(
+    (id: number, plantingSite: PlantingSitePutRequestBody) => {
+      const dispatched = dispatch(updatePlantingSite({ id, plantingSite }));
+      setRequestId(dispatched.requestId);
+    },
+    [dispatch]
+  );
+
+  return useMemo<Response>(
+    () => ({
+      update,
+      result,
+    }),
+    [update, result]
+  );
+}

--- a/src/scenes/PlantingSitesRouter/hooks/usePlantingSiteUpdate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/usePlantingSiteUpdate.ts
@@ -14,7 +14,7 @@ export type Response = {
 /**
  * Hook to create a planting site
  */
-export default function usePlantingSiteCreate(): Response {
+export default function usePlantingSiteUpdate(): Response {
   const dispatch = useAppDispatch();
   const [requestId, setRequestId] = useState<string>('');
   const result = useAppSelector(selectPlantingSiteUpdate(requestId));

--- a/src/scenes/PlantingSitesRouter/hooks/usePlantingSiteValidate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/usePlantingSiteValidate.ts
@@ -32,10 +32,8 @@ export default function usePlantingSiteValidate(): Response {
   );
 
   useEffect(() => {
-    if (result) {
-      if (result.status === 'error') {
-        snackbar.toastError(strings.GENERIC_ERROR);
-      }
+    if (result?.status === 'error') {
+      snackbar.toastError(strings.GENERIC_ERROR);
     }
   }, [result, snackbar]);
 

--- a/src/scenes/PlantingSitesRouter/index.tsx
+++ b/src/scenes/PlantingSitesRouter/index.tsx
@@ -20,22 +20,18 @@ import PlantingSitesList from './view/PlantingSitesList';
 /**
  * This page will route to the correct component based on url params
  */
-export type PlantingSitesProps = {
-  reloadTracking: () => void;
-};
-
-export default function PlantingSites({ reloadTracking }: PlantingSitesProps): JSX.Element {
+export default function PlantingSites(): JSX.Element {
   return (
     <Routes>
-      <Route path={'/new'} element={<PlantingSiteCreate reloadPlantingSites={reloadTracking} />} />
+      <Route path={'/new'} element={<PlantingSiteCreate />} />
       <Route path={'/draft/*'} element={<PlantingSitesDraftRouter />} />
-      <Route path={'/:plantingSiteId/*'} element={<PlantingSitesRouter reloadTracking={reloadTracking} />} />
+      <Route path={'/:plantingSiteId/*'} element={<PlantingSitesRouter />} />
       <Route path={'*'} element={<PlantingSitesList />} />
     </Routes>
   );
 }
 
-export function PlantingSitesRouter({ reloadTracking }: PlantingSitesProps): JSX.Element {
+export function PlantingSitesRouter(): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const { plantingSiteId } = useParams<{ plantingSiteId: string }>();
 
@@ -66,7 +62,7 @@ export function PlantingSitesRouter({ reloadTracking }: PlantingSitesProps): JSX
   return (
     <Routes>
       <Route path={'/zone/:zoneId'} element={<PlantingSiteZoneView />} />
-      <Route path={'/edit'} element={<PlantingSiteCreate reloadPlantingSites={reloadTracking} />} />
+      <Route path={'/edit'} element={<PlantingSiteCreate plantingSiteId={Number(plantingSiteId)} />} />
       <Route path={'*'} element={<PlantingSiteView />} />
     </Routes>
   );

--- a/src/scenes/PlantingSitesRouter/view/PlantingSiteView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSiteView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { BusySpinner } from '@terraware/web-components';
 
@@ -8,11 +8,25 @@ import { usePlantingSiteData } from 'src/providers/Tracking/PlantingSiteContext'
 import GenericSiteView from './GenericSiteView';
 
 export default function PlantingSiteView(): JSX.Element {
-  const { plantingSite } = usePlantingSiteData();
+  const { isLoading, plantingSite } = usePlantingSiteData();
+
+  // Use a delay effect for loading to handle quick updates of data
+  const [delayedLoading, setDelayedLoading] = useState(isLoading);
+  useEffect(() => {
+    if (isLoading) {
+      setDelayedLoading(true); // immediately true when loading starts
+    } else {
+      const timeout = setTimeout(() => {
+        setDelayedLoading(false); // delay turning false
+      }, 500);
+      return () => clearTimeout(timeout); // cleanup if loading toggles back quickly
+    }
+  }, [isLoading]);
+
   return (
     <TfMain>
-      {plantingSite === undefined && <BusySpinner withSkrim={true} />}
-      {plantingSite !== undefined && <GenericSiteView plantingSite={plantingSite} />}
+      {(delayedLoading || plantingSite === undefined) && <BusySpinner withSkrim={true} />}
+      {!delayedLoading && plantingSite !== undefined && <GenericSiteView plantingSite={plantingSite} />}
     </TfMain>
   );
 }

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -1400,6 +1400,7 @@ PLANTING_SITE_CREATE_EXCLUSIONS_INSTRUCTIONS_DESCRIPTION,This video shows how to
 PLANTING_SITE_CREATE_EXCLUSIONS_INSTRUCTIONS_TITLE,Drawing Exclusion Area Boundaries,
 PLANTING_SITE_CREATE_INSTRUCTIONS_DESCRIPTION,This video shows how to use the drawing {0} tool to draw the boundary of the planting site.,
 PLANTING_SITE_CREATE_INSTRUCTIONS_TITLE,Drawing Site Boundaries,
+PLANTING_SITE_CREATED,Planting site created!,
 PLANTING_SITE_DELETED,Planting site deleted!,
 PLANTING_SITE_PROGRESS,Planting Site Progress,
 PLANTING_SITE_SAVED,Planting Site Saved,


### PR DESCRIPTION
This fixes some unwanted behaviors around editing of planting sites and draft planting sites. 

Previously some of the calls were made directly using async calls, which lead to state changes not handled and reloading not happening correctly.