### PR TITLE
SW-8254: Species appearing in Observation pages (tables and cards) when there is no data yet (FOLLOW-UP)

### DIFF
--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/SpeciesSurvivalRateChart.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/SpeciesSurvivalRateChart.tsx
@@ -42,7 +42,7 @@ export default function SpeciesSurvivalRateChart({
       }
     });
 
-    const hideData = isTemporary || data.values.length === 0;
+    const hideData = isTemporary || !data.values.some((v) => v > 0);
 
     return {
       labels: hideData ? [] : data.labels,
@@ -54,7 +54,7 @@ export default function SpeciesSurvivalRateChart({
     };
   }, [species, isTemporary]);
 
-  const hasData = chartData.datasets[0].values.length > 0;
+  const hasData = chartData.datasets[0].values.some((v) => typeof v === 'number' && v > 0);
 
   return (
     <Box position='relative' height='100%'>


### PR DESCRIPTION
This PR fixes an issue in the Species Survival Rate Chart:

When all species have a `survivalRate` of `0`, the previous check (`values.length > 0`) treated that as having data — so species names rendered on the x-axis with invisible zero-height bars and no overlay. Changed to `values.some(v => v > 0)` so all-zero survival rates are treated as "no data," clearing the labels and showing the "Data is not yet available" overlay.