### PR TITLE
SW-7376 Include species names in ad-hoc observation CSV

### DIFF
--- a/src/scenes/ObservationsRouter/adhoc/AdHocObservationDetails.tsx
+++ b/src/scenes/ObservationsRouter/adhoc/AdHocObservationDetails.tsx
@@ -79,10 +79,7 @@ export default function AdHocObservationDetails(props: AdHocObservationDetailsPr
       if (optionItem.value === 'match') {
         return setShowMatchSpeciesModal(true);
       } else if (optionItem.value === 'export' && observation && plantingSite) {
-        void exportAdHocObservationDetails({
-          adHocObservation: observation as AdHocObservationResults,
-          plantingSite,
-        });
+        void exportAdHocObservationDetails(observation as AdHocObservationResults, plantingSite, species);
       }
     },
     [observation, plantingSite]

--- a/src/scenes/ObservationsRouter/adhoc/AdHocObservationDetails.tsx
+++ b/src/scenes/ObservationsRouter/adhoc/AdHocObservationDetails.tsx
@@ -82,7 +82,7 @@ export default function AdHocObservationDetails(props: AdHocObservationDetailsPr
         void exportAdHocObservationDetails(observation as AdHocObservationResults, plantingSite, species);
       }
     },
-    [observation, plantingSite]
+    [observation, plantingSite, species]
   );
 
   const data: Record<string, any>[] = useMemo(() => {


### PR DESCRIPTION
The exported species list CSV for an ad-hoc observation only
included names that were added as custom species during the
observation, not names that were already on the organization's
species list.