### PR TITLE
SW-8218: Planting Site: Investigate precision of area values and make higher precision values available

### DIFF
--- a/src/components/ActivityLog/ActivityHighlightsView.tsx
+++ b/src/components/ActivityLog/ActivityHighlightsView.tsx
@@ -18,6 +18,7 @@ import { ACTIVITY_MEDIA_FILE_ENDPOINT } from 'src/services/ActivityService';
 import { FUNDER_ACTIVITY_MEDIA_FILE_ENDPOINT } from 'src/services/funder/FunderActivityService';
 import { AcceleratorReport } from 'src/types/AcceleratorReport';
 import { ActivityMediaFile, activityTypeLabel } from 'src/types/Activity';
+import { useNumberFormatter } from 'src/utils/useNumberFormatter';
 import useQuery from 'src/utils/useQuery';
 import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
 
@@ -96,10 +97,10 @@ const HEIGHT_OFFSET_PX = 204;
 
 const HEIGHT_OFFSET_MOBILE_PX = 240;
 
-const getReportIndicators = (strings: any) => [
+const getReportIndicators = (strings: any, numberFormatter: ReturnType<typeof useNumberFormatter>) => [
   {
     indicator: 'Hectares Planted',
-    formatter: (value: number) => strings.formatString(strings.X_HA, value),
+    formatter: (value: number) => strings.formatString(strings.X_HA, numberFormatter.format(value, { decimals: 1 })),
   },
   { indicator: 'Species Planted', formatter: (value: number) => value },
   { indicator: 'Trees Planted', formatter: (value: number) => value },
@@ -122,6 +123,8 @@ type ActivityHighlightSlide = {
 
 const ActivityHighlightsView = ({ activities, projectId, selectedQuarter }: ActivityHighlightsViewProps) => {
   const { activeLocale, strings } = useLocalization();
+  const numberFormatter = useNumberFormatter();
+  const reportIndicators = useMemo(() => getReportIndicators(strings, numberFormatter), [numberFormatter, strings]);
   const theme = useTheme();
   const mapDrawerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<MapRef | null>(null);
@@ -494,7 +497,7 @@ const ActivityHighlightsView = ({ activities, projectId, selectedQuarter }: Acti
                             flexWrap: 'wrap',
                           }}
                         >
-                          {getReportIndicators(strings).map(({ indicator, formatter }) => {
+                          {reportIndicators.map(({ indicator, formatter }) => {
                             const selIndicator = slide.report?.autoCalculatedIndicators?.find((ind) =>
                               isFunderRoute
                                 ? (ind as PublishedReportPayload['autoCalculatedIndicators'][0]).name === indicator

--- a/src/components/ListMapView/index.tsx
+++ b/src/components/ListMapView/index.tsx
@@ -4,7 +4,7 @@ import { Box, Typography, useTheme } from '@mui/material';
 
 import Card from 'src/components/common/Card';
 import ListMapSelector, { View } from 'src/components/common/ListMapSelector';
-import strings from 'src/strings';
+import { useLocalization } from 'src/providers/hooks';
 import { Stratum } from 'src/types/Tracking';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import { useNumberFormatter } from 'src/utils/useNumberFormatter';
@@ -33,6 +33,7 @@ export default function ListMapView({
   initialView,
   data,
 }: ListMapViewProps): JSX.Element {
+  const { strings } = useLocalization();
   const [view, setView] = useState<View>(initialView);
   const theme = useTheme();
   const numberFormatter = useNumberFormatter();
@@ -66,6 +67,16 @@ export default function ListMapView({
     return total;
   }, [data]);
 
+  const plantingSiteAreaHaDisplayValue = useMemo(
+    () => strings.formatString(strings.X_HA, numberFormatter.format(siteAreaHa, { decimals: 1 })),
+    [numberFormatter, siteAreaHa, strings]
+  );
+
+  const plantingCompleteAreaDisplayValue = useMemo(
+    () => strings.formatString(strings.X_HA, numberFormatter.format(plantingCompleteArea, { decimals: 1 })),
+    [numberFormatter, plantingCompleteArea, strings]
+  );
+
   useEffect(() => {
     updateView(initialView);
   }, [initialView, updateView]);
@@ -94,12 +105,10 @@ export default function ListMapView({
               justifyContent='start'
             >
               <Typography fontSize={'16px'} fontWeight={'600'} marginRight={theme.spacing(3)}>
-                {strings.PLANTING_SITE_AREA}:{' '}
-                {strings.formatString(strings.X_HA, numberFormatter.format(siteAreaHa))?.toString()}
+                {strings.PLANTING_SITE_AREA}: {plantingSiteAreaHaDisplayValue}
               </Typography>
               <Typography fontSize={'16px'} fontWeight={'600'} marginRight={theme.spacing(3)}>
-                {strings.PLANTING_COMPLETE_AREA}:{' '}
-                {strings.formatString(strings.X_HA, numberFormatter.format(plantingCompleteArea))?.toString()}
+                {strings.PLANTING_COMPLETE_AREA}: {plantingCompleteAreaDisplayValue}
               </Typography>
             </Box>
           )}

--- a/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
+++ b/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
@@ -119,7 +119,7 @@ export default function PlantsPrimaryPageView({
       .map((proj) => ({ label: proj.name, value: proj.id }));
     iOptions?.unshift({ label: strings.NO_PROJECT, value: -1 });
     return iOptions;
-  }, [projects, projectsWithPlantingSites]);
+  }, [projects, projectsWithPlantingSites, strings]);
 
   const isRolledUpView = useMemo(() => {
     return projectId !== undefined && selectedPlantingSiteId === -1;

--- a/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
+++ b/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
@@ -11,9 +11,8 @@ import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import useOrganizationPlantingSites from 'src/hooks/useOrganizationPlantingSites';
-import { useOrganization } from 'src/providers';
+import { useLocalization, useOrganization } from 'src/providers';
 import { useListProjectsQuery } from 'src/queries/generated/projects';
-import strings from 'src/strings';
 import { PlantingSite } from 'src/types/Tracking';
 
 import SurvivalRateMessageV2 from '../SurvivalRate/SurvivalRateMessageV2';
@@ -68,6 +67,7 @@ export default function PlantsPrimaryPageView({
   actionButton,
   allowAllAsSiteSelection,
 }: PlantsPrimaryPageViewProps): JSX.Element {
+  const { strings } = useLocalization();
   const theme = useTheme();
   const { isDesktop, isMobile } = useDeviceInfo();
   const contentRef = useRef(null);

--- a/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
+++ b/src/components/PlantsPrimaryPage/PlantsPrimaryPageView.tsx
@@ -253,9 +253,10 @@ export default function PlantsPrimaryPageView({
                       {strings.formatString(
                         strings.X_HA,
                         isRolledUpView ? (
-                          <FormattedNumber value={Math.round(totalArea * 100) / 100} />
+                          <FormattedNumber decimals={1} value={totalArea} />
                         ) : (
                           <FormattedNumber
+                            decimals={1}
                             value={plantingSites.find((ps) => ps.id === selectedPlantingSiteId)?.areaHa || 0}
                           />
                         )

--- a/src/components/ProjectField/LandUseModelTypeCard.tsx
+++ b/src/components/ProjectField/LandUseModelTypeCard.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 
 import { useTheme } from '@mui/material';
 
-import strings from 'src/strings';
+import { useLocalization } from 'src/providers/hooks';
 import { LAND_USE_MODEL_TYPES, LandUseModelType } from 'src/types/AcceleratorProject';
 import { NumberFormatter } from 'src/types/Number';
 
@@ -15,6 +15,7 @@ type LandUseModelTypeCardProps = {
 };
 
 const LandUseModelTypeCard = ({ selectedTypes, modelHectares, numberFormatter }: LandUseModelTypeCardProps) => {
+  const { strings } = useLocalization();
   const theme = useTheme();
 
   const value = useMemo(() => {
@@ -28,12 +29,14 @@ const LandUseModelTypeCard = ({ selectedTypes, modelHectares, numberFormatter }:
       }
       let hectaresString = '--';
       if (modelHectares[type] >= 0) {
-        hectaresString = strings.formatString(strings.X_HA, numberFormatter.format(modelHectares[type]))?.toString();
+        hectaresString = strings
+          .formatString(strings.X_HA, numberFormatter.format(modelHectares[type], { decimals: 1 }))
+          ?.toString();
       }
       output.push(`${type} (${hectaresString})`);
     }
     return output.join('/');
-  }, [modelHectares, numberFormatter, selectedTypes]);
+  }, [modelHectares, numberFormatter, selectedTypes, strings]);
 
   return (
     <InvertedCard

--- a/src/components/common/FormattedNumber.tsx
+++ b/src/components/common/FormattedNumber.tsx
@@ -2,10 +2,11 @@ import { useNumberFormatter } from 'src/utils/useNumberFormatter';
 
 interface FormattedNumberProps {
   value: number;
+  decimals?: number;
 }
 
-export default function FormattedNumber({ value }: FormattedNumberProps) {
+export default function FormattedNumber({ value, decimals }: FormattedNumberProps) {
   const numberFormatter = useNumberFormatter();
 
-  return numberFormatter.format(value);
+  return numberFormatter.format(value, decimals !== undefined ? { decimals } : undefined);
 }

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/ProjectProfileView.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/ProjectProfileView.tsx
@@ -150,7 +150,7 @@ const ProjectProfileView = ({
         md={isTablet ? 6 : 12}
         backgroundColor={theme.palette.TwClrBaseGray100}
         label={label}
-        value={value && strings.formatString(strings.X_HA, numberFormatter.format(value))?.toString()}
+        value={value && strings.formatString(strings.X_HA, numberFormatter.format(value, { decimals: 1 }))?.toString()}
       />
     );
     switch (acceleratorProject?.phase) {
@@ -192,6 +192,42 @@ const ProjectProfileView = ({
   const reportIndicatorCardFormatter = useCallback(
     (value: number | undefined) => (value ? formatNumberScale(value, value < 999 ? 0 : 1) : '0'),
     []
+  );
+
+  const confirmedReforestableLandDisplayValue = useMemo(
+    () =>
+      projectDetails?.confirmedReforestableLand &&
+      strings
+        .formatString(strings.X_HA, numberFormatter.format(projectDetails.confirmedReforestableLand, { decimals: 1 }))
+        ?.toString(),
+    [numberFormatter, projectDetails, strings]
+  );
+
+  const minProjectAreaDisplayValue = useMemo(
+    () =>
+      projectDetails?.minProjectArea &&
+      strings
+        .formatString(strings.X_HA, numberFormatter.format(projectDetails.minProjectArea, { decimals: 1 }))
+        ?.toString(),
+    [numberFormatter, projectDetails, strings]
+  );
+
+  const projectAreaDisplayValue = useMemo(
+    () =>
+      projectDetails?.projectArea &&
+      strings
+        .formatString(strings.X_HA, numberFormatter.format(projectDetails.projectArea, { decimals: 1 }))
+        ?.toString(),
+    [numberFormatter, projectDetails, strings]
+  );
+
+  const totalExpansionPotentialDisplayValue = useMemo(
+    () =>
+      projectDetails?.totalExpansionPotential &&
+      strings
+        .formatString(strings.X_HA, numberFormatter.format(projectDetails.totalExpansionPotential, { decimals: 1 }))
+        ?.toString(),
+    [numberFormatter, projectDetails, strings]
   );
 
   return (
@@ -414,21 +450,13 @@ const ProjectProfileView = ({
             <ProjectDataDisplay
               label={strings.ELIGIBLE_AREA}
               md={12}
-              value={
-                projectDetails?.confirmedReforestableLand &&
-                strings
-                  .formatString(strings.X_HA, numberFormatter.format(projectDetails.confirmedReforestableLand))
-                  ?.toString()
-              }
+              value={confirmedReforestableLandDisplayValue}
               tooltip={strings.ELIGIBLE_AREA_DESCRIPTION}
             />
             <ProjectDataDisplay
               label={strings.MIN_PROJECT_AREA}
               md={12}
-              value={
-                projectDetails?.minProjectArea &&
-                strings.formatString(strings.X_HA, numberFormatter.format(projectDetails.minProjectArea))?.toString()
-              }
+              value={minProjectAreaDisplayValue}
               tooltip={strings.MIN_PROJECT_AREA_DESCRIPTION}
             />
           </Grid>
@@ -438,21 +466,13 @@ const ProjectProfileView = ({
             <ProjectDataDisplay
               label={strings.PROJECT_AREA}
               md={12}
-              value={
-                projectDetails?.projectArea &&
-                strings.formatString(strings.X_HA, numberFormatter.format(projectDetails.projectArea))?.toString()
-              }
+              value={projectAreaDisplayValue}
               tooltip={strings.PROJECT_AREA_DESCRIPTION}
             />
             <ProjectDataDisplay
               label={strings.EXPANSION_POTENTIAL}
               md={12}
-              value={
-                projectDetails?.totalExpansionPotential &&
-                strings
-                  .formatString(strings.X_HA, numberFormatter.format(projectDetails.totalExpansionPotential))
-                  ?.toString()
-              }
+              value={totalExpansionPotentialDisplayValue}
               tooltip={strings.EXPANSION_POTENTIAL_DESCRIPTION}
             />
           </Grid>

--- a/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
+++ b/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
@@ -15,7 +15,6 @@ import { useLocalization, useOrganization } from 'src/providers';
 import { useLazyGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { useLazySearchPlantingSitesQuery } from 'src/queries/search/plantingSites';
 import SimplePlantingSiteMap from 'src/scenes/PlantsDashboardRouter/components/SimplePlantingSiteMap';
-import strings from 'src/strings';
 import { isAdmin } from 'src/utils/organization';
 import useMapboxToken from 'src/utils/useMapboxToken';
 import { useNumberFormatter } from 'src/utils/useNumberFormatter';
@@ -23,6 +22,7 @@ import { useNumberFormatter } from 'src/utils/useNumberFormatter';
 import StatsCardItem from './StatsCardItem';
 
 export const PlantingSiteStats = () => {
+  const { strings } = useLocalization();
   const numberFormatter = useNumberFormatter();
   const { isDesktop } = useDeviceInfo();
   const theme = useTheme();
@@ -68,6 +68,14 @@ export const PlantingSiteStats = () => {
       setSelectedPlantingSiteId(plantingSiteSummaries[0].id);
     }
   }, [plantingSiteSummaries, selectedPlantingSiteId]);
+
+  const plantingSiteAreaHaDisplayValue = useMemo(
+    () =>
+      plantingSite?.areaHa
+        ? strings.formatString(strings.X_HA, numberFormatter.format(plantingSite.areaHa, { decimals: 1 }))?.toString()
+        : undefined,
+    [numberFormatter, plantingSite, strings]
+  );
 
   const plantingCompleteArea = useMemo(() => {
     let total = 0;
@@ -182,11 +190,7 @@ export const PlantingSiteStats = () => {
               label='Area'
               showLink={false}
               showBorder={!isDesktop}
-              value={
-                plantingSite?.areaHa
-                  ? strings.formatString(strings.X_HA, numberFormatter.format(plantingSite.areaHa))?.toString()
-                  : undefined
-              }
+              value={plantingSiteAreaHaDisplayValue}
             />
           </Grid>
 

--- a/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
+++ b/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
@@ -91,6 +91,11 @@ export const PlantingSiteStats = () => {
     return total;
   }, [plantingSite]);
 
+  const plantingCompleteAreaDisplayValue = useMemo(
+    () => strings.formatString(strings.X_HA, numberFormatter.format(plantingCompleteArea, { decimals: 1 }))?.toString(),
+    [numberFormatter, plantingCompleteArea, strings]
+  );
+
   const latestObservationCompletedTime = useMemo(() => {
     if (plantingSite?.latestObservationCompletedTime) {
       return getDateDisplayValue(plantingSite.latestObservationCompletedTime);
@@ -234,7 +239,7 @@ export const PlantingSiteStats = () => {
               showLink={false}
               showTooltip={true}
               tooltipText={strings.TOTAL_HECTARES_PLANTED_TOOLTIP}
-              value={numberFormatter.format(plantingCompleteArea)}
+              value={plantingCompleteAreaDisplayValue}
             />
           </Grid>
 

--- a/src/scenes/NurseryRouter/PlantingProgressMapDialog.tsx
+++ b/src/scenes/NurseryRouter/PlantingProgressMapDialog.tsx
@@ -99,7 +99,7 @@ export default function PlantingProgressMapDialog({
         <Typography fontSize='16px' fontWeight={400}>
           {strings.AREA_HA}
           {': '}
-          <FormattedNumber value={substratumAreaHa} />
+          <FormattedNumber decimals={1} value={substratumAreaHa} />
         </Typography>
         <Typography fontSize='16px' fontWeight={400}>
           <FormattedNumber value={totalPlants} />

--- a/src/scenes/ObservationsRouterV2/Map/index.tsx
+++ b/src/scenes/ObservationsRouterV2/Map/index.tsx
@@ -146,7 +146,7 @@ const ObservationMapWrapper = ({
               {plantingSite?.areaHa !== undefined &&
                 strings.formatString(
                   strings.X_HA_IN_TOTAL_PLANTING_AREA,
-                  <FormattedNumber value={Math.round(plantingSite.areaHa * 100) / 100} />
+                  <FormattedNumber decimals={1} value={plantingSite.areaHa} />
                 )}
             </Typography>
           </Box>

--- a/src/scenes/PlantingSitesRouter/view/BoundariesAndStrata.tsx
+++ b/src/scenes/PlantingSitesRouter/view/BoundariesAndStrata.tsx
@@ -77,6 +77,11 @@ export default function BoundariesAndStrata({
     return total;
   }, [plantingSite]);
 
+  const plantingCompleteAreaDisplayValue = useMemo(
+    () => strings.formatString(strings.X_HA, numberFormatter.format(plantingCompleteArea, { decimals: 1 })),
+    [numberFormatter, plantingCompleteArea, strings]
+  );
+
   const plantingSiteAreaHaDisplayValue = useMemo(
     () =>
       strings
@@ -109,8 +114,7 @@ export default function BoundariesAndStrata({
                     {strings.PLANTING_SITE_AREA}: {plantingSiteAreaHaDisplayValue}
                   </Typography>
                   <Typography fontSize={'16px'} fontWeight={'600'} marginRight={theme.spacing(3)}>
-                    {strings.PLANTING_COMPLETE_AREA}:{' '}
-                    {strings.formatString(strings.X_HA, numberFormatter.format(plantingCompleteArea))?.toString()}
+                    {strings.PLANTING_COMPLETE_AREA}: {plantingCompleteAreaDisplayValue}
                   </Typography>
                 </Box>
               )}

--- a/src/scenes/PlantingSitesRouter/view/BoundariesAndStrata.tsx
+++ b/src/scenes/PlantingSitesRouter/view/BoundariesAndStrata.tsx
@@ -14,9 +14,9 @@ import PlantingSiteMapLegend from 'src/components/common/PlantingSiteMapLegend';
 import Search, { SearchProps } from 'src/components/common/SearchFiltersWrapper';
 import usePlantingSite from 'src/hooks/usePlantingSite';
 import usePlantingSiteHistory from 'src/hooks/usePlantingSiteHistory';
+import { useLocalization } from 'src/providers/hooks';
 import { useListPlantingSiteHistoryIdsQuery } from 'src/queries/search/plantingSiteHistories';
 import { MapService } from 'src/services';
-import strings from 'src/strings';
 import { MapEntityId, MapSourceProperties } from 'src/types/Map';
 import { regexMatch } from 'src/utils/search';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
@@ -38,6 +38,7 @@ export default function BoundariesAndStrata({
   setView,
   view,
 }: BoundariesAndStrataProps): JSX.Element {
+  const { strings } = useLocalization();
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
   const numberFormatter = useNumberFormatter();
@@ -76,6 +77,14 @@ export default function BoundariesAndStrata({
     return total;
   }, [plantingSite]);
 
+  const plantingSiteAreaHaDisplayValue = useMemo(
+    () =>
+      strings
+        .formatString(strings.X_HA, numberFormatter.format(plantingSite?.areaHa || 0, { decimals: 1 }))
+        ?.toString(),
+    [numberFormatter, plantingSite, strings]
+  );
+
   return (
     <Box sx={view === 'map' ? { display: 'flex', flexGrow: 1, flexDirection: 'column' } : undefined}>
       <Box display='flex' flexGrow={0} alignItems='center'>
@@ -97,8 +106,7 @@ export default function BoundariesAndStrata({
               {(plantingSite.areaHa || 0) > 0 && view === 'map' && (
                 <Box display='flex' flexDirection='row' flex={1}>
                   <Typography fontSize={'16px'} fontWeight={'600'} marginRight={theme.spacing(3)}>
-                    {strings.PLANTING_SITE_AREA}:{' '}
-                    {strings.formatString(strings.X_HA, numberFormatter.format(plantingSite.areaHa || 0))?.toString()}
+                    {strings.PLANTING_SITE_AREA}: {plantingSiteAreaHaDisplayValue}
                   </Typography>
                   <Typography fontSize={'16px'} fontWeight={'600'} marginRight={theme.spacing(3)}>
                     {strings.PLANTING_COMPLETE_AREA}:{' '}
@@ -121,6 +129,7 @@ type PlantingSiteMapViewProps = {
 };
 
 function PlantingSiteMapView({ search }: PlantingSiteMapViewProps): JSX.Element | null {
+  const { strings } = useLocalization();
   const numberFormatter = useNumberFormatter();
   const { isDesktop } = useDeviceInfo();
   const [includedLayers, setIncludedLayers] = useState<MapLayer[]>(['Planting Site', 'Strata', 'Monitoring Plots']);
@@ -225,7 +234,7 @@ function PlantingSiteMapView({ search }: PlantingSiteMapViewProps): JSX.Element 
               key: strings.AREA_HA,
               value:
                 stratumHistory?.areaHa && stratumHistory?.areaHa > 0
-                  ? numberFormatter.format(stratumHistory?.areaHa)
+                  ? numberFormatter.format(stratumHistory?.areaHa, { decimals: 1 })
                   : '',
             },
             {
@@ -257,7 +266,7 @@ function PlantingSiteMapView({ search }: PlantingSiteMapViewProps): JSX.Element 
               key: strings.AREA_HA,
               value:
                 substratumHistory?.areaHa && substratumHistory?.areaHa > 0
-                  ? numberFormatter.format(substratumHistory?.areaHa)
+                  ? numberFormatter.format(substratumHistory?.areaHa, { decimals: 1 })
                   : '',
             },
             { key: strings.PLANTING_COMPLETE, value: substratum?.plantingCompleted ? strings.YES : strings.NO },
@@ -271,7 +280,7 @@ function PlantingSiteMapView({ search }: PlantingSiteMapViewProps): JSX.Element 
         return null;
       }
     },
-    [numberFormatter, plantingSite, selectedHistory, timeZone]
+    [numberFormatter, plantingSite, selectedHistory, strings, timeZone]
   );
 
   if (!plantingSite?.boundary) {

--- a/src/scenes/PlantingSitesRouter/view/GenericStratumView.tsx
+++ b/src/scenes/PlantingSitesRouter/view/GenericStratumView.tsx
@@ -16,6 +16,7 @@ import { APP_PATHS } from 'src/constants';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import strings from 'src/strings';
 import { MinimalPlantingSite, MinimalStratum } from 'src/types/Tracking';
+import { useNumberFormatter } from 'src/utils/useNumberFormatter';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 
 const columns = (): TableColumnType[] => [
@@ -53,6 +54,7 @@ export default function GenericStratumView({ plantingSite, stratum }: GenericStr
   const { plantingSiteId } = useParams<{ plantingSiteId: string }>();
   const defaultTimeZone = useDefaultTimeZone();
   const timeZone = plantingSite.timeZone ?? defaultTimeZone.get().id;
+  const numberFormatter = useNumberFormatter();
 
   const searchProps = useMemo<SearchProps>(
     () => ({
@@ -94,7 +96,7 @@ export default function GenericStratumView({ plantingSite, stratum }: GenericStr
             columns={columns}
             rows={stratum?.substrata ?? []}
             orderBy='name'
-            Renderer={DetailsRenderer(timeZone)}
+            Renderer={DetailsRenderer(timeZone, numberFormatter)}
           />
         </Box>
       </Card>
@@ -103,7 +105,7 @@ export default function GenericStratumView({ plantingSite, stratum }: GenericStr
 }
 
 const DetailsRenderer =
-  (timeZone: string) =>
+  (timeZone: string, numberFormatter: ReturnType<typeof useNumberFormatter>) =>
   // eslint-disable-next-line react/display-name
   (props: RendererProps<TableRowType>): JSX.Element => {
     const { column, value } = props;
@@ -116,7 +118,13 @@ const DetailsRenderer =
     };
 
     if (column.key === 'areaHa') {
-      return <CellRenderer {...props} value={value || ''} sx={textStyles} />;
+      return (
+        <CellRenderer
+          {...props}
+          value={typeof value === 'number' ? numberFormatter.format(value, { decimals: 1 }) : ''}
+          sx={textStyles}
+        />
+      );
     }
 
     if (column.key === 'latestObservationCompletedTime') {

--- a/src/scenes/PlantingSitesRouter/view/PlantingSiteDetailsTable.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSiteDetailsTable.tsx
@@ -11,6 +11,7 @@ import { RendererProps } from 'src/components/common/table/types';
 import { APP_PATHS } from 'src/constants';
 import strings from 'src/strings';
 import { MinimalPlantingSite, MinimalSubstratum } from 'src/types/Tracking';
+import { useNumberFormatter } from 'src/utils/useNumberFormatter';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 
 /**
@@ -59,6 +60,7 @@ const columns = (): TableColumnType[] => [
 export default function PlantingSiteDetailsTable({ plantingSite }: PlantingSiteDetailsTableProps): JSX.Element {
   const defaultTimeZone = useDefaultTimeZone();
   const timeZone = plantingSite.timeZone ?? defaultTimeZone.get().id;
+  const numberFormatter = useNumberFormatter();
 
   return (
     <Box>
@@ -67,14 +69,14 @@ export default function PlantingSiteDetailsTable({ plantingSite }: PlantingSiteD
         columns={columns}
         rows={plantingSite.strata ?? []}
         orderBy='name'
-        Renderer={DetailsRenderer(timeZone, plantingSite.id)}
+        Renderer={DetailsRenderer(timeZone, plantingSite.id, numberFormatter)}
       />
     </Box>
   );
 }
 
 const DetailsRenderer =
-  (timeZone: string, plantingSiteId: number) =>
+  (timeZone: string, plantingSiteId: number, numberFormatter: ReturnType<typeof useNumberFormatter>) =>
   // eslint-disable-next-line react/display-name
   (props: RendererProps<TableRowType>): JSX.Element => {
     const { column, row, value } = props;
@@ -121,7 +123,13 @@ const DetailsRenderer =
     }
 
     if (column.key === 'areaHa') {
-      return <CellRenderer {...props} value={value || ''} sx={textStyles} />;
+      return (
+        <CellRenderer
+          {...props}
+          value={typeof value === 'number' ? numberFormatter.format(value, { decimals: 1 }) : ''}
+          sx={textStyles}
+        />
+      );
     }
 
     if (column.key === 'substrata') {

--- a/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
+++ b/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
@@ -297,7 +297,7 @@ export default function PlantsDashboardView({
                 {plantingSite?.areaHa !== undefined &&
                   strings.formatString(
                     strings.X_HA_IN_TOTAL_PLANTING_AREA,
-                    <FormattedNumber value={Math.round(plantingSite.areaHa * 100) / 100} />
+                    <FormattedNumber value={plantingSite.areaHa} decimals={1} />
                   )}
               </Typography>
               <PlantDashboardMap plantingSiteId={plantingSite.id} />

--- a/src/scenes/PlantsDashboardRouter/components/MapStatsDrawer.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/MapStatsDrawer.tsx
@@ -230,7 +230,7 @@ const MapStatsDrawer = ({
 
       results.push({
         key: strings.AREA_HA,
-        value: properties.areaHa ? `${numberFormatter.format(properties.areaHa)}` : strings.UNKNOWN,
+        value: properties.areaHa ? `${numberFormatter.format(properties.areaHa, { decimals: 1 })}` : strings.UNKNOWN,
       });
 
       if (properties.observed) {

--- a/src/scenes/PlantsDashboardRouter/components/MultiplePlantingSiteMap.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/MultiplePlantingSiteMap.tsx
@@ -35,7 +35,7 @@ export default function MultiplePlantingSiteMap({ projectId }: MultiplePlantingS
         <Typography fontSize='20px' fontWeight={600}>
           {strings.formatString(
             strings.X_HA_IN_TOTAL_PLANTING_AREA,
-            <FormattedNumber value={Math.round(totalArea * 100) / 100} />
+            <FormattedNumber decimals={1} value={totalArea} />
           )}
         </Typography>
         <PlantDashboardMap projectId={projectId} />

--- a/src/scenes/PlantsDashboardRouter/components/PlantsAndSpeciesCard.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/PlantsAndSpeciesCard.tsx
@@ -114,7 +114,7 @@ export default function PlantsAndSpeciesCard({
           <Box flexBasis='100%'>
             <Box display={'flex'} alignItems={'center'}>
               <Typography fontSize='24px' fontWeight={600} paddingRight={1}>
-                {strings.formatString(strings.X_HA, <FormattedNumber value={Math.round(totalPlantedArea * 10) / 10} />)}
+                {strings.formatString(strings.X_HA, <FormattedNumber decimals={1} value={totalPlantedArea} />)}
               </Typography>
               <Tooltip
                 title={
@@ -139,7 +139,10 @@ export default function PlantsAndSpeciesCard({
                 textAlign='right'
                 color={theme.palette.TwClrTxtSecondary}
               >
-                {strings.formatString(strings.TARGET_HECTARES_PLANTED, <FormattedNumber value={totalArea || 0} />)}
+                {strings.formatString(
+                  strings.TARGET_HECTARES_PLANTED,
+                  <FormattedNumber decimals={1} value={totalArea || 0} />
+                )}
               </Typography>
             </Box>
             <Box marginTop={1}>

--- a/src/types/Number.ts
+++ b/src/types/Number.ts
@@ -1,3 +1,3 @@
 export type NumberFormatter = {
-  format: (num?: number) => string;
+  format: (num?: number, options?: { decimals?: number }) => string;
 };

--- a/src/utils/useNumberFormatter.ts
+++ b/src/utils/useNumberFormatter.ts
@@ -13,18 +13,31 @@ const getLocaleToUse = (locale?: string) => (locale === 'gx' ? 'fr' : locale || 
 export const useNumberFormatter = (): NumberFormatter => {
   const { activeLocale } = useLocalization();
 
-  const intlFormat = useMemo(() => {
-    let localeToUse = getLocaleToUse(activeLocale ?? undefined);
+  const localeToUse = useMemo(() => {
+    let locale = getLocaleToUse(activeLocale ?? undefined);
     if (activeLocale && supportedLocales) {
       const localeDetails = findLocaleDetails(supportedLocales, activeLocale);
-      localeToUse = localeDetails.id;
+      locale = localeDetails.id;
     }
-    return new Intl.NumberFormat(localeToUse);
+    return locale;
   }, [activeLocale]);
 
+  const intlFormat = useMemo(() => new Intl.NumberFormat(localeToUse), [localeToUse]);
+
   const format = useCallback(
-    (num?: number) => (typeof num === 'undefined' ? '' : intlFormat.format(num)),
-    [intlFormat]
+    (num?: number, options?: { decimals?: number }) => {
+      if (typeof num === 'undefined') {
+        return '';
+      }
+      if (options?.decimals !== undefined) {
+        return new Intl.NumberFormat(localeToUse, {
+          minimumFractionDigits: options.decimals,
+          maximumFractionDigits: options.decimals,
+        }).format(num);
+      }
+      return intlFormat.format(num);
+    },
+    [intlFormat, localeToUse]
   );
 
   return useMemo(() => {

--- a/src/utils/useNumberFormatter.ts
+++ b/src/utils/useNumberFormatter.ts
@@ -31,7 +31,7 @@ export const useNumberFormatter = (): NumberFormatter => {
       }
       if (options?.decimals !== undefined) {
         return new Intl.NumberFormat(localeToUse, {
-          minimumFractionDigits: options.decimals,
+          minimumFractionDigits: 0,
           maximumFractionDigits: options.decimals,
         }).format(num);
       }


### PR DESCRIPTION
This PR includes changes to **round hectare display values to 1 decimal place**:

- Extended `useNumberFormatter`'s `format()` to accept an optional `{ decimals }` option, allowing callers to specify decimal precision
- Updated `FormattedNumber` with a corresponding `decimals` prop
- Applied `{ decimals: 1 }` to all `areaHa` display callsites across the app, including planting site/stratum tables, map drawers, dashboard cards, the project profile view, and activity highlights
- Also removed pre-existing `Math.round` workarounds that were inconsistently rounding to 1–2 decimal places.