### PR TITLE
Use scene bounds from metadata instead of hardcoded

### DIFF
--- a/src/components/GaussianSplat/walkthrough-camera.ts
+++ b/src/components/GaussianSplat/walkthrough-camera.ts
@@ -59,7 +59,7 @@ export class WalkthroughCamera extends Script {
   boundsCenter = new Vec3(0, 0, 0);
 
   /** @attribute */
-  boundsXZRadius = 10;
+  boundsRadius = 10;
 
   /** @attribute */
   freeFly = false;
@@ -258,12 +258,14 @@ export class WalkthroughCamera extends Script {
     const pos = this.entity.getPosition();
     const dx = pos.x - this.boundsCenter.x;
     const dz = pos.z - this.boundsCenter.z;
-    const radius = Math.sqrt(dx * dx + dz * dz) || this.boundsXZRadius * 0.5;
+    const radius = Math.sqrt(dx * dx + dz * dz) || this.boundsRadius * 0.5;
     const currentAngle = Math.atan2(dz, dx);
     const newAngle = currentAngle + (yawDelta * Math.PI) / 180;
     const nx = this.boundsCenter.x + radius * Math.cos(newAngle);
     const nz = this.boundsCenter.z + radius * Math.sin(newAngle);
-    const ny = this._hasGroundPlane ? yOnPlane(nx, nz, this._planeNormal, this._planePoint, pos.y) : pos.y;
+    const ny = this._hasGroundPlane
+      ? yOnPlane(nx, nz, this._planeNormal, this._planePoint, this.boundsCenter.y)
+      : this.boundsCenter.y;
     this.entity.setPosition(nx, ny, nz);
 
     const faceDx = this.boundsCenter.x - nx;
@@ -336,8 +338,8 @@ export class WalkthroughCamera extends Script {
       const cdx = nx - this.boundsCenter.x;
       const cdz = nz - this.boundsCenter.z;
       const dist = Math.sqrt(cdx * cdx + cdz * cdz);
-      if (dist > this.boundsXZRadius) {
-        const scale = this.boundsXZRadius / dist;
+      if (dist > this.boundsRadius) {
+        const scale = this.boundsRadius / dist;
         nx = this.boundsCenter.x + cdx * scale;
         nz = this.boundsCenter.z + cdz * scale;
       }

--- a/src/scenes/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/scenes/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -90,14 +90,23 @@ const VirtualWalkthroughViewer = ({
     [data]
   );
 
-  const boundsXZRadius = useMemo(() => {
+  const sceneBoundsRadius = useMemo(() => {
+    if (data?.sceneBounds?.m !== undefined) {
+      return data.sceneBounds.m;
+    }
     const dx = cameraPosition[0] - origin[0];
     const dy = cameraPosition[1] - origin[1];
     const dz = cameraPosition[2] - origin[2];
     return Math.sqrt(dx * dx + dy * dy + dz * dz) * 0.5;
-  }, [cameraPosition, origin]);
+  }, [cameraPosition, data?.sceneBounds, origin]);
 
-  const boundsCenter = useMemo(() => new Vec3(origin[0], cameraPosition[1], origin[2]), [origin, cameraPosition]);
+  const sceneBoundsCenter = useMemo(
+    () =>
+      data?.sceneBounds
+        ? new Vec3(data.sceneBounds.x, data.sceneBounds.y, data.sceneBounds.z)
+        : new Vec3(origin[0], cameraPosition[1], origin[2]),
+    [data?.sceneBounds, origin, cameraPosition]
+  );
 
   const groundPlane = useMemo<Vec3[]>(
     () => (data?.groundPlane?.length === 3 ? data.groundPlane.map((p) => new Vec3(p.x, p.y, p.z)) : []),
@@ -281,8 +290,8 @@ const VirtualWalkthroughViewer = ({
           <Camera clearColor='#EAF8FF' fov={60} />
           <Script
             script={WalkthroughCamera}
-            boundsCenter={boundsCenter}
-            boundsXZRadius={boundsXZRadius}
+            boundsCenter={sceneBoundsCenter}
+            boundsRadius={sceneBoundsRadius}
             enableFly={!isTextFieldFocused}
           />
         </Entity>


### PR DESCRIPTION
The scene bounds is calculated in splatter and saved to the model metadata, then returned in the splat info endpoint. Use this for the bounding circle instead of the hardcoded circle. Note that it is coplanar to the ground plane (and calculated as such), and returned as a PointZM, meaning that it has X, Y, Z, and M where M is the radius. 

Also rename `boundsXZRadius` to `boundsRadius` now that it is no longer on the XZ plane. 