### PR TITLE
SW-7086 Add plot number to biomass CSVs

### DIFF
--- a/src/services/ObservationsService.ts
+++ b/src/services/ObservationsService.ts
@@ -174,7 +174,14 @@ const exportBiomassPlotCsv = async (observationId: number): Promise<any> => {
 const exportBiomassSpeciesCsv = async (observationId: number): Promise<any> => {
   return SearchService.searchCsv({
     prefix: 'plantingSites.observations.observationPlots.biomassDetails.species',
-    fields: ['name', 'quadratSpecies_position', 'quadratSpecies_abundancePercent', 'isInvasive', 'isThreatened'],
+    fields: [
+      'monitoringPlot_plotNumber',
+      'name',
+      'quadratSpecies_position',
+      'quadratSpecies_abundancePercent',
+      'isInvasive',
+      'isThreatened',
+    ],
     sortOrder: [{ field: 'name' }, { field: 'quadratSpecies_position' }],
     search: {
       operation: 'and',
@@ -187,6 +194,7 @@ const exportBiomassTreesShrubsCsv = async (observationId: number): Promise<any> 
   return SearchService.searchCsv({
     prefix: 'plantingSites.observations.observationPlots.recordedTrees',
     fields: [
+      'monitoringPlot_plotNumber',
       'treeNumber',
       'trunkNumber',
       'biomassSpecies_name',


### PR DESCRIPTION
Include the monitoring plot number in the two exported CSVs for
biomass observations that didn't already have it. The plot number
is the same on every row in those CSVs since biomass observations
are always single-plot, but if people combine multiple CSVs from
different observations, this will help them tell which data came
from which plot.