### PR TITLE
SW-8306 Fix fetch-tag.sh

### DIFF
--- a/.buildkite/scripts/lib/fetch-tag.sh
+++ b/.buildkite/scripts/lib/fetch-tag.sh
@@ -30,5 +30,5 @@ while true; do
     DEPTH=$((DEPTH + STEP))
 
     echo "Fetching with depth=$DEPTH"
-    git fetch --deepen=$STEP
+    git fetch origin "$(git rev-parse --abbrev-ref HEAD)" --depth=$DEPTH
 done


### PR DESCRIPTION
Adds back the explicit refspec. --deepen shouldn't be necessary as long as the refspec is explicit