### PR TITLE
Activity Create/Edit: Remove cover photo is always first from activity media sort

### DIFF
--- a/src/components/ActivityLog/ActivityDetailsForm.tsx
+++ b/src/components/ActivityLog/ActivityDetailsForm.tsx
@@ -310,18 +310,7 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
           isModified: false,
           type: 'existing' as const,
         }))
-        .sort((a, b) => {
-          // cover photos always come first
-          if (a.data.isCoverPhoto && !b.data.isCoverPhoto) {
-            return -1;
-          }
-          if (!a.data.isCoverPhoto && b.data.isCoverPhoto) {
-            return 1;
-          }
-
-          // then sort by listPosition
-          return (a.data.listPosition || 0) - (b.data.listPosition || 0);
-        });
+        .sort((a, b) => a.data.listPosition - b.data.listPosition);
       setMediaFiles(existingMediaItems);
     }
   }, [isEditing, activity]);


### PR DESCRIPTION
This PR includes a small adjustment to the activity media sort in Create/Edit views: remove cover photo is always first.