### PR TITLE
Fix 502 Bad Gateway when running remote backend on local

### DIFF
--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
   },
 
   server: {
+    host: '0.0.0.0',
     htmlFallback: false,
     historyApiFallback: true,
     proxy: {


### PR DESCRIPTION
## Summary

Fix `502 Bad Gateway` errors when running the frontend locally with the remote backend proxy.

### Root cause

The recent `@rsbuild/core` v2 upgrade (#5628) changed the default dev server bind address. The server now listens only on the IPv6 loopback (`[::1]:3000`) instead of all interfaces, so the nginx container in remote-backend can no longer reach it via `host.docker.internal:3000` and returns `502`.

## Fix

Set `server.host: '0.0.0.0'` in rsbuild.config.ts so the dev server binds to all interfaces, restoring the pre-v2 behavior.