### PR TITLE
Activity Log: Fix logic that determines which activity log view to nav to on save

### DIFF
--- a/src/components/ActivityLog/ActivityDetailsForm.tsx
+++ b/src/components/ActivityLog/ActivityDetailsForm.tsx
@@ -134,13 +134,13 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
   );
 
   const navToActivityLog = useCallback(() => {
-    if (isAcceleratorRoute && !source) {
-      goToAcceleratorActivityLog();
-    } else if (
+    if (
       isAcceleratorRoute &&
       source === APP_PATHS.ACCELERATOR_PROJECT_VIEW.replace(':projectId', projectId.toString())
     ) {
       goToParticipantProject(projectId);
+    } else if (isAcceleratorRoute) {
+      goToAcceleratorActivityLog();
     } else {
       goToActivityLog();
     }


### PR DESCRIPTION
In [my recent PR](https://github.com/terraware/terraware-web/pull/4536), I made a change to when and what value was passed as the `source` url param when navigating to the Activity Create/Edit views, but I neglected to update a related function that determines which activity log view to navigate to on save.