### PR TITLE
Fixed legend sizing

### DIFF
--- a/src/components/NewMap/MapLegend.tsx
+++ b/src/components/NewMap/MapLegend.tsx
@@ -241,8 +241,8 @@ const MapLegend = ({ legends }: MapLegendProps): JSX.Element => {
       padding={theme.spacing(2, 1)}
       flexDirection={'column'}
       maxWidth={isDesktop ? '184px' : 'stretch'}
-      minWidth={isDesktop ? '160px' : undefined}
-      width={isDesktop ? 'auto' : 'stretch'}
+      minWidth={isDesktop ? '184px' : undefined}
+      width={isDesktop ? '184px' : 'stretch'}
       margin={0}
       overflow={'scroll'}
     >


### PR DESCRIPTION
[Screen Recording 2025-08-21 at 2.06.26 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/572c4be7-0b3f-4991-9c9e-898be3562509.mov" />](https://app.graphite.dev/user-attachments/video/572c4be7-0b3f-4991-9c9e-898be3562509.mov)

This fixes an issue with legend resizing during drawer open/close