### PR TITLE
SW-7456 Remove Add-Planting-Site button when user is missing permission

### DIFF
--- a/src/components/emptyStatePages/PlantsDashboardEmptyMessage.tsx
+++ b/src/components/emptyStatePages/PlantsDashboardEmptyMessage.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Button } from '@terraware/web-components';
 
 import useNavigateTo from 'src/hooks/useNavigateTo';
-import { useOrganization } from 'src/providers';
+import { useOrganization, useUser } from 'src/providers';
 import strings from 'src/strings';
 import { isAdmin } from 'src/utils/organization';
 
@@ -12,6 +12,14 @@ export default function PlantsDashboardEmptyMessage(): JSX.Element {
   const { goToPlantingSitesView } = useNavigateTo();
   const { selectedOrganization } = useOrganization();
   const theme = useTheme();
+  const { isAllowed } = useUser();
+
+  const isAllowedCreatePlantingSite = useMemo(
+    () => isAllowed('CREATE_PLANTING_SITE', { organization: selectedOrganization }),
+    [isAllowed, selectedOrganization]
+  );
+
+  const goToCreatePlantingSite = useCallback(() => goToPlantingSitesView(true), [goToPlantingSitesView]);
 
   return (
     <Box
@@ -38,9 +46,11 @@ export default function PlantsDashboardEmptyMessage(): JSX.Element {
             ? strings.DASHBOARD_NO_PLANTING_SITES_DESCRIPTION_ADMIN
             : strings.DASHBOARD_NO_PLANTING_SITES_DESCRIPTION_NON_ADMIN}
         </Typography>
-        <Box marginTop={2}>
-          <Button onClick={() => goToPlantingSitesView(true)} label={strings.ADD_A_PLANTING_SITE} />
-        </Box>
+        {isAllowedCreatePlantingSite && (
+          <Box marginTop={2}>
+            <Button onClick={goToCreatePlantingSite} label={strings.ADD_A_PLANTING_SITE} />
+          </Box>
+        )}
       </Box>
     </Box>
   );

--- a/src/components/emptyStatePages/PlantsDashboardEmptyMessage.tsx
+++ b/src/components/emptyStatePages/PlantsDashboardEmptyMessage.tsx
@@ -37,12 +37,12 @@ export default function PlantsDashboardEmptyMessage(): JSX.Element {
       </Box>
       <Box>
         <Typography fontSize={'20px'} fontWeight={600}>
-          {isAdmin(selectedOrganization)
+          {isAllowedCreatePlantingSite
             ? strings.DASHBOARD_NO_PLANTING_SITES_TITLE_ADMIN
             : strings.DASHBOARD_NO_PLANTING_SITES_TITLE_NON_ADMIN}
         </Typography>
         <Typography paddingTop={1}>
-          {isAdmin(selectedOrganization)
+          {isAllowedCreatePlantingSite
             ? strings.DASHBOARD_NO_PLANTING_SITES_DESCRIPTION_ADMIN
             : strings.DASHBOARD_NO_PLANTING_SITES_DESCRIPTION_NON_ADMIN}
         </Typography>

--- a/src/components/emptyStatePages/PlantsDashboardEmptyMessage.tsx
+++ b/src/components/emptyStatePages/PlantsDashboardEmptyMessage.tsx
@@ -6,7 +6,6 @@ import { Button } from '@terraware/web-components';
 import useNavigateTo from 'src/hooks/useNavigateTo';
 import { useOrganization, useUser } from 'src/providers';
 import strings from 'src/strings';
-import { isAdmin } from 'src/utils/organization';
 
 export default function PlantsDashboardEmptyMessage(): JSX.Element {
   const { goToPlantingSitesView } = useNavigateTo();

--- a/src/utils/acl.ts
+++ b/src/utils/acl.ts
@@ -49,6 +49,7 @@ type PermissionDeliverable =
 type PermissionDocuments = 'CREATE_DOCUMENTS';
 type PermissionFunder = 'READ_FUNDING_ENTITIES' | 'MANAGE_FUNDING_ENTITIES' | 'INVITE_FUNDER';
 type PermissionGlobalRole = 'READ_GLOBAL_ROLES' | 'ASSIGN_GLOBAL_ROLE_TO_USER' | 'ASSIGN_SOME_GLOBAL_ROLES';
+type PermissionOrganization = 'CREATE_PLANTING_SITE';
 type PermissionParticipant =
   | 'CREATE_PARTICIPANTS'
   | 'READ_PARTICIPANTS'
@@ -75,6 +76,7 @@ export type GlobalRolePermission =
   | PermissionDocuments
   | PermissionFunder
   | PermissionGlobalRole
+  | PermissionOrganization
   | PermissionParticipant
   | PermissionParticipantProject;
 
@@ -251,6 +253,17 @@ const isAllowedDeleteNonPublishedActivities: PermissionCheckFn<DeleteNonPublishe
 };
 
 /**
+ * Function related to create planting site, since the permission also applies to
+ * org roles, we need to check the passed-in organization
+ */
+type CreatePlantingSiteMetadata = { organization: Organization };
+const isAllowedCreatePlantingSite: PermissionCheckFn<CreatePlantingSiteMetadata> = (
+  user: User,
+  _: GlobalRolePermission,
+  metadata?: CreatePlantingSiteMetadata
+) => isAcceleratorAdmin(user) || isAdmin(metadata?.organization);
+
+/**
  * This is the main ACL entrypoint where all permissions are indicated through a global role
  * array or a function that returns a boolean
  */
@@ -263,6 +276,7 @@ const ACL: Record<GlobalRolePermission, UserGlobalRoles | PermissionCheckFn> = {
   CREATE_COHORTS: AcceleratorAdminPlus,
   CREATE_DOCUMENTS: TFExpertPlus,
   CREATE_PARTICIPANTS: AcceleratorAdminPlus,
+  CREATE_PLANTING_SITE: isAllowedCreatePlantingSite,
   CREATE_SUBMISSION: isAllowedCreateSubmission,
   DELETE_ACTIVITIES_NON_PUBLISHED: isAllowedDeleteNonPublishedActivities,
   DELETE_ACTIVITIES_PUBLISHED: AcceleratorAdminPlus,


### PR DESCRIPTION
An organization Manager went to the plants dashboard for an org that didn't have a planting site. The dashboard displayed the Add Planting Site button and the user tried to create a planting site but it threw a server error because only org admins can create planting sites. 

Remove the button from the dashboard if the user doesn't have permission to add a planting site. 