### PR TITLE
Fix prefer-arrow-functions lint errors

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -69,11 +69,9 @@ jobs:
         run: yarn generate-strings
 
       # Remove the jsx-no-bind rule because it has lots of errors currently
-      # The rest of the rules should be fixed and then removed from this list of rules to disable
       - name: Run linter
         run: >
           yarn lint --rule "react/jsx-no-bind: 0"
-          --rule "prefer-arrow/prefer-arrow-functions: 0"
 
       - name: Do typescript check
         run: yarn ts

--- a/src/components/common/Chart/emptyDoughnutPlugin.ts
+++ b/src/components/common/Chart/emptyDoughnutPlugin.ts
@@ -2,11 +2,11 @@
 
 export const emptyDoughnutPlugin = {
   id: 'emptyDoughnut',
-  afterDraw(
+  afterDraw: (
     chart: { data?: any; chartArea?: any; ctx?: any },
     args: any,
     options: { color: any; width: any; radiusDecrease: any }
-  ) {
+  ) => {
     const { datasets } = chart.data;
     const { color, width, radiusDecrease } = options;
     let hasData = false;

--- a/src/scenes/PlantsDashboardRouter/components/htmlLegendPlugin.ts
+++ b/src/scenes/PlantsDashboardRouter/components/htmlLegendPlugin.ts
@@ -24,7 +24,7 @@ export const getOrCreateLegendList = (chart: any, id: string) => {
 export const htmlLegendPlugin = {
   id: 'htmlLegend',
   // See how this get called here https://www.chartjs.org/docs/latest/developers/plugins.html
-  afterUpdate(chart: Chart, args: any, options: { containerID: string }) {
+  afterUpdate: (chart: Chart, args: any, options: { containerID: string }) => {
     const ul = getOrCreateLegendList(chart, options.containerID);
 
     // Remove old legend items


### PR DESCRIPTION
Both of these are in chartjs plugins. It seems to be working fine as arrow functions instead. Tested on plants dashboard.