### PR TITLE
Reorganize set-environment.sh

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -151,7 +151,7 @@ jobs:
         env:
           REACT_APP_TERRAWARE_API: ''
           REACT_APP_TERRAWARE_FE_BUILD_VERSION: ${{ env.APP_VERSION }}
-          REACT_APP_MIXPANEL_TOKEN: ${{ secrets[env.MIXPANEL_SECRET] }}
+          REACT_APP_MIXPANEL_TOKEN: ${{ secrets[env.MIXPANEL_SECRET_NAME] }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Clean up the CI script that sets environment variables:

* Remove support for a "QA" tier, which we no longer have.
* Remove redundant checks for `IS_CD`.
* Split the environment variables into two blocks, one for
  values and one for secret names.
* Rename the Mixpanel secret name environment variable for
  consistency with the other secret names.