### PR TITLE
SW-7450 Make map location sticky and map view style sticky

### DIFF
--- a/src/components/ActivityLog/MapSplitView.tsx
+++ b/src/components/ActivityLog/MapSplitView.tsx
@@ -167,7 +167,7 @@ export default function MapSplitView({
       params.set('lat', view.viewState.latitude.toString());
       params.set('lng', view.viewState.longitude.toString());
       params.set('zoom', view.viewState.zoom.toString());
-      setSearchParams(params);
+      setSearchParams(params, { replace: true });
     },
     [searchParams, setSearchParams]
   );

--- a/src/components/ActivityLog/MapSplitView.tsx
+++ b/src/components/ActivityLog/MapSplitView.tsx
@@ -118,11 +118,6 @@ export default function MapSplitView({
     );
   }, [plantingSites]);
 
-  const boundingBox = useMemo(() => {
-    const multipolygons = siteFeatures.map((feature) => feature.geometry);
-    return getBoundingBox(multipolygons);
-  }, [siteFeatures]);
-
   const mapFeatures = useMemo((): MapFeatureSection[] => {
     return [
       {
@@ -158,11 +153,13 @@ export default function MapSplitView({
   }, [currentProjectId, projectId, setSearchParams]);
 
   useEffect(() => {
-    if (!initialMapViewState && boundingBox) {
+    if (!initialMapViewState && siteFeatures.length > 0) {
       // If no map view state is provided, move map to features
+      const multipolygons = siteFeatures.map((feature) => feature.geometry);
+      const boundingBox = getBoundingBox(multipolygons);
       fitBounds(boundingBox);
     }
-  }, [boundingBox, fitBounds, initialMapViewState]);
+  }, [fitBounds, initialMapViewState, siteFeatures]);
 
   const onMapMoveCallback = useCallback(
     (view: ViewStateChangeEvent) => {

--- a/src/components/ActivityLog/MapSplitView.tsx
+++ b/src/components/ActivityLog/MapSplitView.tsx
@@ -174,7 +174,6 @@ export default function MapSplitView({
     },
     [searchParams, setSearchParams]
   );
-  );
 
   return (
     <Box display='flex' flexDirection='column' flexGrow={1}>

--- a/src/components/ActivityLog/MapSplitView.tsx
+++ b/src/components/ActivityLog/MapSplitView.tsx
@@ -166,13 +166,14 @@ export default function MapSplitView({
 
   const onMapMoveCallback = useCallback(
     (view: ViewStateChangeEvent) => {
-      setSearchParams({
-        lat: view.viewState.latitude.toString(),
-        lng: view.viewState.longitude.toString(),
-        zoom: view.viewState.zoom.toString(),
-      });
+      const params = new URLSearchParams(searchParams);
+      params.set('lat', view.viewState.latitude.toString());
+      params.set('lng', view.viewState.longitude.toString());
+      params.set('zoom', view.viewState.zoom.toString());
+      setSearchParams(params);
     },
-    [setSearchParams]
+    [searchParams, setSearchParams]
+  );
   );
 
   return (

--- a/src/components/ActivityLog/MapSplitView.tsx
+++ b/src/components/ActivityLog/MapSplitView.tsx
@@ -38,6 +38,7 @@ export default function MapSplitView({
   const { strings } = useLocalization();
   const mapRef = useRef<MapRef | null>(null);
   const { fitBounds } = useMapUtils(mapRef);
+  const { plantingSites } = useProjectPlantingSites(projectId);
   const [searchParams, setSearchParams] = useSearchParams();
   const [currentProjectId, setCurrentProjectId] = useState(projectId);
 
@@ -102,8 +103,6 @@ export default function MapSplitView({
     });
   }, [activities, activityMarkerHighlighted, onActivityMarkerClickCallback]);
 
-  const { plantingSites } = useProjectPlantingSites(projectId);
-
   const siteFeatures = useMemo((): MapLayerFeature[] => {
     return (
       plantingSites?.map(
@@ -159,7 +158,7 @@ export default function MapSplitView({
   }, [currentProjectId, projectId, setSearchParams]);
 
   useEffect(() => {
-    if (!initialMapViewState) {
+    if (!initialMapViewState && boundingBox) {
       // If no map view state is provided, move map to features
       fitBounds(boundingBox);
     }

--- a/src/components/ActivityLog/MapSplitView.tsx
+++ b/src/components/ActivityLog/MapSplitView.tsx
@@ -1,18 +1,18 @@
-import React, { MutableRefObject, useCallback, useEffect, useMemo, useRef } from 'react';
-import { MapRef } from 'react-map-gl/mapbox';
+import React, { MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { MapRef, ViewStateChangeEvent } from 'react-map-gl/mapbox';
+import { useSearchParams } from 'react-router';
 
 import { Box, useTheme } from '@mui/material';
 
 import MapComponent, { MapFeatureSection } from 'src/components/NewMap';
-import { MapLayerFeature, MapMarker, MapMarkerGroup } from 'src/components/NewMap/types';
+import ColorKeyControl from 'src/components/NewMap/ColorKeyControl';
+import { MapLayerFeature, MapMarker, MapMarkerGroup, MapViewState } from 'src/components/NewMap/types';
+import useMapUtils from 'src/components/NewMap/useMapUtils';
+import { getBoundingBox } from 'src/components/NewMap/utils';
 import { useProjectPlantingSites } from 'src/hooks/useProjectPlantingSites';
 import { useLocalization } from 'src/providers';
 import { Activity, activityTypeColor } from 'src/types/Activity';
 import useMapboxToken from 'src/utils/useMapboxToken';
-
-import ColorKeyControl from '../NewMap/ColorKeyControl';
-import useMapUtils from '../NewMap/useMapUtils';
-import { getBoundingBox } from '../NewMap/utils';
 
 type MapSplitViewProps = {
   activities?: Activity[];
@@ -34,37 +34,37 @@ export default function MapSplitView({
   topComponent,
 }: MapSplitViewProps): JSX.Element {
   const theme = useTheme();
-  const { token, mapId } = useMapboxToken();
+  const { mapId, refreshToken, token } = useMapboxToken();
   const { strings } = useLocalization();
   const mapRef = useRef<MapRef | null>(null);
   const { fitBounds } = useMapUtils(mapRef);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [currentProjectId, setCurrentProjectId] = useState(projectId);
 
   const onActivityMarkerClickCallback = useCallback(
     (activityId: number, fileId: number) => () => onActivityMarkerClick?.(activityId, fileId),
     [onActivityMarkerClick]
   );
 
-  const { plantingSites } = useProjectPlantingSites(projectId);
+  const [initialMapViewState, setInitialMapViewState] = useState((): MapViewState | undefined => {
+    const latParam = searchParams.get('lat');
+    const lngParam = searchParams.get('lng');
+    const zoomParam = searchParams.get('zoom');
 
-  const siteFeatures = useMemo((): MapLayerFeature[] => {
-    return (
-      plantingSites?.map(
-        (site): MapLayerFeature => ({
-          featureId: `${site.id}`,
-          label: site.name,
-          geometry: {
-            type: 'MultiPolygon',
-            coordinates: site.boundary?.coordinates ?? [],
-          },
-        })
-      ) ?? []
-    );
-  }, [plantingSites]);
+    if (latParam && lngParam && zoomParam) {
+      const latitude = Number(latParam);
+      const longitude = Number(lngParam);
+      const zoom = Number(zoomParam);
 
-  const boundingBox = useMemo(() => {
-    const multipolygons = siteFeatures.map((feature) => feature.geometry);
-    return getBoundingBox(multipolygons);
-  }, [siteFeatures]);
+      if (!isNaN(latitude) && !isNaN(longitude) && !isNaN(zoom)) {
+        return {
+          latitude,
+          longitude,
+          zoom,
+        };
+      }
+    }
+  });
 
   const markerGroups = useMemo((): MapMarkerGroup[] => {
     if (!activities) {
@@ -102,6 +102,28 @@ export default function MapSplitView({
     });
   }, [activities, activityMarkerHighlighted, onActivityMarkerClickCallback]);
 
+  const { plantingSites } = useProjectPlantingSites(projectId);
+
+  const siteFeatures = useMemo((): MapLayerFeature[] => {
+    return (
+      plantingSites?.map(
+        (site): MapLayerFeature => ({
+          featureId: `${site.id}`,
+          label: site.name,
+          geometry: {
+            type: 'MultiPolygon',
+            coordinates: site.boundary?.coordinates ?? [],
+          },
+        })
+      ) ?? []
+    );
+  }, [plantingSites]);
+
+  const boundingBox = useMemo(() => {
+    const multipolygons = siteFeatures.map((feature) => feature.geometry);
+    return getBoundingBox(multipolygons);
+  }, [siteFeatures]);
+
   const mapFeatures = useMemo((): MapFeatureSection[] => {
     return [
       {
@@ -130,8 +152,29 @@ export default function MapSplitView({
   }, [markerGroups, siteFeatures, strings, theme]);
 
   useEffect(() => {
-    fitBounds(boundingBox);
-  }, [boundingBox, fitBounds]);
+    if (projectId !== currentProjectId) {
+      setInitialMapViewState(undefined);
+      setCurrentProjectId(projectId);
+    }
+  }, [currentProjectId, projectId, setSearchParams]);
+
+  useEffect(() => {
+    if (!initialMapViewState) {
+      // If no map view state is provided, move map to features
+      fitBounds(boundingBox);
+    }
+  }, [boundingBox, fitBounds, initialMapViewState]);
+
+  const onMapMoveCallback = useCallback(
+    (view: ViewStateChangeEvent) => {
+      setSearchParams({
+        lat: view.viewState.latitude.toString(),
+        lng: view.viewState.longitude.toString(),
+        zoom: view.viewState.zoom.toString(),
+      });
+    },
+    [setSearchParams]
+  );
 
   return (
     <Box display='flex' flexDirection='column' flexGrow={1}>
@@ -146,8 +189,11 @@ export default function MapSplitView({
         features={mapFeatures}
         hideLegend
         initialSelectedLayerId='sites'
+        initialViewState={initialMapViewState}
         mapRef={mapRef}
         mapId={mapId}
+        onMapMove={onMapMoveCallback}
+        onTokenExpired={refreshToken}
         token={token ?? ''}
         controlTopLeft={<ColorKeyControl />}
       />

--- a/src/components/NewMap/types.tsx
+++ b/src/components/NewMap/types.tsx
@@ -3,6 +3,8 @@ import { MultiPolygon } from 'geojson';
 
 export type MapBounds = { minLat: number; minLng: number; maxLat: number; maxLng: number };
 
+export type MapViewState = { latitude: number; longitude: number; zoom: number };
+
 /**
  * Properties class for GeoJson, with a few reserved object defined.
  */

--- a/src/components/NewMap/useMapUtils.ts
+++ b/src/components/NewMap/useMapUtils.ts
@@ -1,13 +1,14 @@
 import { MutableRefObject, useCallback, useMemo } from 'react';
 import { MapRef } from 'react-map-gl/mapbox';
 
-import { MapBounds } from './types';
+import { MapBounds, MapViewState } from './types';
 import { isBoundsValid } from './utils';
 
 const useMapUtils = (mapRef: MutableRefObject<MapRef | null>) => {
   const easeTo = useCallback(
-    (latitude: number, longitude: number, zoom?: number) => {
+    (viewState: MapViewState) => {
       const map = mapRef.current;
+      const { latitude, longitude, zoom } = viewState;
 
       if (map) {
         map.easeTo({
@@ -46,13 +47,29 @@ const useMapUtils = (mapRef: MutableRefObject<MapRef | null>) => {
     }
   }, [mapRef]);
 
+  const getCurrentViewState = useCallback((): MapViewState | undefined => {
+    const map = mapRef.current;
+
+    if (map) {
+      const center = map.getCenter();
+      const zoom = map.getZoom();
+
+      return {
+        latitude: center.lat,
+        longitude: center.lng,
+        zoom,
+      };
+    }
+  }, [mapRef]);
+
   return useMemo(
     () => ({
       easeTo,
       fitBounds,
       getCurrentBounds,
+      getCurrentViewState,
     }),
-    [easeTo, fitBounds, getCurrentBounds]
+    [easeTo, fitBounds, getCurrentBounds, getCurrentViewState]
   );
 };
 

--- a/src/components/NewMap/useMapUtils.ts
+++ b/src/components/NewMap/useMapUtils.ts
@@ -5,13 +5,13 @@ import { MapBounds, MapViewState } from './types';
 import { isBoundsValid } from './utils';
 
 const useMapUtils = (mapRef: MutableRefObject<MapRef | null>) => {
-  const easeTo = useCallback(
+  const jumpTo = useCallback(
     (viewState: MapViewState) => {
       const map = mapRef.current;
       const { latitude, longitude, zoom } = viewState;
 
       if (map) {
-        map.easeTo({
+        map.jumpTo({
           center: { lat: latitude, lng: longitude },
           zoom,
         });
@@ -26,10 +26,15 @@ const useMapUtils = (mapRef: MutableRefObject<MapRef | null>) => {
       const { minLat, minLng, maxLat, maxLng } = bbox;
 
       if (map && isBoundsValid(bbox)) {
-        map.fitBounds([
-          { lat: minLat, lng: minLng },
-          { lat: maxLat, lng: maxLng },
-        ]);
+        map.fitBounds(
+          [
+            { lat: minLat, lng: minLng },
+            { lat: maxLat, lng: maxLng },
+          ],
+          {
+            animate: false,
+          }
+        );
       }
     },
     [mapRef]
@@ -64,12 +69,12 @@ const useMapUtils = (mapRef: MutableRefObject<MapRef | null>) => {
 
   return useMemo(
     () => ({
-      easeTo,
+      jumpTo,
       fitBounds,
       getCurrentBounds,
       getCurrentViewState,
     }),
-    [easeTo, fitBounds, getCurrentBounds, getCurrentViewState]
+    [jumpTo, fitBounds, getCurrentBounds, getCurrentViewState]
   );
 };
 

--- a/src/components/NewMap/useStickyMapViewStyle.ts
+++ b/src/components/NewMap/useStickyMapViewStyle.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { MapViewStyle, MapViewStyles } from './types';
+
+type StickyMapViewStyleProps = {
+  defaultStyle: MapViewStyle;
+  key: string;
+};
+
+const getStyleFromSession = (key: string): string => {
+  try {
+    return sessionStorage.getItem(key) || '';
+  } catch (e) {
+    return '';
+  }
+};
+
+const writeStyleToSession = (key: string, style: MapViewStyle): void => {
+  try {
+    sessionStorage.setItem(key, style);
+  } catch (e) {
+    /* empty */
+  }
+};
+
+const useStickyMapViewStyle = ({ defaultStyle, key }: StickyMapViewStyleProps) => {
+  const [mapViewStyle, setMapViewStyle] = useState(defaultStyle);
+
+  const updateMapViewStyle = useCallback(
+    (newStyle: MapViewStyle) => {
+      setMapViewStyle(newStyle);
+      writeStyleToSession(key, newStyle);
+    },
+    [key]
+  );
+
+  useEffect(() => {
+    // If there is a "last viewed" tab in the session, use that, otherwise send to default
+    const sessionStyle = getStyleFromSession(key);
+    if (sessionStyle && (MapViewStyles as string[]).includes(sessionStyle)) {
+      setMapViewStyle(sessionStyle as MapViewStyle);
+      return;
+    }
+  }, [key]);
+
+  return {
+    mapViewStyle,
+    updateMapViewStyle,
+  };
+};
+
+export default useStickyMapViewStyle;

--- a/src/components/NewMap/utils.ts
+++ b/src/components/NewMap/utils.ts
@@ -40,9 +40,7 @@ const getBoundsZoomLevel = (bounds: MapBounds, mapWidth: number, mapHeight: numb
   return Math.floor(Math.min(latZoom, lngZoom));
 };
 
-const getBoundingBox = (
-  multipolygons: MultiPolygon[]
-): { minLat: number; minLng: number; maxLat: number; maxLng: number } => {
+const getBoundingBox = (multipolygons: MultiPolygon[]): MapBounds => {
   let minLat = Infinity;
   let maxLat = -Infinity;
   let minLng = Infinity;

--- a/src/hooks/useNavigateTo.ts
+++ b/src/hooks/useNavigateTo.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { APP_PATHS } from 'src/constants';
 import { ModuleContentType } from 'src/types/Module';

--- a/src/hooks/useNavigateTo.ts
+++ b/src/hooks/useNavigateTo.ts
@@ -27,9 +27,7 @@ export default function useNavigateTo() {
         if (params.has('zoom')) {
           newParams.set('zoom', params.get('zoom')!);
         }
-
         newParams.set('source', window.location.pathname);
-
         navigate({
           pathname: APP_PATHS.ACCELERATOR_ACTIVITY_LOG_NEW.replace(':projectId', `${projectId}`),
           search: newParams.toString(),

--- a/src/hooks/useNavigateTo.ts
+++ b/src/hooks/useNavigateTo.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { APP_PATHS } from 'src/constants';
 import { ModuleContentType } from 'src/types/Module';
@@ -9,6 +9,21 @@ import { useSyncNavigate } from './useSyncNavigate';
 export default function useNavigateTo() {
   const navigate = useSyncNavigate();
 
+  const searchParamsWtihMapViewState = () => {
+    const params = new URLSearchParams(location.search);
+    const newParams = new URLSearchParams();
+    if (params.has('lat')) {
+      newParams.set('lat', params.get('lat')!);
+    }
+    if (params.has('lng')) {
+      newParams.set('lng', params.get('lng')!);
+    }
+    if (params.has('zoom')) {
+      newParams.set('zoom', params.get('zoom')!);
+    }
+    return newParams;
+  };
+
   return useMemo(
     () => ({
       goToAccelerator: () => {
@@ -16,65 +31,34 @@ export default function useNavigateTo() {
       },
 
       goToAcceleratorActivityCreate: (projectId: number) => {
-        const params = new URLSearchParams(location.search);
-        const newParams = new URLSearchParams();
-        if (params.has('lat')) {
-          newParams.set('lat', params.get('lat')!);
-        }
-        if (params.has('lng')) {
-          newParams.set('lng', params.get('lng')!);
-        }
-        if (params.has('zoom')) {
-          newParams.set('zoom', params.get('zoom')!);
-        }
-        newParams.set('source', window.location.pathname);
+        const params = searchParamsWtihMapViewState();
+        params.set('source', window.location.pathname);
         navigate({
           pathname: APP_PATHS.ACCELERATOR_ACTIVITY_LOG_NEW.replace(':projectId', `${projectId}`),
-          search: newParams.toString(),
+          search: params.toString(),
         });
       },
 
       goToAcceleratorActivityEdit: (projectId: number, activityId: number) => {
-        const params = new URLSearchParams(location.search);
-        const newParams = new URLSearchParams();
-        if (params.has('lat')) {
-          newParams.set('lat', params.get('lat')!);
-        }
-        if (params.has('lng')) {
-          newParams.set('lng', params.get('lng')!);
-        }
-        if (params.has('zoom')) {
-          newParams.set('zoom', params.get('zoom')!);
-        }
-        newParams.set('source', window.location.pathname);
+        const params = searchParamsWtihMapViewState();
+        params.set('source', window.location.pathname);
         navigate({
           pathname: APP_PATHS.ACCELERATOR_ACTIVITY_LOG_EDIT.replace(':projectId', `${projectId}`).replace(
             ':activityId',
             `${activityId}`
           ),
-          search: newParams.toString(),
+          search: params.toString(),
         });
       },
 
       goToAcceleratorActivityLog: (activityId?: number) => {
-        const params = new URLSearchParams(location.search);
-        const newParams = new URLSearchParams();
-        if (params.has('lat')) {
-          newParams.set('lat', params.get('lat')!);
-        }
-        if (params.has('lng')) {
-          newParams.set('lng', params.get('lng')!);
-        }
-        if (params.has('zoom')) {
-          newParams.set('zoom', params.get('zoom')!);
-        }
+        const params = searchParamsWtihMapViewState();
         if (activityId !== undefined) {
-          newParams.set('activityId', activityId.toString());
+          params.set('activityId', activityId.toString());
         }
-
         navigate({
           pathname: APP_PATHS.ACCELERATOR_ACTIVITY_LOG,
-          search: newParams.toString(),
+          search: params.toString(),
         });
       },
 
@@ -128,65 +112,32 @@ export default function useNavigateTo() {
         }),
 
       goToActivityCreate: (projectId: number) => {
-        const params = new URLSearchParams(location.search);
-        const newParams = new URLSearchParams();
-        if (params.has('lat')) {
-          newParams.set('lat', params.get('lat')!);
-        }
-        if (params.has('lng')) {
-          newParams.set('lng', params.get('lng')!);
-        }
-        if (params.has('zoom')) {
-          newParams.set('zoom', params.get('zoom')!);
-        }
-
+        const params = searchParamsWtihMapViewState();
         navigate({
           pathname: APP_PATHS.ACTIVITY_LOG_NEW.replace(':projectId', `${projectId}`),
-          search: newParams.toString(),
+          search: params.toString(),
         });
       },
 
       goToActivityEdit: (projectId: number, activityId: number) => {
-        const params = new URLSearchParams(location.search);
-        const newParams = new URLSearchParams();
-        if (params.has('lat')) {
-          newParams.set('lat', params.get('lat')!);
-        }
-        if (params.has('lng')) {
-          newParams.set('lng', params.get('lng')!);
-        }
-        if (params.has('zoom')) {
-          newParams.set('zoom', params.get('zoom')!);
-        }
-
+        const params = searchParamsWtihMapViewState();
         navigate({
           pathname: APP_PATHS.ACTIVITY_LOG_EDIT.replace(':projectId', `${projectId}`).replace(
             ':activityId',
             `${activityId}`
           ),
-          search: newParams.toString(),
+          search: params.toString(),
         });
       },
 
       goToActivityLog: (activityId?: number) => {
-        const params = new URLSearchParams(location.search);
-        const newParams = new URLSearchParams();
-        if (params.has('lat')) {
-          newParams.set('lat', params.get('lat')!);
-        }
-        if (params.has('lng')) {
-          newParams.set('lng', params.get('lng')!);
-        }
-        if (params.has('zoom')) {
-          newParams.set('zoom', params.get('zoom')!);
-        }
+        const params = searchParamsWtihMapViewState();
         if (activityId !== undefined) {
-          newParams.set('activityId', activityId.toString());
+          params.set('activityId', activityId.toString());
         }
-
         navigate({
           pathname: APP_PATHS.ACTIVITY_LOG,
-          search: newParams.toString(),
+          search: params.toString(),
         });
       },
 
@@ -367,11 +318,16 @@ export default function useNavigateTo() {
           search: 'tab=participants',
         }),
 
-      goToParticipantProject: (projectId: number, activityId?: number) =>
+      goToParticipantProject: (projectId: number, activityId?: number) => {
+        const params = searchParamsWtihMapViewState();
+        if (activityId !== undefined) {
+          params.set('activityId', activityId.toString());
+        }
         navigate({
           pathname: APP_PATHS.ACCELERATOR_PROJECT_VIEW.replace(':projectId', `${projectId}`),
-          search: activityId ? `activityId=${activityId}` : undefined,
-        }),
+          search: params.toString(),
+        });
+      },
 
       goToParticipantProjectEdit: (projectId: number) =>
         navigate({ pathname: APP_PATHS.ACCELERATOR_PROJECT_EDIT.replace(':projectId', `${projectId}`) }),

--- a/src/hooks/useNavigateTo.ts
+++ b/src/hooks/useNavigateTo.ts
@@ -17,33 +17,66 @@ export default function useNavigateTo() {
 
       goToAcceleratorActivityCreate: (projectId: number) => {
         const params = new URLSearchParams(location.search);
-        params.set('source', window.location.pathname);
+        const newParams = new URLSearchParams();
+        if (params.has('lat')) {
+          newParams.set('lat', params.get('lat')!);
+        }
+        if (params.has('lng')) {
+          newParams.set('lng', params.get('lng')!);
+        }
+        if (params.has('zoom')) {
+          newParams.set('zoom', params.get('zoom')!);
+        }
+
+        newParams.set('source', window.location.pathname);
+
         navigate({
           pathname: APP_PATHS.ACCELERATOR_ACTIVITY_LOG_NEW.replace(':projectId', `${projectId}`),
-          search: params.toString(),
+          search: newParams.toString(),
         });
       },
 
       goToAcceleratorActivityEdit: (projectId: number, activityId: number) => {
         const params = new URLSearchParams(location.search);
-        params.set('source', window.location.pathname);
+        const newParams = new URLSearchParams();
+        if (params.has('lat')) {
+          newParams.set('lat', params.get('lat')!);
+        }
+        if (params.has('lng')) {
+          newParams.set('lng', params.get('lng')!);
+        }
+        if (params.has('zoom')) {
+          newParams.set('zoom', params.get('zoom')!);
+        }
+        newParams.set('source', window.location.pathname);
         navigate({
           pathname: APP_PATHS.ACCELERATOR_ACTIVITY_LOG_EDIT.replace(':projectId', `${projectId}`).replace(
             ':activityId',
             `${activityId}`
           ),
-          search: params.toString(),
+          search: newParams.toString(),
         });
       },
 
       goToAcceleratorActivityLog: (activityId?: number) => {
         const params = new URLSearchParams(location.search);
-        if (activityId !== undefined) {
-          params.set('activityId', activityId.toString());
+        const newParams = new URLSearchParams();
+        if (params.has('lat')) {
+          newParams.set('lat', params.get('lat')!);
         }
+        if (params.has('lng')) {
+          newParams.set('lng', params.get('lng')!);
+        }
+        if (params.has('zoom')) {
+          newParams.set('zoom', params.get('zoom')!);
+        }
+        if (activityId !== undefined) {
+          newParams.set('activityId', activityId.toString());
+        }
+
         navigate({
           pathname: APP_PATHS.ACCELERATOR_ACTIVITY_LOG,
-          search: params.toString(),
+          search: newParams.toString(),
         });
       },
 
@@ -97,30 +130,65 @@ export default function useNavigateTo() {
         }),
 
       goToActivityCreate: (projectId: number) => {
+        const params = new URLSearchParams(location.search);
+        const newParams = new URLSearchParams();
+        if (params.has('lat')) {
+          newParams.set('lat', params.get('lat')!);
+        }
+        if (params.has('lng')) {
+          newParams.set('lng', params.get('lng')!);
+        }
+        if (params.has('zoom')) {
+          newParams.set('zoom', params.get('zoom')!);
+        }
+
         navigate({
           pathname: APP_PATHS.ACTIVITY_LOG_NEW.replace(':projectId', `${projectId}`),
-          search: location.search,
+          search: newParams.toString(),
         });
       },
 
       goToActivityEdit: (projectId: number, activityId: number) => {
+        const params = new URLSearchParams(location.search);
+        const newParams = new URLSearchParams();
+        if (params.has('lat')) {
+          newParams.set('lat', params.get('lat')!);
+        }
+        if (params.has('lng')) {
+          newParams.set('lng', params.get('lng')!);
+        }
+        if (params.has('zoom')) {
+          newParams.set('zoom', params.get('zoom')!);
+        }
+
         navigate({
           pathname: APP_PATHS.ACTIVITY_LOG_EDIT.replace(':projectId', `${projectId}`).replace(
             ':activityId',
             `${activityId}`
           ),
-          search: location.search,
+          search: newParams.toString(),
         });
       },
 
       goToActivityLog: (activityId?: number) => {
         const params = new URLSearchParams(location.search);
-        if (activityId !== undefined) {
-          params.set('activityId', activityId.toString());
+        const newParams = new URLSearchParams();
+        if (params.has('lat')) {
+          newParams.set('lat', params.get('lat')!);
         }
+        if (params.has('lng')) {
+          newParams.set('lng', params.get('lng')!);
+        }
+        if (params.has('zoom')) {
+          newParams.set('zoom', params.get('zoom')!);
+        }
+        if (activityId !== undefined) {
+          newParams.set('activityId', activityId.toString());
+        }
+
         navigate({
           pathname: APP_PATHS.ACTIVITY_LOG,
-          search: params.toString(),
+          search: newParams.toString(),
         });
       },
 

--- a/src/hooks/useNavigateTo.ts
+++ b/src/hooks/useNavigateTo.ts
@@ -16,26 +16,34 @@ export default function useNavigateTo() {
       },
 
       goToAcceleratorActivityCreate: (projectId: number) => {
+        const params = new URLSearchParams(location.search);
+        params.set('source', window.location.pathname);
         navigate({
           pathname: APP_PATHS.ACCELERATOR_ACTIVITY_LOG_NEW.replace(':projectId', `${projectId}`),
-          search: `source=${window.location.pathname}`,
+          search: params.toString(),
         });
       },
 
       goToAcceleratorActivityEdit: (projectId: number, activityId: number) => {
+        const params = new URLSearchParams(location.search);
+        params.set('source', window.location.pathname);
         navigate({
           pathname: APP_PATHS.ACCELERATOR_ACTIVITY_LOG_EDIT.replace(':projectId', `${projectId}`).replace(
             ':activityId',
             `${activityId}`
           ),
-          search: `source=${window.location.pathname}`,
+          search: params.toString(),
         });
       },
 
       goToAcceleratorActivityLog: (activityId?: number) => {
+        const params = new URLSearchParams(location.search);
+        if (activityId !== undefined) {
+          params.set('activityId', activityId.toString());
+        }
         navigate({
           pathname: APP_PATHS.ACCELERATOR_ACTIVITY_LOG,
-          search: activityId ? `activityId=${activityId}` : undefined,
+          search: params.toString(),
         });
       },
 
@@ -89,7 +97,10 @@ export default function useNavigateTo() {
         }),
 
       goToActivityCreate: (projectId: number) => {
-        navigate({ pathname: APP_PATHS.ACTIVITY_LOG_NEW.replace(':projectId', `${projectId}`) });
+        navigate({
+          pathname: APP_PATHS.ACTIVITY_LOG_NEW.replace(':projectId', `${projectId}`),
+          search: location.search,
+        });
       },
 
       goToActivityEdit: (projectId: number, activityId: number) => {
@@ -98,13 +109,18 @@ export default function useNavigateTo() {
             ':activityId',
             `${activityId}`
           ),
+          search: location.search,
         });
       },
 
       goToActivityLog: (activityId?: number) => {
+        const params = new URLSearchParams(location.search);
+        if (activityId !== undefined) {
+          params.set('activityId', activityId.toString());
+        }
         navigate({
           pathname: APP_PATHS.ACTIVITY_LOG,
-          search: activityId ? `activityId=${activityId}` : undefined,
+          search: params.toString(),
         });
       },
 

--- a/src/hooks/useNavigateTo.ts
+++ b/src/hooks/useNavigateTo.ts
@@ -9,7 +9,7 @@ import { useSyncNavigate } from './useSyncNavigate';
 export default function useNavigateTo() {
   const navigate = useSyncNavigate();
 
-  const searchParamsWtihMapViewState = () => {
+  const searchParamsWithMapViewState = () => {
     const params = new URLSearchParams(location.search);
     const newParams = new URLSearchParams();
     if (params.has('lat')) {
@@ -31,7 +31,7 @@ export default function useNavigateTo() {
       },
 
       goToAcceleratorActivityCreate: (projectId: number) => {
-        const params = searchParamsWtihMapViewState();
+        const params = searchParamsWithMapViewState();
         params.set('source', window.location.pathname);
         navigate({
           pathname: APP_PATHS.ACCELERATOR_ACTIVITY_LOG_NEW.replace(':projectId', `${projectId}`),
@@ -40,7 +40,7 @@ export default function useNavigateTo() {
       },
 
       goToAcceleratorActivityEdit: (projectId: number, activityId: number) => {
-        const params = searchParamsWtihMapViewState();
+        const params = searchParamsWithMapViewState();
         params.set('source', window.location.pathname);
         navigate({
           pathname: APP_PATHS.ACCELERATOR_ACTIVITY_LOG_EDIT.replace(':projectId', `${projectId}`).replace(
@@ -52,7 +52,7 @@ export default function useNavigateTo() {
       },
 
       goToAcceleratorActivityLog: (activityId?: number) => {
-        const params = searchParamsWtihMapViewState();
+        const params = searchParamsWithMapViewState();
         if (activityId !== undefined) {
           params.set('activityId', activityId.toString());
         }
@@ -112,7 +112,7 @@ export default function useNavigateTo() {
         }),
 
       goToActivityCreate: (projectId: number) => {
-        const params = searchParamsWtihMapViewState();
+        const params = searchParamsWithMapViewState();
         navigate({
           pathname: APP_PATHS.ACTIVITY_LOG_NEW.replace(':projectId', `${projectId}`),
           search: params.toString(),
@@ -120,7 +120,7 @@ export default function useNavigateTo() {
       },
 
       goToActivityEdit: (projectId: number, activityId: number) => {
-        const params = searchParamsWtihMapViewState();
+        const params = searchParamsWithMapViewState();
         navigate({
           pathname: APP_PATHS.ACTIVITY_LOG_EDIT.replace(':projectId', `${projectId}`).replace(
             ':activityId',
@@ -131,7 +131,7 @@ export default function useNavigateTo() {
       },
 
       goToActivityLog: (activityId?: number) => {
-        const params = searchParamsWtihMapViewState();
+        const params = searchParamsWithMapViewState();
         if (activityId !== undefined) {
           params.set('activityId', activityId.toString());
         }
@@ -319,7 +319,7 @@ export default function useNavigateTo() {
         }),
 
       goToParticipantProject: (projectId: number, activityId?: number) => {
-        const params = searchParamsWtihMapViewState();
+        const params = searchParamsWithMapViewState();
         if (activityId !== undefined) {
           params.set('activityId', activityId.toString());
         }

--- a/src/scenes/AcceleratorRouter/Applications/ApplicationReview.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationReview.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button } from '@terraware/web-components';
 
 import ProjectFieldTextAreaDisplay from 'src/components/ProjectField/TextAreaDisplay';
+import useBoolean from 'src/hooks/useBoolean';
 import useNavigateTo from 'src/hooks/useNavigateTo';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useUser } from 'src/providers';
@@ -28,7 +29,7 @@ const ApplicationReview = ({ application }: ApplicationReviewProps) => {
   const { reload } = useApplicationData();
   const navigate = useSyncNavigate();
 
-  const [isReviewModalOpen, setIsReviewModalOpen] = useState<boolean>(false);
+  const [isReviewModalOpen, , openReviewModal, closeReviewModal] = useBoolean(false);
 
   const onReviewSubmitted = useCallback(() => {
     reload(() => navigate(0));
@@ -40,7 +41,7 @@ const ApplicationReview = ({ application }: ApplicationReviewProps) => {
         <ApplicationReviewModal
           application={application}
           open={isReviewModalOpen}
-          onClose={() => setIsReviewModalOpen(false)}
+          onClose={closeReviewModal}
           onSuccess={onReviewSubmitted}
         />
       )}
@@ -81,9 +82,7 @@ const ApplicationReview = ({ application }: ApplicationReviewProps) => {
             // they also lack permission to review the application or leave feedback
             disabled={!canUpdateInternalComments}
             label={strings.REVIEW_APPLICATION}
-            onClick={() => {
-              setIsReviewModalOpen(true);
-            }}
+            onClick={openReviewModal}
             size={'small'}
             priority={'secondary'}
             style={{

--- a/src/scenes/PlantsDashboardRouter/components/PlantDashboardMap.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/PlantDashboardMap.tsx
@@ -62,7 +62,7 @@ const PlantDashboardMap = ({
   plantingSites,
   observationResults,
 }: PlantDashboardMapProps): JSX.Element => {
-  const { token, mapId } = useMapboxToken();
+  const { mapId, refreshToken, token } = useMapboxToken();
   const mapRef = useRef<MapRef | null>(null);
   const { strings } = useLocalization();
   const theme = useTheme();
@@ -652,6 +652,7 @@ const PlantDashboardMap = ({
       initialSelectedLayerId={'zones'}
       mapId={mapId}
       mapRef={mapRef}
+      onTokenExpired={refreshToken}
       token={token}
       setDrawerOpen={setDrawerOpenCallback}
       setHighlightVisible={setHighlightVisible}


### PR DESCRIPTION
This PR implements live update of lat/lng/zoom on search params when using the map on activity views. This allows further navigation to keep the map view state. An added benefit is that user is now able to share exactly the map location to other users via the URL as well.

This also implemented sticky map view style using session storage for a more seamless experience.

A note is that, all activity navigation needs to implement preserving search params to ensure the sticky location works correctly.

Also fixed another issue with token not being defined yet, causing a brief error. 