### PR TITLE
SW-8353 Wire useNewTables to New Observation Results Tables feature flag

### DIFF
--- a/src/components/NewMap/MapPhotoDrawer.tsx
+++ b/src/components/NewMap/MapPhotoDrawer.tsx
@@ -6,7 +6,7 @@ import { Box } from '@mui/material';
 import MapDrawerTable, { MapDrawerTableRow } from 'src/components/MapDrawerTable';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import useBoolean from 'src/hooks/useBoolean';
 import useOrganizationFeatures from 'src/hooks/useOrganizationFeatures';
 import { useLocalization } from 'src/providers';
@@ -36,7 +36,7 @@ const MapPhotoDrawer = ({
   const orgFeatures = useOrganizationFeatures();
 
   const { format } = useNumberFormatter();
-  const { data } = useOneObservationResults({ observationId });
+  const { data } = useGetOneObservationResults({ observationId });
   const [virtualWalkthroughOpen, setVirtualWalkthroughOpen] = useBoolean(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const isVirtualPlotsEnabled = !!orgFeatures?.virtualWalkthrough?.enabled;

--- a/src/components/NewMap/MapPhotoDrawer.tsx
+++ b/src/components/NewMap/MapPhotoDrawer.tsx
@@ -6,11 +6,11 @@ import { Box } from '@mui/material';
 import MapDrawerTable, { MapDrawerTableRow } from 'src/components/MapDrawerTable';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
+import { useOneObservationResults } from 'src/hooks/observations';
 import useBoolean from 'src/hooks/useBoolean';
 import useOrganizationFeatures from 'src/hooks/useOrganizationFeatures';
 import { useLocalization } from 'src/providers';
 import { ObservationSplatPayload } from 'src/queries/generated/observationSplats';
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import VirtualPlotData from 'src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/VirtualPlotData';
 import VirtualWalkthroughModal from 'src/scenes/VirtualWalkthrough/VirtualWalkthroughModal';
 import { ObservationMonitoringPlotPhotoWithGps } from 'src/types/Observations';
@@ -36,7 +36,7 @@ const MapPhotoDrawer = ({
   const orgFeatures = useOrganizationFeatures();
 
   const { format } = useNumberFormatter();
-  const { data } = useGetObservationResultsQuery({ observationId });
+  const { data } = useOneObservationResults({ observationId });
   const [virtualWalkthroughOpen, setVirtualWalkthroughOpen] = useBoolean(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const isVirtualPlotsEnabled = !!orgFeatures?.virtualWalkthrough?.enabled;

--- a/src/components/NewMap/MapPlantDrawer.tsx
+++ b/src/components/NewMap/MapPlantDrawer.tsx
@@ -4,7 +4,7 @@ import { Box } from '@mui/material';
 
 import MapDrawerTable, { MapDrawerTableRow } from 'src/components/MapDrawerTable';
 import { APP_PATHS } from 'src/constants';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import { RecordedPlant } from 'src/types/Observations';
@@ -21,7 +21,7 @@ const MapPlantDrawer = ({ monitoringPlotId, observationId, plant }: MapPlantDraw
   const { activeLocale, strings } = useLocalization();
 
   const { format } = useNumberFormatter();
-  const { currentData: observationResultResponse } = useOneObservationResults({
+  const { currentData: observationResultResponse } = useGetOneObservationResults({
     observationId,
     depth: 'Plant',
   });

--- a/src/components/NewMap/MapPlantDrawer.tsx
+++ b/src/components/NewMap/MapPlantDrawer.tsx
@@ -4,9 +4,9 @@ import { Box } from '@mui/material';
 
 import MapDrawerTable, { MapDrawerTableRow } from 'src/components/MapDrawerTable';
 import { APP_PATHS } from 'src/constants';
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { RecordedPlant } from 'src/types/Observations';
 import { getShortDate } from 'src/utils/dateFormatter';
 import { useNumberFormatter } from 'src/utils/useNumberFormatter';
@@ -21,7 +21,7 @@ const MapPlantDrawer = ({ monitoringPlotId, observationId, plant }: MapPlantDraw
   const { activeLocale, strings } = useLocalization();
 
   const { format } = useNumberFormatter();
-  const { currentData: observationResultResponse } = useGetObservationResultsQuery({
+  const { currentData: observationResultResponse } = useOneObservationResults({
     observationId,
     depth: 'Plant',
   });

--- a/src/components/NewMap/MapTreeDrawer.tsx
+++ b/src/components/NewMap/MapTreeDrawer.tsx
@@ -3,9 +3,10 @@ import React, { type JSX, useMemo } from 'react';
 import { Box } from '@mui/material';
 
 import MapDrawerTable, { MapDrawerTableRow } from 'src/components/MapDrawerTable';
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
-import { ExistingTreePayload, useGetObservationResultsQuery } from 'src/queries/generated/observations';
+import { ExistingTreePayload } from 'src/queries/generated/observations';
 
 type MapTreeDrawerProps = {
   observationId: number;
@@ -14,7 +15,7 @@ type MapTreeDrawerProps = {
 
 const MapTreeDrawer = ({ observationId, tree }: MapTreeDrawerProps): JSX.Element | undefined => {
   const { strings } = useLocalization();
-  const { data } = useGetObservationResultsQuery({ observationId, depth: 'Plant' });
+  const { data } = useOneObservationResults({ observationId, depth: 'Plant' });
 
   const { species } = useSpeciesData();
 

--- a/src/components/NewMap/MapTreeDrawer.tsx
+++ b/src/components/NewMap/MapTreeDrawer.tsx
@@ -3,7 +3,7 @@ import React, { type JSX, useMemo } from 'react';
 import { Box } from '@mui/material';
 
 import MapDrawerTable, { MapDrawerTableRow } from 'src/components/MapDrawerTable';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import { ExistingTreePayload } from 'src/queries/generated/observations';
@@ -15,7 +15,7 @@ type MapTreeDrawerProps = {
 
 const MapTreeDrawer = ({ observationId, tree }: MapTreeDrawerProps): JSX.Element | undefined => {
   const { strings } = useLocalization();
-  const { data } = useOneObservationResults({ observationId, depth: 'Plant' });
+  const { data } = useGetOneObservationResults({ observationId, depth: 'Plant' });
 
   const { species } = useSpeciesData();
 

--- a/src/components/SeedFundReports/LocationSelection/PlantingSite.tsx
+++ b/src/components/SeedFundReports/LocationSelection/PlantingSite.tsx
@@ -10,11 +10,11 @@ import PlantingSiteSpeciesCellRenderer from 'src/components/SeedFundReports/Loca
 import { transformNumericValue } from 'src/components/SeedFundReports/LocationSelection/util';
 import OverviewItemCard from 'src/components/common/OverviewItemCard';
 import Table from 'src/components/common/table';
+import { useOneObservationResults } from 'src/hooks/observations';
 import usePlantingSite from 'src/hooks/usePlantingSite';
 import usePlantingSiteReportedPlants from 'src/hooks/usePlantingSiteReportedPlants';
 import { useLocalization } from 'src/providers';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
-import { useLazyGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { useSearchObservationDatesQuery } from 'src/queries/search/plantingSites';
 import { ReportPlantingSite } from 'src/types/Report';
 import { GrowthForm } from 'src/types/Species';
@@ -62,7 +62,10 @@ const LocationSectionPlantingSite = (props: LocationSectionProps): JSX.Element =
 
   const { plantingSite } = usePlantingSite(plantingSiteId);
 
-  const [getLatestObservation, getLatestObservationResponse] = useLazyGetObservationResultsQuery();
+  const getLatestObservationResponse = useOneObservationResults({
+    observationId: plantingSite?.latestObservationId,
+    depth: 'Plot',
+  });
 
   const { currentData: upcomingObservationDates } = useSearchObservationDatesQuery({
     plantingSiteId,
@@ -72,18 +75,6 @@ const LocationSectionPlantingSite = (props: LocationSectionProps): JSX.Element =
     plantingSiteId,
     state: ['InProgress'],
   });
-
-  useEffect(() => {
-    if (plantingSite?.latestObservationId) {
-      void getLatestObservation(
-        {
-          observationId: plantingSite?.latestObservationId,
-          depth: 'Plot',
-        },
-        true
-      );
-    }
-  }, [getLatestObservation, plantingSite?.latestObservationId]);
 
   const latestObservationResult = useMemo(
     () => getLatestObservationResponse.currentData?.observation,

--- a/src/components/SeedFundReports/LocationSelection/PlantingSite.tsx
+++ b/src/components/SeedFundReports/LocationSelection/PlantingSite.tsx
@@ -10,7 +10,7 @@ import PlantingSiteSpeciesCellRenderer from 'src/components/SeedFundReports/Loca
 import { transformNumericValue } from 'src/components/SeedFundReports/LocationSelection/util';
 import OverviewItemCard from 'src/components/common/OverviewItemCard';
 import Table from 'src/components/common/table';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import usePlantingSite from 'src/hooks/usePlantingSite';
 import usePlantingSiteReportedPlants from 'src/hooks/usePlantingSiteReportedPlants';
 import { useLocalization } from 'src/providers';
@@ -62,7 +62,7 @@ const LocationSectionPlantingSite = (props: LocationSectionProps): JSX.Element =
 
   const { plantingSite } = usePlantingSite(plantingSiteId);
 
-  const getLatestObservationResponse = useOneObservationResults({
+  const getLatestObservationResponse = useGetOneObservationResults({
     observationId: plantingSite?.latestObservationId,
     depth: 'Plot',
   });

--- a/src/features.ts
+++ b/src/features.ts
@@ -1,7 +1,11 @@
 import { CachedUserService } from 'src/services';
 import env from 'src/utils/useEnvironment';
 
-export type FeatureName = 'Show Production View' | 'Virtual Monitoring Plots' | 'Weighted Survival Rates';
+export type FeatureName =
+  | 'Show Production View'
+  | 'Virtual Monitoring Plots'
+  | 'Weighted Survival Rates'
+  | 'New Observation Results Tables';
 
 export type Feature = {
   name: FeatureName;
@@ -51,6 +55,15 @@ export const OPT_IN_FEATURES: Feature[] = [
     enabled: false,
     allowInternalProduction: false,
     description: ['Average strata survival rate on a weighted basis for planting sites'],
+    disclosure: ['This is a WIP'],
+  },
+  {
+    name: 'New Observation Results Tables',
+    preferenceName: 'newObservationResultsTables',
+    active: true,
+    enabled: false,
+    allowInternalProduction: false,
+    description: ['Use new observation results tables for observation results APIs'],
     disclosure: ['This is a WIP'],
   },
 ];

--- a/src/hooks/observations/index.ts
+++ b/src/hooks/observations/index.ts
@@ -1,0 +1,3 @@
+export { default as useListObservationResults } from './useListObservationResults';
+export { default as useOneObservationResults } from './useOneObservationResults';
+export type { ObservationDepth } from './types';

--- a/src/hooks/observations/index.ts
+++ b/src/hooks/observations/index.ts
@@ -1,3 +1,3 @@
 export { default as useListObservationResults } from './useListObservationResults';
-export { default as useOneObservationResults } from './useOneObservationResults';
+export { default as useGetOneObservationResults } from './useOneObservationResults';
 export type { ObservationDepth } from './types';

--- a/src/hooks/observations/types.ts
+++ b/src/hooks/observations/types.ts
@@ -1,0 +1,3 @@
+import { GetObservationResultsApiArg } from 'src/queries/generated/observations';
+
+export type ObservationDepth = GetObservationResultsApiArg['depth'];

--- a/src/hooks/observations/useListObservationResults.ts
+++ b/src/hooks/observations/useListObservationResults.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+
+import isEnabled from 'src/features';
+import { useLazyListObservationResultsQuery } from 'src/queries/generated/observations';
+import { ObservationState } from 'src/types/Observations';
+
+import { ObservationDepth } from './types';
+
+type UseListObservationResultsArgs = {
+  organizationId: number | undefined;
+  plantingSiteId?: number;
+  depth?: ObservationDepth;
+  state?: ObservationState[];
+  limit?: number;
+};
+
+const useListObservationResults = ({
+  organizationId,
+  plantingSiteId,
+  depth,
+  state,
+  limit,
+}: UseListObservationResultsArgs) => {
+  const useNewTables = isEnabled('New Observation Results Tables');
+  const [listObservationResults, result] = useLazyListObservationResultsQuery();
+
+  useEffect(() => {
+    if (organizationId !== undefined) {
+      void listObservationResults({ organizationId, plantingSiteId, depth, state, limit, useNewTables }, true);
+    }
+  }, [depth, limit, listObservationResults, organizationId, plantingSiteId, state, useNewTables]);
+
+  return result;
+};
+
+export default useListObservationResults;

--- a/src/hooks/observations/useOneObservationResults.ts
+++ b/src/hooks/observations/useOneObservationResults.ts
@@ -5,12 +5,12 @@ import { useLazyGetObservationResultsQuery } from 'src/queries/generated/observa
 
 import { ObservationDepth } from './types';
 
-type UseOneObservationResultsArgs = {
+type UseGetOneObservationResultsArgs = {
   observationId: number | undefined;
   depth?: ObservationDepth;
 };
 
-const useOneObservationResults = ({ observationId, depth }: UseOneObservationResultsArgs) => {
+const useGetOneObservationResults = ({ observationId, depth }: UseGetOneObservationResultsArgs) => {
   const useNewTables = isEnabled('New Observation Results Tables');
   const [getObservationResults, result] = useLazyGetObservationResultsQuery();
 
@@ -23,4 +23,4 @@ const useOneObservationResults = ({ observationId, depth }: UseOneObservationRes
   return result;
 };
 
-export default useOneObservationResults;
+export default useGetOneObservationResults;

--- a/src/hooks/observations/useOneObservationResults.ts
+++ b/src/hooks/observations/useOneObservationResults.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+import isEnabled from 'src/features';
+import { useLazyGetObservationResultsQuery } from 'src/queries/generated/observations';
+
+import { ObservationDepth } from './types';
+
+type UseOneObservationResultsArgs = {
+  observationId: number | undefined;
+  depth?: ObservationDepth;
+};
+
+const useOneObservationResults = ({ observationId, depth }: UseOneObservationResultsArgs) => {
+  const useNewTables = isEnabled('New Observation Results Tables');
+  const [getObservationResults, result] = useLazyGetObservationResultsQuery();
+
+  useEffect(() => {
+    if (observationId !== undefined) {
+      void getObservationResults({ observationId, depth, useNewTables }, true);
+    }
+  }, [depth, getObservationResults, observationId, useNewTables]);
+
+  return result;
+};
+
+export default useOneObservationResults;

--- a/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
+++ b/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
@@ -8,11 +8,11 @@ import AddLink from 'src/components/common/AddLink';
 import Link from 'src/components/common/Link';
 import PlantingSiteSelector from 'src/components/common/PlantingSiteSelector';
 import { APP_PATHS } from 'src/constants';
+import { useOneObservationResults } from 'src/hooks/observations';
 import usePlantingSite from 'src/hooks/usePlantingSite';
 import usePlantingSiteReportedPlants from 'src/hooks/usePlantingSiteReportedPlants';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
-import { useLazyGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { useLazySearchPlantingSitesQuery } from 'src/queries/search/plantingSites';
 import SimplePlantingSiteMap from 'src/scenes/PlantsDashboardRouter/components/SimplePlantingSiteMap';
 import { isAdmin } from 'src/utils/organization';
@@ -37,7 +37,9 @@ export const PlantingSiteStats = () => {
   const { plantingSite } = usePlantingSite(selectedPlantingSiteId);
   const { plantingSiteReportedPlants } = usePlantingSiteReportedPlants(selectedPlantingSiteId);
   const [search, { data: plantingSiteSummariesData }] = useLazySearchPlantingSitesQuery();
-  const [getObservationResults, getObservationResultsResponse] = useLazyGetObservationResultsQuery();
+  const getObservationResultsResponse = useOneObservationResults({
+    observationId: plantingSite?.latestObservationId,
+  });
 
   const plantingSiteSummaries = useMemo(() => plantingSiteSummariesData ?? [], [plantingSiteSummariesData]);
   const latestObservationResult = useMemo(
@@ -55,12 +57,6 @@ export const PlantingSiteStats = () => {
       );
     }
   }, [search, selectedOrganization]);
-
-  useEffect(() => {
-    if (plantingSite && plantingSite.latestObservationId) {
-      void getObservationResults({ observationId: plantingSite.latestObservationId }, true);
-    }
-  }, [getObservationResults, plantingSite]);
 
   useEffect(() => {
     if (plantingSiteSummaries.length && selectedPlantingSiteId === undefined) {

--- a/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
+++ b/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
@@ -8,7 +8,7 @@ import AddLink from 'src/components/common/AddLink';
 import Link from 'src/components/common/Link';
 import PlantingSiteSelector from 'src/components/common/PlantingSiteSelector';
 import { APP_PATHS } from 'src/constants';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import usePlantingSite from 'src/hooks/usePlantingSite';
 import usePlantingSiteReportedPlants from 'src/hooks/usePlantingSiteReportedPlants';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
@@ -37,7 +37,7 @@ export const PlantingSiteStats = () => {
   const { plantingSite } = usePlantingSite(selectedPlantingSiteId);
   const { plantingSiteReportedPlants } = usePlantingSiteReportedPlants(selectedPlantingSiteId);
   const [search, { data: plantingSiteSummariesData }] = useLazySearchPlantingSitesQuery();
-  const getObservationResultsResponse = useOneObservationResults({
+  const getObservationResultsResponse = useGetOneObservationResults({
     observationId: plantingSite?.latestObservationId,
   });
 

--- a/src/scenes/ObservationsRouterV2/ListView/PlantMonitoringList.tsx
+++ b/src/scenes/ObservationsRouterV2/ListView/PlantMonitoringList.tsx
@@ -20,14 +20,12 @@ import TextTruncated from 'src/components/common/TextTruncated';
 import TableRowPopupMenu from 'src/components/common/table/TableRowPopupMenu';
 import EmptyStateContent from 'src/components/emptyStatePages/EmptyStateContent';
 import { APP_PATHS } from 'src/constants';
+import { useListObservationResults } from 'src/hooks/observations';
 import useOrganizationPlantingSites from 'src/hooks/useOrganizationPlantingSites';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import useTableState from 'src/hooks/useTableState';
 import { useLocalization, useOrganization } from 'src/providers';
-import {
-  useLazyListAdHocObservationResultsQuery,
-  useLazyListObservationResultsQuery,
-} from 'src/queries/generated/observations';
+import { useLazyListAdHocObservationResultsQuery } from 'src/queries/generated/observations';
 import { PlantingSitePayload } from 'src/queries/generated/plantingSites';
 import { useLazyGetAllT0SiteDataSetQuery } from 'src/queries/generated/t0';
 import { useLazyGetPlotsWithObservationsQuery } from 'src/queries/search/t0';
@@ -157,7 +155,11 @@ const PlantMonitoringList = ({ plantingSiteId }: PlantMonitoringListProps) => {
   const adHocTableState = useTableState(ADHOC_STORAGE_KEY, { persistFilters: true });
 
   const { plantingSites } = useOrganizationPlantingSites({ full: true });
-  const [listObservationResults, listObservationsResultsResponse] = useLazyListObservationResultsQuery();
+  const listObservationsResultsResponse = useListObservationResults({
+    organizationId: selectedPlotSelection !== 'adHoc' ? selectedOrganization?.id : undefined,
+    plantingSiteId,
+    depth: 'Stratum',
+  });
   const [listAdHocObservationResults, listAdHocObservationResultsResponse] = useLazyListAdHocObservationResultsQuery();
   const [getT0SiteDataSet, getT0SiteDataSetResponse] = useLazyGetAllT0SiteDataSetQuery();
   const [getPlotsWithObservations, getPlotsWithObservationsResponse] = useLazyGetPlotsWithObservationsQuery();
@@ -186,34 +188,17 @@ const PlantMonitoringList = ({ plantingSiteId }: PlantMonitoringListProps) => {
   );
 
   useEffect(() => {
-    if (selectedOrganization) {
-      if (selectedPlotSelection === 'adHoc') {
-        void listAdHocObservationResults(
-          {
-            organizationId: selectedOrganization.id,
-            plantingSiteId,
-            includePlants: true,
-          },
-          true
-        );
-      } else {
-        void listObservationResults(
-          {
-            organizationId: selectedOrganization.id,
-            plantingSiteId,
-            depth: 'Stratum',
-          },
-          true
-        );
-      }
+    if (selectedOrganization && selectedPlotSelection === 'adHoc') {
+      void listAdHocObservationResults(
+        {
+          organizationId: selectedOrganization.id,
+          plantingSiteId,
+          includePlants: true,
+        },
+        true
+      );
     }
-  }, [
-    listAdHocObservationResults,
-    listObservationResults,
-    selectedPlotSelection,
-    selectedOrganization,
-    plantingSiteId,
-  ]);
+  }, [listAdHocObservationResults, selectedPlotSelection, selectedOrganization, plantingSiteId]);
 
   useEffect(() => {
     if (plantingSiteId) {

--- a/src/scenes/ObservationsRouterV2/Map/BiomassObservationStatsDrawer.tsx
+++ b/src/scenes/ObservationsRouterV2/Map/BiomassObservationStatsDrawer.tsx
@@ -4,7 +4,7 @@ import { Box, CircularProgress } from '@mui/material';
 import { getDateDisplayValue } from '@terraware/web-components/utils';
 
 import MapDrawerTable, { MapDrawerTableRow } from 'src/components/MapDrawerTable';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import usePlantingSite from 'src/hooks/usePlantingSite';
 import { useLocalization } from 'src/providers';
 import { getShortDate } from 'src/utils/dateFormatter';
@@ -30,7 +30,7 @@ const BiomassObservationStatsDrawer = ({
   const { activeLocale, strings } = useLocalization();
   const defaultTimezone = useDefaultTimeZone().get().id;
 
-  const { data: observationResultsResponse, isLoading: observationResultsLoading } = useOneObservationResults({
+  const { data: observationResultsResponse, isLoading: observationResultsLoading } = useGetOneObservationResults({
     observationId,
   });
   const { plantingSite, isLoading: plantingSiteLoading } = usePlantingSite(plantingSiteId);

--- a/src/scenes/ObservationsRouterV2/Map/BiomassObservationStatsDrawer.tsx
+++ b/src/scenes/ObservationsRouterV2/Map/BiomassObservationStatsDrawer.tsx
@@ -4,9 +4,9 @@ import { Box, CircularProgress } from '@mui/material';
 import { getDateDisplayValue } from '@terraware/web-components/utils';
 
 import MapDrawerTable, { MapDrawerTableRow } from 'src/components/MapDrawerTable';
+import { useOneObservationResults } from 'src/hooks/observations';
 import usePlantingSite from 'src/hooks/usePlantingSite';
 import { useLocalization } from 'src/providers';
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { getShortDate } from 'src/utils/dateFormatter';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 
@@ -30,7 +30,7 @@ const BiomassObservationStatsDrawer = ({
   const { activeLocale, strings } = useLocalization();
   const defaultTimezone = useDefaultTimeZone().get().id;
 
-  const { data: observationResultsResponse, isLoading: observationResultsLoading } = useGetObservationResultsQuery({
+  const { data: observationResultsResponse, isLoading: observationResultsLoading } = useOneObservationResults({
     observationId,
   });
   const { plantingSite, isLoading: plantingSiteLoading } = usePlantingSite(plantingSiteId);

--- a/src/scenes/ObservationsRouterV2/Map/ObservationMap.tsx
+++ b/src/scenes/ObservationsRouterV2/Map/ObservationMap.tsx
@@ -29,7 +29,7 @@ import usePlantingSiteMapLegend from 'src/components/NewMap/usePlantingSiteMapLe
 import usePlotPhotosMapLegend from 'src/components/NewMap/usePlotPhotosMapLegend';
 import useSurvivalRateMapLegend from 'src/components/NewMap/useSurvivalRateMapLegend';
 import { getBoundingBoxFromPoints } from 'src/components/NewMap/utils';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import useOrganizationFeatures from 'src/hooks/useOrganizationFeatures';
 import useOrganizationPlantingSites from 'src/hooks/useOrganizationPlantingSites';
 import usePlantingSiteHistory from 'src/hooks/usePlantingSiteHistory';
@@ -173,7 +173,7 @@ const ObservationMap = ({
   const [selectedObservationId, setSelectedObservationId] = useState<number>();
   const [selectedAdHocObservationId, setSelectedAdHocObservationId] = useState<number | 'all'>('all');
 
-  const getObservationResponse = useOneObservationResults({
+  const getObservationResponse = useGetOneObservationResults({
     observationId: selectedObservationId,
     depth: 'Plant',
   });

--- a/src/scenes/ObservationsRouterV2/Map/ObservationMap.tsx
+++ b/src/scenes/ObservationsRouterV2/Map/ObservationMap.tsx
@@ -29,6 +29,7 @@ import usePlantingSiteMapLegend from 'src/components/NewMap/usePlantingSiteMapLe
 import usePlotPhotosMapLegend from 'src/components/NewMap/usePlotPhotosMapLegend';
 import useSurvivalRateMapLegend from 'src/components/NewMap/useSurvivalRateMapLegend';
 import { getBoundingBoxFromPoints } from 'src/components/NewMap/utils';
+import { useOneObservationResults } from 'src/hooks/observations';
 import useOrganizationFeatures from 'src/hooks/useOrganizationFeatures';
 import useOrganizationPlantingSites from 'src/hooks/useOrganizationPlantingSites';
 import usePlantingSiteHistory from 'src/hooks/usePlantingSiteHistory';
@@ -38,7 +39,6 @@ import {
   ExistingTreePayload,
   ObservationMonitoringPlotResultsPayload,
   ObservationResultsPayload,
-  useLazyGetObservationResultsQuery,
 } from 'src/queries/generated/observations';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import {
@@ -130,7 +130,6 @@ const ObservationMap = ({
   const { plantingSites } = useOrganizationPlantingSites({ full: true });
   const [getPlantingSite, getPlantingSiteResult] = useLazyGetPlantingSiteQuery();
   const [listObservationSplats, listObservationSplatsResult] = useLazyListObservationSplatsQuery();
-  const [getObservation, getObservationResponse] = useLazyGetObservationResultsQuery();
 
   useEffect(() => {
     if (selectedOrganization && plantingSiteId !== undefined) {
@@ -174,11 +173,10 @@ const ObservationMap = ({
   const [selectedObservationId, setSelectedObservationId] = useState<number>();
   const [selectedAdHocObservationId, setSelectedAdHocObservationId] = useState<number | 'all'>('all');
 
-  useEffect(() => {
-    if (selectedObservationId) {
-      void getObservation({ observationId: selectedObservationId, depth: 'Plant' }, true);
-    }
-  }, [getObservation, selectedObservationId]);
+  const getObservationResponse = useOneObservationResults({
+    observationId: selectedObservationId,
+    depth: 'Plant',
+  });
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/src/scenes/ObservationsRouterV2/Map/ObservationStatsDrawer.tsx
+++ b/src/scenes/ObservationsRouterV2/Map/ObservationStatsDrawer.tsx
@@ -6,10 +6,10 @@ import MapDrawerTable, { MapDrawerTableRow } from 'src/components/MapDrawerTable
 import { MapLayerFeatureId } from 'src/components/NewMap/types';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
+import { useOneObservationResults } from 'src/hooks/observations';
 import usePlantingSite from 'src/hooks/usePlantingSite';
 import usePlantingSiteHistory from 'src/hooks/usePlantingSiteHistory';
 import { useLocalization, useOrganization } from 'src/providers';
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { MonitoringPlotStatus, ObservationState } from 'src/types/Observations';
 import { isManagerOrHigher } from 'src/utils/organization';
 
@@ -50,7 +50,7 @@ const ObservationStatsDrawer = ({
   const { selectedOrganization } = useOrganization();
   const replaceObservationPlotEnabled = isManagerOrHigher(selectedOrganization);
 
-  const { data: observationResultsResponse, isLoading: observationResultsLoading } = useGetObservationResultsQuery({
+  const { data: observationResultsResponse, isLoading: observationResultsLoading } = useOneObservationResults({
     observationId,
   });
   const { plantingSite, isLoading: plantingSiteLoading } = usePlantingSite(plantingSiteId);

--- a/src/scenes/ObservationsRouterV2/Map/ObservationStatsDrawer.tsx
+++ b/src/scenes/ObservationsRouterV2/Map/ObservationStatsDrawer.tsx
@@ -6,7 +6,7 @@ import MapDrawerTable, { MapDrawerTableRow } from 'src/components/MapDrawerTable
 import { MapLayerFeatureId } from 'src/components/NewMap/types';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import usePlantingSite from 'src/hooks/usePlantingSite';
 import usePlantingSiteHistory from 'src/hooks/usePlantingSiteHistory';
 import { useLocalization, useOrganization } from 'src/providers';
@@ -50,7 +50,7 @@ const ObservationStatsDrawer = ({
   const { selectedOrganization } = useOrganization();
   const replaceObservationPlotEnabled = isManagerOrHigher(selectedOrganization);
 
-  const { data: observationResultsResponse, isLoading: observationResultsLoading } = useOneObservationResults({
+  const { data: observationResultsResponse, isLoading: observationResultsLoading } = useGetOneObservationResults({
     observationId,
   });
   const { plantingSite, isLoading: plantingSiteLoading } = usePlantingSite(plantingSiteId);

--- a/src/scenes/ObservationsRouterV2/Map/index.tsx
+++ b/src/scenes/ObservationsRouterV2/Map/index.tsx
@@ -4,7 +4,7 @@ import { MapRef } from 'react-map-gl/mapbox';
 import { Box, Typography, useTheme } from '@mui/material';
 
 import FormattedNumber from 'src/components/common/FormattedNumber';
-import { useListObservationResults, useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults, useListObservationResults } from 'src/hooks/observations';
 import { useLocalization, useOrganization } from 'src/providers';
 import { ObservationResultsPayload, useLazyListAdHocObservationResultsQuery } from 'src/queries/generated/observations';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
@@ -61,7 +61,7 @@ const ObservationMapWrapper = ({
     [getPlantingSiteResult.data?.site, plantingSiteId]
   );
 
-  const getObservationResultResponse = useOneObservationResults({ observationId });
+  const getObservationResultResponse = useGetOneObservationResults({ observationId });
 
   const listObservationsResultsResponse = useListObservationResults({
     organizationId: plantingSiteId !== undefined && !observationId && !isBiomass ? selectedOrganization?.id : undefined,

--- a/src/scenes/ObservationsRouterV2/Map/index.tsx
+++ b/src/scenes/ObservationsRouterV2/Map/index.tsx
@@ -4,13 +4,9 @@ import { MapRef } from 'react-map-gl/mapbox';
 import { Box, Typography, useTheme } from '@mui/material';
 
 import FormattedNumber from 'src/components/common/FormattedNumber';
+import { useListObservationResults, useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization, useOrganization } from 'src/providers';
-import {
-  ObservationResultsPayload,
-  useLazyGetObservationResultsQuery,
-  useLazyListAdHocObservationResultsQuery,
-  useLazyListObservationResultsQuery,
-} from 'src/queries/generated/observations';
+import { ObservationResultsPayload, useLazyListAdHocObservationResultsQuery } from 'src/queries/generated/observations';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 
@@ -48,8 +44,6 @@ const ObservationMapWrapper = ({
   }, [isMapVisible]);
 
   const [getPlantingSite, getPlantingSiteResult] = useLazyGetPlantingSiteQuery();
-  const [getObservationResult, getObservationResultResponse] = useLazyGetObservationResultsQuery();
-  const [listObservationResults, listObservationsResultsResponse] = useLazyListObservationResultsQuery();
   const [listAdHocObservationResults, listAdHocObservationResultsResponse] = useLazyListAdHocObservationResultsQuery();
   const [selectedObservationResults, setSelectedObservationResults] = useState<ObservationResultsPayload[]>([]);
   const [selectedAdHocObservationResults, setSelectedAdHocObservationResults] = useState<ObservationResultsPayload[]>(
@@ -67,11 +61,13 @@ const ObservationMapWrapper = ({
     [getPlantingSiteResult.data?.site, plantingSiteId]
   );
 
-  useEffect(() => {
-    if (observationId) {
-      void getObservationResult({ observationId });
-    }
-  }, [getObservationResult, observationId]);
+  const getObservationResultResponse = useOneObservationResults({ observationId });
+
+  const listObservationsResultsResponse = useListObservationResults({
+    organizationId: plantingSiteId !== undefined && !observationId && !isBiomass ? selectedOrganization?.id : undefined,
+    plantingSiteId,
+    depth: 'Site',
+  });
 
   useEffect(() => {
     if (selectedOrganization && plantingSiteId !== undefined && !observationId) {
@@ -83,25 +79,8 @@ const ObservationMapWrapper = ({
         },
         true
       );
-      if (!isBiomass) {
-        void listObservationResults(
-          {
-            organizationId: selectedOrganization.id,
-            plantingSiteId,
-            depth: 'Site',
-          },
-          true
-        );
-      }
     }
-  }, [
-    isBiomass,
-    listAdHocObservationResults,
-    listObservationResults,
-    observationId,
-    plantingSiteId,
-    selectedOrganization,
-  ]);
+  }, [listAdHocObservationResults, observationId, plantingSiteId, selectedOrganization]);
 
   const singleObservationResult = useMemo(
     () => getObservationResultResponse.data?.observation,

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/BiomassMeasurementsDetails.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/BiomassMeasurementsDetails.tsx
@@ -8,7 +8,7 @@ import { getDateDisplayValue } from '@terraware/web-components/utils';
 import { Crumb } from 'src/components/BreadCrumbs';
 import Page from 'src/components/Page';
 import { APP_PATHS } from 'src/constants';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import { getShortDate } from 'src/utils/dateFormatter';
@@ -37,7 +37,7 @@ const BiomassMeasurementsDetails = (): JSX.Element => {
     return crumbsData;
   }, [strings.OBSERVATIONS]);
 
-  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
+  const { data: observationResultsResponse } = useGetOneObservationResults({ observationId });
   const [getPlantingSite, getPlantingSiteResult] = useLazyGetPlantingSiteQuery();
 
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/BiomassMeasurementsDetails.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/BiomassMeasurementsDetails.tsx
@@ -8,8 +8,8 @@ import { getDateDisplayValue } from '@terraware/web-components/utils';
 import { Crumb } from 'src/components/BreadCrumbs';
 import Page from 'src/components/Page';
 import { APP_PATHS } from 'src/constants';
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import { getShortDate } from 'src/utils/dateFormatter';
 import useStickyTabs from 'src/utils/useStickyTabs';
@@ -37,7 +37,7 @@ const BiomassMeasurementsDetails = (): JSX.Element => {
     return crumbsData;
   }, [strings.OBSERVATIONS]);
 
-  const { data: observationResultsResponse } = useGetObservationResultsQuery({ observationId });
+  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
   const [getPlantingSite, getPlantingSiteResult] = useLazyGetPlantingSiteQuery();
 
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/BiomassObservationDataTab.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/BiomassObservationDataTab.tsx
@@ -6,8 +6,8 @@ import { Button, Icon, Textfield, Tooltip } from '@terraware/web-components';
 import { getDateDisplayValue } from '@terraware/web-components/utils';
 
 import Card from 'src/components/common/Card';
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import { getConditionString } from 'src/redux/features/observations/utils';
 import LiveTreesPerSpecies from 'src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/LiveTreesPerSpecies';
@@ -33,7 +33,7 @@ const BiomassObservationDataTab = () => {
   const observationId = Number(params.observationId);
 
   const [getPlantingSite, plantingSiteResponse] = useLazyGetPlantingSiteQuery();
-  const { data: observationResultsResponse } = useGetObservationResultsQuery({ observationId });
+  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const monitoringPlot = useMemo(() => results?.adHocPlot, [results?.adHocPlot]);
   const plotLocation = useMemo(() => {

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/BiomassObservationDataTab.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/BiomassObservationDataTab.tsx
@@ -6,7 +6,7 @@ import { Button, Icon, Textfield, Tooltip } from '@terraware/web-components';
 import { getDateDisplayValue } from '@terraware/web-components/utils';
 
 import Card from 'src/components/common/Card';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import { getConditionString } from 'src/redux/features/observations/utils';
@@ -33,7 +33,7 @@ const BiomassObservationDataTab = () => {
   const observationId = Number(params.observationId);
 
   const [getPlantingSite, plantingSiteResponse] = useLazyGetPlantingSiteQuery();
-  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
+  const { data: observationResultsResponse } = useGetOneObservationResults({ observationId });
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const monitoringPlot = useMemo(() => results?.adHocPlot, [results?.adHocPlot]);
   const plotLocation = useMemo(() => {

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/BiomassPhotosTab.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/BiomassPhotosTab.tsx
@@ -6,7 +6,7 @@ import { Button } from '@terraware/web-components';
 
 import Card from 'src/components/common/Card';
 import { APP_PATHS } from 'src/constants';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization } from 'src/providers';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
@@ -20,7 +20,7 @@ const BiomassPhotosTab = () => {
   const params = useParams<{ observationId: string }>();
   const observationId = Number(params.observationId);
 
-  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
+  const { data: observationResultsResponse } = useGetOneObservationResults({ observationId });
   const [getPlantingSite, plantingSiteResponse] = useLazyGetPlantingSiteQuery();
 
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/BiomassPhotosTab.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/BiomassPhotosTab.tsx
@@ -6,9 +6,9 @@ import { Button } from '@terraware/web-components';
 
 import Card from 'src/components/common/Card';
 import { APP_PATHS } from 'src/constants';
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization } from 'src/providers';
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import EventLog from 'src/scenes/ObservationsRouterV2/SingleView/EventLog';
 import MonitoringPlotPhotosWithActions from 'src/scenes/ObservationsRouterV2/SingleView/MonitoringPlotPhotosWithActions';
@@ -20,7 +20,7 @@ const BiomassPhotosTab = () => {
   const params = useParams<{ observationId: string }>();
   const observationId = Number(params.observationId);
 
-  const { data: observationResultsResponse } = useGetObservationResultsQuery({ observationId });
+  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
   const [getPlantingSite, plantingSiteResponse] = useLazyGetPlantingSiteQuery();
 
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/EditBiomassQualitativeDataModal.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/EditBiomassQualitativeDataModal.tsx
@@ -13,11 +13,11 @@ import {
 } from '@terraware/web-components';
 import { DateTime } from 'luxon';
 
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import {
   BiomassUpdateOperationPayload,
   ObservationPlotUpdateOperationPayload,
-  useGetObservationResultsQuery,
   useUpdateCompletedObservationPlotMutation,
 } from 'src/queries/generated/observations';
 import { getPlotConditionsOptions } from 'src/redux/features/observations/utils';
@@ -45,7 +45,7 @@ const EditBiomassQualitativeDataModal = ({ initialFormData, open, setOpen }: Edi
 
   const params = useParams<{ observationId: string }>();
   const observationId = Number(params.observationId);
-  const { data: observationResultsResponse } = useGetObservationResultsQuery({ observationId });
+  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
   const [update] = useUpdateCompletedObservationPlotMutation();
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
 

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/EditBiomassQualitativeDataModal.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/EditBiomassQualitativeDataModal.tsx
@@ -13,7 +13,7 @@ import {
 } from '@terraware/web-components';
 import { DateTime } from 'luxon';
 
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import {
   BiomassUpdateOperationPayload,
@@ -45,7 +45,7 @@ const EditBiomassQualitativeDataModal = ({ initialFormData, open, setOpen }: Edi
 
   const params = useParams<{ observationId: string }>();
   const observationId = Number(params.observationId);
-  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
+  const { data: observationResultsResponse } = useGetOneObservationResults({ observationId });
   const [update] = useUpdateCompletedObservationPlotMutation();
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
 

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/EditNotesModal.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/EditNotesModal.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router';
 import { Box } from '@mui/material';
 import { Button, DialogBox } from '@terraware/web-components';
 
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import {
   QuadratUpdateOperationPayload,
@@ -24,7 +24,7 @@ const EditNotesModal = ({ onClose }: EditNotesModalProps) => {
   const { strings } = useLocalization();
   const params = useParams<{ observationId: string }>();
   const observationId = Number(params.observationId);
-  const { data: observationResultsResponse } = useOneObservationResults({
+  const { data: observationResultsResponse } = useGetOneObservationResults({
     observationId,
   });
   const observationResults = useMemo(

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/EditNotesModal.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/EditNotesModal.tsx
@@ -4,10 +4,10 @@ import { useParams } from 'react-router';
 import { Box } from '@mui/material';
 import { Button, DialogBox } from '@terraware/web-components';
 
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import {
   QuadratUpdateOperationPayload,
-  useGetObservationResultsQuery,
   useUpdateCompletedObservationPlotMutation,
 } from 'src/queries/generated/observations';
 import useForm from 'src/utils/useForm';
@@ -24,7 +24,7 @@ const EditNotesModal = ({ onClose }: EditNotesModalProps) => {
   const { strings } = useLocalization();
   const params = useParams<{ observationId: string }>();
   const observationId = Number(params.observationId);
-  const { data: observationResultsResponse } = useGetObservationResultsQuery({
+  const { data: observationResultsResponse } = useOneObservationResults({
     observationId,
   });
   const observationResults = useMemo(

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/InvasiveAndThreatenedSpeciesTab.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/InvasiveAndThreatenedSpeciesTab.tsx
@@ -5,8 +5,8 @@ import { Box, Typography, useTheme } from '@mui/material';
 import { Button, Icon } from '@terraware/web-components';
 
 import Card from 'src/components/common/Card';
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import EventLog from 'src/scenes/ObservationsRouterV2/SingleView/EventLog';
 
 import EditNotesModal from './EditNotesModal';
@@ -18,7 +18,7 @@ const InvasiveAndThreatenedSpeciesTab = () => {
   const { strings } = useLocalization();
 
   const observationId = Number(params.observationId);
-  const { data: observationResultsResponse } = useGetObservationResultsQuery({ observationId });
+  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const monitoringPlot = useMemo(() => results?.adHocPlot, [results?.adHocPlot]);
 

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/InvasiveAndThreatenedSpeciesTab.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/InvasiveAndThreatenedSpeciesTab.tsx
@@ -5,7 +5,7 @@ import { Box, Typography, useTheme } from '@mui/material';
 import { Button, Icon } from '@terraware/web-components';
 
 import Card from 'src/components/common/Card';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import EventLog from 'src/scenes/ObservationsRouterV2/SingleView/EventLog';
 
@@ -18,7 +18,7 @@ const InvasiveAndThreatenedSpeciesTab = () => {
   const { strings } = useLocalization();
 
   const observationId = Number(params.observationId);
-  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
+  const { data: observationResultsResponse } = useGetOneObservationResults({ observationId });
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const monitoringPlot = useMemo(() => results?.adHocPlot, [results?.adHocPlot]);
 

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/QuadratComponent.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/QuadratComponent.tsx
@@ -3,8 +3,8 @@ import { useParams } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import MonitoringPlotPhotos from 'src/scenes/ObservationsRouterV2/SingleView/MonitoringPlotPhotos';
 import { ObservationMonitoringPlotPosition, getQuadratLabel } from 'src/types/Observations';
 
@@ -20,7 +20,7 @@ const QuadratComponent = ({ position }: QuadratComponentProps) => {
   const { strings } = useLocalization();
 
   const observationId = Number(params.observationId);
-  const { data: observationResultsResponse } = useGetObservationResultsQuery({ observationId });
+  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const monitoringPlot = useMemo(() => results?.adHocPlot, [results?.adHocPlot]);
   const biomassMeasurements = useMemo(() => results?.biomassMeasurements, [results?.biomassMeasurements]);

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/QuadratComponent.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/QuadratComponent.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import MonitoringPlotPhotos from 'src/scenes/ObservationsRouterV2/SingleView/MonitoringPlotPhotos';
 import { ObservationMonitoringPlotPosition, getQuadratLabel } from 'src/types/Observations';
@@ -20,7 +20,7 @@ const QuadratComponent = ({ position }: QuadratComponentProps) => {
   const { strings } = useLocalization();
 
   const observationId = Number(params.observationId);
-  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
+  const { data: observationResultsResponse } = useGetOneObservationResults({ observationId });
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const monitoringPlot = useMemo(() => results?.adHocPlot, [results?.adHocPlot]);
   const biomassMeasurements = useMemo(() => results?.biomassMeasurements, [results?.biomassMeasurements]);

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/QuadratSpeciesEditableTable.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/QuadratSpeciesEditableTable.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router';
 import { TextField } from '@mui/material';
 import { EditableTable, EditableTableColumn } from '@terraware/web-components';
 
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import {
@@ -43,7 +43,7 @@ export default function QuadratSpeciesEditableTable({
 
   const params = useParams<{ observationId: string }>();
   const observationId = Number(params.observationId);
-  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
+  const { data: observationResultsResponse } = useGetOneObservationResults({ observationId });
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const [update] = useUpdateCompletedObservationPlotMutation();
   const [optimisticValues, setOptimisticValues] = useState<Record<string, Partial<SpeciesRow>>>({});

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/QuadratSpeciesEditableTable.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/QuadratSpeciesEditableTable.tsx
@@ -4,13 +4,13 @@ import { useParams } from 'react-router';
 import { TextField } from '@mui/material';
 import { EditableTable, EditableTableColumn } from '@terraware/web-components';
 
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import {
   BiomassSpeciesUpdateOperationPayload,
   QuadratSpeciesUpdateOperationPayload,
   UpdateObservationRequestPayload,
-  useGetObservationResultsQuery,
   useUpdateCompletedObservationPlotMutation,
 } from 'src/queries/generated/observations';
 
@@ -43,7 +43,7 @@ export default function QuadratSpeciesEditableTable({
 
   const params = useParams<{ observationId: string }>();
   const observationId = Number(params.observationId);
-  const { data: observationResultsResponse } = useGetObservationResultsQuery({ observationId });
+  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const [update] = useUpdateCompletedObservationPlotMutation();
   const [optimisticValues, setOptimisticValues] = useState<Record<string, Partial<SpeciesRow>>>({});

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/TreesAndShrubsEditableTable.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/TreesAndShrubsEditableTable.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router';
 import { IconButton, useTheme } from '@mui/material';
 import { EditableTable, EditableTableColumn, Icon } from '@terraware/web-components';
 
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import {
@@ -27,7 +27,7 @@ export default function TreesAndShrubsEditableTable(): JSX.Element {
   const { strings } = useLocalization();
 
   const observationId = Number(params.observationId);
-  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
+  const { data: observationResultsResponse } = useGetOneObservationResults({ observationId });
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
 
   const [update] = useUpdateCompletedObservationPlotMutation();

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/TreesAndShrubsEditableTable.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/TreesAndShrubsEditableTable.tsx
@@ -4,13 +4,13 @@ import { useParams } from 'react-router';
 import { IconButton, useTheme } from '@mui/material';
 import { EditableTable, EditableTableColumn, Icon } from '@terraware/web-components';
 
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import {
   BiomassSpeciesUpdateOperationPayload,
   RecordedTreeUpdateOperationPayload,
   UpdateObservationRequestPayload,
-  useGetObservationResultsQuery,
   useUpdateCompletedObservationPlotMutation,
 } from 'src/queries/generated/observations';
 import TreeNoteModal from 'src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/TreeNoteModal';
@@ -27,7 +27,7 @@ export default function TreesAndShrubsEditableTable(): JSX.Element {
   const { strings } = useLocalization();
 
   const observationId = Number(params.observationId);
-  const { data: observationResultsResponse } = useGetObservationResultsQuery({ observationId });
+  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
 
   const [update] = useUpdateCompletedObservationPlotMutation();

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/EditMonitoringPlotQualitativeDataModal.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/EditMonitoringPlotQualitativeDataModal.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router';
 import { Box } from '@mui/material';
 import { Button, DialogBox, DropdownItem, MultiSelect, Textfield } from '@terraware/web-components';
 
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import {
   ObservationPlotUpdateOperationPayload,
@@ -35,7 +35,7 @@ const EditMonitoringPlotQualitativeDataModal = ({ initialFormData, open, setOpen
   const observationId = Number(params.observationId);
   const monitoringPlotId = Number(params.monitoringPlotId);
 
-  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
+  const { data: observationResultsResponse } = useGetOneObservationResults({ observationId });
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const monitoringPlot = useMemo(
     () =>

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/EditMonitoringPlotQualitativeDataModal.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/EditMonitoringPlotQualitativeDataModal.tsx
@@ -4,11 +4,11 @@ import { useParams } from 'react-router';
 import { Box } from '@mui/material';
 import { Button, DialogBox, DropdownItem, MultiSelect, Textfield } from '@terraware/web-components';
 
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import {
   ObservationPlotUpdateOperationPayload,
   UpdateCompletedObservationPlotApiArg,
-  useGetObservationResultsQuery,
   useUpdateCompletedObservationPlotMutation,
 } from 'src/queries/generated/observations';
 import { getPlotConditionsOptions } from 'src/redux/features/observations/utils';
@@ -35,7 +35,7 @@ const EditMonitoringPlotQualitativeDataModal = ({ initialFormData, open, setOpen
   const observationId = Number(params.observationId);
   const monitoringPlotId = Number(params.monitoringPlotId);
 
-  const { data: observationResultsResponse } = useGetObservationResultsQuery({ observationId });
+  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const monitoringPlot = useMemo(
     () =>

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/MonitoringPlotEditPhotos.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/MonitoringPlotEditPhotos.tsx
@@ -8,7 +8,7 @@ import { isVideoFile } from 'src/components/ActivityLog/ActivityMediaForm';
 import Page from 'src/components/Page';
 import Card from 'src/components/common/Card';
 import { APP_PATHS } from 'src/constants';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import {
   DeletePlotPhotoApiArg,
@@ -46,7 +46,7 @@ const MonitoringPlotEditPhotos = () => {
 
   const snackbar = useSnackbar();
 
-  const { data: getObservationResultsApiResponse } = useOneObservationResults({ observationId });
+  const { data: getObservationResultsApiResponse } = useGetOneObservationResults({ observationId });
 
   const observationResults = useMemo(
     () => getObservationResultsApiResponse?.observation,

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/MonitoringPlotEditPhotos.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/MonitoringPlotEditPhotos.tsx
@@ -8,13 +8,13 @@ import { isVideoFile } from 'src/components/ActivityLog/ActivityMediaForm';
 import Page from 'src/components/Page';
 import Card from 'src/components/common/Card';
 import { APP_PATHS } from 'src/constants';
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import {
   DeletePlotPhotoApiArg,
   UpdatePlotPhotoApiArg,
   UploadOtherPlotMediaApiArg,
   useDeletePlotPhotoMutation,
-  useGetObservationResultsQuery,
   useUpdatePlotPhotoMutation,
   useUploadOtherPlotMediaMutation,
 } from 'src/queries/generated/observations';
@@ -46,7 +46,7 @@ const MonitoringPlotEditPhotos = () => {
 
   const snackbar = useSnackbar();
 
-  const { data: getObservationResultsApiResponse } = useGetObservationResultsQuery({ observationId });
+  const { data: getObservationResultsApiResponse } = useOneObservationResults({ observationId });
 
   const observationResults = useMemo(
     () => getObservationResultsApiResponse?.observation,

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/MonitoringPlotObservationDataTab.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/MonitoringPlotObservationDataTab.tsx
@@ -6,7 +6,7 @@ import { Button, Icon, IconTooltip } from '@terraware/web-components';
 import { getDateDisplayValue, useDeviceInfo } from '@terraware/web-components/utils';
 
 import Card from 'src/components/common/Card';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import { getConditionString } from 'src/redux/features/observations/utils';
@@ -37,7 +37,7 @@ const MonitoringPlotObservationDataTab = () => {
   const monitoringPlotId = Number(params.monitoringPlotId);
 
   const [getPlantingSite, plantingSiteResponse] = useLazyGetPlantingSiteQuery();
-  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
+  const { data: observationResultsResponse } = useGetOneObservationResults({ observationId });
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const monitoringPlot = useMemo(
     () =>

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/MonitoringPlotObservationDataTab.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/MonitoringPlotObservationDataTab.tsx
@@ -6,8 +6,8 @@ import { Button, Icon, IconTooltip } from '@terraware/web-components';
 import { getDateDisplayValue, useDeviceInfo } from '@terraware/web-components/utils';
 
 import Card from 'src/components/common/Card';
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import { getConditionString } from 'src/redux/features/observations/utils';
 import ObservationDataNumbers from 'src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/ObservationDataNumbers';
@@ -37,7 +37,7 @@ const MonitoringPlotObservationDataTab = () => {
   const monitoringPlotId = Number(params.monitoringPlotId);
 
   const [getPlantingSite, plantingSiteResponse] = useLazyGetPlantingSiteQuery();
-  const { data: observationResultsResponse } = useGetObservationResultsQuery({ observationId });
+  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const monitoringPlot = useMemo(
     () =>

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/MonitoringPlotPhotosTab.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/MonitoringPlotPhotosTab.tsx
@@ -6,9 +6,9 @@ import { Button } from '@terraware/web-components';
 
 import Card from 'src/components/common/Card';
 import { APP_PATHS } from 'src/constants';
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization } from 'src/providers';
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import EventLog from 'src/scenes/ObservationsRouterV2/SingleView/EventLog';
 import MonitoringPlotPhotosWithActions from 'src/scenes/ObservationsRouterV2/SingleView/MonitoringPlotPhotosWithActions';
@@ -23,7 +23,7 @@ const MonitoringPlotPhotosTab = () => {
   const monitoringPlotId = Number(params.monitoringPlotId);
   const navigate = useSyncNavigate();
 
-  const { data: observationResultsResponse } = useGetObservationResultsQuery({ observationId });
+  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
   const [getPlantingSite, plantingSiteResponse] = useLazyGetPlantingSiteQuery();
 
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/MonitoringPlotPhotosTab.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/MonitoringPlotPhotosTab.tsx
@@ -6,7 +6,7 @@ import { Button } from '@terraware/web-components';
 
 import Card from 'src/components/common/Card';
 import { APP_PATHS } from 'src/constants';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization } from 'src/providers';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
@@ -23,7 +23,7 @@ const MonitoringPlotPhotosTab = () => {
   const monitoringPlotId = Number(params.monitoringPlotId);
   const navigate = useSyncNavigate();
 
-  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
+  const { data: observationResultsResponse } = useGetOneObservationResults({ observationId });
   const [getPlantingSite, plantingSiteResponse] = useLazyGetPlantingSiteQuery();
 
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/MonitoringPlotSpeciesEditableTable.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/MonitoringPlotSpeciesEditableTable.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router';
 
 import { EditableTable, EditableTableColumn } from '@terraware/web-components';
 
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import {
   MonitoringSpeciesUpdateOperationPayload,
@@ -24,7 +24,7 @@ export default function MonitoringPlotSpeciesEditableTable(): JSX.Element {
   const observationId = Number(params.observationId);
   const monitoringPlotId = Number(params.monitoringPlotId);
 
-  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
+  const { data: observationResultsResponse } = useGetOneObservationResults({ observationId });
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const monitoringPlot = useMemo(
     () =>

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/MonitoringPlotSpeciesEditableTable.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/MonitoringPlotSpeciesEditableTable.tsx
@@ -3,11 +3,11 @@ import { useParams } from 'react-router';
 
 import { EditableTable, EditableTableColumn } from '@terraware/web-components';
 
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import {
   MonitoringSpeciesUpdateOperationPayload,
   UpdateCompletedObservationPlotApiArg,
-  useGetObservationResultsQuery,
   useUpdateCompletedObservationPlotMutation,
 } from 'src/queries/generated/observations';
 import { ObservationSpeciesResults } from 'src/types/Observations';
@@ -24,7 +24,7 @@ export default function MonitoringPlotSpeciesEditableTable(): JSX.Element {
   const observationId = Number(params.observationId);
   const monitoringPlotId = Number(params.monitoringPlotId);
 
-  const { data: observationResultsResponse } = useGetObservationResultsQuery({ observationId });
+  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const monitoringPlot = useMemo(
     () =>

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/index.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/index.tsx
@@ -8,8 +8,8 @@ import { Crumb } from 'src/components/BreadCrumbs';
 import Page from 'src/components/Page';
 import SurvivalRateMessageV2 from 'src/components/SurvivalRate/SurvivalRateMessageV2';
 import { APP_PATHS } from 'src/constants';
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import VirtualWalkthroughModal from 'src/scenes/VirtualWalkthrough/VirtualWalkthroughModal';
 import useStickyTabs from 'src/utils/useStickyTabs';
@@ -25,7 +25,7 @@ const MonitoringPlotDetails = (): JSX.Element => {
   const observationId = Number(params.observationId);
   const stratumName = params.stratumName;
   const monitoringPlotId = Number(params.monitoringPlotId);
-  const { data: observationResultsResponse } = useGetObservationResultsQuery({ observationId });
+  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
   const [getPlantingSite, getPlantingSiteResult] = useLazyGetPlantingSiteQuery();
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const plantingSite = useMemo(() => getPlantingSiteResult.data?.site, [getPlantingSiteResult.data?.site]);

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/index.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/index.tsx
@@ -8,7 +8,7 @@ import { Crumb } from 'src/components/BreadCrumbs';
 import Page from 'src/components/Page';
 import SurvivalRateMessageV2 from 'src/components/SurvivalRate/SurvivalRateMessageV2';
 import { APP_PATHS } from 'src/constants';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import VirtualWalkthroughModal from 'src/scenes/VirtualWalkthrough/VirtualWalkthroughModal';
@@ -25,7 +25,7 @@ const MonitoringPlotDetails = (): JSX.Element => {
   const observationId = Number(params.observationId);
   const stratumName = params.stratumName;
   const monitoringPlotId = Number(params.monitoringPlotId);
-  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
+  const { data: observationResultsResponse } = useGetOneObservationResults({ observationId });
   const [getPlantingSite, getPlantingSiteResult] = useLazyGetPlantingSiteQuery();
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const plantingSite = useMemo(() => getPlantingSiteResult.data?.site, [getPlantingSiteResult.data?.site]);

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Site/StratumList.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Site/StratumList.tsx
@@ -16,9 +16,9 @@ import {
 
 import Link from 'src/components/common/Link';
 import { APP_PATHS } from 'src/constants';
+import { useOneObservationResults } from 'src/hooks/observations';
 import useTableState from 'src/hooks/useTableState';
 import { useLocalization } from 'src/providers/hooks';
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 
@@ -57,7 +57,7 @@ export default function StratumList(): JSX.Element {
     showGlobalFilter,
   } = useTableState(STORAGE_KEY, { persistFilters: true });
 
-  const { data: observationResultsResponse, isLoading } = useGetObservationResultsQuery({ observationId });
+  const { data: observationResultsResponse, isLoading } = useOneObservationResults({ observationId });
   const [getPlantingSite, plantingSiteResponse] = useLazyGetPlantingSiteQuery();
 
   useEffect(() => {

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Site/StratumList.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Site/StratumList.tsx
@@ -16,7 +16,7 @@ import {
 
 import Link from 'src/components/common/Link';
 import { APP_PATHS } from 'src/constants';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import useTableState from 'src/hooks/useTableState';
 import { useLocalization } from 'src/providers/hooks';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
@@ -57,7 +57,7 @@ export default function StratumList(): JSX.Element {
     showGlobalFilter,
   } = useTableState(STORAGE_KEY, { persistFilters: true });
 
-  const { data: observationResultsResponse, isLoading } = useOneObservationResults({ observationId });
+  const { data: observationResultsResponse, isLoading } = useGetOneObservationResults({ observationId });
   const [getPlantingSite, plantingSiteResponse] = useLazyGetPlantingSiteQuery();
 
   useEffect(() => {

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Site/index.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Site/index.tsx
@@ -11,7 +11,7 @@ import Page from 'src/components/Page';
 import SurvivalRateMessageV2 from 'src/components/SurvivalRate/SurvivalRateMessageV2';
 import Card from 'src/components/common/Card';
 import { APP_PATHS } from 'src/constants';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import ObservationMapWrapper from 'src/scenes/ObservationsRouterV2/Map';
@@ -56,7 +56,7 @@ const SiteDetails = (): JSX.Element => {
     return crumbsData;
   }, [strings.OBSERVATIONS]);
 
-  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
+  const { data: observationResultsResponse } = useGetOneObservationResults({ observationId });
   const [getPlantingSite, getPlantingSiteResult] = useLazyGetPlantingSiteQuery();
 
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Site/index.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Site/index.tsx
@@ -11,8 +11,8 @@ import Page from 'src/components/Page';
 import SurvivalRateMessageV2 from 'src/components/SurvivalRate/SurvivalRateMessageV2';
 import Card from 'src/components/common/Card';
 import { APP_PATHS } from 'src/constants';
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import ObservationMapWrapper from 'src/scenes/ObservationsRouterV2/Map';
 import MatchSpeciesModal from 'src/scenes/ObservationsRouterV2/SingleView/MatchSpeciesModal';
@@ -56,7 +56,7 @@ const SiteDetails = (): JSX.Element => {
     return crumbsData;
   }, [strings.OBSERVATIONS]);
 
-  const { data: observationResultsResponse } = useGetObservationResultsQuery({ observationId });
+  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
   const [getPlantingSite, getPlantingSiteResult] = useLazyGetPlantingSiteQuery();
 
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/MonitoringPlotList.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/MonitoringPlotList.tsx
@@ -18,7 +18,7 @@ import Card from 'src/components/common/Card';
 import Link from 'src/components/common/Link';
 import TableRowPopupMenu from 'src/components/common/table/TableRowPopupMenu';
 import { APP_PATHS } from 'src/constants';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import useTableState from 'src/hooks/useTableState';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
@@ -94,7 +94,7 @@ export default function MonitoringPlotList(): JSX.Element {
     showGlobalFilter,
   } = useTableState(STORAGE_KEY, { persistFilters: true });
 
-  const { data: observationResultsResponse, isLoading } = useOneObservationResults({ observationId });
+  const { data: observationResultsResponse, isLoading } = useGetOneObservationResults({ observationId });
   const [getPlantingSite, plantingSiteResponse] = useLazyGetPlantingSiteQuery();
 
   const observationResult = useMemo(

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/MonitoringPlotList.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/MonitoringPlotList.tsx
@@ -18,9 +18,9 @@ import Card from 'src/components/common/Card';
 import Link from 'src/components/common/Link';
 import TableRowPopupMenu from 'src/components/common/table/TableRowPopupMenu';
 import { APP_PATHS } from 'src/constants';
+import { useOneObservationResults } from 'src/hooks/observations';
 import useTableState from 'src/hooks/useTableState';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import { useReassignPlotModal } from 'src/scenes/ObservationsRouterV2/Reassign';
 import { ObservationState, getPlotStatus } from 'src/types/Observations';
@@ -94,7 +94,7 @@ export default function MonitoringPlotList(): JSX.Element {
     showGlobalFilter,
   } = useTableState(STORAGE_KEY, { persistFilters: true });
 
-  const { data: observationResultsResponse, isLoading } = useGetObservationResultsQuery({ observationId });
+  const { data: observationResultsResponse, isLoading } = useOneObservationResults({ observationId });
   const [getPlantingSite, plantingSiteResponse] = useLazyGetPlantingSiteQuery();
 
   const observationResult = useMemo(

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/index.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/index.tsx
@@ -10,8 +10,8 @@ import Page from 'src/components/Page';
 import SurvivalRateMessageV2 from 'src/components/SurvivalRate/SurvivalRateMessageV2';
 import Card from 'src/components/common/Card';
 import { APP_PATHS } from 'src/constants';
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import { getShortDate } from 'src/utils/dateFormatter';
 import { getObservationSpeciesDeadPlantsCount, getObservationSpeciesLivePlantsCount } from 'src/utils/observation';
@@ -29,7 +29,7 @@ const StratumDetails = (): JSX.Element => {
   const observationId = Number(params.observationId);
   const stratumName = params.stratumName;
 
-  const { data: observationResultsResponse } = useGetObservationResultsQuery({ observationId });
+  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
   const [getPlantingSite, getPlantingSiteResult] = useLazyGetPlantingSiteQuery();
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const stratumResult = useMemo(

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/index.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/index.tsx
@@ -10,7 +10,7 @@ import Page from 'src/components/Page';
 import SurvivalRateMessageV2 from 'src/components/SurvivalRate/SurvivalRateMessageV2';
 import Card from 'src/components/common/Card';
 import { APP_PATHS } from 'src/constants';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useLocalization } from 'src/providers';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import { getShortDate } from 'src/utils/dateFormatter';
@@ -29,7 +29,7 @@ const StratumDetails = (): JSX.Element => {
   const observationId = Number(params.observationId);
   const stratumName = params.stratumName;
 
-  const { data: observationResultsResponse } = useOneObservationResults({ observationId });
+  const { data: observationResultsResponse } = useGetOneObservationResults({ observationId });
   const [getPlantingSite, getPlantingSiteResult] = useLazyGetPlantingSiteQuery();
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const stratumResult = useMemo(

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/index.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/index.tsx
@@ -3,7 +3,7 @@ import { Route, Routes, useParams } from 'react-router';
 
 import { BusySpinner } from '@terraware/web-components';
 
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
+import { useOneObservationResults } from 'src/hooks/observations';
 
 import MonitoringPlotDetails from './MonitoringPlot';
 import MonitoringPlotEditPhotos from './MonitoringPlot/MonitoringPlotEditPhotos';
@@ -14,7 +14,7 @@ const PlantMonitoringView = (): JSX.Element => {
   const params = useParams<{ observationId: string }>();
   const observationId = Number(params.observationId);
 
-  const { data: observationResultsResponse, isLoading: observationResultsLoading } = useGetObservationResultsQuery({
+  const { data: observationResultsResponse, isLoading: observationResultsLoading } = useOneObservationResults({
     observationId,
   });
 

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/index.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/index.tsx
@@ -3,7 +3,7 @@ import { Route, Routes, useParams } from 'react-router';
 
 import { BusySpinner } from '@terraware/web-components';
 
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 
 import MonitoringPlotDetails from './MonitoringPlot';
 import MonitoringPlotEditPhotos from './MonitoringPlot/MonitoringPlotEditPhotos';
@@ -14,7 +14,7 @@ const PlantMonitoringView = (): JSX.Element => {
   const params = useParams<{ observationId: string }>();
   const observationId = Number(params.observationId);
 
-  const { data: observationResultsResponse, isLoading: observationResultsLoading } = useOneObservationResults({
+  const { data: observationResultsResponse, isLoading: observationResultsLoading } = useGetOneObservationResults({
     observationId,
   });
 

--- a/src/scenes/ObservationsRouterV2/SingleView/index.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/index.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router';
 
 import { BusySpinner } from '@terraware/web-components';
 
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 
 import BiomassMeasurementsView from './BiomassMeasurements';
 import PlantMonitoringView from './PlantMonitoring';
@@ -12,7 +12,7 @@ const ObservationSingleView = (): JSX.Element => {
   const params = useParams<{ observationId: string }>();
   const observationId = Number(params.observationId);
 
-  const { data: observationResultsResponse, isLoading: observationResultsLoading } = useOneObservationResults({
+  const { data: observationResultsResponse, isLoading: observationResultsLoading } = useGetOneObservationResults({
     observationId,
   });
 

--- a/src/scenes/ObservationsRouterV2/SingleView/index.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/index.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router';
 
 import { BusySpinner } from '@terraware/web-components';
 
-import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
+import { useOneObservationResults } from 'src/hooks/observations';
 
 import BiomassMeasurementsView from './BiomassMeasurements';
 import PlantMonitoringView from './PlantMonitoring';
@@ -12,7 +12,7 @@ const ObservationSingleView = (): JSX.Element => {
   const params = useParams<{ observationId: string }>();
   const observationId = Number(params.observationId);
 
-  const { data: observationResultsResponse, isLoading: observationResultsLoading } = useGetObservationResultsQuery({
+  const { data: observationResultsResponse, isLoading: observationResultsLoading } = useOneObservationResults({
     observationId,
   });
 

--- a/src/scenes/ObservationsRouterV2/useObservationExports.ts
+++ b/src/scenes/ObservationsRouterV2/useObservationExports.ts
@@ -4,6 +4,7 @@ import { getDateDisplayValue } from '@terraware/web-components/utils';
 import sanitize from 'sanitize-filename';
 
 import { APP_PATHS } from 'src/constants';
+import isEnabled from 'src/features';
 import { useLocalization, useOrganization } from 'src/providers';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import {
@@ -25,6 +26,7 @@ const useObservationExports = () => {
   const { activeLocale, strings } = useLocalization();
   const { selectedOrganization } = useOrganization();
   const defaultTimeZone = useDefaultTimeZone().get().id;
+  const useNewTables = isEnabled('New Observation Results Tables');
   const [getObservationResults] = useLazyGetObservationResultsQuery();
   const [exportBiomassPlots] = useLazyExportBiomassPlotsCsvQuery();
   const [exportBiomassSpecies] = useLazyExportBiomassSpeciesCsvQuery();
@@ -283,7 +285,7 @@ const useObservationExports = () => {
 
   const downloadObservationResults = useCallback(
     async (observationId: number) => {
-      const results = await getObservationResults({ observationId, depth: 'Plant' }, true).unwrap();
+      const results = await getObservationResults({ observationId, depth: 'Plant', useNewTables }, true).unwrap();
       const observationResults = results.observation;
 
       const siteResults = await getPlantingSite(
@@ -317,6 +319,7 @@ const useObservationExports = () => {
     [
       getObservationResults,
       getPlantingSite,
+      useNewTables,
       makeObservationCsv,
       makePlotSpeciesCsv,
       selectedOrganization?.timeZone,
@@ -328,7 +331,7 @@ const useObservationExports = () => {
 
   const downloadObservationCsv = useCallback(
     async (observationId: number) => {
-      const results = await getObservationResults({ observationId, depth: 'Plant' }, true).unwrap();
+      const results = await getObservationResults({ observationId, depth: 'Plant', useNewTables }, true).unwrap();
       const observationResults = results.observation;
 
       const siteResults = await getPlantingSite(
@@ -362,6 +365,7 @@ const useObservationExports = () => {
       defaultTimeZone,
       getObservationResults,
       getPlantingSite,
+      useNewTables,
       makeObservationCsv,
       selectedOrganization?.timeZone,
     ]
@@ -370,7 +374,7 @@ const useObservationExports = () => {
   const downloadObservationGpx = useCallback(
     async (observationId: number) => {
       const content = await exportObservationGpx(observationId, true).unwrap();
-      const results = await getObservationResults({ observationId, depth: 'Plant' }, true).unwrap();
+      const results = await getObservationResults({ observationId, depth: 'Plant', useNewTables }, true).unwrap();
       const observationResults = results.observation;
 
       const siteResults = await getPlantingSite(
@@ -403,13 +407,14 @@ const useObservationExports = () => {
       exportObservationGpx,
       getObservationResults,
       getPlantingSite,
+      useNewTables,
       selectedOrganization?.timeZone,
     ]
   );
 
   const downloadBiomassObservationDetails = useCallback(
     async (observationId: number) => {
-      const results = await getObservationResults({ observationId, depth: 'Plant' }, true).unwrap();
+      const results = await getObservationResults({ observationId, depth: 'Plant', useNewTables }, true).unwrap();
       const observationResults = results.observation;
 
       const siteResults = await getPlantingSite(
@@ -449,6 +454,7 @@ const useObservationExports = () => {
       exportBiomassTreesShrubs,
       getObservationResults,
       getPlantingSite,
+      useNewTables,
       strings.BIOMASS_OBSERVATION_FILENAME_PREFIX,
       strings.PLOT,
       strings.SPECIES_CLASSIFICATION,

--- a/src/scenes/PlantsDashboardRouter/components/PlantDashboardMap.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/PlantDashboardMap.tsx
@@ -26,7 +26,7 @@ import usePlantingSiteMapLegend from 'src/components/NewMap/usePlantingSiteMapLe
 import usePlotPhotosMapLegend from 'src/components/NewMap/usePlotPhotosMapLegend';
 import useSurvivalRateMapLegend from 'src/components/NewMap/useSurvivalRateMapLegend';
 import { getBoundingBoxFromPoints } from 'src/components/NewMap/utils';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import usePlantingSiteHistory from 'src/hooks/usePlantingSiteHistory';
 import useProjectPlantingSites from 'src/hooks/useProjectPlantingSites';
 import { useLazyListObservationSummariesQuery } from 'src/queries/generated/observations';
@@ -77,7 +77,7 @@ const PlantDashboardMap = ({ plantingSiteId, projectId }: PlantDashboardMapProps
 
   const plantingSite = useMemo(() => getPlantingSiteResponse.currentData?.site, [getPlantingSiteResponse]);
 
-  const getObservationResultResponse = useOneObservationResults({
+  const getObservationResultResponse = useGetOneObservationResults({
     observationId: plantingSite?.latestObservationId,
     depth: 'Plant',
   });

--- a/src/scenes/PlantsDashboardRouter/components/PlantDashboardMap.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/PlantDashboardMap.tsx
@@ -26,12 +26,10 @@ import usePlantingSiteMapLegend from 'src/components/NewMap/usePlantingSiteMapLe
 import usePlotPhotosMapLegend from 'src/components/NewMap/usePlotPhotosMapLegend';
 import useSurvivalRateMapLegend from 'src/components/NewMap/useSurvivalRateMapLegend';
 import { getBoundingBoxFromPoints } from 'src/components/NewMap/utils';
+import { useOneObservationResults } from 'src/hooks/observations';
 import usePlantingSiteHistory from 'src/hooks/usePlantingSiteHistory';
 import useProjectPlantingSites from 'src/hooks/useProjectPlantingSites';
-import {
-  useLazyGetObservationResultsQuery,
-  useLazyListObservationSummariesQuery,
-} from 'src/queries/generated/observations';
+import { useLazyListObservationSummariesQuery } from 'src/queries/generated/observations';
 import { PlantingSiteHistoryPayload, useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import { MapService } from 'src/services';
 import {
@@ -68,7 +66,6 @@ const PlantDashboardMap = ({ plantingSiteId, projectId }: PlantDashboardMapProps
   const { selectedLayer, plantingSiteLegendGroup } = usePlantingSiteMapLegend('strata');
   const { plantingSites: projectPlantingSites } = useProjectPlantingSites({ full: true, projectId });
   const [getPlantingSite, getPlantingSiteResponse] = useLazyGetPlantingSiteQuery();
-  const [getObservationResult, getObservationResultResponse] = useLazyGetObservationResultsQuery();
   const [listObservataionSummary, listObservataionSummaryResponse] = useLazyListObservationSummariesQuery();
 
   useEffect(() => {
@@ -80,11 +77,10 @@ const PlantDashboardMap = ({ plantingSiteId, projectId }: PlantDashboardMapProps
 
   const plantingSite = useMemo(() => getPlantingSiteResponse.currentData?.site, [getPlantingSiteResponse]);
 
-  useEffect(() => {
-    if (plantingSite?.latestObservationId) {
-      void getObservationResult({ observationId: plantingSite.latestObservationId, depth: 'Plant' }, true);
-    }
-  }, [getObservationResult, plantingSite]);
+  const getObservationResultResponse = useOneObservationResults({
+    observationId: plantingSite?.latestObservationId,
+    depth: 'Plant',
+  });
 
   const latestSummary = useMemo(() => {
     if (listObservataionSummaryResponse.currentData?.summaries.length) {

--- a/src/scenes/VirtualWalkthrough/VirtualWalkthroughsView.tsx
+++ b/src/scenes/VirtualWalkthrough/VirtualWalkthroughsView.tsx
@@ -1,4 +1,4 @@
-import React, { type JSX, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { type JSX, useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router';
 
 import { Box, useTheme } from '@mui/material';
@@ -9,8 +9,8 @@ import ScrollToTop from 'src/components/common/ScrollToTop';
 import TfMain from 'src/components/common/TfMain';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
+import { useOneObservationResults } from 'src/hooks/observations';
 import { useLocalization, useOrganization } from 'src/providers';
-import { useLazyGetObservationResultsQuery } from 'src/queries/generated/observations';
 import {
   OrganizationVirtualWalkthrough,
   useSearchVirtualWalkthroughsQuery,
@@ -48,13 +48,9 @@ export default function VirtualWalkthroughsView(): JSX.Element {
   );
 
   const isPlotFile = virtualWalkthroughModalFile?.type === 'Plot';
-  const [getObservationResults, { data: observationResultsData }] = useLazyGetObservationResultsQuery();
-
-  useEffect(() => {
-    if (isPlotFile && virtualWalkthroughModalFile?.observationId) {
-      void getObservationResults({ observationId: virtualWalkthroughModalFile.observationId });
-    }
-  }, [getObservationResults, isPlotFile, virtualWalkthroughModalFile?.observationId]);
+  const { data: observationResultsData } = useOneObservationResults({
+    observationId: isPlotFile ? virtualWalkthroughModalFile?.observationId : undefined,
+  });
 
   const virtualPlotBelowComponent = useMemo(() => {
     if (!isPlotFile || !observationResultsData) {

--- a/src/scenes/VirtualWalkthrough/VirtualWalkthroughsView.tsx
+++ b/src/scenes/VirtualWalkthrough/VirtualWalkthroughsView.tsx
@@ -9,7 +9,7 @@ import ScrollToTop from 'src/components/common/ScrollToTop';
 import TfMain from 'src/components/common/TfMain';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
-import { useOneObservationResults } from 'src/hooks/observations';
+import { useGetOneObservationResults } from 'src/hooks/observations';
 import { useLocalization, useOrganization } from 'src/providers';
 import {
   OrganizationVirtualWalkthrough,
@@ -48,7 +48,7 @@ export default function VirtualWalkthroughsView(): JSX.Element {
   );
 
   const isPlotFile = virtualWalkthroughModalFile?.type === 'Plot';
-  const { data: observationResultsData } = useOneObservationResults({
+  const { data: observationResultsData } = useGetOneObservationResults({
     observationId: isPlotFile ? virtualWalkthroughModalFile?.observationId : undefined,
   });
 


### PR DESCRIPTION
Add wrapper hooks useOneObservationResults and useListObservationResults
under src/hooks/observations/ that auto-inject useNewTables from the
'New Observation Results Tables' opt-in flag. Migrate all observation
results call sites to the wrappers; useObservationExports.ts keeps the
generated lazy hook for imperative trigger style and injects useNewTables
manually.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>