### PR TITLE
Use average camera height from metadata instead of 0

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -7582,6 +7582,7 @@ export interface components {
         };
         GetObservationSplatInfoResponsePayload: {
             annotations: components["schemas"]["SplatAnnotationPayload"][];
+            averageCameraHeight?: number;
             cameraPosition?: components["schemas"]["CoordinatePayload"];
             groundColor?: string;
             groundPlane?: components["schemas"]["CoordinatePayload"][];
@@ -8912,6 +8913,9 @@ export interface components {
             withdrawnDate: string;
         };
         NurseryWithdrawalPhotoPayload: {
+            /** Format: date-time */
+            capturedTime?: string;
+            gpsCoordinates?: components["schemas"]["Point"];
             /** Format: int64 */
             id: number;
         };

--- a/src/components/GaussianSplat/walkthrough-camera.ts
+++ b/src/components/GaussianSplat/walkthrough-camera.ts
@@ -67,6 +67,9 @@ export class WalkthroughCamera extends Script {
   /** @attribute */
   enableFly = true;
 
+  /** @attribute */
+  averageCameraHeight = 0;
+
   /**
    * Three world-space points defining the ground plane.
    * When provided, the camera Y position is derived from this plane during non-freeFly movement.
@@ -264,7 +267,7 @@ export class WalkthroughCamera extends Script {
     const nx = this.boundsCenter.x + radius * Math.cos(newAngle);
     const nz = this.boundsCenter.z + radius * Math.sin(newAngle);
     const ny = this._hasGroundPlane
-      ? yOnPlane(nx, nz, this._planeNormal, this._planePoint, this.boundsCenter.y)
+      ? yOnPlane(nx, nz, this._planeNormal, this._planePoint, this.boundsCenter.y) + this.averageCameraHeight
       : this.boundsCenter.y;
     this.entity.setPosition(nx, ny, nz);
 
@@ -346,7 +349,7 @@ export class WalkthroughCamera extends Script {
     }
 
     const groundY = this._hasGroundPlane
-      ? yOnPlane(nx, nz, this._planeNormal, this._planePoint, this.boundsCenter.y)
+      ? yOnPlane(nx, nz, this._planeNormal, this._planePoint, this.boundsCenter.y) + this.averageCameraHeight
       : this.boundsCenter.y;
     this.entity.setPosition(nx, this.freeFly ? ny : groundY, nz);
   }

--- a/src/queries/generated/nurseryWithdrawals.ts
+++ b/src/queries/generated/nurseryWithdrawals.ts
@@ -158,7 +158,28 @@ export type CreateNurseryWithdrawalRequestPayload = {
   substratumId?: number;
   withdrawnDate: string;
 };
+export type CrsProperties = {
+  /** Name of the coordinate reference system. This must be in the form EPSG:nnnn where nnnn is the numeric identifier of a coordinate system in the EPSG dataset. The default is Longitude/Latitude EPSG:4326, which is the coordinate system +for GeoJSON. */
+  name: string;
+};
+export type Crs = {
+  properties: CrsProperties;
+  type: 'name';
+};
+export type GeometryBase = {
+  crs?: Crs;
+  type: 'Point' | 'LineString' | 'Polygon' | 'MultiPoint' | 'MultiLineString' | 'MultiPolygon' | 'GeometryCollection';
+};
+export type Point = {
+  type: 'Point';
+} & GeometryBase & {
+    /** A single position consisting of X, Y, and optional Z values in the coordinate system specified by the crs field. */
+    coordinates: number[];
+    type: 'Point';
+  };
 export type NurseryWithdrawalPhotoPayload = {
+  capturedTime?: string;
+  gpsCoordinates?: Point;
   id: number;
 };
 export type ListWithdrawalPhotosResponsePayload = {

--- a/src/queries/generated/observationSplats.ts
+++ b/src/queries/generated/observationSplats.ts
@@ -160,6 +160,7 @@ export type SplatAnnotationPayload = {
 };
 export type GetObservationSplatInfoResponsePayload = {
   annotations: SplatAnnotationPayload[];
+  averageCameraHeight?: number;
   cameraPosition?: CoordinatePayload;
   groundColor?: string;
   groundPlane?: CoordinatePayload[];

--- a/src/queries/generated/organizationSplats.ts
+++ b/src/queries/generated/organizationSplats.ts
@@ -126,6 +126,7 @@ export type SplatAnnotationPayload = {
 };
 export type GetObservationSplatInfoResponsePayload = {
   annotations: SplatAnnotationPayload[];
+  averageCameraHeight?: number;
   cameraPosition?: CoordinatePayload;
   groundColor?: string;
   groundPlane?: CoordinatePayload[];

--- a/src/scenes/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/scenes/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -113,6 +113,8 @@ const VirtualWalkthroughViewer = ({
     [data?.groundPlane]
   );
 
+  const averageCameraHeight = data?.averageCameraHeight ?? 0;
+
   useEffect(() => {
     setCamera(origin, cameraPosition);
   }, [origin, cameraPosition, setCamera]);
@@ -293,6 +295,7 @@ const VirtualWalkthroughViewer = ({
             boundsCenter={sceneBoundsCenter}
             boundsRadius={sceneBoundsRadius}
             enableFly={!isTextFieldFocused}
+            averageCameraHeight={averageCameraHeight}
           />
         </Entity>
         <Script script={XrControllers} enabled={!isEdit} />


### PR DESCRIPTION
The average camera height is calculated in splatter and saved to the model metadata, then returned in the splat info endpoint. Use this to apply an offset from the ground plane for bounded flight.