### PR TITLE
SW-7084: Planting Sites: Maps - remove "Monitoring Plots" from the zone and subzone popovers

### DIFF
--- a/src/scenes/PlantingSitesRouter/view/BoundariesAndZones.tsx
+++ b/src/scenes/PlantingSitesRouter/view/BoundariesAndZones.tsx
@@ -265,10 +265,6 @@ function PlantingSiteMapView({ search }: PlantingSiteMapViewProps): JSX.Element 
             },
             { key: strings.SUBZONES, value: zone?.plantingSubzones.length ?? 0 },
             {
-              key: strings.MONITORING_PLOTS,
-              value: zone?.numPermanentPlots ?? 0,
-            },
-            {
               key: strings.LAST_OBSERVED,
               value: zone?.latestObservationCompletedTime
                 ? getDateDisplayValue(zone.latestObservationCompletedTime, timeZone)
@@ -289,7 +285,6 @@ function PlantingSiteMapView({ search }: PlantingSiteMapViewProps): JSX.Element 
               value: subzoneHistory?.areaHa && subzoneHistory?.areaHa > 0 ? subzoneHistory?.areaHa : '',
             },
             { key: strings.PLANTING_COMPLETE, value: subzone?.plantingCompleted ? strings.YES : strings.NO },
-            { key: strings.MONITORING_PLOTS, value: subzone?.monitoringPlots.length ?? 0 },
           ];
         } else {
           return null;


### PR DESCRIPTION
This PR removes "Monitoring Plots" information from the Zone & Subzone popovers that display in the Planting Site map.