### PR TITLE
SW-8372 Update season payload name type to match BE

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -9608,8 +9608,14 @@ export interface components {
             endDate: string;
             /** Format: int64 */
             id: number;
+            name: string;
+            /** Format: int64 */
+            plantingSiteId: number;
+            speciesTargets: components["schemas"]["SpeciesTargetPayload"][];
             /** Format: date */
             startDate: string;
+            /** @enum {string} */
+            status: "Active" | "Upcoming" | "Past End Date" | "Closed";
         };
         PlantingSiteHistoryPayload: {
             areaHa?: number;
@@ -9687,7 +9693,7 @@ export interface components {
             name: string;
             /** Format: int64 */
             organizationId: number;
-            plantingSeasons: components["schemas"]["PlantingSeasonPayload"][];
+            plantingSeasons: components["schemas"]["SimplePlantingSeasonPayload"][];
             /**
              * @deprecated
              * @description Use strata instead
@@ -10545,7 +10551,7 @@ export interface components {
             cursor?: string;
             fields: string[];
             filters?: components["schemas"]["PrefixedSearch"][];
-            prefix?: "accessionCollectors" | "accessions" | "applications" | "bags" | "batchSubLocations" | "batchWithdrawals" | "batches" | "countries" | "countrySubdivisions" | "deliverables" | "deliveries" | "documentTemplates" | "documents" | "draftPlantingSites" | "events" | "facilities" | "facilityInventories" | "facilityInventoryTotals" | "geolocations" | "internalTags" | "inventories" | "mediaFiles" | "modules" | "monitoringPlotHistories" | "monitoringPlots" | "nurserySpeciesProjects" | "nurseryWithdrawalPhotos" | "nurseryWithdrawals" | "observationBiomassDetails" | "observationBiomassQuadratSpecies" | "observationBiomassSpecies" | "observationPlotConditions" | "observationPlotResult" | "observationPlots" | "observationSiteResult" | "observationStratumResult" | "observationSubstratumResult" | "observations" | "organizationInternalTags" | "organizationUsers" | "organizations" | "participantProjectSpecies" | "plantingSeasons" | "plantingSiteHistories" | "plantingSitePopulations" | "plantingSites" | "plantings" | "projectAcceleratorDetails" | "projectDeliverables" | "projectInternalUsers" | "projectLandUseModelTypes" | "projectModules" | "projectVariableValues" | "projectVariables" | "projects" | "recordedTrees" | "reports" | "species" | "speciesEcosystemTypes" | "speciesGrowthForms" | "speciesPlantMaterialSourcingMethods" | "speciesProblems" | "speciesSuccessionalGroups" | "strata" | "stratumHistories" | "stratumPopulations" | "subLocations" | "substrata" | "substratumHistories" | "substratumPopulations" | "users" | "variableSelectOptions" | "viabilityTestResults" | "viabilityTests" | "withdrawals";
+            prefix?: "accessionCollectors" | "accessions" | "applications" | "bags" | "batchSubLocations" | "batchWithdrawals" | "batches" | "countries" | "countrySubdivisions" | "deliverables" | "deliveries" | "documentTemplates" | "documents" | "draftPlantingSites" | "events" | "facilities" | "facilityInventories" | "facilityInventoryTotals" | "geolocations" | "internalTags" | "inventories" | "mediaFiles" | "modules" | "monitoringPlotHistories" | "monitoringPlots" | "nurserySpeciesProjects" | "nurseryWithdrawalPhotos" | "nurseryWithdrawals" | "observationBiomassDetails" | "observationBiomassQuadratSpecies" | "observationBiomassSpecies" | "observationPlotConditions" | "observationPlotResult" | "observationPlots" | "observationSiteResult" | "observationStratumResult" | "observationSubstratumResult" | "observations" | "organizationInternalTags" | "organizationUsers" | "organizations" | "participantProjectSpecies" | "plantingSeasonSpeciesTargets" | "plantingSeasons" | "plantingSiteHistories" | "plantingSitePopulations" | "plantingSites" | "plantings" | "projectAcceleratorDetails" | "projectDeliverables" | "projectInternalUsers" | "projectLandUseModelTypes" | "projectModules" | "projectVariableValues" | "projectVariables" | "projects" | "recordedTrees" | "reports" | "species" | "speciesEcosystemTypes" | "speciesGrowthForms" | "speciesPlantMaterialSourcingMethods" | "speciesProblems" | "speciesSuccessionalGroups" | "strata" | "stratumHistories" | "stratumPopulations" | "subLocations" | "substrata" | "substratumHistories" | "substratumPopulations" | "users" | "variableSelectOptions" | "viabilityTestResults" | "viabilityTests" | "withdrawals";
             search?: components["schemas"]["SearchNodePayload"];
             sortOrder?: components["schemas"]["SearchSortOrderElement"][];
         };
@@ -10647,6 +10653,14 @@ export interface components {
         SimpleErrorResponsePayload: {
             error: components["schemas"]["ErrorDetails"];
             status: components["schemas"]["SuccessOrError"];
+        };
+        SimplePlantingSeasonPayload: {
+            /** Format: date */
+            endDate: string;
+            /** Format: int64 */
+            id: number;
+            /** Format: date */
+            startDate: string;
         };
         SimpleSuccessResponsePayload: {
             status: components["schemas"]["SuccessOrError"];

--- a/src/queries/generated/plantingSeasons.ts
+++ b/src/queries/generated/plantingSeasons.ts
@@ -84,10 +84,19 @@ export type UpsertSpeciesTargetApiArg = {
   plantingSeasonId: number;
   upsertPlantingSeasonSpeciesTargetRequestPayload: UpsertPlantingSeasonSpeciesTargetRequestPayload;
 };
+export type SpeciesTargetPayload = {
+  quantity: number;
+  speciesId: number;
+  substratumId: number;
+};
 export type PlantingSeasonPayload = {
   endDate: string;
   id: number;
+  name: string;
+  plantingSiteId: number;
+  speciesTargets: SpeciesTargetPayload[];
   startDate: string;
+  status: 'Active' | 'Upcoming' | 'Past End Date' | 'Closed';
 };
 export type SuccessOrError = 'ok' | 'error';
 export type ListPlantingSeasonsResponsePayload = {
@@ -123,11 +132,6 @@ export type UpdatePlantingSeasonRequestPayload = {
   endDate: string;
   name: string;
   startDate: string;
-};
-export type SpeciesTargetPayload = {
-  quantity: number;
-  speciesId: number;
-  substratumId: number;
 };
 export type ListSpeciesTargetsResponsePayload = {
   status: SuccessOrError;

--- a/src/queries/generated/plantingSites.ts
+++ b/src/queries/generated/plantingSites.ts
@@ -144,7 +144,7 @@ export type MultiPolygon = {
     coordinates: number[][][][];
     type: 'MultiPolygon';
   };
-export type PlantingSeasonPayload = {
+export type SimplePlantingSeasonPayload = {
   endDate: string;
   id: number;
   startDate: string;
@@ -219,7 +219,7 @@ export type PlantingSitePayload = {
   latestObservationId?: number;
   name: string;
   organizationId: number;
-  plantingSeasons: PlantingSeasonPayload[];
+  plantingSeasons: SimplePlantingSeasonPayload[];
   /** Use strata instead */
   plantingZones?: PlantingZonePayload[];
   projectId?: number;

--- a/src/scenes/PlantingSitesRouter/view/PlantingSiteDetailsCard.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSiteDetailsCard.tsx
@@ -7,7 +7,7 @@ import { DateTime } from 'luxon';
 
 import { useProjects } from 'src/hooks/useProjects';
 import strings from 'src/strings';
-import { MinimalPlantingSite, PlantingSeason } from 'src/types/Tracking';
+import { MinimalPlantingSite, SimplePlantingSeason } from 'src/types/Tracking';
 import { useLocationTimeZone } from 'src/utils/useTimeZoneUtils';
 
 export type PlantingSiteDetailsCardProps = {
@@ -27,7 +27,7 @@ export default function PlantingSiteDetailsCard({ plantingSite }: PlantingSiteDe
     return 4;
   };
 
-  const plantingSeasons = useMemo<PlantingSeason[]>(() => {
+  const plantingSeasons = useMemo<SimplePlantingSeason[]>(() => {
     if (plantingSite.plantingSeasons) {
       const today = DateTime.fromJSDate(new Date(), { zone: tz.id }).toISODate();
       if (today) {

--- a/src/types/Tracking.ts
+++ b/src/types/Tracking.ts
@@ -40,7 +40,7 @@ export type MonitoringPlotSearchResult = {
 };
 
 // planting seasons
-export type PlantingSeason = components['schemas']['PlantingSeasonPayload'];
+export type SimplePlantingSeason = components['schemas']['SimplePlantingSeasonPayload'];
 export type UpdatedPlantingSeason = components['schemas']['UpdatedPlantingSeasonPayload'];
 
 export type Location = {
@@ -65,7 +65,7 @@ export type MinimalPlantingSite = Location & {
   id: number;
   name: string;
   organizationId: number;
-  plantingSeasons: PlantingSeason[];
+  plantingSeasons: SimplePlantingSeason[];
   strata?: MinimalStratum[];
   projectId?: number;
 };

--- a/src/utils/draftPlantingSiteUtils.test.ts
+++ b/src/utils/draftPlantingSiteUtils.test.ts
@@ -1,4 +1,4 @@
-import { MultiPolygon, PlantingSeason, MinimalStratum } from 'src/types/Tracking';
+import { MultiPolygon, SimplePlantingSeason, MinimalStratum } from 'src/types/Tracking';
 import { DraftPlantingSite, DraftPlantingSitePayload } from 'src/types/PlantingSite';
 import { fromDraft, toDraft } from './draftPlantingSiteUtils';
 
@@ -122,7 +122,7 @@ const substratum22: MultiPolygon = {
   ],
 };
 
-const plantingSeasons: PlantingSeason[] = [{ id: 1, startDate: '2024-01-01', endDate: '2024-02-01' }];
+const plantingSeasons: SimplePlantingSeason[] = [{ id: 1, startDate: '2024-01-01', endDate: '2024-02-01' }];
 
 const strata: MinimalStratum[] = [
   {

--- a/src/utils/draftPlantingSiteUtils.ts
+++ b/src/utils/draftPlantingSiteUtils.ts
@@ -5,7 +5,7 @@ import {
   SiteEditStep,
   SiteType,
 } from 'src/types/PlantingSite';
-import { MinimalStratum, MultiPolygon, PlantingSeason } from 'src/types/Tracking';
+import { MinimalStratum, MultiPolygon, SimplePlantingSeason } from 'src/types/Tracking';
 
 /**
  * Utils to convert from DraftPlantingSitePayload `data` JSON
@@ -63,7 +63,7 @@ export const toDraft = (payload: DraftPlantingSitePayload): DraftPlantingSite =>
 
   const boundary: MultiPolygon | undefined = data.boundary as MultiPolygon | undefined;
   const exclusion: MultiPolygon | undefined = data.exclusion as MultiPolygon | undefined;
-  const plantingSeasons: PlantingSeason[] = data.plantingSeasons as PlantingSeason[];
+  const plantingSeasons: SimplePlantingSeason[] = data.plantingSeasons as SimplePlantingSeason[];
   const strata: MinimalStratum[] | undefined = data.strata as MinimalStratum[] | undefined;
   const siteEditStep: SiteEditStep = data.siteEditStep as SiteEditStep;
   const siteType: SiteType = data.siteType as SiteType;


### PR DESCRIPTION
`PlantingSeasonPayload` was an overloaded class type, causing the schema generation to only have one version of it. The BE renamed this to `SimplePlantingSeasonPayload`; update the FE to match.

Waiting on https://github.com/terraware/terraware-server/pull/4470