### PR TITLE
Clean-up docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,20 +3,12 @@
 ## Build and Development Commands
 
 - Build: `yarn build`
-- Run: `yarn run`
+- Run: `yarn start` (or `yarn start:dev` to skip the increased Node heap size)
 - Format code: `yarn format`
 - Run all unit tests: `yarn test`
 - TypeScript check: `yarn ts`
-- Run linter:
-
-```shell
-yarn lint \
-  --rule 'react/jsx-no-bind: 0' \
-  --rule 'react-hooks/immutability: 0' \
-  --rule 'react-hooks/refs: 0' \
-  --rule 'react-hooks/set-state-in-effect: 0' \
-  --rule 'react-hooks/static-components: 0'
-```
+- Run linter: `yarn lint:dev` (disables a few `react-hooks` and `react/jsx-no-bind` rules that are noisy during local
+  development; CI runs the stricter `yarn lint`)
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 This is the front end web app for the [Terraware](https://terraware.io/) application
 from [Terraformation](https://terraformation.com/).
 
-The web app provides seed inventory management capabilities - with two main areas of focus: the seed processing workflow
-and monitoring of a seed bank's physical infrastructure.
+Terraware Web is the front end for the Terraware platform. It supports seed bank inventory and processing, nursery
+management, planting sites and observations, and the Accelerator program (deliverables, modules, and variables), along
+with funder-facing views.
 
 ## About this open-source project
 
@@ -26,41 +27,42 @@ but not everything is ready yet.
 
 ## How to Run the App in Development Mode
 
-1. Copy `.env.sample` from the root directory of this repo to the same directory, with the filename `.env`
-   1. If you work for Terraformation and are using existing Keycloak setup, refer to the secrets in the "Onboarding
-      Plan for Frontend WebApp Developers" confluence page
-2. Login to Docker hub
+1. Copy `.env.sample` from the root directory of this repo to the same directory, with the filename `.env`. See
+   `.env.sample` for the full list of supported variables and inline comments.
+   1. If you work for Terraformation and are using the existing Keycloak setup, refer to the secrets in the "Onboarding
+      Plan for Frontend WebApp Developers" Confluence page.
+2. Login to Docker hub:
 
-```shell
-docker login
-```
+   ```shell
+   docker login
+   ```
 
-3. Install dependencies
+3. Install dependencies:
 
-```shell
-yarn
-```
+   ```shell
+   yarn
+   ```
 
-4. Start the app
+4. Start the app:
 
-```shell
-yarn docker:start  # Run the server code
-yarn start         # Run the front-end code
-```
+   ```shell
+   yarn docker:start  # Run the server code
+   yarn start         # Run the front-end code
+   ```
 
-5. Login. If you configured your environment variables correctly then you'll be taken to a keycloak login page. You may
-   also try to login using through this API endpoint.
+5. Login. If you configured your environment variables correctly then you'll be taken to a Keycloak login page.
+   Alternatively, navigate directly to the following URL to start the login flow:
 
-```shell
-http://localhost:8080/api/v1/login?redirect=http://localhost:3000/
-```
+   ```
+   http://localhost:8080/api/v1/login?redirect=http://localhost:3000/
+   ```
 
-6. Stop the app
+6. Stop the app:
 
-```shell
-yarn docker:stop
-# Stop the process running the frontend
-```
+   ```shell
+   yarn docker:stop
+   # Then stop the process running the frontend
+   ```
 
 ### How to Generate Translations
 
@@ -90,9 +92,8 @@ yarn translate:start &
 
 ### How to Generate RTK Query code
 
-The file `./rtk-codegen.config.ts` configures the endpoints to be generated, and the desintation files. You will need to
-update
-this file to generate new sets of API.
+The file `./rtk-codegen.config.ts` configures the endpoints to be generated, and the destination files. You will need to
+update this file to generate new sets of API.
 
 1. Update `./rtk-codegen.config.ts`
 2. Generate new queries
@@ -101,9 +102,8 @@ this file to generate new sets of API.
    yarn generate-queries
    ```
 
-3. Add tags/invalidations
-   This step is neccessary for RTK Query to function correctly. This configures data invalidation behaviors.
-   Add `providedTags`/`invalidateTags` behaviors to endpoints under `src/queries/extensions`
+3. Add tags/invalidations. This step is necessary for RTK Query to function correctly. This configures data invalidation
+   behaviors. Add `providedTags`/`invalidateTags` behaviors to endpoints under `src/queries/extensions`.
 
 ## How to Contribute
 
@@ -113,17 +113,18 @@ completed.
 ```shell
 yarn generate-types  # generate types for any server side API changes
 yarn format          # run code formatter
-yarn lint            # run linter to check for code quality issues
+yarn lint:dev        # run linter for local development (CI runs the stricter `yarn lint`)
 yarn ts              # run the typescript types checker
-yarn translate       # generate translations; requires OpenAI API key
 yarn test            # run the rstest (unit and integration) tests
+# If you added or changed strings in src/strings/csv/en.csv, also run:
+#   yarn translate   # generate translations; requires OPENAI_API_KEY in .env
 # run the end to end tests, see the section below for more details
 ```
 
 Tip: you can run everything except the end-to-end tests using:
 
 ```shell
-yarn generate-types && yarn format && yarn lint && yarn ts && yarn test
+yarn generate-types && yarn format && yarn lint:dev && yarn ts && yarn test
 ```
 
 ## How to Run the End-to-End Tests
@@ -141,7 +142,7 @@ contents of that database and reload them later. You can also rename the existin
 ```shell
 # connect to another local psql database that isn't terraware
 psql postgres
-# rename the existing terraware database to save it's contents
+# rename the existing terraware database to save its contents
 ALTER DATABASE terraware RENAME TO terrawareTEMP;
 ```
 
@@ -207,8 +208,8 @@ yarn docker:stop:prod
 
 ## Useful links
 
-- The API Swagger documentation [link](http://localhost:8080/docs)
-- Buildkite pipeline (builds and deployments) [link](https://buildkite.com/terraformation/terraware-web); see also [.buildkite/README.md](.buildkite/README.md)
-- PostgreSQL command line client docs [link](https://www.postgresql.org/docs/current/app-psql.html)
-- Remote backend instructions (running a local FE with staging/production
-  BE) [link](https://github.com/terraware/terraware-web/tree/main/remote-backend#readme)
+- [The API Swagger documentation](http://localhost:8080/docs)
+- [Buildkite pipeline (builds and deployments)](https://buildkite.com/terraformation/terraware-web); see also
+  [.buildkite/README.md](.buildkite/README.md)
+- [PostgreSQL command line client docs](https://www.postgresql.org/docs/current/app-psql.html)
+- [Remote backend instructions (running a local FE with staging/production BE)](https://github.com/terraware/terraware-web/tree/main/remote-backend#readme)

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -15,3 +15,8 @@ Agent definitions live in `.claude/agents/`. Each agent is a Markdown file with 
 Both **Claude Code** and **GitHub Copilot** read agent files from `.claude/agents/`. Agents are available as subagents that either tool can invoke during conversations, using the agent name defined in the YAML frontmatter at the top of each file (e.g., `docs-agent`, `test-agent`, `security-agent`).
 
 Both tools also read `AGENTS.md` at the project root for shared configuration (tech stack, code style, workflow instructions) that applies to all agents.
+
+## Shared instructions
+
+Both tools read [AGENTS.md](../AGENTS.md) at the repo root for shared configuration (tech stack, code style, workflow).
+[CLAUDE.md](../CLAUDE.md) is a thin pointer that re-exports `AGENTS.md` for Claude Code.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,24 @@
 # Terraware Web Documentation
 
-- [AI Agents](ai-agents.md)
+## Getting started
+
+- [Project README](../README.md) — setup, dev workflow, contribution checklist
+- [AI Agents](ai-agents.md) — Claude Code subagents and shared agent configuration
+
+## Testing
+
+- [Playwright end-to-end tests](../playwright/README.md)
+- [Database dumps used by E2E tests](../dump/README.md)
+
+## Infrastructure
+
+- [Buildkite CI pipeline notes](../.buildkite/README.md)
+- [Local environment using a remote backend](../remote-backend/README.md)
+
+## Generated artifacts
+
+The following are produced by CI and only present in published doc bundles:
+
 - [Dependency license report](license-report.html)
 - [Git log since last release](unreleased.log)
-- [Unit Test coverage](coverage/lcov-report/index.html)
+- [Unit test coverage](coverage/lcov-report/index.html)

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -31,7 +31,7 @@ Follow these steps to create new test users and give them the correct permission
 1. Run `yarn server:reset` to ensure you don't have data modifications locally
 1. In terraware, change to super admin by updating cookie using e2e/utils/userUtils.ts
 1. Go to Settings/People in the navbar. Add Person
-1. Run this get the link from the text email for adding the user
+1. Run this to get the link from the text email for adding the user:
    `docker logs terraware-web-terraware-server-1 | grep auth.staging.terraware.io | head -1`
 1. Paste this link into an incognito window and create the user on staging keycloak (recommend using password of
    `password`). Close the window once it gets to the Check Email page.

--- a/remote-backend/README.md
+++ b/remote-backend/README.md
@@ -9,21 +9,21 @@ a remote backend, e.g., if you want to test how a UI change works with a real-wo
 Here's how to set that up using Docker Desktop on MacOS.
 
 1. From the directory of this readme, generate a self-signed certificate. The following command should work. You'll only
-   need
-   to do this once.
-   1. You might need to change `--` to `-` for all params in this request if it fails
+   need to do this once.
 
-```shell
-openssl req \
---x509 \
---nodes \
---days 3650 \
---subj "/C=US/ST=HI/O=Terraformation/CN=localhost" \
---addext "subjectAltName=DNS:localhost" \
---newkey rsa:2048 \
---keyout self-signed.key \
---out self-signed.crt
-```
+   ```shell
+   openssl req \
+   --x509 \
+   --nodes \
+   --days 3650 \
+   --subj "/C=US/ST=HI/O=Terraformation/CN=localhost" \
+   --addext "subjectAltName=DNS:localhost" \
+   --newkey rsa:2048 \
+   --keyout self-signed.key \
+   --out self-signed.crt
+   ```
+
+   If you have a very old `openssl`, drop one dash from each long option (e.g., `-x509` instead of `--x509`).
 
 2. Figure out the server URL you want to use, e.g., `https://terraware.io` for production.
 3. Set `PUBLIC_TERRAWARE_API` to that URL in the `.env` file in the repo root directory.


### PR DESCRIPTION
**NOTE: This PR was generated by @docs-agent and PR description was generated by Copilot.**

This pull request updates the project documentation to improve clarity, accuracy, and usability for developers. The changes refine development instructions, enhance descriptions of the platform, clarify usage of scripts, and organize documentation for easier navigation. Below are the most important changes grouped by theme.

**Project and Platform Description:**

* Expanded and clarified the project overview in `README.md` to better describe the full scope of the Terraware platform, including nursery management, planting sites, observations, and the Accelerator program.

**Documentation Structure and Navigation:**

* Reorganized `docs/index.md` to provide a clearer entry point for documentation, grouping links by Getting Started, Testing, Infrastructure, and Generated Artifacts.
* Added a new section to `docs/ai-agents.md` explaining how both Claude Code and GitHub Copilot use shared configuration from `AGENTS.md`, and clarified the purpose of `CLAUDE.md`.

**Development Workflow and Scripts:**

* Updated `AGENTS.md` and `README.md` to clarify and correct development commands, including the usage of `yarn start`, `yarn start:dev`, and `yarn lint:dev` for local development, while noting that CI uses the stricter `yarn lint`.
* Improved step-by-step instructions in `README.md` for setting up the development environment, including more detailed guidance on `.env` variables, login procedures, and stopping the app.

**Clarity and Quality Improvements:**

* Fixed typos and improved grammar throughout documentation, and clarified instructions for generating RTK Query code and translations.
* Updated formatting and link styles in `README.md` for consistency and readability, including the "Useful links" section.

**Playwright and Remote Backend Docs:**

* Clarified setup steps in `playwright/README.md` for creating test users, and improved instructions in `remote-backend/README.md` for generating self-signed certificates, including notes for compatibility with older versions of `openssl`.