### PR TITLE
SW-7198: Observations: Ability to download Ad Hoc Plant Monitoring data (FOLLOW-UP)

### DIFF
--- a/src/scenes/ObservationsRouter/exportAdHocObservations.ts
+++ b/src/scenes/ObservationsRouter/exportAdHocObservations.ts
@@ -58,8 +58,8 @@ const makeAdHocObservationsResultsCsv = ({
     plantingSiteName: observation.plantingSiteName,
     startDate: getDateDisplayValue(observation.startDate, plantingSite?.timeZone),
     totalLive: observation.totalLive,
-    totalPlants: observation.totalPlants,
-    totalSpecies: observation.totalSpecies,
+    totalPlants: observation.adHocPlot?.totalPlants,
+    totalSpecies: observation.adHocPlot?.totalSpecies,
   }));
 
   return makeCsv(columnHeaders, data);

--- a/src/scenes/ObservationsRouter/exportAdHocObservations.ts
+++ b/src/scenes/ObservationsRouter/exportAdHocObservations.ts
@@ -194,7 +194,7 @@ const makeAdHocObservationCsv = ({
       deadPlants: aggregateSpeciesData.totalDead || 0,
       totalSpecies: adHocObservation.adHocPlot.totalSpecies || 0,
       conditions:
-        adHocObservation.adHocPlot?.conditions.map((condition) => getConditionString(condition)).join(', ') || '- -',
+        adHocObservation.adHocPlot?.conditions.map((condition) => getConditionString(condition)).join(', ') || '',
       notes: adHocObservation.adHocPlot?.notes || '',
     },
   ];


### PR DESCRIPTION
This PR includes some follow-up changes to fix a couple of issues discovered during QA:

- Use empty string rather than hyphenated empty value placeholder
- Fix Total Plants & Total Species values are always zero when exporting Ad Hoc Plant Monitoring Observations Table