### PR TITLE
SW-7165 Fix withdrawal modal sending incorrect units sometimes

### DIFF
--- a/playwright/e2e/suites/accession.spec.ts
+++ b/playwright/e2e/suites/accession.spec.ts
@@ -110,7 +110,7 @@ export default function AccessionTests() {
     await expect(page.getByRole('main')).toContainText('Coconut');
   });
 
-  test('Withdraw to Nursery', async ({ page }, testInfo) => {
+  test('Withdraw to Nursery by weight', async ({ page }, testInfo) => {
     await page.goto('http://127.0.0.1:3000');
 
     await waitFor(page, '#home');
@@ -208,5 +208,33 @@ export default function AccessionTests() {
     await page.getByRole('button', { name: 'Save' }).click();
     await page.getByRole('button', { name: 'Apply Result' }).click();
     await expect(page.locator('#row1-viabilityPercent')).toContainText('90%');
+  });
+
+  test('Withdraw to Nursery by Seed Count', async ({ page }, testInfo) => {
+    await page.goto('http://127.0.0.1:3000');
+    await waitFor(page, '#home');
+
+    await page.getByRole('button', { name: 'Seeds' }).click();
+    await page.getByRole('button', { name: 'Accessions' }).click();
+    await page.locator('#row1-accessionNumber').getByText('25-1-2-001').click();
+    await page.getByRole('button', { name: 'Withdraw' }).click();
+    await page.locator('#destinationFacilityId').getByRole('textbox').click();
+    await page
+      .getByText(/My New Nursery/)
+      .nth(0)
+      .click();
+    await page.getByLabel('Seed Count', { exact: true }).check();
+
+    await page.locator('#withdrawnQuantity').getByRole('textbox').fill('10');
+
+    await page.locator('#saveWithdraw').click();
+    await expect(page.getByRole('main')).toContainText('65 Grams');
+    await expect(page.getByRole('main')).toContainText('~65 ct');
+    await page.getByRole('tab', { name: 'History' }).click();
+    await expect(page.getByLabel('History')).toContainText('Super Admin withdrew 10 seeds for nursery');
+    await page.getByRole('button', { name: 'Seedlings' }).click();
+    await page.getByRole('button', { name: 'Inventory', ...exactOptions }).click();
+    await expect(page.locator('#row1-species_scientificName')).toContainText('Coconut');
+    await expect(page.locator('#row1-germinatingQuantity')).toContainText('310');
   });
 }

--- a/playwright/e2e/suites/accession.spec.ts
+++ b/playwright/e2e/suites/accession.spec.ts
@@ -110,7 +110,7 @@ export default function AccessionTests() {
     await expect(page.getByRole('main')).toContainText('Coconut');
   });
 
-  test('Withdraw to Nursery by weight', async ({ page }, testInfo) => {
+  test('Withdraw to Nursery by seed count', async ({ page }, testInfo) => {
     await page.goto('http://127.0.0.1:3000');
 
     await waitFor(page, '#home');
@@ -124,7 +124,8 @@ export default function AccessionTests() {
       .getByText(/My New Nursery/)
       .nth(0)
       .click();
-    await page.locator('#withdrawnQuantity').getByRole('spinbutton').fill('300');
+    await page.getByLabel('Seed Count', { exact: true }).check();
+    await page.locator('#withdrawnQuantity').getByRole('textbox').fill('300');
     await page.getByRole('button', { name: 'Add Notes' }).click();
     await page.locator('textarea').fill('Adding some test notes here!');
     await page.locator('#saveWithdraw').click();
@@ -208,33 +209,5 @@ export default function AccessionTests() {
     await page.getByRole('button', { name: 'Save' }).click();
     await page.getByRole('button', { name: 'Apply Result' }).click();
     await expect(page.locator('#row1-viabilityPercent')).toContainText('90%');
-  });
-
-  test('Withdraw to Nursery by Seed Count', async ({ page }, testInfo) => {
-    await page.goto('http://127.0.0.1:3000');
-    await waitFor(page, '#home');
-
-    await page.getByRole('button', { name: 'Seeds' }).click();
-    await page.getByRole('button', { name: 'Accessions' }).click();
-    await page.locator('#row1-accessionNumber').getByText('25-1-2-001').click();
-    await page.getByRole('button', { name: 'Withdraw' }).click();
-    await page.locator('#destinationFacilityId').getByRole('textbox').click();
-    await page
-      .getByText(/My New Nursery/)
-      .nth(0)
-      .click();
-    await page.getByLabel('Seed Count', { exact: true }).check();
-
-    await page.locator('#withdrawnQuantity').getByRole('textbox').fill('10');
-
-    await page.locator('#saveWithdraw').click();
-    await expect(page.getByRole('main')).toContainText('65 Grams');
-    await expect(page.getByRole('main')).toContainText('~65 ct');
-    await page.getByRole('tab', { name: 'History' }).click();
-    await expect(page.getByLabel('History')).toContainText('Super Admin withdrew 10 seeds for nursery');
-    await page.getByRole('button', { name: 'Seedlings' }).click();
-    await page.getByRole('button', { name: 'Inventory', ...exactOptions }).click();
-    await expect(page.locator('#row1-species_scientificName')).toContainText('Coconut');
-    await expect(page.locator('#row1-germinatingQuantity')).toContainText('310');
   });
 }

--- a/src/scenes/AccessionsRouter/withdraw/CountWithdrawal.tsx
+++ b/src/scenes/AccessionsRouter/withdraw/CountWithdrawal.tsx
@@ -8,7 +8,7 @@ import { Accession, Withdrawal } from 'src/types/Accession';
 
 export interface CountWithdrawalProps {
   accession: Accession;
-  onWithdrawCtUpdate: (withdrawnQuantity: Withdrawal['withdrawnQuantity'], valid: boolean) => void;
+  onWithdrawCtUpdate: (withdrawnQuantity: number, valid: boolean) => void;
 }
 
 export default function CountWithdrawal(props: CountWithdrawalProps): JSX.Element {
@@ -55,13 +55,7 @@ export default function CountWithdrawal(props: CountWithdrawalProps): JSX.Elemen
     }
 
     valid = validateAmount(value);
-    onWithdrawCtUpdate(
-      {
-        quantity: value || 0,
-        units: 'Seeds',
-      },
-      valid
-    );
+    onWithdrawCtUpdate(value || 0, valid);
   };
 
   const onSelectAll = (id: string, withdrawAll: boolean) => {

--- a/src/scenes/AccessionsRouter/withdraw/WithdrawModal.tsx
+++ b/src/scenes/AccessionsRouter/withdraw/WithdrawModal.tsx
@@ -154,6 +154,8 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
             (accession.subsetCount / accession.subsetWeight.quantity)
         );
       }
+    } else if (!isByWeight) {
+      return withdrawalQty;
     }
     return estimated;
   }, [accession, isByWeight, withdrawalQty]);


### PR DESCRIPTION
The withdrawal modal would send incorrect units, depending on the order of operations in the dialog. 

This is a pretty hefty change to this modal, and thorough testing should be completed around this (Alex is working on this).