### PR TITLE
SW-8327 The thumbnail for models manually marked as "Needs Attention" should remain clickable

### DIFF
--- a/src/scenes/VirtualWalkthrough/VirtualWalkthroughsTable.tsx
+++ b/src/scenes/VirtualWalkthrough/VirtualWalkthroughsTable.tsx
@@ -105,7 +105,7 @@ export default function VirtualWalkthroughsTable({
   const ThumbnailCell = useCallback(
     ({ cell }: { cell: MRT_Cell<OrganizationVirtualWalkthrough> }) => {
       const file = cell.row.original;
-      if (file.splatStatus === 'Preparing') {
+      if (file.splatStatus === 'Preparing' || file.splatStatus === 'Errored') {
         return null;
       }
       const fileId = cell.getValue<number>();


### PR DESCRIPTION
They are already clickable. Probably the one that was not clickable was a failed one, so this PR hides the thumbnail for failed virtual walkthroughs