### PR TITLE
SW-8306 Fix Could not find history error

### DIFF
--- a/.buildkite/scripts/lib/fetch-tag.sh
+++ b/.buildkite/scripts/lib/fetch-tag.sh
@@ -16,8 +16,6 @@ MAX_DEPTH=500
 STEP=50
 DEPTH=0
 
-HEAD_REF="$(git rev-parse HEAD)"
-
 while true; do
     if git merge-base --is-ancestor "$SEARCH_TAG" HEAD >/dev/null 2>&1; then
         echo "Found history from $SEARCH_TAG to HEAD"
@@ -32,5 +30,5 @@ while true; do
     DEPTH=$((DEPTH + STEP))
 
     echo "Fetching with depth=$DEPTH"
-    git fetch --depth=$DEPTH origin "$HEAD_REF"
+    git fetch --depth=$DEPTH
 done


### PR DESCRIPTION
In `git fetch --depth=$DEPTH origin "$HEAD_REF"` GitHub doesn't support fetching arbitrary SHAs by default. So the history never actually deepens beyond the initial 1 commit from the shallow clone, and merge-base --is-ancestor keeps failing regardless of how many loop iterations run.

By changing to `git fetch --depth=$DEPTH` the history actually deepens