### PR TITLE
SW-7037 Fix withdrawal log with deleted batches

### DIFF
--- a/src/services/NurseryWithdrawalService.ts
+++ b/src/services/NurseryWithdrawalService.ts
@@ -138,12 +138,14 @@ const listNurseryWithdrawals = async (
         (batchWithdrawals || deletedSpecies).map((batchWithdrawal) => batchWithdrawal.batch_species_scientificName)
       );
 
-      const projectNames = new Set(batchWithdrawals.map((batchWithdrawal) => batchWithdrawal.batch_project_name));
+      const projectNames = batchWithdrawals
+        ? Array.from(new Set(batchWithdrawals.map((batchWithdrawal) => batchWithdrawal.batch_project_name))).sort()
+        : [];
 
       return {
         ...remaining,
         speciesScientificNames: Array.from(speciesScientificNames).sort(),
-        project_names: Array.from(projectNames).sort(),
+        project_names: projectNames,
       };
     });
   }


### PR DESCRIPTION
If a nursery batch is deleted, references to it are deleted from
the `batch_withdrawals` table, meaning we can have a withdrawal
with no batches. This was causing the withdrawal history page to
fail because it assumed that every withdrawal was associated
with at least one batch.