### PR TITLE
SW-7119 Add support for ECS deployment

### DIFF
--- a/.github/scripts/set-environment.sh
+++ b/.github/scripts/set-environment.sh
@@ -24,6 +24,8 @@ docker_tags="${docker_image}:$commit_sha,${docker_image}:${TIER}"
 echo "APP_VERSION=$APP_VERSION
 COMMIT_SHA=$commit_sha
 DOCKER_TAGS=$docker_tags
+ECS_CLUSTER_VAR_NAME=${TIER}_ECS_CLUSTER
+ECS_SERVICE_VAR_NAME=${TIER}_ECS_SERVICE
 IS_CD=true
 TIER=$TIER" >> $GITHUB_ENV
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -187,12 +187,22 @@ jobs:
           oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
           tags: tag:github
 
-      - name: Deploy
+      - name: Deploy to EC2
         if: env.IS_CD == 'true'
         env:
           SSH_KEY: ${{ secrets[env.SSH_KEY_SECRET_NAME] }}
           SSH_USER: ${{ secrets[env.SSH_USER_SECRET_NAME] }}
         run: ./.github/scripts/deploy.sh
+
+      - name: Deploy to ECS
+        if: vars[env.ECS_CLUSTER_VAR_NAME] != '' && vars[env.ECS_SERVICE_VAR_NAME] != ''
+        run: |
+          aws ecs update-service --cluster ${{ vars[env.ECS_CLUSTER_VAR_NAME] }} --service ${{ vars[env.ECS_SERVICE_VAR_NAME] }} --force-new-deployment
+
+      - name: Wait for ECS deployment to become stable
+        if: vars[env.ECS_CLUSTER_VAR_NAME] != '' && vars[env.ECS_SERVICE_VAR_NAME] != ''
+        run: |
+          aws ecs wait services-stable --cluster ${{ vars[env.ECS_CLUSTER_VAR_NAME] }} --service ${{ vars[env.ECS_SERVICE_VAR_NAME] }}
 
       - name: Jira Login
         if: env.TIER == 'PROD'


### PR DESCRIPTION
For prod and staging deploys, if the repo has variables whose names are
the tier name followed by `_ECS_CLUSTER` and `_ECS_SERVICE` (for
example, `STAGING_ECS_CLUSTER`), deploy to that ECS cluster/service.

For now, we deploy to the EC2 instances whether or not we deploy
to ECS. This will let us test ECS deployment without disrupting the
existing prod/staging environments.