### PR TITLE
Fix eqeqeq lint errors

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -73,7 +73,6 @@ jobs:
       - name: Run linter
         run: >
           yarn lint --rule "react/jsx-no-bind: 0"
-          --rule "eqeqeq: 0"
           --rule "prefer-arrow/prefer-arrow-functions: 0"
 
       - name: Do typescript check

--- a/src/components/SeedFundReports/LocationSelection/Nursery.tsx
+++ b/src/components/SeedFundReports/LocationSelection/Nursery.tsx
@@ -28,6 +28,7 @@ const LocationSectionNursery = (props: LocationSectionProps): JSX.Element => {
           editable={editable}
           onChange={(value) => onUpdateLocation('capacity', transformNumericValue(value, { min: 0 }))}
           type='text'
+          /* eslint-disable-next-line eqeqeq */
           errorText={validate && (location as ReportNursery).capacity == null ? strings.REQUIRED_FIELD : ''}
           tooltipTitle={strings.REPORT_NURSERY_CAPACITY_INFO}
         />

--- a/src/components/SeedFundReports/LocationSelection/PlantingSitesSpeciesCellRenderer.tsx
+++ b/src/components/SeedFundReports/LocationSelection/PlantingSitesSpeciesCellRenderer.tsx
@@ -70,6 +70,7 @@ type TableCellInputProps = {
 function TableCellInput(props: TableCellInputProps): JSX.Element {
   const { id, initialValue, isPercentage, onConfirmEdit, className, sx, validate } = props;
   const [inputValue, setInputValue] = useState(initialValue);
+  /* eslint-disable-next-line eqeqeq */
   const inputInvalid = inputValue == null || inputValue === '';
 
   return (

--- a/src/components/SeedFundReports/LocationSelection/index.tsx
+++ b/src/components/SeedFundReports/LocationSelection/index.tsx
@@ -151,6 +151,7 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
           }}
           type='text'
           tooltipTitle={strings.REPORT_TOTAL_PAID_WORKERS_INFO}
+          /* eslint-disable-next-line eqeqeq */
           errorText={validate && location.workers.paidWorkers == null ? strings.REQUIRED_FIELD : ''}
         />
       </Grid>
@@ -169,6 +170,7 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
           }}
           type='text'
           tooltipTitle={strings.REPORT_TOTAL_WOMEN_PAID_WORKERS_INFO}
+          /* eslint-disable-next-line eqeqeq */
           errorText={validate && location.workers.femalePaidWorkers == null ? strings.REQUIRED_FIELD : ''}
         />
       </Grid>
@@ -187,6 +189,7 @@ export default function LocationSection(props: LocationSectionProps): JSX.Elemen
           }}
           type='text'
           tooltipTitle={strings.REPORT_TOTAL_VOLUNTEERS_INFO}
+          /* eslint-disable-next-line eqeqeq */
           errorText={validate && location.workers.volunteers == null ? strings.REQUIRED_FIELD : ''}
         />
       </Grid>

--- a/src/components/SeedFundReports/ReportEdit.tsx
+++ b/src/components/SeedFundReports/ReportEdit.tsx
@@ -225,11 +225,13 @@ export default function ReportEdit(): JSX.Element {
     }
 
     const emptyWorkerField = (location: any) => {
+      /* eslint-disable eqeqeq */
       return (
         location.workers.paidWorkers == null ||
         location.workers.femalePaidWorkers == null ||
         location.workers.volunteers == null
       );
+      /* eslint-enable eqeqeq */
     };
     const emptySeedbankFields = iReport.seedBanks?.findIndex((sb) => {
       return (
@@ -253,6 +255,7 @@ export default function ReportEdit(): JSX.Element {
         (!nursery.buildStartedDate ||
           !nursery.buildCompletedDate ||
           !nursery.operationStartedDate ||
+          /* eslint-disable-next-line eqeqeq */
           nursery.capacity == null ||
           !buildStartedDateValid(nursery) ||
           !buildCompletedDateValid(nursery) ||
@@ -265,6 +268,7 @@ export default function ReportEdit(): JSX.Element {
     }
 
     const emptyPlantingSitesFields = iReport.plantingSites?.findIndex((plantingSite) => {
+      /* eslint-disable eqeqeq */
       const speciesDataMissing =
         plantingSite.species?.some((sp) => sp.totalPlanted == null || sp.mortalityRateInField == null) ?? false;
       return (
@@ -277,6 +281,7 @@ export default function ReportEdit(): JSX.Element {
           speciesDataMissing ||
           emptyWorkerField(plantingSite))
       );
+      /* eslint-enable eqeqeq */
     });
     if (emptyPlantingSitesFields !== undefined && emptyPlantingSitesFields >= 0) {
       return `planting-site-${emptyPlantingSitesFields}`;

--- a/src/scenes/ModulesRouter/ListViewHeader.tsx
+++ b/src/scenes/ModulesRouter/ListViewHeader.tsx
@@ -38,7 +38,7 @@ const ListViewHeader = () => {
     <Dropdown
       onChange={(id) => {
         const projectId = +id;
-        if (projectId != currentParticipantProject?.id) {
+        if (projectId !== currentParticipantProject?.id) {
           setCurrentParticipantProject(projectId);
           goToModules(projectId);
         }

--- a/src/utils/documentProducer/variables.ts
+++ b/src/utils/documentProducer/variables.ts
@@ -59,6 +59,7 @@ export const variableDependencyMet = (variable: VariableWithValues, allVariables
         return variable.dependencyValue.toLowerCase() === `${rawDependsOnValue as string}`.toLowerCase();
       }
 
+      /* eslint-disable-next-line eqeqeq */
       return variable.dependencyValue == rawDependsOnValue;
     case 'gt':
       return Number(rawDependsOnValue) > Number(variable.dependencyValue);
@@ -82,6 +83,7 @@ export const variableDependencyMet = (variable: VariableWithValues, allVariables
         }
       }
 
+      /* eslint-disable-next-line eqeqeq */
       return variable.dependencyValue != rawDependsOnValue;
   }
 };


### PR DESCRIPTION
Many of the usages were null-ish checks (`foo == null`) which were intentional for form validation, thus I disabled the rule for these. I also disabled it for `variableDependencyMet` as the `dependencyValue` is `string` but the `rawDependsOnValue` is `number | number[] | string`, so I'm assuming the non triple equals was intentional.