### PR TITLE
SW-7423 "Survival Rate Settings" should be grayed out

### DIFF
--- a/src/scenes/ObservationsRouter/PlantMonitoring.tsx
+++ b/src/scenes/ObservationsRouter/PlantMonitoring.tsx
@@ -121,12 +121,12 @@ export default function PlantMonitoring(props: PlantMonitoringProps): JSX.Elemen
             </Box>
           </>
         )}
-        {selectedPlantingSite && isSurvivalRateCalculationEnabled && (
+        {selectedPlantingSite && isSurvivalRateCalculationEnabled && selectedPlotSelection === 'assigned' && (
           <Link
             onClick={navigateToSurvivalRateSettings}
             fontSize='16px'
             style={{ paddingLeft: theme.spacing(2) }}
-            disabled={selectedPlantingSite.id === -1}
+            disabled={selectedPlantingSite.id === -1 || (observationsResults?.length || 0) === 0}
           >
             {strings.SURVIVAL_RATE_SETTINGS}
           </Link>


### PR DESCRIPTION
- Grayed out for Planting Sites without any Assigned Plot Plant Monitoring Observations
- Shouldn't be showing for adHoc observations