### PR TITLE
Add protocol to external project links when missing

### DIFF
--- a/src/scenes/AcceleratorRouter/ParticipantProjects/EditView/ProjectProfileEdit.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/EditView/ProjectProfileEdit.tsx
@@ -56,6 +56,16 @@ const variableStableIds = [
   carbonCertificationsStableId,
 ];
 
+const EXTERNAL_LINK_KEYS = [
+  'googleFolderUrl',
+  'verraLink',
+  'clickUpLink',
+  'hubSpotUrl',
+  'riskTrackerLink',
+  'slackLink',
+  'gisReportsLink',
+] as const;
+
 const ProjectProfileEdit = () => {
   const dispatch = useAppDispatch();
   const theme = useTheme();
@@ -239,6 +249,14 @@ const ProjectProfileEdit = () => {
     };
 
     const updatedRecord = { ...participantProjectRecord } as ParticipantProject;
+
+    EXTERNAL_LINK_KEYS.forEach((key) => {
+      const value = updatedRecord[key];
+      if (value && !/^https?:\/\//.test(`${value}`)) {
+        updatedRecord[key] = `https://${value}`;
+      }
+    });
+
     const typesToRemove = Object.keys(participantProjectRecord?.landUseModelHectares || {}).filter(
       (type) => !(updatedRecord.landUseModelTypes as string[]).includes(type)
     );


### PR DESCRIPTION
When an external project profile link is missing a protocol, automatically add `https://` to it. If it already has a protocol (https or http) then do nothing.