### PR TITLE
Update HelpSupportHome and Contact Form to use strings from useLocalization hook

### DIFF
--- a/src/scenes/HelpSupportRouter/ContactUsForm.tsx
+++ b/src/scenes/HelpSupportRouter/ContactUsForm.tsx
@@ -15,7 +15,6 @@ import { useLocalization, useUser } from 'src/providers';
 import { requestSubmitSupportRequest } from 'src/redux/features/support/supportAsyncThunks';
 import { selectSupportRequestSubmitRequest } from 'src/redux/features/support/supportSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
-import strings from 'src/strings';
 import {
   AttachmentRequest,
   SupportRequest,
@@ -35,7 +34,7 @@ const MAX_FILE_SIZE = 200;
 const ContactUsForm = () => {
   const dispatch = useAppDispatch();
   const { isDesktop } = useDeviceInfo();
-  const { activeLocale } = useLocalization();
+  const { strings } = useLocalization();
   const { user } = useUser();
   const theme = useTheme();
   const pathParams = useParams<{ requestType: string }>();
@@ -51,11 +50,11 @@ const ContactUsForm = () => {
   const crumbs: Crumb[] = useMemo(
     () => [
       {
-        name: activeLocale ? strings.HELP_SUPPORT : '',
+        name: strings.HELP_SUPPORT,
         to: APP_PATHS.HELP_SUPPORT,
       },
     ],
-    [activeLocale]
+    [strings]
   );
 
   const { types } = useSupportData();
@@ -129,7 +128,7 @@ const ContactUsForm = () => {
       const dispatched = dispatch(requestSubmitSupportRequest(supportRequest));
       setSubmitSupportRequestId(dispatched.requestId);
     }
-  }, [supportRequest, dispatch]);
+  }, [supportRequest, strings, dispatch]);
 
   const handleOnSave = useCallback(() => {
     submit();
@@ -147,16 +146,16 @@ const ContactUsForm = () => {
       snackbar.toastSuccess(strings.formatString(strings.THANK_YOU_FOR_CONTACTING_SUPPORT, `${issueKey}`));
       goToHelpSupport();
     }
-  }, [activeLocale, submitSupportRequest, snackbar, goToHelpSupport]);
+  }, [submitSupportRequest, snackbar, goToHelpSupport, strings]);
 
   const supportRequestTitle = useMemo(
-    () => (supportRequestType ? getSupportRequestName(supportRequestType) : ''),
-    [supportRequestType]
+    () => (supportRequestType ? getSupportRequestName(supportRequestType, strings) : ''),
+    [supportRequestType, strings]
   );
 
   const supportRequestInstructions = useMemo(
-    () => (supportRequestType ? getSupportRequestInstructions(supportRequestType) : ''),
-    [supportRequestType]
+    () => (supportRequestType ? getSupportRequestInstructions(supportRequestType, strings) : ''),
+    [supportRequestType, strings]
   );
 
   // Confirming that no uploads are pending.

--- a/src/scenes/HelpSupportRouter/HelpSupportHome.tsx
+++ b/src/scenes/HelpSupportRouter/HelpSupportHome.tsx
@@ -12,7 +12,6 @@ import { IconName } from 'src/components/common/icon/icons';
 import { useDocLinks } from 'src/docLinks';
 import useNavigateTo from 'src/hooks/useNavigateTo';
 import { useLocalization } from 'src/providers';
