### PR TITLE
SW-7037 Hide withdrawals from deleted batches

### DIFF
--- a/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
@@ -24,6 +24,7 @@ import {
   AndNodePayload,
   FieldNodePayload,
   FieldOptionsMap,
+  NotNodePayload,
   OrNodePayload,
   SearchNodePayload,
   SearchResponseElement,
@@ -157,7 +158,7 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   const getSearchChildren = useCallback(() => {
     const { type, values } = parseSearchTerm(debouncedSearchTerm);
     const finalSearchValueChildren: SearchNodePayload[] = [];
-    const searchValueChildren: FieldNodePayload[] = [];
+    const searchValueChildren: SearchNodePayload[] = [];
     if (debouncedSearchTerm) {
       const fromNurseryNode: FieldNodePayload = {
         operation: 'field',
@@ -182,6 +183,21 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
         values,
       };
       searchValueChildren.push(speciesNameNode);
+    } else {
+      // If the batch was deleted before we added the server-side logic to deal with deleting
+      // batches that have withdrawals, there won't be any batchWithdrawals values. In that
+      // case, we can't show the species name or the total withdrawn. Filter withdrawals without
+      // batches out since they're useless to show.
+      const batchExistsNode: NotNodePayload = {
+        operation: 'not',
+        child: {
+          operation: 'field',
+          field: 'batchWithdrawals.batch_id',
+          type: 'Exact',
+          values: [null],
+        },
+      };
+      searchValueChildren.push(batchExistsNode);
     }
 
     const filterValueChildren: SearchNodePayload[] = [...Object.values(filters)];

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
@@ -183,21 +183,6 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
         values,
       };
       searchValueChildren.push(speciesNameNode);
-    } else {
-      // If the batch was deleted before we added the server-side logic to deal with deleting
-      // batches that have withdrawals, there won't be any batchWithdrawals values. In that
-      // case, we can't show the species name or the total withdrawn. Filter withdrawals without
-      // batches out since they're useless to show.
-      const batchExistsNode: NotNodePayload = {
-        operation: 'not',
-        child: {
-          operation: 'field',
-          field: 'batchWithdrawals.batch_id',
-          type: 'Exact',
-          values: [null],
-        },
-      };
-      searchValueChildren.push(batchExistsNode);
     }
 
     const filterValueChildren: SearchNodePayload[] = [...Object.values(filters)];
@@ -228,6 +213,22 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
       };
       finalSearchValueChildren.push(filterValueNodes);
     }
+
+    // If the batch was deleted before we added the server-side logic to deal with deleting batches
+    // that have withdrawals, there won't be any batchWithdrawals values. In that case, we can't
+    // show the species name or the total withdrawn. Filter withdrawals without batches out since
+    // they're useless to show.
+    const batchExistsNode: NotNodePayload = {
+      operation: 'not',
+      child: {
+        operation: 'field',
+        field: 'batchWithdrawals.batch_id',
+        type: 'Exact',
+        values: [null],
+      },
+    };
+    finalSearchValueChildren.push(batchExistsNode);
+
     return finalSearchValueChildren;
   }, [filters, debouncedSearchTerm]);
 


### PR DESCRIPTION
If a seedling batch was deleted before we added the server-side
logic to detect deletion of batches with existing withdrawals,
its withdrawals were showing up in the withdrawal log with
quantities of 0 and a species name of "<deleted species>".
Update the search criteria to filter those withdrawals out
since they are misleading and we can't show anything useful
about them.