### PR TITLE
SW-7106 Update web-components and make funding entities project dropdown autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@mui/styled-engine-sc": "^5.14.12",
     "@mui/styles": "^6.2.0",
     "@reduxjs/toolkit": "^1.9.3",
-    "@terraware/web-components": "^3.4.27",
+    "@terraware/web-components": "^3.4.28",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/playwright/e2e/suites/fundingEntities.spec.ts
+++ b/playwright/e2e/suites/fundingEntities.spec.ts
@@ -62,7 +62,7 @@ export default function FundingEntitiesTests() {
     await page.getByText('Existing Funding Entity', exactOptions).click();
     await page.getByRole('button', { name: 'Edit Funding Entity' }).click();
     await page.locator('#name > input').fill(updatedEntityName);
-    await page.getByPlaceholder('Select...').locator('../../../../..').locator('button').first().click();
+    await page.getByPlaceholder('Select...').locator('../../../../../..').locator('button').nth(2).click(); // remove first project
     await page.getByText('Add Project').click();
     await page.getByPlaceholder('Select...').click();
     await page

--- a/src/scenes/AcceleratorRouter/FundingEntities/MultiProjectsEdit.tsx
+++ b/src/scenes/AcceleratorRouter/FundingEntities/MultiProjectsEdit.tsx
@@ -75,6 +75,7 @@ const MultiProjectsEdit = (props: ProjectsEditProps): JSX.Element => {
                 const _project = setFn({ projectId: -1 });
                 selectProject(index, _project.projectId);
               }}
+              autoComplete
             />
           </Grid>
           <Grid item xs={1} display={'flex'} flexDirection={'column-reverse'}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4593,10 +4593,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terraware/web-components@^3.4.27":
-  version "3.4.27"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.4.27.tgz#603bb10a4af6cc20805ea067d543e8dcfb729336"
-  integrity sha512-b/PFLJRAS2c69sCySHc22dUKUjgcMHX+jtzV0tAbKIt/iJvgHkwCkpvrEWrngdL9+OgXzljEJPZGtXCNaW2pQA==
+"@terraware/web-components@^3.4.28":
+  version "3.4.28"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-3.4.28.tgz#5714067e556e412084aab4367f59eabea142b7b5"
+  integrity sha512-Gcp4VQzPgU0zoMdXDkBMoE8uPfD0ww4iQh5fwZ8PmAj+h/cpGfVFPLpOGaKLI/dtN3wU2O8iTt0VykCr/hFtaA==
   dependencies:
     "@dnd-kit/core" "^6.0.7"
     "@dnd-kit/sortable" "^7.0.2"


### PR DESCRIPTION
Bring in web-components v3.4.28 to include larger dropdown height for all dropdowns.

Add autocomplete to Funding Entities form for selecting projects to simplify.