### PR TITLE
Allow for seeding the random chart color section during e2e tests

### DIFF
--- a/playwright/e2e/suites/screenshots/observationDetailsScreenshots.spec.ts
+++ b/playwright/e2e/suites/screenshots/observationDetailsScreenshots.spec.ts
@@ -59,6 +59,7 @@ test.describe('ObservationDetailsScreenshots', () => {
     await page.addInitScript(() => {
       localStorage.clear();
       sessionStorage.clear();
+      window.__CHART_COLOR_SEED__ = 1;
     });
     await page.goto('/');
     await waitFor(page, '#home');

--- a/playwright/e2e/suites/screenshots/plantsDashboardScreenshots.spec.ts
+++ b/playwright/e2e/suites/screenshots/plantsDashboardScreenshots.spec.ts
@@ -60,6 +60,7 @@ test.describe('PlantsDashboardScreenshots', () => {
     await page.addInitScript(() => {
       localStorage.clear();
       sessionStorage.clear();
+      window.__CHART_COLOR_SEED__ = 1;
     });
     await page.goto('/');
     await waitFor(page, '#home', 15000);

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
@@ -61,8 +61,13 @@ const DEFAULT_SORT_ORDER: SearchSortOrder = {
 };
 
 // Menu cell component that can use hooks
-const MenuCellComponent = ({ row, reloadData }: { row: SearchResponseElement; reloadData: () => void }) => {
-  const [undoModalOpened, setUndoModalOpened] = useState(false);
+const MenuCellComponent = ({
+  row,
+  onUndo,
+}: {
+  row: SearchResponseElement;
+  onUndo: (row: SearchResponseElement) => void;
+}) => {
   const navigate = useSyncNavigate();
   const { NURSERY_TRANSFER } = NurseryWithdrawalPurposes;
 
@@ -76,14 +81,7 @@ const MenuCellComponent = ({ row, reloadData }: { row: SearchResponseElement; re
   }, [navigate, row.delivery_id]);
 
   if (row.purpose !== NURSERY_TRANSFER && !row.undoesWithdrawalId && !row.undoneByWithdrawalId) {
-    return (
-      <>
-        {undoModalOpened && (
-          <UndoWithdrawalModal onClose={() => setUndoModalOpened(false)} row={row} reload={reloadData} />
-        )}
-        <WithdrawalHistoryMenu reassign={handleReassign} withdrawal={row} undo={() => setUndoModalOpened(true)} />
-      </>
-    );
+    return <WithdrawalHistoryMenu reassign={handleReassign} withdrawal={row} undo={() => onUndo(row)} />;
   }
   return null;
 };
@@ -150,6 +148,7 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
 
   const numberFormatter = useNumberFormatter();
   const [reloadTrigger, setReloadTrigger] = useState(0);
+  const [undoModalRow, setUndoModalRow] = useState<SearchResponseElement | null>(null);
 
   const reloadData = useCallback(() => {
     setReloadTrigger((prev) => prev + 1);
@@ -289,13 +288,10 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
     [numberFormatter]
   );
 
-  const MenuCell = useCallback(
-    ({ cell }: { cell: MRT_Cell<SearchResponseElement> }) => {
-      const row = cell.row.original;
-      return <MenuCellComponent row={row} reloadData={reloadData} />;
-    },
-    [reloadData]
-  );
+  const MenuCell = useCallback(({ cell }: { cell: MRT_Cell<SearchResponseElement> }) => {
+    const row = cell.row.original;
+    return <MenuCellComponent row={row} onUndo={setUndoModalRow} />;
+  }, []);
 
   const columns = useMemo<EditableTableColumn<SearchResponseElement>[]>(
     () => [
@@ -778,99 +774,111 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   }, [dispatch, searchChildren, searchSortOrder, selectedOrganization, pagination, reloadTrigger]);
 
   return (
-    <EditableTable
-      key='nursery-withdrawals-table'
-      clearAllFiltersLabel={strings.CLEAR_ALL_FILTERS}
-      columns={columns}
-      data={rows || []}
-      enableEditing={false}
-      enableSorting={true}
-      enableGlobalFilter={true}
-      enableColumnFilters={true}
-      enableColumnOrdering={true}
-      storageKey={TABLE_STATE_STORAGE_KEY}
-      enablePagination={true}
-      enableTopToolbar={true}
-      enableBottomToolbar={true}
-      initialSorting={sorting}
-      tableOptions={{
-        state: {
-          pagination,
-          sorting,
-          columnFilters,
-          columnVisibility,
-          showColumnFilters,
-          showGlobalFilter,
-          globalFilter: searchValue,
-          density,
-          columnOrder,
-        },
-        onPaginationChange: setPagination,
-        onSortingChange: setSorting,
-        onColumnFiltersChange: setColumnFilters,
-        onColumnVisibilityChange: setColumnVisibility,
-        onShowColumnFiltersChange: setShowColumnFilters,
-        onShowGlobalFilterChange: setShowGlobalFilter,
-        onGlobalFilterChange: setSearchValue,
-        onColumnOrderChange: setColumnOrder,
-        onDensityChange,
-        manualPagination: true,
-        manualSorting: true,
-        manualFiltering: true,
-        rowCount: totalRowCount || 0,
-        enableColumnPinning: true,
-        enableColumnActions: true,
-        enableHiding: true,
-        enableGrouping: false,
-        enableColumnDragging: true,
-        positionGlobalFilter: 'right',
-        renderToolbarInternalActions: ({ table }) => (
-          <Box display='flex' gap={0.5}>
-            <Tooltip title={strings.EXPORT}>
-              <IconButton onClick={() => void onExport()}>
-                <Icon name='iconExport' size='medium' />
-              </IconButton>
-            </Tooltip>
-            <MRT_ToggleGlobalFilterButton table={table} />
-            <MRT_ToggleFiltersButton table={table} />
-            <MRT_ShowHideColumnsButton table={table} />
-            <MRT_ToggleDensePaddingButton table={table} />
-            <MRT_ToggleFullScreenButton table={table} />
-          </Box>
-        ),
-        muiTableBodyProps: {
-          sx: {
-            '& tr:nth-of-type(odd) > td': {
-              backgroundColor: theme.palette.TwClrBaseGray025,
+    <>
+      {undoModalRow && (
+        <UndoWithdrawalModal
+          onClose={() => setUndoModalRow(null)}
+          row={undoModalRow}
+          reload={() => {
+            setUndoModalRow(null);
+            reloadData();
+          }}
+        />
+      )}
+      <EditableTable
+        key='nursery-withdrawals-table'
+        clearAllFiltersLabel={strings.CLEAR_ALL_FILTERS}
+        columns={columns}
+        data={rows || []}
+        enableEditing={false}
+        enableSorting={true}
+        enableGlobalFilter={true}
+        enableColumnFilters={true}
+        enableColumnOrdering={true}
+        storageKey={TABLE_STATE_STORAGE_KEY}
+        enablePagination={true}
+        enableTopToolbar={true}
+        enableBottomToolbar={true}
+        initialSorting={sorting}
+        tableOptions={{
+          state: {
+            pagination,
+            sorting,
+            columnFilters,
+            columnVisibility,
+            showColumnFilters,
+            showGlobalFilter,
+            globalFilter: searchValue,
+            density,
+            columnOrder,
+          },
+          onPaginationChange: setPagination,
+          onSortingChange: setSorting,
+          onColumnFiltersChange: setColumnFilters,
+          onColumnVisibilityChange: setColumnVisibility,
+          onShowColumnFiltersChange: setShowColumnFilters,
+          onShowGlobalFilterChange: setShowGlobalFilter,
+          onGlobalFilterChange: setSearchValue,
+          onColumnOrderChange: setColumnOrder,
+          onDensityChange,
+          manualPagination: true,
+          manualSorting: true,
+          manualFiltering: true,
+          rowCount: totalRowCount || 0,
+          enableColumnPinning: true,
+          enableColumnActions: true,
+          enableHiding: true,
+          enableGrouping: false,
+          enableColumnDragging: true,
+          positionGlobalFilter: 'right',
+          renderToolbarInternalActions: ({ table }) => (
+            <Box display='flex' gap={0.5}>
+              <Tooltip title={strings.EXPORT}>
+                <IconButton onClick={() => void onExport()}>
+                  <Icon name='iconExport' size='medium' />
+                </IconButton>
+              </Tooltip>
+              <MRT_ToggleGlobalFilterButton table={table} />
+              <MRT_ToggleFiltersButton table={table} />
+              <MRT_ShowHideColumnsButton table={table} />
+              <MRT_ToggleDensePaddingButton table={table} />
+              <MRT_ToggleFullScreenButton table={table} />
+            </Box>
+          ),
+          muiTableBodyProps: {
+            sx: {
+              '& tr:nth-of-type(odd) > td': {
+                backgroundColor: theme.palette.TwClrBaseGray025,
+              },
             },
           },
-        },
-        muiTablePaperProps: {
-          elevation: 0,
-        },
-        muiTopToolbarProps: {
-          sx: {
-            position: 'relative',
-            '& > .MuiBox-root': {
+          muiTablePaperProps: {
+            elevation: 0,
+          },
+          muiTopToolbarProps: {
+            sx: {
               position: 'relative',
-            },
-            '& .Mui-ToolbarDropZone': {
-              display: 'none',
-            },
-          },
-        },
-        muiTableHeadCellProps: ({ column }) =>
-          column.id === 'menu' ? { sx: { '& .Mui-TableHeadCell-Content': { display: 'none' } } } : {},
-        muiTableBodyCellProps: ({ row, column }) => ({ id: `row${row.index + 1}-${column.id}` }),
-        muiTableBodyRowProps: {
-          sx: {
-            '& td': {
-              borderBottom: 'none',
+              '& > .MuiBox-root': {
+                position: 'relative',
+              },
+              '& .Mui-ToolbarDropZone': {
+                display: 'none',
+              },
             },
           },
-        },
-      }}
-      sx={{ padding: 0 }}
-    />
+          muiTableHeadCellProps: ({ column }) =>
+            column.id === 'menu' ? { sx: { '& .Mui-TableHeadCell-Content': { display: 'none' } } } : {},
+          muiTableBodyCellProps: ({ row, column }) => ({ id: `row${row.index + 1}-${column.id}` }),
+          muiTableBodyRowProps: {
+            sx: {
+              '& td': {
+                borderBottom: 'none',
+              },
+            },
+          },
+        }}
+        sx={{ padding: 0 }}
+      />
+    </>
   );
 }

--- a/src/utils/generateRandomColor.tsx
+++ b/src/utils/generateRandomColor.tsx
@@ -18,17 +18,14 @@ const terrawareColors = (theme: Theme) => [
   theme.palette.TwClrBaseLightGreen300,
 ];
 
-// mulberry32: small, fast, deterministic PRNG. Used only when a seed is set
-// (e.g. by Playwright via window.__CHART_COLOR_SEED__) so screenshot tests
-// can rely on stable chart colors across runs.
+// Simple linear congruential generator — deterministic given the same seed.
+// Used only when a seed is set (e.g. by Playwright via window.__CHART_COLOR_SEED__)
+// so screenshot tests can rely on stable chart colors across runs.
 const createSeededRandom = (seed: number) => {
-  let state = seed >>> 0;
+  let state = Math.abs(Math.floor(seed)) || 1;
   return () => {
-    state = (state + 0x6d2b79f5) >>> 0;
-    let t = state;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    state = (state * 9301 + 49297) % 233280;
+    return state / 233280;
   };
 };
 

--- a/src/utils/generateRandomColor.tsx
+++ b/src/utils/generateRandomColor.tsx
@@ -1,5 +1,11 @@
 import { Theme } from '@mui/material';
 
+declare global {
+  interface Window {
+    __CHART_COLOR_SEED__?: number;
+  }
+}
+
 const terrawareColors = (theme: Theme) => [
   theme.palette.TwClrBaseYellow300,
   theme.palette.TwClrBaseRed300,
@@ -12,23 +18,43 @@ const terrawareColors = (theme: Theme) => [
   theme.palette.TwClrBaseLightGreen300,
 ];
 
-const generateRandomColor = () => {
-  return `#${Math.floor(Math.random() * 16777215).toString(16)}`;
+// mulberry32: small, fast, deterministic PRNG. Used only when a seed is set
+// (e.g. by Playwright via window.__CHART_COLOR_SEED__) so screenshot tests
+// can rely on stable chart colors across runs.
+const createSeededRandom = (seed: number) => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const getRandom = (): (() => number) => {
+  if (typeof window !== 'undefined' && typeof window.__CHART_COLOR_SEED__ === 'number') {
+    return createSeededRandom(window.__CHART_COLOR_SEED__);
+  }
+  return Math.random;
+};
+
+const generateRandomColor = (random: () => number = getRandom()) => {
+  return `#${Math.floor(random() * 16777215).toString(16)}`;
 };
 
 const generateRandomColors = (numberOfColors: number) => {
-  const colors = Array.from({ length: numberOfColors }).map(() => {
-    return generateRandomColor();
-  });
-  return colors;
+  const random = getRandom();
+  return Array.from({ length: numberOfColors }, () => generateRandomColor(random));
 };
 
 const generateTerrawareRandomColors = (theme: Theme, numberOfColors: number) => {
+  const random = getRandom();
   const terrawareColorsList = terrawareColors(theme);
   const colors = Array.from({ length: numberOfColors }).map(() => {
-    const randomIndex = Math.floor(Math.random() * terrawareColorsList.length);
+    const randomIndex = Math.floor(random() * terrawareColorsList.length);
     const selectedColor = terrawareColorsList.splice(randomIndex, 1);
-    return selectedColor[0] || generateRandomColor();
+    return selectedColor[0] || generateRandomColor(random);
   });
   return colors;
 };


### PR DESCRIPTION
Use a seedable rng (mulberry32) when running e2e tests to keep chart.js colors consistent between test runs.