-import strings from 'src/strings';
 import {
   ORDERED_SUPPORT_REQUEST_TYPES,
   getSupportRequestDescription,
@@ -31,7 +30,7 @@ type ListItemContent = {
   onClick: () => void;
 };
 export default function HelpSupportHome(): JSX.Element {
-  const { activeLocale } = useLocalization();
+  const { strings } = useLocalization();
   const { isMobile, isDesktop } = useDeviceInfo();
   const docLinks = useDocLinks();
   const theme = useTheme();
@@ -41,12 +40,12 @@ export default function HelpSupportHome(): JSX.Element {
   const knowledgeBaseItem: ListItemContent = useMemo(() => {
     return {
       icon: 'iconLibrary',
-      title: activeLocale ? strings.KNOWLEDGE_BASE : '',
-      description: activeLocale ? strings.DESCRIPTION_KNOWLEDGE_BASE : '',
-      buttonText: activeLocale ? strings.KNOWLEDGE_BASE : '',
+      title: strings.KNOWLEDGE_BASE,
+      description: strings.DESCRIPTION_KNOWLEDGE_BASE,
+      buttonText: strings.KNOWLEDGE_BASE,
       onClick: () => window.open(docLinks.knowledge_base),
     };
-  }, [activeLocale, docLinks.knowledge_base]);
+  }, [strings, docLinks.knowledge_base]);
 
   const jiraListItems = useMemo(() => {
     return ORDERED_SUPPORT_REQUEST_TYPES.filter((type) => (types ?? []).includes(type)).map(

--- a/src/scenes/HelpSupportRouter/HelpSupportHome.tsx
+++ b/src/scenes/HelpSupportRouter/HelpSupportHome.tsx
@@ -51,13 +51,13 @@ export default function HelpSupportHome(): JSX.Element {
     return ORDERED_SUPPORT_REQUEST_TYPES.filter((type) => (types ?? []).includes(type)).map(
       (type): ListItemContent => ({
         icon: getSupportRequestIconName(type),
-        title: getSupportRequestName(type),
-        description: getSupportRequestDescription(type),
-        buttonText: getSupportRequestName(type),
+        title: getSupportRequestName(type, strings),
+        description: getSupportRequestDescription(type, strings),
+        buttonText: getSupportRequestName(type, strings),
         onClick: () => goToContactUsForm(type),
       })
     );
-  }, [types, goToContactUsForm]);
+  }, [types, goToContactUsForm, strings]);
 
   const listItemContent = useMemo(() => [knowledgeBaseItem, ...jiraListItems], [jiraListItems, knowledgeBaseItem]);
 

--- a/src/types/Support.ts
+++ b/src/types/Support.ts
@@ -1,7 +1,7 @@
 import { components } from 'src/api/types/generated-schema';
 import { IconName } from 'src/components/common/icon/icons';
 import { Statuses } from 'src/redux/features/asyncUtils';
-import strings from 'src/strings';
+import defaultStrings from 'src/strings';
 
 export type SupportRequestType = components['schemas']['SubmitSupportRequestPayload']['requestType'];
 
@@ -18,7 +18,7 @@ export type AttachmentRequest = {
 
 export const ORDERED_SUPPORT_REQUEST_TYPES: SupportRequestType[] = ['Bug Report', 'Feature Request', 'Contact Us'];
 
-export const getSupportRequestName = (type: SupportRequestType): string => {
+export const getSupportRequestName = (type: SupportRequestType, strings: typeof defaultStrings): string => {
   switch (type) {
     case 'Bug Report':
       return strings.BUG_REPORT;
@@ -29,7 +29,7 @@ export const getSupportRequestName = (type: SupportRequestType): string => {
   }
 };
 
-export const getSupportRequestDescription = (type: SupportRequestType): string => {
+export const getSupportRequestDescription = (type: SupportRequestType, strings: typeof defaultStrings): string => {
   switch (type) {
     case 'Bug Report':
       return strings.BUG_REPORT_DESCRIPTION;
@@ -40,7 +40,7 @@ export const getSupportRequestDescription = (type: SupportRequestType): string =
   }
 };
 
-export const getSupportRequestInstructions = (type: SupportRequestType): string => {
+export const getSupportRequestInstructions = (type: SupportRequestType, strings: typeof defaultStrings): string => {
   switch (type) {
     case 'Bug Report':
       return strings.BUG_REPORT_INSTRUCTIONS;


### PR DESCRIPTION
This implementation passes the new `strings` object into the helper functions in `Support.ts`. If another method is preferred this can be updated.