### PR TITLE
SW-7088 Fail CI on missing translations

### DIFF
--- a/scripts/generate-strings.js
+++ b/scripts/generate-strings.js
@@ -8,4 +8,4 @@ const { convertAllLocales } = require('../src/strings/export');
 const csvDir = 'src/strings/csv';
 const stringsDir = 'src/strings';
 
-convertAllLocales(csvDir, stringsDir);
+convertAllLocales(csvDir, stringsDir, false);

--- a/src/strings/csv/es.csv
+++ b/src/strings/csv/es.csv
@@ -1957,6 +1957,7 @@ TOOLTIP_TIME_ZONE_PLANTING_SITE,Usamos zonas horarias para notificaciones y para
 TOOLTIP_TIME_ZONE_SEEDBANK,Usamos zonas horarias para notificaciones y para determinar la fecha correcta para su región. Seleccione la zona horaria que corresponda a este banco de semillas. Todo el trabajo realizado en este banco de semillas usará esta zona horaria.,1b3db070
 TOOLTIP_TOTAL_PLANTS,"Las plantas en total observadas incluyen las plantas vivas y muertas de especies conocidas y desconocidas; no obstante, no incluyen las plantas registradas como preexistentes.",d21e64f0
 TOOLTIP_TOTAL_QUANTITY,La cantidad total es la suma de las cantidades no listas y listas.,4a6f0489
+TOOLTIP_TOTAL_QUANTITY_PREV,La cantidad total es la suma de las cantidades listas y no listas.,0da12307
 TOOLTIP_TOTAL_WITHDRAWN,El número total de plantas extraídas para cualquier fin.,2de74db3
 TOOLTIP_VIABILITY_TEST_AGAR_PETRI_DISH,Plato que contiene un medio de cultivo de agar solidificado.,7391d8f5
 TOOLTIP_VIABILITY_TEST_CHEMICAL,Tratar las semillas con una hormona de crecimiento vegetal u otra sustancia química para romper la latencia fisiológica.,b836cc92

--- a/src/strings/csv/fr.csv
+++ b/src/strings/csv/fr.csv
@@ -1956,6 +1956,7 @@ TOOLTIP_TIME_ZONE_PLANTING_SITE,Nous utilisons les fuseaux horaires pour les not
 TOOLTIP_TIME_ZONE_SEEDBANK,Nous utilisons les fuseaux horaires pour les notifications et pour déterminer la date correcte pour votre région. Sélectionnez le fuseau horaire qui s'applique à cette banque de semences. Tous les travaux effectués dans cette banque de semences utiliseront ce fuseau horaire.,1b3db070
 TOOLTIP_TOTAL_PLANTS,"Le nombre total de plantes observées comprend les plantes vivantes et mortes d'espèces connues et inconnues, mais ne comprend pas les plantes enregistrées comme préexistantes.",d21e64f0
 TOOLTIP_TOTAL_QUANTITY,La quantité totale est la somme des quantités non prêtes et prêtes.,4a6f0489
+TOOLTIP_TOTAL_QUANTITY_PREV,La quantité totale est la somme des quantités prêtes et non prêtes.,0da12307
 TOOLTIP_TOTAL_WITHDRAWN,Le nombre total de plantes retirées pour n'importe quelle raison.,2de74db3
 TOOLTIP_VIABILITY_TEST_AGAR_PETRI_DISH,Un plat qui contient un milieu de croissance composé d'agar solidifié.,7391d8f5
 TOOLTIP_VIABILITY_TEST_CHEMICAL,Traitement des semences avec une hormone de croissance végétale ou un autre produit chimique pour rompre la dormance physiologique.,b836cc92


### PR DESCRIPTION
Change the JavaScript strings file generation step in the CI workflow
to not default to English text for any strings that are missing
translations. This will cause a build failure since the list of
keys in English won't match the lists in other languages.

In dev environments, output warnings about missing translations, but
continue to default to English to avoid showing build failure errors
before autotranslate has finished generating translations.