### PR TITLE
SW-8332 Fix Nursery Withdrawals Table Export

### DIFF
--- a/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
@@ -129,8 +129,8 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
       'destinationName',
       'projectNames',
       'purpose',
-      'speciesScientificNames',
-      'substratumShortNames',
+      'speciesNames',
+      'substratumShortName',
     ],
     persistFilters: true,
   });

--- a/src/scenes/NurseryRouter/exportNurseryData.ts
+++ b/src/scenes/NurseryRouter/exportNurseryData.ts
@@ -78,29 +78,29 @@ const makeNurseryWithdrawalResultsCsv = ({
   const columnHeaders = [
     { key: 'withdrawnDate', displayLabel: strings.DATE },
     { key: 'purpose', displayLabel: strings.PURPOSE },
-    { key: 'facility_name', displayLabel: strings.FROM_NURSERY },
+    { key: 'nurseryName', displayLabel: strings.FROM_NURSERY },
     { key: 'destinationName', displayLabel: strings.PLANTING_SITE },
-    { key: 'project_names', displayLabel: strings.PROJECTS },
-    { key: 'stratumNames', displayLabel: strings.TO_STRATUM },
-    { key: 'substratumShortNames', displayLabel: strings.TO_SUBSTRATUM },
-    { key: 'speciesScientificNames', displayLabel: strings.SPECIES },
+    { key: 'projectNames', displayLabel: strings.PROJECTS },
+    { key: 'stratumName', displayLabel: strings.TO_STRATUM },
+    { key: 'substratumShortName', displayLabel: strings.TO_SUBSTRATUM },
+    { key: 'speciesNames', displayLabel: strings.SPECIES },
     { key: 'totalWithdrawn', displayLabel: strings.TOTAL_QUANTITY },
     { key: 'withdrawalActive', displayLabel: strings.WITHDRAWAL_ACTIVE },
   ];
 
   const data = nurseryWithdrawalResults.map((withdrawal) => ({
     withdrawnDate: withdrawal.withdrawnDate,
-    purpose: purposeLabel(withdrawal['purpose(raw)']),
-    facility_name: withdrawal.facility_name,
+    purpose: purposeLabel(withdrawal.purpose),
+    nurseryName: withdrawal.nurseryName,
     destinationName: withdrawal.destinationName,
-    project_names: (withdrawal.project_names as string[] | undefined)?.filter((name: string) => !!name).join(', '),
-    stratumNames: withdrawal.stratumNames,
-    substratumShortNames: withdrawal.substratumShortNames,
-    speciesScientificNames: (withdrawal.speciesScientificNames as string[] | undefined)?.join(', '),
-    totalWithdrawn: withdrawal['totalWithdrawn(raw)'],
+    projectNames: (withdrawal.projectNames as string[] | undefined)?.filter((name: string) => !!name).join(', '),
+    stratumName: withdrawal.stratumName,
+    substratumShortName: withdrawal.substratumShortName,
+    speciesNames: (withdrawal.speciesNames as string[] | undefined)?.join(', '),
+    totalWithdrawn: withdrawal.totalWithdrawn,
     withdrawalActive: withdrawal.undoneByWithdrawalId
       ? strings.NO
-      : withdrawal['purpose(raw)'] === 'Undo'
+      : withdrawal.purpose === 'Undo'
         ? strings.NA
         : strings.YES,
   }));

--- a/src/scenes/NurseryRouter/exportNurseryData.ts
+++ b/src/scenes/NurseryRouter/exportNurseryData.ts
@@ -1,11 +1,10 @@
 import { DateTime } from 'luxon';
 
+import { SearchNurseryWithdrawalPayload } from 'src/queries/search/nurseries';
 import strings from 'src/strings';
 import { purposeLabel } from 'src/types/Batch';
 import { PlantingProgressType } from 'src/types/PlantingSite';
 import { downloadCsv, makeCsv } from 'src/utils/csv';
-
-import { SearchNurseryWithdrawalPayload } from '../../queries/search/nurseries';
 
 const makePlantingProgressCsv = ({
   plantingProgress,

--- a/src/scenes/NurseryRouter/exportNurseryData.ts
+++ b/src/scenes/NurseryRouter/exportNurseryData.ts
@@ -5,6 +5,8 @@ import { purposeLabel } from 'src/types/Batch';
 import { PlantingProgressType } from 'src/types/PlantingSite';
 import { downloadCsv, makeCsv } from 'src/utils/csv';
 
+import { SearchNurseryWithdrawalPayload } from '../../queries/search/nurseries';
+
 const makePlantingProgressCsv = ({
   plantingProgress,
 }: {
@@ -68,7 +70,7 @@ const makePlantingProgressCsv = ({
   return makeCsv(columnHeaders, data);
 };
 
-type NurseryWithdrawalResults = any[];
+type NurseryWithdrawalResults = SearchNurseryWithdrawalPayload[];
 
 const makeNurseryWithdrawalResultsCsv = ({
   nurseryWithdrawalResults,
@@ -93,10 +95,10 @@ const makeNurseryWithdrawalResultsCsv = ({
     purpose: purposeLabel(withdrawal.purpose),
     nurseryName: withdrawal.nurseryName,
     destinationName: withdrawal.destinationName,
-    projectNames: (withdrawal.projectNames as string[] | undefined)?.filter((name: string) => !!name).join(', '),
+    projectNames: withdrawal.projectNames?.filter((name: string) => !!name).join(', '),
     stratumName: withdrawal.stratumName,
     substratumShortName: withdrawal.substratumShortName,
-    speciesNames: (withdrawal.speciesNames as string[] | undefined)?.join(', '),
+    speciesNames: withdrawal.speciesNames?.join(', '),
     totalWithdrawn: withdrawal.totalWithdrawn,
     withdrawalActive: withdrawal.undoneByWithdrawalId
       ? strings.NO


### PR DESCRIPTION
The Nursery Withdrawals table export was broken after the table was switched to RTK query, because the property names no longer matched what was expected by the export. Fix the property names and change from `any[]` to `SearchNurseryWithdrawalPayload[]` to help reduce this regression in the future.