### PR TITLE
SW-7267 Don't limit observation CSVs to 25 rows

### DIFF
--- a/src/services/ObservationsService.ts
+++ b/src/services/ObservationsService.ts
@@ -85,6 +85,7 @@ const exportCsv = async (observationId: number): Promise<any> => {
       field: 'id',
       values: [`${observationId}`],
     },
+    count: 0,
   });
 };
 
@@ -127,6 +128,7 @@ const exportBiomassObservationsCsv = async (organizationId: number, plantingSite
         },
       ],
     },
+    count: 0,
   });
 };
 
@@ -168,6 +170,7 @@ const exportBiomassPlotCsv = async (observationId: number): Promise<any> => {
       field: 'id',
       values: [`${observationId}`],
     },
+    count: 0,
   });
 };
 
@@ -187,6 +190,7 @@ const exportBiomassSpeciesCsv = async (observationId: number): Promise<any> => {
       operation: 'and',
       children: [{ operation: 'field', type: 'Exact', field: 'observation_id', values: [`${observationId}`] }],
     },
+    count: 0,
   });
 };
 
@@ -215,6 +219,7 @@ const exportBiomassTreesShrubsCsv = async (observationId: number): Promise<any> 
       field: 'observation_id',
       values: [`${observationId}`],
     },
+    count: 0,
   });
 };
 

--- a/src/types/Search.ts
+++ b/src/types/Search.ts
@@ -19,7 +19,10 @@ export type FieldOptionsMap = { [key: string]: { partial: boolean; values: (stri
 
 export type SearchRequestPayloadWithOptionalSearch = components['schemas']['SearchRequestPayload'];
 /** Search request payload that requires a search node to be specified. */
-export type SearchRequestPayload = components['schemas']['SearchRequestPayload'] & { search: SearchNodePayload };
+export type SearchRequestPayload = components['schemas']['SearchRequestPayload'] & {
+  count: number;
+  search: SearchNodePayload;
+};
 export type OptionalSearchRequestPayload = components['schemas']['SearchRequestPayload'];
 
 export const isFieldNodePayload = (node: SearchNodePayload): node is FieldNodePayload => node.operation === 'field';


### PR DESCRIPTION
The search API defaults to a result count of 25, but for CSV
exports of observation data, we want to export the full data set.
Update the request payloads to set the desired count to 0, which
means no limit. Update the search request payload type declaration
to guard against anyone forgetting to set the count in the future.