### PR TITLE
SW-7092 Don't save invalid substrate type

### DIFF
--- a/src/scenes/AccessionsRouter/viabilityTesting/NewViabilityTestModal.tsx
+++ b/src/scenes/AccessionsRouter/viabilityTesting/NewViabilityTestModal.tsx
@@ -340,6 +340,10 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
       if (testCompleted && !readOnly) {
         record.endDate = getTodaysDateFormatted(tz.id);
       }
+      const validSubstrates = getSubstratesAccordingToType(record.testType);
+      if (!validSubstrates.find((substrate) => substrate.value === record.substrate)) {
+        record.substrate = undefined;
+      }
       let response;
       if (record.id === -1) {
         response = await AccessionService.createViabilityTest(record, accession.id);


### PR DESCRIPTION
The lists of substrates for lab and nursery viability tests aren't
the same.

When you're adding a viability test to an accession, if you select
a substrate that's only valid for the current test type then switch
to the other test type, we clear out the substrate selection in the
UI. But we remember the old selection so that if you switch back
to the initial test type again, your previously-selected substrate
will reappear.

But if you selected a substrate that's only valid for the current
test type, switch test types, and then save the viability test, we
were trying to create the test with an invalid substrate for its
type, which caused the request to be rejected by the server.

Change the "save" logic so it reflects the UI's behavior, clearing
out the substrate type if it's not valid.