### PR TITLE
SW-7126 Don't show 0 live plants if no observation data

### DIFF
--- a/src/scenes/ObservationsRouterV2/ListView/PlantMonitoringList.tsx
+++ b/src/scenes/ObservationsRouterV2/ListView/PlantMonitoringList.tsx
@@ -243,7 +243,10 @@ const PlantMonitoringList = ({ plantingSiteId }: PlantMonitoringListProps) => {
         const observationDate = completedDate ?? observationResult.startDate;
         const adHocPlot = observationResult.adHocPlot;
         const species = selectedPlotSelection === 'adHoc' ? adHocPlot?.species ?? [] : observationResult.species;
-        const totalLive = species.reduce((total, plantSpecies) => (total += plantSpecies.totalLive), 0);
+        const totalLive =
+          species.length > 0
+            ? species.reduce((total, plantSpecies) => (total += plantSpecies.totalLive), 0)
+            : undefined;
 
         const totalPlants =
           selectedPlotSelection === 'adHoc' ? adHocPlot?.totalPlants ?? 0 : observationResult.totalPlants;


### PR DESCRIPTION
In the observations list view, we were showing a live plant count
of 0 for observations that hadn't happened yet.  Leave the cell
blank instead.