### PR TITLE
SW-7013: Observations: Add total number of "Live Plants" to Plant Monitoring Observations (Follow-up)

### DIFF
--- a/src/scenes/ObservationsRouter/common/AggregatedPlantsStats.tsx
+++ b/src/scenes/ObservationsRouter/common/AggregatedPlantsStats.tsx
@@ -5,7 +5,7 @@ import { IconTooltip } from '@terraware/web-components';
 
 import Card from 'src/components/common/Card';
 import OverviewItemCard from 'src/components/common/OverviewItemCard';
-import strings from 'src/strings';
+import { useLocalization } from 'src/providers/hooks';
 import { ObservationSpeciesResults } from 'src/types/Observations';
 import { getObservationSpeciesLivePlantsCount } from 'src/utils/observation';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
@@ -31,6 +31,7 @@ export default function AggregatedPlantsStats({
   species,
   hasObservedPermanentPlots,
 }: AggregatedPlantsStatsProps): JSX.Element {
+  const { strings } = useLocalization();
   const { isMobile } = useDeviceInfo();
   const infoCardGridSize = isMobile ? 12 : 3;
   const chartGridSize = isMobile ? 12 : 6;
@@ -40,12 +41,12 @@ export default function AggregatedPlantsStats({
   const handleMissingData = (num?: number) => (!completedTime && !num ? '' : num);
 
   const getData = () => [
-    { label: strings.LIVE_PLANTS, value: handleMissingData(livePlants) },
+    { label: strings.LIVE_PLANTS, tooltip: strings.TOOLTIP_LIVE_PLANTS, value: handleMissingData(livePlants) },
     { label: strings.SPECIES, value: handleMissingData(totalSpecies) },
     {
       label: strings.PLANTING_DENSITY,
+      tooltip: strings.PLANTING_DENSITY_MISSING_TOOLTIP,
       value: plantingDensity,
-      toolTip: strings.PLANTING_DENSITY_MISSING_TOOLTIP,
     },
     { label: strings.MORTALITY_RATE, value: hasObservedPermanentPlots ? handleMissingData(mortalityRate) : '' },
   ];
@@ -59,7 +60,7 @@ export default function AggregatedPlantsStats({
               isEditable={false}
               title={data.label}
               contents={data.value?.toString() ?? null}
-              titleInfoTooltip={data.toolTip}
+              titleInfoTooltip={data.tooltip}
             />
           </Grid>
         ))}

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -2111,6 +2111,7 @@ TOOLTIP_DASHBOARD_TOTAL_ACTIVE_ACCESSIONS,"This number represents all accessions
 TOOLTIP_ECOSYSTEM_TYPE,"Relatively large units of land or water containing a distinct assemblage of natural communities sharing a large majority of species, dynamics, and environmental conditions.",
 TOOLTIP_GERMINATING_QUANTITY,Germinating indicates that seedlings have not yet emerged from seeds. Germinating quantity does not count toward the total quantity.,
 TOOLTIP_INVENTORY_ADD_ACCESSION_ID,The ID of the accession used to create this batch.  Unavailable for species that don't have any accessions.,
+TOOLTIP_LIVE_PLANTS,"Live Plants observed includes only plants recorded as live; it does not include plants recorded as pre-existing.",
 TOOLTIP_NOT_READY_QUANTITY,What determines a plant as “not ready” is up to your team and is often species specific. For example: size of plant or amount of time acclimated.,
 TOOLTIP_READY_QUANTITY,What determines a plant as “ready” is up to your team and is often species specific. For example: size of plant or amount of time acclimated.,
 TOOLTIP_SCIENTIFIC_NAME,The binomial Latin name (genus + species) currently accepted in the botanical literature.,


### PR DESCRIPTION
This PR includes a follow-up change to add a tooltip and a couple of other minor changes:

- Add tooltip for newly added label "Live Plants"
- Get `strings` from `useLocalization` hook
- Adjust casing: toolTip --> tooltip