### PR TITLE
SW-6774 Show empty mortality rate chart

### DIFF
--- a/src/scenes/ObservationsRouter/common/AggregatedPlantsStats.tsx
+++ b/src/scenes/ObservationsRouter/common/AggregatedPlantsStats.tsx
@@ -63,7 +63,7 @@ export default function AggregatedPlantsStats({
         ))}
       </Grid>
       <Grid container spacing={3}>
-        <Grid item xs={hasObservedPermanentPlots ? chartGridSize : chartGridSize * 2}>
+        <Grid item xs={chartGridSize}>
           <ChartWrapper
             title={
               <Box display='flex'>
@@ -75,13 +75,11 @@ export default function AggregatedPlantsStats({
             <SpeciesTotalPlantsChart species={species} minHeight='170px' />
           </ChartWrapper>
         </Grid>
-        {hasObservedPermanentPlots && (
-          <Grid item xs={chartGridSize}>
-            <ChartWrapper title={strings.MORTALITY_RATE_PER_SPECIES}>
-              <SpeciesMortalityRateChart species={species} minHeight='170px' />
-            </ChartWrapper>
-          </Grid>
-        )}
+        <Grid item xs={chartGridSize}>
+          <ChartWrapper title={strings.MORTALITY_RATE_PER_SPECIES}>
+            <SpeciesMortalityRateChart species={hasObservedPermanentPlots ? species : []} minHeight='170px' />
+          </ChartWrapper>
+        </Grid>
       </Grid>
     </Box>
   );


### PR DESCRIPTION
Rather than removing the mortality rate chart entirely when the
current observation has no completed permanent plots, show an empty
version of it.