### PR TITLE
SW-8337: Planting Progress: Map - do not show "See Withdrawal History" in drawers when there are no withdrawals

### DIFF
--- a/src/scenes/NurseryRouter/PlantingProgressMapDrawer.tsx
+++ b/src/scenes/NurseryRouter/PlantingProgressMapDrawer.tsx
@@ -79,7 +79,7 @@ export default function PlantingProgressMapDrawer({
         totalPlants: stratumStats?.totalPlants ?? 0,
         speciesList: stratumStats?.species ?? [],
         substratumNamesForFilter: substratumNames,
-        showWithdrawalHistory: true,
+        showWithdrawalHistory: !!stratumStats?.totalPlants,
         showMarkComplete: false,
       };
     }
@@ -92,7 +92,7 @@ export default function PlantingProgressMapDrawer({
         totalPlants: substratumStats?.totalPlants ?? 0,
         speciesList: substratumStats?.species ?? [],
         substratumNamesForFilter: [substratumName],
-        showWithdrawalHistory: true,
+        showWithdrawalHistory: !!substratumStats?.totalPlants,
         showMarkComplete: true,
       };
     }


### PR DESCRIPTION
This PR includes a change to conditionally show the "See Withdrawal History" link in the Planting Progress map drawers, when there are withdrawals for the given strata/substrata.