### PR TITLE
SW-7407 Don't request t0 data if no planting site

### DIFF
--- a/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
+++ b/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
@@ -86,11 +86,11 @@ export default function PlantsDashboardView({
   }, [latestResult, plantingSite]);
 
   useEffect(() => {
-    if (plantingSite) {
+    if (isSurvivalRateCalculationEnabled && plantingSite && plantingSite.id !== -1) {
       const request = dispatch(requestPlantingSiteT0(plantingSite.id));
       setRequestId(request.requestId);
     }
-  }, [dispatch, plantingSite]);
+  }, [dispatch, isSurvivalRateCalculationEnabled, plantingSite]);
 
   useEffect(() => {
     if (plantingSiteT0Response?.status === 'success') {

--- a/src/scenes/SurvivalRateSettings/EditSurvivalRateSettings.tsx
+++ b/src/scenes/SurvivalRateSettings/EditSurvivalRateSettings.tsx
@@ -55,7 +55,7 @@ const EditSurvivalRateSettings = () => {
   const snackbar = useSnackbar();
 
   const reload = useCallback(() => {
-    if (plantingSite) {
+    if (plantingSite && plantingSite.id !== -1) {
       const request = dispatch(requestPlantingSiteT0(plantingSite.id));
       setRequestId(request.requestId);
       const requestPlots = dispatch(requestPermanentPlotsWithObservations(plantingSite.id));

--- a/src/scenes/SurvivalRateSettings/index.tsx
+++ b/src/scenes/SurvivalRateSettings/index.tsx
@@ -46,7 +46,7 @@ const SurvivalRateSettings = () => {
   }, [plantingSiteId, setSelectedPlantingSite]);
 
   useEffect(() => {
-    if (plantingSite) {
+    if (plantingSite && plantingSite.id !== -1) {
       const request = dispatch(requestPlantingSiteT0(plantingSite.id));
       setRequestId(request.requestId);
       const requestPlots = dispatch(requestPermanentPlotsWithObservations(plantingSite.id));


### PR DESCRIPTION
A server error showed up for a -1 planting site, and was traced back to the plants dashboard's request for t0 data for survival rates. This was incorrect for 2 reasons:
1. Survival rates isn't enabled in prod right now
1. We shouldn't be requesting data when a planting site id is -1. 

Fix this so that the plants dashboard only queries t0 data when survival rate calculation is enabled, and only query t0 data when `plantingSite.id !== -1` (in more pages than just the plants dashboard.