### PR TITLE
SW-7126 Don't show 0 live plants if no data

### DIFF
--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Site/StratumList.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Site/StratumList.tsx
@@ -20,6 +20,7 @@ import { useGetOneObservationResults } from 'src/hooks/observations';
 import useTableState from 'src/hooks/useTableState';
 import { useLocalization } from 'src/providers/hooks';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
+import { getObservationSpeciesLivePlantsCount } from 'src/utils/observation';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 
 const STORAGE_KEY = 'observation-site-stratum-table';
@@ -72,7 +73,7 @@ export default function StratumList(): JSX.Element {
   const rows = useMemo((): StratumRow[] => {
     if (observationResultsResponse) {
       return observationResultsResponse.observation.strata.map((stratum): StratumRow => {
-        const totalLive = stratum.species.reduce((total, plotSpecies) => total + plotSpecies.totalLive, 0);
+        const totalLive = getObservationSpeciesLivePlantsCount(stratum.species);
         return {
           observationId: observationResultsResponse.observation.observationId,
           stratumName: stratum.name,

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/MonitoringPlotList.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/MonitoringPlotList.tsx
@@ -24,6 +24,7 @@ import { useLocalization, useOrganization } from 'src/providers/hooks';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import { useReassignPlotModal } from 'src/scenes/ObservationsRouterV2/Reassign';
 import { ObservationState, getPlotStatus } from 'src/types/Observations';
+import { getObservationSpeciesLivePlantsCount } from 'src/utils/observation';
 import { isManagerOrHigher } from 'src/utils/organization';
 import { makeDateRangeFilterFn } from 'src/utils/tableFilters';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
@@ -120,7 +121,7 @@ export default function MonitoringPlotList(): JSX.Element {
     if (observationResult && stratumResult) {
       return stratumResult.substrata.flatMap((substratum) =>
         substratum.monitoringPlots.map((plot): MonitoringPlotRow => {
-          const totalLive = plot.species.reduce((total, plotSpecies) => total + plotSpecies.totalLive, 0);
+          const totalLive = getObservationSpeciesLivePlantsCount(plot.species);
           return {
             observationId,
             observationState: observationResult.state,

--- a/src/utils/observation.ts
+++ b/src/utils/observation.ts
@@ -4,13 +4,13 @@ import { ObservationSpeciesResults, ObservationSpeciesResultsPayload } from 'src
 export const getObservationSpeciesLivePlantsCount = (
   species: ObservationSpeciesResults[] | ObservationSpeciesResultsPayload[] | undefined
 ): number | undefined => {
-  return species?.reduce((sum, s) => sum + (s.totalLive || 0), 0);
+  return species && species.length > 0 ? species.reduce((sum, s) => sum + (s.totalLive || 0), 0) : undefined;
 };
 
 export const getObservationSpeciesDeadPlantsCount = (
   species: ObservationSpeciesResults[] | ObservationSpeciesResultsPayload[] | undefined
 ): number | undefined => {
-  return species?.reduce((sum, s) => sum + (s.totalDead || 0), 0);
+  return species && species.length > 0 ? species?.reduce((sum, s) => sum + (s.totalDead || 0), 0) : undefined;
 };
 
 export const getBiomassObservationLiveTreeCount = (


### PR DESCRIPTION
If a given plot or stratum hasn't been observed yet, leave
the live plant count blank in the observation views rather
than defaulting it to 0.