### PR TITLE
SW-7290 Table & photo variables should not be showing up in column manager

### DIFF
--- a/src/scenes/AcceleratorRouter/MatrixView/index.tsx
+++ b/src/scenes/AcceleratorRouter/MatrixView/index.tsx
@@ -131,17 +131,6 @@ const MatrixView = () => {
     setRequestVarsId(request.requestId);
   }, [dispatch]);
 
-  useEffect(() => {
-    if (allVariablesResponse?.status === 'success') {
-      setAllVariables(allVariablesResponse.data);
-    }
-  }, [allVariablesResponse]);
-
-  useEffect(() => {
-    const request = dispatch(requestListAllVariables());
-    setRequestVarsId(request.requestId);
-  }, [dispatch]);
-
   const uniqueVariableIds = useMemo(
     () =>
       Array.from(


### PR DESCRIPTION
The code for filtering table and photo variables was already done and working, but I think because of a merge problem there were two repeated useEffects that were overwriting the state