### PR TITLE
SW-7143: Questionnaire Deliverables allow submitting before variables have loaded (FOLLOW-UP)

### DIFF
--- a/src/components/DeliverableView/SpeciesDeliverableCard.tsx
+++ b/src/components/DeliverableView/SpeciesDeliverableCard.tsx
@@ -13,7 +13,7 @@ import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import SpeciesDeliverableStatusMessage from './SpeciesDeliverableStatusMessage';
 
 const SpeciesDeliverableCard = (props: EditProps): JSX.Element => {
-  const { deliverable, setSubmitButtonDisalbed } = props;
+  const { deliverable, setSubmitButtonDisabled } = props;
   const dispatch = useAppDispatch();
 
   const ppsSearchResults = useAppSelector(selectParticipantProjectSpeciesListRequest(deliverable.projectId));
@@ -22,8 +22,8 @@ const SpeciesDeliverableCard = (props: EditProps): JSX.Element => {
     const disabled =
       !ppsSearchResults?.data?.length ||
       ppsSearchResults?.data?.every((species) => species.participantProjectSpecies.submissionStatus === 'Approved');
-    setSubmitButtonDisalbed?.(disabled);
-  }, [ppsSearchResults, setSubmitButtonDisalbed]);
+    setSubmitButtonDisabled?.(disabled);
+  }, [ppsSearchResults, setSubmitButtonDisabled]);
 
   useEffect(() => {
     void dispatch(requestListParticipantProjectSpecies(deliverable.projectId));

--- a/src/components/DeliverableView/types.ts
+++ b/src/components/DeliverableView/types.ts
@@ -6,7 +6,7 @@ export type ViewProps = {
   deliverable: DeliverableWithOverdue;
   hideId?: boolean;
   hideStatusBadge?: boolean;
-  setSubmitButtonDisalbed?: (disabled: boolean) => void;
+  setSubmitButtonDisabled?: (disabled: boolean) => void;
 };
 
 export type EditProps = ViewProps & {

--- a/src/scenes/AcceleratorRouter/Deliverables/DeliverableView.tsx
+++ b/src/scenes/AcceleratorRouter/Deliverables/DeliverableView.tsx
@@ -45,15 +45,15 @@ const DeliverableView = () => {
   const { activeLocale } = useLocalization();
   const { currentDeliverable: deliverable } = useDeliverableData();
 
-  const variablesWithValues: VariableWithValues[] | undefined = useAppSelector((state) =>
-    deliverable?.id && deliverable?.projectId && deliverable?.type === 'Questions'
-      ? selectDeliverableVariablesWithValues(state, deliverable.id, deliverable.projectId)
-      : undefined
+  const variablesWithValues: VariableWithValues[] = useAppSelector((state) =>
+    selectDeliverableVariablesWithValues(state, deliverable?.id || -1, deliverable?.projectId)
   );
+
   const questionsAreLoading = useMemo(
-    () => deliverable?.type === 'Questions' && !variablesWithValues?.length,
-    [deliverable?.type, variablesWithValues?.length]
+    () => deliverable?.type === 'Questions' && !variablesWithValues.length,
+    [deliverable?.type, variablesWithValues.length]
   );
+
   useEffect(() => {
     const _source = query.get('source');
     if (_source) {


### PR DESCRIPTION
In my initial PR for SW-7143 the fix was made on the Accelerator side only. This PR includes some follow-up changes to address the issue on the Participant side:

- Disable deliverable CTA buttons on Participant side while data is loading
- Simplify existing selector
- Fix spelling typo
- Fix other linter issues (no arrow functions)