### PR TITLE
SW-7388 Only display Edit Button when on My Account tab for funders

### DIFF
--- a/src/scenes/Settings/SettingsPage.tsx
+++ b/src/scenes/Settings/SettingsPage.tsx
@@ -139,7 +139,7 @@ const SettingsPage = () => {
                 marginBottom: theme.spacing(2),
               }}
             />
-            {!isEditingAccount && (
+            {!isEditingAccount && activeTab === 'my-account' && (
               <Box display='flex' height='fit-content'>
                 <Button
                   id='edit-account'


### PR DESCRIPTION
The `Edit Account` Button and the 3 dots were displaying on the `User Access` tab in the funder portal, but they don't do anything on that page. 
Only show them on the `My Account` tab. 