### PR TITLE
Activity Log: Render pages in Accelerator

### DIFF
--- a/src/components/ActivityLog/ActivityCreateView.tsx
+++ b/src/components/ActivityLog/ActivityCreateView.tsx
@@ -6,10 +6,11 @@ import { Box, Typography, useTheme } from '@mui/material';
 import Card from 'src/components/common/Card';
 import PageForm from 'src/components/common/PageForm';
 import TfMain from 'src/components/common/TfMain';
-import { APP_PATHS } from 'src/constants';
-import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
+import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
+import useNavigateTo from 'src/hooks/useNavigateTo';
+import { useParticipants } from 'src/hooks/useParticipants';
+import { useProjects } from 'src/hooks/useProjects';
 import { useLocalization } from 'src/providers';
-import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 
 import ActivityDetailsForm from './ActivityDetailsForm';
 import MapSplitView from './MapSplitView';
@@ -17,34 +18,54 @@ import MapSplitView from './MapSplitView';
 export default function ActivityCreateView(): JSX.Element {
   const { strings } = useLocalization();
   const theme = useTheme();
-  const navigate = useSyncNavigate();
-  const { currentParticipantProject } = useParticipantData();
+  const { availableParticipants } = useParticipants();
+  const { isAcceleratorRoute } = useAcceleratorConsole();
+  const { goToAcceleratorActivityLog, goToActivityLog } = useNavigateTo();
   const pathParams = useParams<{ projectId: string }>();
+  const { selectedProject } = useProjects({
+    projectId: pathParams.projectId ? Number(pathParams.projectId) : undefined,
+  });
   const projectId = Number(pathParams.projectId);
 
-  const activityLogLocation = useMemo(
-    () => ({
-      pathname: APP_PATHS.ACTIVITY_LOG,
-    }),
-    []
+  const selectedParticipantProject = useMemo(() => {
+    return availableParticipants
+      .flatMap((participant) =>
+        participant.projects.map((project) => ({
+          dealName: project.projectDealName,
+          id: project.projectId,
+          name: project.projectName,
+          organizationId: project.organizationId,
+          participantId: participant.id,
+        }))
+      )
+      .find((p) => p.id === projectId);
+  }, [availableParticipants, projectId]);
+
+  const projectName = useMemo(
+    () => (isAcceleratorRoute ? selectedParticipantProject?.dealName : selectedProject?.name) || '',
+    [isAcceleratorRoute, selectedParticipantProject?.dealName, selectedProject?.name]
   );
 
-  const goToActivityLog = useCallback(() => {
-    navigate(activityLogLocation);
-  }, [navigate, activityLogLocation]);
+  const navToActivityLog = useCallback(() => {
+    if (isAcceleratorRoute) {
+      goToAcceleratorActivityLog();
+    } else {
+      goToActivityLog();
+    }
+  }, [goToAcceleratorActivityLog, goToActivityLog, isAcceleratorRoute]);
 
   return (
     <TfMain>
       <PageForm
         cancelID='cancelAddActivity'
-        onCancel={goToActivityLog}
-        onSave={goToActivityLog}
+        onCancel={navToActivityLog}
+        onSave={navToActivityLog}
         saveButtonText={strings.SAVE}
         saveID='saveAddActivity'
       >
         <Box marginBottom='32px' marginTop='2px' paddingLeft={theme.spacing(4)}>
           <Typography fontSize='24px' fontWeight={600} lineHeight='32px' variant='h1'>
-            {strings.formatString(strings.ADD_ACTIVITY_FOR_PROJECT, currentParticipantProject?.name || '...')}
+            {projectName ? strings.formatString(strings.ADD_ACTIVITY_FOR_PROJECT, projectName) : strings.ADD_ACTIVITY}
           </Typography>
         </Box>
 

--- a/src/components/PageHeader/PageHeaderProjectFilter.tsx
+++ b/src/components/PageHeader/PageHeaderProjectFilter.tsx
@@ -4,62 +4,72 @@ import { Box, Grid, Typography } from '@mui/material';
 import { Separator } from '@terraware/web-components';
 
 import ProjectsDropdown from 'src/components/ProjectsDropdown';
+import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import { useLocalization } from 'src/providers';
 import theme from 'src/theme';
 import { Project } from 'src/types/Project';
 
 type PageHeaderProjectFilterProps = {
-  allParticipantProjects: Project[];
   currentParticipantProject?: Project;
   projectFilter: { projectId?: number | string };
+  projects: Project[];
   setCurrentParticipantProject: (projectId: string | number) => void;
   setProjectFilter: React.Dispatch<React.SetStateAction<{ projectId?: number | string }>>;
 };
 
 const PageHeaderProjectFilter = ({
-  allParticipantProjects,
   currentParticipantProject,
   projectFilter,
+  projects,
   setCurrentParticipantProject,
   setProjectFilter,
 }: PageHeaderProjectFilterProps) => {
   const { strings } = useLocalization();
+  const { isAcceleratorRoute } = useAcceleratorConsole();
 
+  // set project filter to current participant project or first project, if not set
   useEffect(() => {
-    if (!projectFilter.projectId && currentParticipantProject?.id) {
-      setProjectFilter({ projectId: currentParticipantProject?.id });
+    if (projectFilter.projectId) {
+      return;
     }
-  }, [currentParticipantProject?.id, projectFilter.projectId, setProjectFilter]);
+
+    if (currentParticipantProject?.id) {
+      setProjectFilter({ projectId: currentParticipantProject.id });
+    } else if (projects.length) {
+      setProjectFilter({ projectId: projects[0].id });
+    }
+  }, [currentParticipantProject?.id, projectFilter.projectId, projects, setProjectFilter]);
 
   useEffect(() => {
     if (projectFilter.projectId) {
       setCurrentParticipantProject(projectFilter.projectId);
-    } else if (allParticipantProjects.length === 1) {
-      setCurrentParticipantProject(allParticipantProjects[0].id);
+    } else if (projects.length === 1) {
+      setCurrentParticipantProject(projects[0].id);
     }
-  }, [allParticipantProjects, projectFilter.projectId, setCurrentParticipantProject]);
+  }, [projects, projectFilter.projectId, setCurrentParticipantProject]);
 
   return (
     <Grid container sx={{ alignItems: 'center', flexWrap: 'nowrap', marginTop: theme.spacing(0.5) }}>
       <Grid item>
         <Separator height='40px' />
       </Grid>
-      {allParticipantProjects?.length > 0 && (
+      {projects?.length > 0 && (
         <Grid item>
-          {allParticipantProjects?.length > 1 ? (
+          {projects?.length > 1 ? (
             <Box display='flex'>
-              <Typography sx={{ lineHeight: '40px', marginRight: theme.spacing(1.5) }} component='span'>
-                {strings.PROJECT}
+              <Typography component='span' lineHeight='40px' marginRight='12px' whiteSpace='nowrap'>
+                {isAcceleratorRoute ? strings.DEAL_NAME : strings.PROJECT}
               </Typography>
               <ProjectsDropdown
-                availableProjects={allParticipantProjects}
+                availableProjects={projects}
                 label=''
                 record={projectFilter}
                 setRecord={setProjectFilter}
+                useDealName={isAcceleratorRoute}
               />
             </Box>
           ) : (
-            <Typography>{allParticipantProjects[0].name}</Typography>
+            <Typography>{projects[0].name}</Typography>
           )}
         </Grid>
       )}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,9 @@ export const EMAIL_REGEX =
 
 export enum APP_PATHS {
   ACCELERATOR = '/accelerator',
+  ACCELERATOR_ACTIVITY_LOG = '/accelerator/activity-log',
+  ACCELERATOR_ACTIVITY_LOG_EDIT = '/accelerator/activity-log/:projectId/:activityId/edit',
+  ACCELERATOR_ACTIVITY_LOG_NEW = '/accelerator/activity-log/:projectId/new',
   ACCELERATOR_APPLICATION = '/accelerator/applications/:applicationId',
   ACCELERATOR_APPLICATION_DELIVERABLE = '/accelerator/applications/:applicationId/deliverable/:deliverableId',
   ACCELERATOR_APPLICATION_MAP = '/accelerator/applications/:applicationId/map',

--- a/src/hooks/useNavigateTo.ts
+++ b/src/hooks/useNavigateTo.ts
@@ -15,6 +15,18 @@ export default function useNavigateTo() {
         navigate({ pathname: APP_PATHS.ACCELERATOR });
       },
 
+      goToAcceleratorActivityCreate: (projectId: number) => {
+        navigate({ pathname: APP_PATHS.ACCELERATOR_ACTIVITY_LOG_NEW.replace(':projectId', `${projectId}`) });
+      },
+
+      goToAcceleratorActivityEdit: (projectId: number) => {
+        navigate({ pathname: APP_PATHS.ACCELERATOR_ACTIVITY_LOG_EDIT.replace(':projectId', `${projectId}`) });
+      },
+
+      goToAcceleratorActivityLog: () => {
+        navigate({ pathname: APP_PATHS.ACCELERATOR_ACTIVITY_LOG });
+      },
+
       goToAcceleratorApplication: (applicationId: number) => {
         navigate({ pathname: APP_PATHS.ACCELERATOR_APPLICATION.replace(':applicationId', `${applicationId}`) });
       },
@@ -63,6 +75,18 @@ export default function useNavigateTo() {
         navigate({
           pathname: APP_PATHS.REPORTS_EDIT.replace(':reportId', `${reportId}`).replace(':projectId', `${projectId}`),
         }),
+
+      goToActivityCreate: (projectId: number) => {
+        navigate({ pathname: APP_PATHS.ACTIVITY_LOG_NEW.replace(':projectId', `${projectId}`) });
+      },
+
+      goToActivityEdit: (projectId: number) => {
+        navigate({ pathname: APP_PATHS.ACTIVITY_LOG_EDIT.replace(':projectId', `${projectId}`) });
+      },
+
+      goToActivityLog: () => {
+        navigate({ pathname: APP_PATHS.ACTIVITY_LOG });
+      },
 
       goToApplication: (applicationId: number) => {
         navigate({ pathname: APP_PATHS.APPLICATION_OVERVIEW.replace(':applicationId', `${applicationId}`) });

--- a/src/scenes/AcceleratorRouter/NavBar.tsx
+++ b/src/scenes/AcceleratorRouter/NavBar.tsx
@@ -9,6 +9,7 @@ import NavFooter from 'src/components/common/Navbar/NavFooter';
 import NavItem from 'src/components/common/Navbar/NavItem';
 import Navbar from 'src/components/common/Navbar/Navbar';
 import { APP_PATHS } from 'src/constants';
+import isEnabled from 'src/features';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useUser } from 'src/providers';
@@ -25,6 +26,7 @@ export default function NavBar({ backgroundTransparent, setShowNavBar }: NavBarP
   const { isAllowed } = useUser();
   const mixpanel = useMixpanel();
 
+  const isActivityLogRoute = useMatch({ path: APP_PATHS.ACCELERATOR_ACTIVITY_LOG + '/', end: false });
   const isApplicationRoute = useMatch({ path: APP_PATHS.ACCELERATOR_APPLICATIONS, end: false });
   const isDocumentsRoute = useMatch({ path: APP_PATHS.ACCELERATOR_DOCUMENT_PRODUCER_DOCUMENTS, end: false });
   const isDeliverablesRoute = useMatch({ path: APP_PATHS.ACCELERATOR_DELIVERABLES, end: false });
@@ -40,6 +42,7 @@ export default function NavBar({ backgroundTransparent, setShowNavBar }: NavBarP
 
   const isAllowedViewPeople = isAllowed('READ_GLOBAL_ROLES');
   const isAllowedViewFundingEntities = isAllowed('READ_FUNDING_ENTITIES');
+  const isActivityLogEnabled = isEnabled('Activity Log');
 
   const closeAndNavigateTo = (path: string) => {
     closeNavBar();
@@ -110,6 +113,18 @@ export default function NavBar({ backgroundTransparent, setShowNavBar }: NavBarP
           selected={!!isApplicationRoute}
         />
       }
+
+      {isActivityLogEnabled && (
+        <NavItem
+          icon='checklist'
+          id='activity-log'
+          label={strings.ACTIVITY_LOG}
+          onClick={() => {
+            closeAndNavigateTo(APP_PATHS.ACCELERATOR_ACTIVITY_LOG);
+          }}
+          selected={!!isActivityLogRoute}
+        />
+      )}
 
       <NavSection title={strings.DOC_PRODUCER} />
 

--- a/src/scenes/AcceleratorRouter/index.tsx
+++ b/src/scenes/AcceleratorRouter/index.tsx
@@ -12,6 +12,7 @@ import { getRgbaFromHex } from 'src/utils/color';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import useStateLocation from 'src/utils/useStateLocation';
 
+import ActivityLogRouter from '../ActivityLogRouter';
 import Applications from './Applications';
 import Cohorts from './Cohorts';
 import Deliverables from './Deliverables';
@@ -88,6 +89,7 @@ const AcceleratorRouter = ({ showNavBar, setShowNavBar }: AcceleratorRouterProps
               <Routes>
                 <Route path={APP_PATHS.ACCELERATOR_OVERVIEW} element={<Overview />} />
                 <Route path={`${APP_PATHS.ACCELERATOR_MATRIX_VIEW}/*`} element={<MatrixView />} />
+                <Route path={`${APP_PATHS.ACCELERATOR_ACTIVITY_LOG}/*`} element={<ActivityLogRouter />} />
                 <Route path={`${APP_PATHS.ACCELERATOR_APPLICATIONS}/*`} element={<Applications />} />
                 <Route path={`${APP_PATHS.ACCELERATOR_COHORTS}/*`} element={<Cohorts />} />
                 <Route path={`${APP_PATHS.ACCELERATOR_DELIVERABLES}/*`} element={<Deliverables />} />

--- a/src/scenes/Reports/AcceleratorReportsView.tsx
+++ b/src/scenes/Reports/AcceleratorReportsView.tsx
@@ -41,9 +41,9 @@ const AcceleratorReportsView = () => {
   const PageHeaderLeftComponent = useMemo(
     () => (
       <PageHeaderProjectFilter
-        allParticipantProjects={allParticipantProjects}
         currentParticipantProject={currentParticipantProject}
         projectFilter={projectFilter}
+        projects={allParticipantProjects}
         setCurrentParticipantProject={setCurrentParticipantProject}
         setProjectFilter={setProjectFilter}
       />


### PR DESCRIPTION
This PR includes changes to render the existing Activity Log, Create Activity, and Edit Activity Views in the Accelerator.

I may need to break these out into a discrete router & views for the accelerator side, but re-using the existing router and views for now.