### PR TITLE
SW-7318: Project Lead link goes to user's record People under Org, not Console

### DIFF
--- a/src/components/ProjectField/InlineMeta.tsx
+++ b/src/components/ProjectField/InlineMeta.tsx
@@ -70,7 +70,7 @@ const ProjectFieldInlineMeta = ({
             >
               {userLabel}
             </Typography>
-            {userName ? (
+            {userId && userName ? (
               <Link
                 to={APP_PATHS.ACCELERATOR_PERSON.replace(':userId', `${userId}`)}
                 fontSize={fontSize || '14px'}


### PR DESCRIPTION
This PR includes a change to update the internal lead link in the project profile view to navigate to the console people table rather than the org-level people table.