### PR TITLE
SW-8349 Adding new annotations to a splat causes the model to disappear

### DIFF
--- a/playwright/e2e/suites/survivalRateSettings.spec.ts
+++ b/playwright/e2e/suites/survivalRateSettings.spec.ts
@@ -4,6 +4,8 @@ import { changeToSuperAdmin } from '../utils/userUtils';
 import { exactOptions, selectOrg, waitFor } from '../utils/utils';
 
 test.describe('SurvivalRateSettingsTests', () => {
+  test.describe.configure({ timeout: 120000 });
+
   test.beforeEach(async ({ page, context, baseURL }) => {
     await changeToSuperAdmin(context, baseURL);
     await page.goto('/');
@@ -34,7 +36,7 @@ test.describe('SurvivalRateSettingsTests', () => {
     }
 
     await page.locator('#saveSettings').click();
-    await expect(page.getByText('t0 set for Permanent Plots')).toBeVisible();
+    await expect(page.getByText('t0 set for Permanent Plots')).toBeVisible({ timeout: 60000 });
 
     // Navigate to Dashboard
     if (!(await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).isVisible())) {
@@ -77,7 +79,7 @@ test.describe('SurvivalRateSettingsTests', () => {
     }
 
     await page.locator('#saveSettings').click();
-    await expect(page.getByText('t0 set for Permanent Plots')).toBeVisible();
+    await expect(page.getByText('t0 set for Permanent Plots')).toBeVisible({ timeout: 60000 });
 
     // Navigate to Dashboard
     if (!(await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).isVisible())) {

--- a/src/components/GaussianSplat/SplatModel.tsx
+++ b/src/components/GaussianSplat/SplatModel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { memo, useEffect } from 'react';
 
 import { Entity } from '@playcanvas/react';
 import { GSplat } from '@playcanvas/react/components';
@@ -64,4 +64,4 @@ const SplatModel = ({
   );
 };
 
-export default SplatModel;
+export default memo(SplatModel);


### PR DESCRIPTION
VirtualWalkthroughViewer was re-rendering on every keystroke in the Title field. That cascades to SplatModel which was re-rendering too. The existing useMemo around the <SplatModel /> JSX keeps the element reference stable, but that alone doesn't stop the SplatModel component from re-rendering. React still calls the function component on parent re-render.

With React.memo inSplatModel VirtualWalkthroughViewer still re-renders on every keystroke but React.memo stops the cascade so SplatModel no longer re-renders
  
