### PR TITLE
Activity Log: Fix navigation bug

### DIFF
--- a/src/components/ActivityLog/ActivityDetailsForm.tsx
+++ b/src/components/ActivityLog/ActivityDetailsForm.tsx
@@ -138,7 +138,7 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
       source === APP_PATHS.ACCELERATOR_PROJECT_VIEW.replace(':projectId', projectId.toString())
     ) {
       goToParticipantProject(projectId, editingActivityId);
-    } else if (isAcceleratorRoute && !source) {
+    } else if (isAcceleratorRoute) {
       goToAcceleratorActivityLog(editingActivityId);
     } else {
       goToActivityLog(editingActivityId);


### PR DESCRIPTION
This PR fixes a navigation bug that was causing users to be indirected incorrectly to the activity log on the Terraware side rather than the Console side.