### PR TITLE
SW-7379 Disable ability to remove TF Contacts of any kind in People List

### DIFF
--- a/src/utils/organization.tsx
+++ b/src/utils/organization.tsx
@@ -1,3 +1,4 @@
+import strings from 'src/strings';
 import { Facility, FacilityType } from 'src/types/Facility';
 import { HighOrganizationRolesValues, Organization, OrganizationRole } from 'src/types/Organization';
 import { OrganizationUser } from 'src/types/User';
@@ -35,7 +36,7 @@ export const isMember = <T extends Organization>(organization: T | undefined): o
   return !!organization;
 };
 
-export const isTfContact = (role: OrganizationRole | undefined) => role === 'Terraformation Contact';
+export const isTfContact = (role: OrganizationRole | undefined) => role?.includes(strings.TERRAFORMATION_CONTACT);
 
 export const isContributor = (roleHolder: Organization | OrganizationUser | undefined) => {
   return roleHolder?.role === 'Contributor';


### PR DESCRIPTION
The isTfContact check only checked if the user's role was `=== 'Terraformation Contact'`. When internal users were added, this role was added on to for display, e.g. `Terraformation Contact - Project Lead (Isaac's Project)`, which meant that users could remove TF Contacts, as well as edit them. Additionally, the check didn't work when the language was in any language other than English. 
Update the check to see if the role includes the locale's string for TF Contact.