### PR TITLE
SW-7447 Added map utils to fly or fit bounds, and updated visible marker behaviors

### DIFF
--- a/src/components/ActivityLog/MapSplitView.tsx
+++ b/src/components/ActivityLog/MapSplitView.tsx
@@ -74,8 +74,8 @@ export default function MapSplitView({
           if (media.geolocation) {
             return {
               id: `activity-${activity.id}-media-${media.fileId}`,
-              longitude: media.geolocation.coordinates[1],
-              latitude: media.geolocation.coordinates[0],
+              longitude: media.geolocation.coordinates[0],
+              latitude: media.geolocation.coordinates[1],
               onClick: onActivityMarkerClickCallback(activity.id, media.fileId),
               selected: activityMarkerHighlighted?.(activity.id, media.fileId) ?? false,
             };
@@ -94,13 +94,10 @@ export default function MapSplitView({
           iconName: 'iconPhoto',
           type: 'icon',
         },
+        visible: true,
       };
     });
   }, [activities, activityMarkerHighlighted, onActivityMarkerClickCallback]);
-
-  const visibleMarkers = useMemo(() => {
-    return markerGroups.map((group) => group.markerGroupId);
-  }, [markerGroups]);
 
   const mapFeatures = useMemo((): MapFeatureSection[] => {
     return [
@@ -145,7 +142,6 @@ export default function MapSplitView({
         features={mapFeatures}
         hideLegend
         initialSelectedLayerId='sites'
-        initialVisibleMarkers={visibleMarkers}
         mapRef={mapRef}
         mapId={mapId}
         token={token ?? ''}

--- a/src/components/NewMap/MapBox.tsx
+++ b/src/components/NewMap/MapBox.tsx
@@ -363,6 +363,9 @@ const MapBox = (props: MapBoxProps): JSX.Element => {
   const highlightLayers = useMemo(() => {
     return (
       highlightGroups?.flatMap((group) => {
+        if (!group.visible) {
+          return [];
+        }
         return group.highlights
           .map((highlight, index) => {
             const highlightFeatureIds = highlight.featureIds.map(({ layerId, featureId }) => `${layerId}/${featureId}`);
@@ -421,6 +424,10 @@ const MapBox = (props: MapBoxProps): JSX.Element => {
 
   const markersComponents = useMemo(() => {
     return markerGroups?.flatMap((markerGroup) => {
+      if (!markerGroup.visible) {
+        return [];
+      }
+
       // cluster markers here
       const clusteredMarkers = clusterMarkers(mapRef.current, markerGroup.markers);
 

--- a/src/components/NewMap/MapBox.tsx
+++ b/src/components/NewMap/MapBox.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { MutableRefObject, useCallback, useEffect, useMemo, useState } from 'react';
 import Map, {
   FullscreenControl,
   Layer,
@@ -54,6 +54,7 @@ export type MapBoxProps = {
   layers?: MapLayer[];
   mapId: string;
   mapImageUrls?: string[];
+  mapRef: MutableRefObject<MapRef | null>;
   mapViewStyle: MapViewStyle;
   markerGroups?: MapMarkerGroup[];
   onClickCanvas?: (event: MapMouseEvent) => void;
@@ -81,6 +82,7 @@ const MapBox = (props: MapBoxProps): JSX.Element => {
     initialViewState,
     mapId,
     mapImageUrls,
+    mapRef,
     mapViewStyle,
     markerGroups,
     onClickCanvas,
@@ -88,7 +90,6 @@ const MapBox = (props: MapBoxProps): JSX.Element => {
     token,
   } = props;
   const theme = useTheme();
-  const mapRef = useRef<MapRef | null>(null);
   const { isDesktop } = useDeviceInfo();
   const [cursor, setCursor] = useState<MapCursor>('auto');
   const [hoverFeatureId, setHoverFeatureId] = useState<string>();
@@ -117,7 +118,7 @@ const MapBox = (props: MapBoxProps): JSX.Element => {
         loadImages(map);
       }
     },
-    [loadImages]
+    [loadImages, mapRef]
   );
 
   const onMove = useCallback((view: ViewStateChangeEvent) => {
@@ -415,7 +416,7 @@ const MapBox = (props: MapBoxProps): JSX.Element => {
       });
       event.originalEvent.stopPropagation();
     },
-    [zoom]
+    [mapRef, zoom]
   );
 
   const markersComponents = useMemo(() => {
@@ -473,7 +474,7 @@ const MapBox = (props: MapBoxProps): JSX.Element => {
         }
       });
     });
-  }, [clusterMarkers, markerGroups, onMarkerClick, onMarkerClusterClick, theme]);
+  }, [clusterMarkers, markerGroups, mapRef, onMarkerClick, onMarkerClusterClick, theme]);
 
   const onMouseMove = useCallback((event: MapMouseEvent) => {
     if (event.features && event.features.length) {
@@ -509,7 +510,7 @@ const MapBox = (props: MapBoxProps): JSX.Element => {
     observer.observe(mapRef.current.getContainer());
 
     return () => observer.disconnect();
-  }, []);
+  }, [mapRef]);
 
   useEffect(() => {
     if (!mapRef.current) {
@@ -517,7 +518,7 @@ const MapBox = (props: MapBoxProps): JSX.Element => {
     }
 
     mapRef.current.resize();
-  }, [drawerOpen]);
+  }, [drawerOpen, mapRef]);
 
   // Hovering interactive layers
   const onMouseEnter = useCallback(() => setCursor(cursorInteract ?? 'pointer'), [cursorInteract]);

--- a/src/components/NewMap/types.tsx
+++ b/src/components/NewMap/types.tsx
@@ -1,6 +1,8 @@
 import { IconName } from '@terraware/web-components';
 import { MultiPolygon } from 'geojson';
 
+export type MapBounds = { minLat: number; minLng: number; maxLat: number; maxLng: number };
+
 /**
  * Properties class for GeoJson, with a few reserved object defined.
  */
@@ -62,6 +64,7 @@ export type MapHighlight = {
 export type MapHighlightGroup = {
   highlightId: string;
   highlights: MapHighlight[];
+  visible: boolean;
 };
 
 export type MapMarker = {
@@ -78,6 +81,7 @@ export type MapMarkerGroup = {
   markers: MapMarker[];
   markerGroupId: string;
   style: MapIconComponentStyle;
+  visible: boolean;
 };
 
 export type MapViewStyle = 'Outdoors' | 'Satellite' | 'Light' | 'Dark' | 'Streets';

--- a/src/components/NewMap/useMapUtils.ts
+++ b/src/components/NewMap/useMapUtils.ts
@@ -1,0 +1,43 @@
+import { MutableRefObject, useCallback, useMemo } from 'react';
+import { MapRef } from 'react-map-gl/mapbox';
+
+const useMapUtils = (mapRef: MutableRefObject<MapRef | null>) => {
+  const easeTo = useCallback(
+    (latitude: number, longitude: number, zoom?: number) => {
+      const map = mapRef.current;
+
+      if (map) {
+        map.easeTo({
+          center: { lat: latitude, lng: longitude },
+          zoom,
+        });
+      }
+    },
+    [mapRef]
+  );
+
+  const fitBounds = useCallback(
+    (bbox: { minLat: number; minLng: number; maxLat: number; maxLng: number }) => {
+      const map = mapRef.current;
+      const { minLat, minLng, maxLat, maxLng } = bbox;
+
+      if (map) {
+        map.fitBounds([
+          { lat: minLat, lng: minLng },
+          { lat: maxLat, lng: maxLng },
+        ]);
+      }
+    },
+    [mapRef]
+  );
+
+  return useMemo(
+    () => ({
+      easeTo,
+      fitBounds,
+    }),
+    [easeTo, fitBounds]
+  );
+};
+
+export default useMapUtils;

--- a/src/components/NewMap/useMapUtils.ts
+++ b/src/components/NewMap/useMapUtils.ts
@@ -1,6 +1,8 @@
 import { MutableRefObject, useCallback, useMemo } from 'react';
 import { MapRef } from 'react-map-gl/mapbox';
 
+export type MapBounds = { minLat: number; minLng: number; maxLat: number; maxLng: number };
+
 const useMapUtils = (mapRef: MutableRefObject<MapRef | null>) => {
   const easeTo = useCallback(
     (latitude: number, longitude: number, zoom?: number) => {
@@ -17,7 +19,7 @@ const useMapUtils = (mapRef: MutableRefObject<MapRef | null>) => {
   );
 
   const fitBounds = useCallback(
-    (bbox: { minLat: number; minLng: number; maxLat: number; maxLng: number }) => {
+    (bbox: MapBounds) => {
       const map = mapRef.current;
       const { minLat, minLng, maxLat, maxLng } = bbox;
 
@@ -31,12 +33,25 @@ const useMapUtils = (mapRef: MutableRefObject<MapRef | null>) => {
     [mapRef]
   );
 
+  const getCurrentBounds = useCallback((): MapBounds | undefined => {
+    const bound = mapRef?.current?.getBounds();
+    if (bound) {
+      return {
+        minLat: bound.getSouth(),
+        maxLat: bound.getNorth(),
+        minLng: bound.getWest(),
+        maxLng: bound.getEast(),
+      };
+    }
+  }, [mapRef]);
+
   return useMemo(
     () => ({
       easeTo,
       fitBounds,
+      getCurrentBounds,
     }),
-    [easeTo, fitBounds]
+    [easeTo, fitBounds, getCurrentBounds]
   );
 };
 

--- a/src/components/NewMap/useMapUtils.ts
+++ b/src/components/NewMap/useMapUtils.ts
@@ -1,7 +1,8 @@
 import { MutableRefObject, useCallback, useMemo } from 'react';
 import { MapRef } from 'react-map-gl/mapbox';
 
-export type MapBounds = { minLat: number; minLng: number; maxLat: number; maxLng: number };
+import { MapBounds } from './types';
+import { isBoundsValid } from './utils';
 
 const useMapUtils = (mapRef: MutableRefObject<MapRef | null>) => {
   const easeTo = useCallback(
@@ -23,7 +24,7 @@ const useMapUtils = (mapRef: MutableRefObject<MapRef | null>) => {
       const map = mapRef.current;
       const { minLat, minLng, maxLat, maxLng } = bbox;
 
-      if (map) {
+      if (map && isBoundsValid(bbox)) {
         map.fitBounds([
           { lat: minLat, lng: minLng },
           { lat: maxLat, lng: maxLng },

--- a/src/components/NewMap/utils.ts
+++ b/src/components/NewMap/utils.ts
@@ -1,3 +1,5 @@
+import { MultiPolygon } from 'geojson';
+
 const latToY = (lat: number): number => {
   const rad = (lat * Math.PI) / 180;
   return Math.log(Math.tan(Math.PI / 4 + rad / 2));
@@ -28,4 +30,30 @@ const getBoundsZoomLevel = (
   return Math.floor(Math.min(latZoom, lngZoom));
 };
 
-export { getBoundsZoomLevel };
+const getBoundingBox = (
+  multipolygons: MultiPolygon[]
+): { minLat: number; minLng: number; maxLat: number; maxLng: number } => {
+  let minLat = Infinity;
+  let maxLat = -Infinity;
+  let minLng = Infinity;
+  let maxLng = -Infinity;
+
+  const coordinates = multipolygons
+    .map((multipolygon) => multipolygon.coordinates)
+    .flat()
+    .flat()
+    .flat();
+
+  if (coordinates.length > 0) {
+    for (const [lng, lat] of coordinates) {
+      minLat = Math.min(minLat, lat);
+      maxLat = Math.max(maxLat, lat);
+      minLng = Math.min(minLng, lng);
+      maxLng = Math.max(maxLng, lng);
+    }
+  }
+
+  return { minLat, minLng, maxLat, maxLng };
+};
+
+export { getBoundingBox, getBoundsZoomLevel };

--- a/src/components/NewMap/utils.ts
+++ b/src/components/NewMap/utils.ts
@@ -1,15 +1,25 @@
 import { MultiPolygon } from 'geojson';
 
+import { MapBounds } from './types';
+
 const latToY = (lat: number): number => {
   const rad = (lat * Math.PI) / 180;
   return Math.log(Math.tan(Math.PI / 4 + rad / 2));
 };
 
-const getBoundsZoomLevel = (
-  bounds: { minLat: number; maxLat: number; minLng: number; maxLng: number },
-  mapWidth: number,
-  mapHeight: number
-): number => {
+const isBoundsValid = (bounds: MapBounds) => {
+  const { minLat, maxLat, minLng, maxLng } = bounds;
+
+  // Latitude must be within [-90, 90] and min <= max
+  const latValid = -90 <= minLat && minLat <= maxLat && maxLat <= 90;
+
+  // Longitude must be within [-180, 180]; allow crossing antimeridian
+  const lngValid = -180 <= minLng && minLng <= 180 && -180 <= maxLng && maxLng <= 180;
+
+  return latValid && lngValid;
+};
+
+const getBoundsZoomLevel = (bounds: MapBounds, mapWidth: number, mapHeight: number): number => {
   const TILE_SIZE = 256;
 
   // Latitude fraction (north–south span)
@@ -56,4 +66,4 @@ const getBoundingBox = (
   return { minLat, minLng, maxLat, maxLng };
 };
 
-export { getBoundingBox, getBoundsZoomLevel };
+export { isBoundsValid, getBoundingBox, getBoundsZoomLevel };

--- a/src/scenes/PlantsDashboardRouter/components/PlantDashboardMap.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/PlantDashboardMap.tsx
@@ -418,6 +418,12 @@ const PlantDashboardMap = ({
     [theme]
   );
 
+  const [plotPhotoVisible, setPlotPhotoVisible] = useState<boolean>(false);
+  const [livePlantsVisible, setLivePlantsVisible] = useState<boolean>(false);
+  const [deadPlantsVisible, setDeadPlantsVisible] = useState<boolean>(false);
+  const [mortalityRateVisible, setMortalityRateVisible] = useState<boolean>(false);
+  const [observationEventsVisible, setObservationEventsVisible] = useState<boolean>(false);
+
   const mapFeatures = useMemo((): MapFeatureSection[] => {
     return [
       {
@@ -436,6 +442,7 @@ const PlantDashboardMap = ({
               iconName: 'iconPhoto',
               type: 'icon',
             },
+            visible: plotPhotoVisible,
           },
         ],
         sectionDisabled: disablePhotoMarkers,
@@ -453,6 +460,7 @@ const PlantDashboardMap = ({
               iconName: 'iconLivePlant',
               type: 'icon',
             },
+            visible: livePlantsVisible,
           },
           {
             label: strings.DEAD_PLANTS,
@@ -463,6 +471,7 @@ const PlantDashboardMap = ({
               iconName: 'iconLivePlant',
               type: 'icon',
             },
+            visible: deadPlantsVisible,
           },
         ],
         sectionDisabled: disablePlantMarkers,
@@ -509,6 +518,7 @@ const PlantDashboardMap = ({
               },
             },
           ],
+          visible: observationEventsVisible,
         },
         sectionDisabled: disableObserationEvents || observationResults.length === 0,
         sectionTitle: strings.OBSERVATION_EVENTS,
@@ -550,6 +560,7 @@ const PlantDashboardMap = ({
               },
             },
           ],
+          visible: mortalityRateVisible,
         },
         sectionDisabled: disableMortalityRate || observationResults.length === 0,
         sectionTitle: isSurvivalRateCalculationEnabled ? strings.SURVIVAL_RATE : strings.MORTALITY_RATE,
@@ -588,21 +599,48 @@ const PlantDashboardMap = ({
     ];
   }, [
     baseObservationEventStyle,
+    deadPlantsVisible,
     disableMortalityRate,
     disableObserationEvents,
     disablePhotoMarkers,
     disablePlantMarkers,
     isSurvivalRateCalculationEnabled,
     layers,
-    mortalityRateHighlights.greaterThanFifty,
-    mortalityRateHighlights.lessThanFifty,
-    mortalityRateHighlights.lessThanTwentyFive,
+    livePlantsVisible,
+    mortalityRateHighlights,
+    mortalityRateVisible,
     observationEventsHighlights,
+    observationEventsVisible,
     observationResults,
     photoMarkers,
     plantsMarkers,
+    plotPhotoVisible,
     strings,
   ]);
+
+  const setHighlightVisible = useCallback(
+    (highlightId: string) => (visible: boolean) => {
+      if (highlightId === 'mortalityRate') {
+        setMortalityRateVisible(visible);
+      } else if (highlightId === 'observationEvents') {
+        setObservationEventsVisible(visible);
+      }
+    },
+    []
+  );
+
+  const setMarkerVisible = useCallback(
+    (markerGroupId: string) => (visible: boolean) => {
+      if (markerGroupId === 'plot-photos') {
+        setPlotPhotoVisible(visible);
+      } else if (markerGroupId === 'live-plants') {
+        setLivePlantsVisible(visible);
+      } else if (markerGroupId === 'dead-plants') {
+        setDeadPlantsVisible(visible);
+      }
+    },
+    []
+  );
 
   return token ? (
     <MapComponent
@@ -616,6 +654,8 @@ const PlantDashboardMap = ({
       mapRef={mapRef}
       token={token}
       setDrawerOpen={setDrawerOpenCallback}
+      setHighlightVisible={setHighlightVisible}
+      setMarkerVisible={setMarkerVisible}
     />
   ) : (
     <Box />

--- a/src/scenes/PlantsDashboardRouter/components/PlantDashboardMap.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/PlantDashboardMap.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { MapRef } from 'react-map-gl/mapbox';
 
 import { Box, useTheme } from '@mui/material';
 
@@ -62,6 +63,7 @@ const PlantDashboardMap = ({
   observationResults,
 }: PlantDashboardMapProps): JSX.Element => {
   const { token, mapId } = useMapboxToken();
+  const mapRef = useRef<MapRef | null>(null);
   const { strings } = useLocalization();
   const theme = useTheme();
 
@@ -611,6 +613,7 @@ const PlantDashboardMap = ({
       features={mapFeatures}
       initialSelectedLayerId={'zones'}
       mapId={mapId}
+      mapRef={mapRef}
       token={token}
       setDrawerOpen={setDrawerOpenCallback}
     />


### PR DESCRIPTION
This enables map to be reactive without needing a page reload.

[Screen Recording 2025-09-29 at 2.12.58 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/f80ff1c0-5c74-4775-b40f-52ab8273bf25.mov" />](https://app.graphite.dev/user-attachments/video/f80ff1c0-5c74-4775-b40f-52ab8273bf25.mov)

This will work for MVP but we can include pan speed and other options if needed in the future.

Marker updates:

[Screen Recording 2025-09-29 at 4.24.09 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/8de2b2a3-3b6f-4bd8-9506-a1ecba009b28.mov" />](https://app.graphite.dev/user-attachments/video/8de2b2a3-3b6f-4bd8-9506-a1ecba009b28.mov)

