### PR TITLE
SW-8335: Maps: In Boundaries card, change "Site" to "Planting Site" for accuracy and clarity

### DIFF
--- a/src/components/NewMap/usePlantingSiteMapLegend.ts
+++ b/src/components/NewMap/usePlantingSiteMapLegend.ts
@@ -21,7 +21,7 @@ const usePlantingSiteMapLegend = (defaultLayer?: PlantingSiteMapLayer, disabled?
       items: [
         {
           id: 'sites',
-          label: strings.SITE,
+          label: strings.PLANTING_SITE,
           style: sitesLayerStyle,
         },
         {


### PR DESCRIPTION
This PR updates a map legend label in the map drawers from Site --> Planting Site.