### PR TITLE
Run E2E tests after Vercel deployment

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -49,9 +49,20 @@ steps:
           compressed: 'dist.tgz'
     command: .buildkite/scripts/build-and-test.sh
 
+  - label: ':vercel: Deploy Vercel preview'
+    key: 'vercel-preview'
+    depends_on: 'build-and-test'
+    if: "build.branch != 'main' && build.tag == null"
+    plugins:
+      - *shallow-clone
+      - *load-secrets
+      - *cache-node-modules
+      - *restore-dist
+    command: .buildkite/scripts/deploy-vercel.sh
+
   - label: ':playwright: Run end-to-end tests'
     key: 'e2e-tests'
-    depends_on: 'build-and-test'
+    depends_on: 'vercel-preview'
     if: "build.branch != 'main' && build.tag == null"
     plugins:
       - *shallow-clone
@@ -146,14 +157,3 @@ steps:
       - *load-secrets
       - *cache-node-modules
     command: .buildkite/scripts/deploy-docs.sh
-
-  - label: ':vercel: Deploy Vercel preview'
-    key: 'vercel-preview'
-    depends_on: 'build-and-test'
-    if: "build.branch != 'main' && build.tag == null"
-    plugins:
-      - *shallow-clone
-      - *load-secrets
-      - *cache-node-modules
-      - *restore-dist
-    command: .buildkite/scripts/deploy-vercel.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -53,6 +53,7 @@ steps:
     key: 'vercel-preview'
     depends_on: 'build-and-test'
     if: "build.branch != 'main' && build.tag == null"
+    soft_fail: true
     plugins:
       - *shallow-clone
       - *load-secrets
@@ -62,7 +63,9 @@ steps:
 
   - label: ':playwright: Run end-to-end tests'
     key: 'e2e-tests'
-    depends_on: 'vercel-preview'
+    depends_on:
+      - step: 'vercel-preview'
+        allow_failure: true
     if: "build.branch != 'main' && build.tag == null"
     plugins:
       - *shallow-clone


### PR DESCRIPTION
Rather than deploying to Vercel in parallel with running the E2E
tests, do the Vercel deployment first and then run the tests.
This avoids needing to spin up a second build host.