### PR TITLE
Fix Vercel deploys become inactive

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -63,6 +63,7 @@ jobs:
         uses: chrnorm/deployment-action@v2
         id: vercel_deployment
         with:
+          auto-inactive: false
           environment: Vercel - Preview (tree-location-web)
           initial-status: 'in_progress'
           task: deploy:preview


### PR DESCRIPTION
Disable `auto-inactive` option for vercel deploys:

> Adds a new inactive status to all prior non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment. An inactive status is only added to deployments that had a success state.

The option is `true` by default.

