### PR TITLE
SW-6774 Don't show mortality rates without data

### DIFF
--- a/src/scenes/ObservationsRouter/common/AggregatedPlantsStats.tsx
+++ b/src/scenes/ObservationsRouter/common/AggregatedPlantsStats.tsx
@@ -63,7 +63,7 @@ export default function AggregatedPlantsStats({
         ))}
       </Grid>
       <Grid container spacing={3}>
-        <Grid item xs={chartGridSize}>
+        <Grid item xs={hasObservedPermanentPlots ? chartGridSize : chartGridSize * 2}>
           <ChartWrapper
             title={
               <Box display='flex'>
@@ -75,11 +75,13 @@ export default function AggregatedPlantsStats({
             <SpeciesTotalPlantsChart species={species} minHeight='170px' />
           </ChartWrapper>
         </Grid>
-        <Grid item xs={chartGridSize}>
-          <ChartWrapper title={strings.MORTALITY_RATE_PER_SPECIES}>
-            <SpeciesMortalityRateChart species={species} minHeight='170px' />
-          </ChartWrapper>
-        </Grid>
+        {hasObservedPermanentPlots && (
+          <Grid item xs={chartGridSize}>
+            <ChartWrapper title={strings.MORTALITY_RATE_PER_SPECIES}>
+              <SpeciesMortalityRateChart species={species} minHeight='170px' />
+            </ChartWrapper>
+          </Grid>
+        )}
       </Grid>
     </Box>
   );


### PR DESCRIPTION
We were showing the mortality rates chart on the observation details
page even when there was no observation data yet; if the site had
previous observations where dead plants were observed in permanent
plots, this ended up showing across-the-board mortality rates of
100% since we calculate mortality rates using cumulative dead-plant
totals across observations.

We were already suppressing the numeric contents of the "Mortality
Rate" card if the current observation didn't have any completed
permanent plots; hide the chart in that case too.