### PR TITLE
SW-7175 Fix withdrawal modal's Exceeds message missing

### DIFF
--- a/src/scenes/AccessionsRouter/withdraw/WeightWithdrawal.tsx
+++ b/src/scenes/AccessionsRouter/withdraw/WeightWithdrawal.tsx
@@ -21,7 +21,7 @@ export default function WeightWithdrawal(props: WeightWithdrawalProps): JSX.Elem
   const [estimatedWithdrawnCt, setEstimatedWithdrawnCt] = useState<number>(0);
   const [withdrawnQuantity, setWithdrawnQuantity] = useState<Withdrawal['withdrawnQuantity']>({
     quantity: 0,
-    units: 'Grams',
+    units: accession.remainingQuantity?.units || 'Grams',
   });
   const [withdrawnQtyError, setWithdrawnQtyError] = useState<string>('');
 


### PR DESCRIPTION
The "Exceeds Remaining Quantity" was missing on the withdrawal modal when By Weight was selected, if the original quantity was in a unit other than Grams. This was corrected when the user selects and deselects `Withdraw All`, but it needs to work all the time. 

Set the units equal to the original quantity so that this message works correctly.