### PR TITLE
SW-7369 Remove users without first name from internal list

### DIFF
--- a/src/scenes/AcceleratorRouter/ParticipantProjects/EditView/ProjectProfileEdit.tsx
+++ b/src/scenes/AcceleratorRouter/ParticipantProjects/EditView/ProjectProfileEdit.tsx
@@ -248,10 +248,12 @@ const ProjectProfileEdit = () => {
 
   useEffect(() => {
     if (listUsersRequest?.status === 'success') {
-      const userOptions = listUsersRequest.data?.users.map((user) => ({
-        label: `${user.firstName} ${user.lastName}`,
-        value: user.id,
-      }));
+      const userOptions = listUsersRequest.data?.users
+        .filter((user) => !!user.firstName)
+        .map((user) => ({
+          label: `${user.firstName} ${user.lastName}`,
+          value: user.id,
+        }));
       setGlobalUsersOptions(userOptions);
     }
   }, [listUsersRequest]);


### PR DESCRIPTION
Users that haven't set up their account yet will not have a first name, and thus show up in the list of available Terraformation users in Project Profiles as `undefined undefined`. Remove these users from the list.