### PR TITLE
SW-7139: "Refresh to use the latest version" does not go away

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - main
       - qa
-      - josh/SW-7139-refresh-banner-always-shows
     tags:
       # Semver (these are glob-like patterns, not regexes; the "." has no special meaning)
       - v[0-9].[0-9]+.[0-9]+

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -109,43 +109,6 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
-      - name: Install Vercel CLI
-        run: npm install -g vercel
-
-      - name: Create Vercel project.json for Terraware Web Preview
-        run: |
-          mkdir -p .vercel
-          echo "{\"projectId\":\"${{ secrets.VERCEL_PROJECT_ID_TERRAWARE_WEB_PREVIEW }}\",\"orgId\":\"${{ secrets.VERCEL_ORG_ID }}\"}" > .vercel/project.json
-
-      - name: Pull Vercel project settings for "preview" environment
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Create GitHub deployment for Vercel deploy
-        uses: chrnorm/deployment-action@v2
-        id: vercel_deployment
-        with:
-          environment: Vercel - Preview (tree-location-web)
-          initial-status: 'in_progress'
-          token: '${{ github.token }}'
-
-      - name: Build for Vercel
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Deploy to Vercel (prebuilt)
-        id: vercel_deploy
-        run: |
-          preview_url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
-          echo "preview_url=$preview_url" >> $GITHUB_OUTPUT
-
-      - name: Update GitHub deployment status
-        if: ${{ steps.vercel_deployment.outputs.deployment_id }}
-        uses: chrnorm/deployment-status@v2
-        with:
-          deployment-id: ${{ steps.vercel_deployment.outputs.deployment_id }}
-          environment-url: ${{ steps.vercel_deploy.outputs.preview_url }}
-          state: ${{ job.status == 'success' && 'success' || 'failure' }}
-          token: '${{ github.token }}'
-
       - name: build
         run: yarn build
         env:
@@ -222,3 +185,40 @@ jobs:
         with:
           issueList: ./docs/jiralist.txt
           transition: 'Released to Production from Done'
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel
+
+      - name: Create Vercel project.json for Terraware Web Preview
+        run: |
+          mkdir -p .vercel
+          echo "{\"projectId\":\"${{ secrets.VERCEL_PROJECT_ID_TERRAWARE_WEB_PREVIEW }}\",\"orgId\":\"${{ secrets.VERCEL_ORG_ID }}\"}" > .vercel/project.json
+
+      - name: Pull Vercel project settings for "preview" environment
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Create GitHub deployment for Vercel deploy
+        uses: chrnorm/deployment-action@v2
+        id: vercel_deployment
+        with:
+          environment: Vercel - Preview (tree-location-web)
+          initial-status: 'in_progress'
+          token: '${{ github.token }}'
+
+      - name: Build for Vercel
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to Vercel (prebuilt)
+        id: vercel_deploy
+        run: |
+          preview_url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "preview_url=$preview_url" >> $GITHUB_OUTPUT
+
+      - name: Update GitHub deployment status
+        if: ${{ steps.vercel_deployment.outputs.deployment_id }}
+        uses: chrnorm/deployment-status@v2
+        with:
+          deployment-id: ${{ steps.vercel_deployment.outputs.deployment_id }}
+          environment-url: ${{ steps.vercel_deploy.outputs.preview_url }}
+          state: ${{ job.status == 'success' && 'success' || 'failure' }}
+          token: '${{ github.token }}'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - qa
+      - josh/SW-7139-refresh-banner-always-shows
     tags:
       # Semver (these are glob-like patterns, not regexes; the "." has no special meaning)
       - v[0-9].[0-9]+.[0-9]+

--- a/src/redux/features/appVersion/appVersionSelectors.ts
+++ b/src/redux/features/appVersion/appVersionSelectors.ts
@@ -5,11 +5,8 @@ import { RootState } from 'src/redux/rootReducer';
 export const selectAppVersion = (state: RootState) => state.appVersion.version;
 const currentAppVersion = process.env.REACT_APP_TERRAWARE_FE_BUILD_VERSION;
 
-export const selectIsAppVersionStale = (state: RootState) => {
-  console.log('currentAppVersion:', currentAppVersion);
-  console.log('state.appVersion.version:', state.appVersion.version);
-  return !!state.appVersion.version && state.appVersion.version.toString().trim() !== currentAppVersion;
-};
+export const selectIsAppVersionStale = (state: RootState) =>
+  !!state.appVersion.version && state.appVersion.version.toString().trim() !== currentAppVersion;
 
 // simple example of composable selectors
 export const selectIsAppVersionStaleExample = createSelector(

--- a/src/redux/features/appVersion/appVersionSelectors.ts
+++ b/src/redux/features/appVersion/appVersionSelectors.ts
@@ -5,8 +5,11 @@ import { RootState } from 'src/redux/rootReducer';
 export const selectAppVersion = (state: RootState) => state.appVersion.version;
 const currentAppVersion = process.env.REACT_APP_TERRAWARE_FE_BUILD_VERSION;
 
-export const selectIsAppVersionStale = (state: RootState) =>
-  !!state.appVersion.version && state.appVersion.version.toString().trim() !== currentAppVersion;
+export const selectIsAppVersionStale = (state: RootState) => {
+  console.log('currentAppVersion:', currentAppVersion);
+  console.log('state.appVersion.version:', state.appVersion.version);
+  return !!state.appVersion.version && state.appVersion.version.toString().trim() !== currentAppVersion;
+};
 
 // simple example of composable selectors
 export const selectIsAppVersionStaleExample = createSelector(


### PR DESCRIPTION
`vercel build` resets `REACT_APP_TERRAWARE_FE_BUILD_VERSION` and regenerates `build-version.txt`. This step was unintentionally modifying both before the release build. Moving the Vercel steps to the end of the job avoids blocking the release; a separate job would be a longer-term fix. Will address the longer-term fix in a follow-up PR.
