### PR TITLE
Allow enabling features by org id

### DIFF
--- a/src/components/NewMap/MapPhotoDrawer.tsx
+++ b/src/components/NewMap/MapPhotoDrawer.tsx
@@ -8,7 +8,7 @@ import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
 import isEnabled from 'src/features';
 import useBoolean from 'src/hooks/useBoolean';
-import { useLocalization } from 'src/providers';
+import { useLocalization, useOrganization } from 'src/providers';
 import { ObservationSplatPayload } from 'src/queries/generated/observationSplats';
 import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import VirtualPlotData from 'src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/VirtualPlotData';
@@ -33,12 +33,13 @@ const MapPhotoDrawer = ({
   splat,
 }: MapPhotoDrawerProps): JSX.Element | undefined => {
   const { activeLocale, strings } = useLocalization();
+  const { selectedOrganization } = useOrganization();
 
   const { format } = useNumberFormatter();
   const { data } = useGetObservationResultsQuery({ observationId });
   const [virtualWalkthroughOpen, setVirtualWalkthroughOpen] = useBoolean(false);
   const [searchParams, setSearchParams] = useSearchParams();
-  const isVirtualPlotsEnabled = isEnabled('Virtual Monitoring Plots');
+  const isVirtualPlotsEnabled = isEnabled('Virtual Monitoring Plots', selectedOrganization?.id);
 
   const photoUrl = useMemo(() => {
     if (!photo) {

--- a/src/components/NewMap/usePlotPhotosMapLegend.ts
+++ b/src/components/NewMap/usePlotPhotosMapLegend.ts
@@ -1,16 +1,17 @@
 import { useMemo, useState } from 'react';
 
 import isEnabled from 'src/features';
-import { useLocalization } from 'src/providers';
+import { useLocalization, useOrganization } from 'src/providers';
 
 import { MapMultiSelectLegendGroup } from './MapLegend';
 import useMapFeatureStyles from './useMapFeatureStyles';
 
 const usePlotPhotosMapLegend = (disabled?: boolean) => {
   const { strings } = useLocalization();
+  const { selectedOrganization } = useOrganization();
   const [plotPhotosVisible, setPlotPhotosVisible] = useState<boolean>(false);
   const [virtualPlotVisible, setVirtualPlotVisible] = useState<boolean>(false);
-  const isVirtualPlotsEnabled = isEnabled('Virtual Monitoring Plots');
+  const isVirtualPlotsEnabled = isEnabled('Virtual Monitoring Plots', selectedOrganization?.id);
 
   const { plotPhotoStyle, virtualPlotStyle } = useMapFeatureStyles();
   const plotPhotosLegendGroup = useMemo((): MapMultiSelectLegendGroup => {

--- a/src/features.ts
+++ b/src/features.ts
@@ -15,6 +15,8 @@ export type Feature = {
   allowInternalProduction: boolean;
   description: string[];
   disclosure: string[];
+  // if set, the feature is enabled only for these organization IDs and cannot be toggled by users
+  allowedOrganizationIds?: number[];
   get?: () => boolean;
   set?: (val: boolean) => void;
 };
@@ -43,6 +45,7 @@ export const OPT_IN_FEATURES: Feature[] = [
     allowInternalProduction: false,
     description: ['Support for virtual monitoring plots'],
     disclosure: ['This is a WIP'],
+    allowedOrganizationIds: [243, 123],
   },
 ];
 
@@ -68,6 +71,10 @@ export default function isEnabled(name: FeatureName, organizationId?: number) {
 
   if (feature.get) {
     return feature.get();
+  }
+
+  if (feature.allowedOrganizationIds !== undefined) {
+    return organizationId !== undefined && feature.allowedOrganizationIds.includes(organizationId);
   }
 
   if (!feature.active || feature.enabled) {

--- a/src/scenes/Home/ParticipantHomeView/index.tsx
+++ b/src/scenes/Home/ParticipantHomeView/index.tsx
@@ -19,7 +19,7 @@ const ParticipantHomeView = () => {
   const theme = useTheme();
   const { selectedOrganization } = useOrganization();
 
-  const virtualWalkthroughEnabled = isEnabled('Virtual Monitoring Plots');
+  const virtualWalkthroughEnabled = isEnabled('Virtual Monitoring Plots', selectedOrganization?.id);
 
   return (
     <ParticipantPage>

--- a/src/scenes/Home/TerrawareHomeView/index.tsx
+++ b/src/scenes/Home/TerrawareHomeView/index.tsx
@@ -44,7 +44,7 @@ const TerrawareHomeView = () => {
   const seedBankSummary = useSeedBankSummary();
   const orgNurserySummary = useOrgNurserySummary();
   const showAcceleratorCard = orgPreferences.showAcceleratorCard !== false;
-  const virtualWalkthroughEnabled = isEnabled('Virtual Monitoring Plots');
+  const virtualWalkthroughEnabled = isEnabled('Virtual Monitoring Plots', selectedOrganization?.id);
 
   const [isNewApplicationModalOpen, setIsNewApplicationModalOpen] = useState<boolean>(false);
 

--- a/src/scenes/ObservationsRouterV2/Map/ObservationMap.tsx
+++ b/src/scenes/ObservationsRouterV2/Map/ObservationMap.tsx
@@ -88,7 +88,7 @@ const ObservationMap = ({
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
   const [searchParams] = useSearchParams();
 
-  const isVirtualPlotsEnabled = isEnabled('Virtual Monitoring Plots');
+  const isVirtualPlotsEnabled = isEnabled('Virtual Monitoring Plots', selectedOrganization?.id);
 
   const { selectedLayer, plantingSiteLegendGroup } = usePlantingSiteMapLegend(
     'substrata',

--- a/src/scenes/ObservationsRouterV2/SingleView/MonitoringPlotPhotosWithActions.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/MonitoringPlotPhotosWithActions.tsx
@@ -6,6 +6,7 @@ import { Button } from '@terraware/web-components';
 import ImageLightbox from 'src/components/common/ImageLightbox';
 import MediaItem, { MediaFile } from 'src/components/common/MediaItem';
 import isEnabled from 'src/features';
+import { useOrganization } from 'src/providers';
 import {
   useGenerateObservationSplatFileMutation,
   useListObservationSplatsQuery,
@@ -33,13 +34,14 @@ export default function MonitoringPlotPhotosWithActions({
   photos,
 }: MonitoringPlotPhotosWithActionsProps): JSX.Element {
   const theme = useTheme();
+  const { selectedOrganization } = useOrganization();
   const [lightboxFileId, setLightboxFileId] = useState<number | undefined>(undefined);
   const [generateObservationSplatFile] = useGenerateObservationSplatFileMutation();
   const snackbar = useSnackbar();
   const { data } = useListObservationSplatsQuery({ observationId });
   const observationSplats = useMemo(() => data?.splats || [], [data]);
 
-  const isVirtualPlotsEnabled = isEnabled('Virtual Monitoring Plots');
+  const isVirtualPlotsEnabled = isEnabled('Virtual Monitoring Plots', selectedOrganization?.id);
 
   const rootMediaUrl = useMemo(
     () =>

--- a/src/scenes/OptInFeatures/index.tsx
+++ b/src/scenes/OptInFeatures/index.tsx
@@ -123,7 +123,7 @@ export default function OptInFeaturesView({ refresh }: OptInFeaturesViewProps): 
             >
               Opt-in to see experimental or work-in-progress features
             </Box>
-            {OPT_IN_FEATURES.filter((f) => f.active).map((f, i) => (
+            {OPT_IN_FEATURES.filter((f) => f.active && f.allowedOrganizationIds === undefined).map((f, i) => (
               <Stack
                 spacing={2}
                 sx={{

--- a/src/scenes/OrgRouter/index.tsx
+++ b/src/scenes/OrgRouter/index.tsx
@@ -82,7 +82,7 @@ const OrgRouter = ({ showNavBar, setShowNavBar }: OrgRouterProps) => {
   const hasObservationsResults = useMemo(() => !!countObservationsResult, [countObservationsResult]);
   const hasPlantingSites = useMemo(() => !!countPlantingSitesResult.data, [countPlantingSitesResult.data]);
 
-  const isVirtualWalkthroughEnabled = isEnabled('Virtual Monitoring Plots');
+  const isVirtualWalkthroughEnabled = isEnabled('Virtual Monitoring Plots', selectedOrganization?.id);
 
   const contentStyles = {
     height: '100%',


### PR DESCRIPTION
This will allow features to be enabled by setting the `allowedOrganizationIds` prop. If the `allowedOrganizationIds` prop is set, the feature will not appear on the feature flag opt-in page and will only be enabled for those organizations.