### PR TITLE
Fix type errors from OpenAPI schema changes

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -3011,6 +3011,60 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/planting-seasons/{id}/close": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Closes a planting season. */
+        post: operations["closePlantingSeason"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/planting-seasons/{plantingSeasonId}/scheduled-dates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Gets all scheduled dates for a planting season. */
+        get: operations["getScheduledPlantingDates"];
+        put?: never;
+        /** Creates a new scheduled date for a planting season. */
+        post: operations["createScheduledPlantingDate"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/planting-seasons/{plantingSeasonId}/scheduled-dates/{scheduledPlantingDateId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Gets a single scheduled date for a planting season. */
+        get: operations["getSingleScheduledPlantingDate"];
+        /** Updates a scheduled date for a planting season. */
+        put: operations["updateScheduledPlantingDate"];
+        post?: never;
+        /** Deletes a scheduled date for a planting season. */
+        delete: operations["deleteScheduledPlantingDate"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/planting-seasons/{plantingSeasonId}/species-targets": {
         parameters: {
             query?: never;
@@ -3545,23 +3599,6 @@ export interface paths {
         put?: never;
         /** Get summary statistics about accessions that match a specified set of search criteria. */
         post: operations["summarizeAccessionSearch"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/seedbank/values": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** List the values of a set of search fields for a set of accessions matching certain filter criteria. */
-        post: operations["listFieldValues"];
         delete?: never;
         options?: never;
         head?: never;
@@ -5275,9 +5312,22 @@ export interface components {
             /** Format: int32 */
             listPosition: number;
             /** @description If this file is from an observation, additional observation-specific data about it. */
-            observation?: components["schemas"]["ObservationActivityMediaFilePayload"];
+            observation?: components["schemas"]["ActivityObservationMediaFilePayload"];
             /** @enum {string} */
             type: "Photo" | "Video";
+        };
+        /** @description If this file is from an observation, additional observation-specific data about it. */
+        ActivityObservationMediaFilePayload: {
+            /** Format: int64 */
+            monitoringPlotNumber: number;
+            /** @enum {string} */
+            position?: "SouthwestCorner" | "SoutheastCorner" | "NortheastCorner" | "NorthwestCorner";
+            /** @enum {string} */
+            type: "Plot" | "Quadrat" | "Soil";
+        };
+        ActivityObservationPayload: {
+            /** Format: int64 */
+            observationId: number;
         };
         ActivityPayload: {
             /** Format: date */
@@ -5287,6 +5337,7 @@ export interface components {
             id: number;
             isHighlight: boolean;
             media: components["schemas"]["ActivityMediaFilePayload"][];
+            observation?: components["schemas"]["ActivityObservationPayload"];
             /** Format: date-time */
             publishedTime?: string;
             /** @enum {string} */
@@ -5315,8 +5366,21 @@ export interface components {
             isHiddenOnMap: boolean;
             /** Format: int32 */
             listPosition: number;
+            observation?: components["schemas"]["AdminActivityObservationMediaFilePayload"];
             /** @enum {string} */
             type: "Photo" | "Video";
+        };
+        AdminActivityObservationMediaFilePayload: {
+            /** Format: int64 */
+            monitoringPlotNumber: number;
+            /** @enum {string} */
+            position?: "SouthwestCorner" | "SoutheastCorner" | "NortheastCorner" | "NorthwestCorner";
+            /** @enum {string} */
+            type: "Plot" | "Quadrat" | "Soil";
+        };
+        AdminActivityObservationPayload: {
+            /** Format: int64 */
+            observationId: number;
         };
         AdminActivityPayload: {
             /** Format: int64 */
@@ -5334,6 +5398,7 @@ export interface components {
             modifiedBy: number;
             /** Format: date-time */
             modifiedTime: string;
+            observation?: components["schemas"]["AdminActivityObservationPayload"];
             /** Format: int64 */
             publishedBy?: number;
             /** Format: date-time */
@@ -7358,7 +7423,7 @@ export interface components {
         FieldValuesPayload: {
             /** @description If true, the list of values is too long to return in its entirety and "values" is a partial list. */
             partial: boolean;
-            /** @description List of values in the matching accessions. If there are accessions where the field has no value, this list will contain null (an actual null value, not the string "null"). */
+            /** @description All the values this field could possibly have, whether or not any accessions have them. For fields that allow the user to enter arbitrary values, this is equivalent to querying the list of values without any filter criteria, that is, it's a list of all the user-entered values. */
             values: (string | null)[];
         };
         FunderActivityMediaFilePayload: {
@@ -7373,8 +7438,19 @@ export interface components {
             isHiddenOnMap: boolean;
             /** Format: int32 */
             listPosition: number;
+            observation?: components["schemas"]["FunderObservationActivityMediaFilePayload"];
             /** @enum {string} */
             type: "Photo" | "Video";
+        };
+        FunderActivityObservationPayload: {
+            /** Format: date-time */
+            completedTime: string;
+            /** Format: int32 */
+            livePlants?: number;
+            /** Format: int32 */
+            plantDensity?: number;
+            /** Format: int32 */
+            survivalRate?: number;
         };
         FunderActivityPayload: {
             /** Format: date */
@@ -7384,12 +7460,21 @@ export interface components {
             id: number;
             isHighlight: boolean;
             media: components["schemas"]["FunderActivityMediaFilePayload"][];
+            observation?: components["schemas"]["FunderActivityObservationPayload"];
             /** @enum {string} */
             type: "Seed Collection" | "Nursery and Propagule Operations" | "Planting" | "Monitoring" | "Site Visit" | "Social Impact" | "Drone Flight" | "Others";
         };
         FunderListActivitiesResponsePayload: {
             activities: components["schemas"]["FunderActivityPayload"][];
             status: components["schemas"]["SuccessOrError"];
+        };
+        FunderObservationActivityMediaFilePayload: {
+            /** Format: int64 */
+            monitoringPlotNumber: number;
+            /** @enum {string} */
+            position?: "SouthwestCorner" | "SoutheastCorner" | "NortheastCorner" | "NorthwestCorner";
+            /** @enum {string} */
+            type: "Plot" | "Quadrat" | "Soil";
         };
         FunderPayload: {
             accountCreated: boolean;
@@ -7843,6 +7928,10 @@ export interface components {
             status: components["schemas"]["SuccessOrError"];
             version: components["schemas"]["DocumentSavedVersionPayload"];
         };
+        GetScheduledDateResponsePayload: {
+            scheduledDate: components["schemas"]["ScheduledDatePayload"];
+            status: components["schemas"]["SuccessOrError"];
+        };
         GetSeedBankV1: {
             /** Format: date */
             buildCompletedDate?: string;
@@ -8236,20 +8325,6 @@ export interface components {
             facilities: components["schemas"]["FacilityPayload"][];
             status: components["schemas"]["SuccessOrError"];
         };
-        ListFieldValuesRequestPayload: {
-            /** Format: int64 */
-            facilityId?: number;
-            fields: string[];
-            /** Format: int64 */
-            organizationId?: number;
-            search?: components["schemas"]["SearchNodePayload"];
-        };
-        ListFieldValuesResponsePayload: {
-            results: {
-                [key: string]: components["schemas"]["FieldValuesPayload"];
-            };
-            status: components["schemas"]["SuccessOrError"];
-        };
         ListFundingEntitiesPayload: {
             fundingEntities: components["schemas"]["FundingEntityPayload"][];
             status: components["schemas"]["SuccessOrError"];
@@ -8408,6 +8483,10 @@ export interface components {
         };
         ListReportsResponsePayload: {
             reports: components["schemas"]["ListReportsResponseElement"][];
+            status: components["schemas"]["SuccessOrError"];
+        };
+        ListScheduledDatesResponsePayload: {
+            scheduledDates: components["schemas"]["ScheduledDatePayload"][];
             status: components["schemas"]["SuccessOrError"];
         };
         ListSpeciesResponsePayload: {
@@ -9010,15 +9089,6 @@ export interface components {
             /** Format: int64 */
             id: number;
         };
-        /** @description If this file is from an observation, additional observation-specific data about it. */
-        ObservationActivityMediaFilePayload: {
-            /** Format: int64 */
-            monitoringPlotNumber: number;
-            /** @enum {string} */
-            position?: "SouthwestCorner" | "SoutheastCorner" | "NortheastCorner" | "NorthwestCorner";
-            /** @enum {string} */
-            type: "Plot" | "Quadrat" | "Soil";
-        };
         ObservationBirdnetResultPayload: {
             /** Format: int64 */
             fileId: number;
@@ -9082,7 +9152,7 @@ export interface components {
              * Format: int32
              * @description Number of live plants per hectare.
              */
-            plantingDensity: number;
+            plantingDensity?: number;
             plants?: components["schemas"]["RecordedPlantPayload"][];
             /**
              * Format: int32
@@ -9101,12 +9171,12 @@ export interface components {
              * Format: int32
              * @description Total number of plants recorded. Includes all plants, regardless of live/dead status or species.
              */
-            totalPlants: number;
+            totalPlants?: number;
             /**
              * Format: int32
              * @description Total number of species observed, not counting dead plants. Includes plants with Known and Other certainties. In the case of Other, each distinct user-supplied species name is counted as a separate species for purposes of this total.
              */
-            totalSpecies: number;
+            totalSpecies?: number;
             /** @description Information about plants of unknown species, if any were observed. */
             unknownSpecies?: components["schemas"]["ObservationSpeciesResultsPayload"];
         };
@@ -9222,7 +9292,7 @@ export interface components {
              * Format: int32
              * @description Estimated planting density for the site, based on the observed planting densities of monitoring plots.
              */
-            plantingDensity: number;
+            plantingDensity?: number;
             /** Format: int32 */
             plantingDensityStdDev?: number;
             /** Format: int64 */
@@ -9240,9 +9310,9 @@ export interface components {
             /** Format: int32 */
             survivalRateStdDev?: number;
             /** Format: int32 */
-            totalPlants: number;
+            totalPlants?: number;
             /** Format: int32 */
-            totalSpecies: number;
+            totalSpecies?: number;
             /** @enum {string} */
             type: "Monitoring" | "Biomass Measurements";
         };
@@ -9261,7 +9331,7 @@ export interface components {
             certainty: "Known" | "Other" | "Unknown";
             /**
              * Format: int32
-             * @description Number of live plants observed in permanent plots in this observation, not including existing plants. 0 if ths is a plot-level result for a temporary monitoring plot.
+             * @description Number of live plants observed in permanent plots in this observation, not including existing plants. 0 if this is a plot-level result for a temporary monitoring plot.
              */
             permanentLive: number;
             /**
@@ -9320,7 +9390,7 @@ export interface components {
              * Format: int32
              * @description Estimated planting density for the stratum based on the observed planting densities of monitoring plots.
              */
-            plantingDensity: number;
+            plantingDensity?: number;
             /** Format: int32 */
             plantingDensityStdDev?: number;
             species: components["schemas"]["ObservationSpeciesResultsPayload"][];
@@ -9339,12 +9409,12 @@ export interface components {
              * Format: int32
              * @description Total number of plants recorded. Includes all plants, regardless of live/dead status or species.
              */
-            totalPlants: number;
+            totalPlants?: number;
             /**
              * Format: int32
              * @description Total number of species observed, not counting dead plants. Includes plants with Known and Other certainties. In the case of Other, each distinct user-supplied species name is counted as a separate species for purposes of this total.
              */
-            totalSpecies: number;
+            totalSpecies?: number;
         };
         /** @description Percentage of plants of all species in this stratum's permanent monitoring plots that have survived since the t0 point. */
         ObservationSubstratumResultsPayload: {
@@ -9364,7 +9434,7 @@ export interface components {
              * Format: int32
              * @description Estimated planting density for the substratum based on the observed planting densities of monitoring plots.
              */
-            plantingDensity: number;
+            plantingDensity?: number;
             /** Format: int32 */
             plantingDensityStdDev?: number;
             species: components["schemas"]["ObservationSpeciesResultsPayload"][];
@@ -9381,12 +9451,12 @@ export interface components {
              * Format: int32
              * @description Total number of plants recorded. Includes all plants, regardless of live/dead status or species.
              */
-            totalPlants: number;
+            totalPlants?: number;
             /**
              * Format: int32
              * @description Total number of species observed, not counting dead plants. Includes plants with Known and Other certainties. In the case of Other, each distinct user-supplied species name is counted as a separate species for purposes of this total.
              */
-            totalSpecies: number;
+            totalSpecies?: number;
         };
         ObservationUpdateOperationPayload: {
             type: string;
@@ -9650,7 +9720,7 @@ export interface components {
              * Format: int32
              * @description Estimated planting density for the site, based on the observed planting densities of monitoring plots.
              */
-            plantingDensity: number;
+            plantingDensity?: number;
             /** Format: int32 */
             plantingDensityStdDev?: number;
             /** Format: int64 */
@@ -9669,12 +9739,12 @@ export interface components {
              * Format: int32
              * @description Total number of plants recorded from the latest observations of each substratum within each stratum. Includes all plants, regardless of live/dead status or species.
              */
-            totalPlants: number;
+            totalPlants?: number;
             /**
              * Format: int32
              * @description Total number of species observed, not counting dead plants. Includes plants with Known and Other certainties. In the case of Other, each distinct user-supplied species name is counted as a separate species for purposes of this total.
              */
-            totalSpecies: number;
+            totalSpecies?: number;
         };
         PlantingSitePayload: {
             adHocPlots: components["schemas"]["MonitoringPlotPayload"][];
@@ -10525,6 +10595,26 @@ export interface components {
             id: number;
             status: components["schemas"]["SuccessOrError"];
         };
+        ScheduledDatePayload: {
+            /** Format: date */
+            date: string;
+            /** Format: int64 */
+            scheduledPlantingDateId: number;
+            species: components["schemas"]["ScheduledPlantingDateSpeciesPayload"][];
+        };
+        ScheduledPlantingDateRequestPayload: {
+            /** Format: date */
+            date: string;
+            species: components["schemas"]["ScheduledPlantingDateSpeciesPayload"][];
+        };
+        ScheduledPlantingDateSpeciesPayload: {
+            /** Format: int32 */
+            quantity: number;
+            /** Format: int64 */
+            speciesId: number;
+            /** Format: int64 */
+            substratumId: number;
+        };
         Score: {
             /** @enum {string} */
             category: "Carbon" | "Finance" | "Forestry" | "Legal" | "Social Impact" | "GIS" | "Climate Impact" | "Expansion Potential" | "Experience and Understanding" | "Operational Capacity" | "Responsiveness and Attention to Detail" | "Values Alignment";
@@ -10540,6 +10630,7 @@ export interface components {
         SearchCountResponsePayload: {
             /** Format: int64 */
             count: number;
+            status: components["schemas"]["SuccessOrError"];
         };
         /** @description A search criterion. The search will return results that match this criterion. The criterion can be composed of other search criteria to form arbitrary Boolean search expressions. TYPESCRIPT-OVERRIDE-TYPE-WITH-ANY */
         SearchNodePayload: {
@@ -10551,7 +10642,7 @@ export interface components {
             cursor?: string;
             fields: string[];
             filters?: components["schemas"]["PrefixedSearch"][];
-            prefix?: "accessionCollectors" | "accessions" | "applications" | "bags" | "batchSubLocations" | "batchWithdrawals" | "batches" | "countries" | "countrySubdivisions" | "deliverables" | "deliveries" | "documentTemplates" | "documents" | "draftPlantingSites" | "events" | "facilities" | "facilityInventories" | "facilityInventoryTotals" | "geolocations" | "internalTags" | "inventories" | "mediaFiles" | "modules" | "monitoringPlotHistories" | "monitoringPlots" | "nurserySpeciesProjects" | "nurseryWithdrawalPhotos" | "nurseryWithdrawals" | "observationBiomassDetails" | "observationBiomassQuadratSpecies" | "observationBiomassSpecies" | "observationPlotConditions" | "observationPlotResult" | "observationPlots" | "observationSiteResult" | "observationStratumResult" | "observationSubstratumResult" | "observations" | "organizationInternalTags" | "organizationUsers" | "organizations" | "participantProjectSpecies" | "plantingSeasonSpeciesTargets" | "plantingSeasons" | "plantingSiteHistories" | "plantingSitePopulations" | "plantingSites" | "plantings" | "projectAcceleratorDetails" | "projectDeliverables" | "projectInternalUsers" | "projectLandUseModelTypes" | "projectModules" | "projectVariableValues" | "projectVariables" | "projects" | "recordedTrees" | "reports" | "species" | "speciesEcosystemTypes" | "speciesGrowthForms" | "speciesPlantMaterialSourcingMethods" | "speciesProblems" | "speciesSuccessionalGroups" | "strata" | "stratumHistories" | "stratumPopulations" | "subLocations" | "substrata" | "substratumHistories" | "substratumPopulations" | "users" | "variableSelectOptions" | "viabilityTestResults" | "viabilityTests" | "withdrawals";
+            prefix?: "accessionCollectors" | "accessions" | "applications" | "bags" | "batchSubLocations" | "batchWithdrawals" | "batches" | "countries" | "countrySubdivisions" | "deliverables" | "deliveries" | "documentTemplates" | "documents" | "draftPlantingSites" | "events" | "facilities" | "facilityInventories" | "facilityInventoryTotals" | "geolocations" | "internalTags" | "inventories" | "mediaFiles" | "modules" | "monitoringPlotHistories" | "monitoringPlots" | "nurserySpeciesProjects" | "nurseryWithdrawalPhotos" | "nurseryWithdrawals" | "observationBiomassDetails" | "observationBiomassQuadratSpecies" | "observationBiomassSpecies" | "observationPlotConditions" | "observationPlotResult" | "observationPlots" | "observationSiteResult" | "observationStratumResult" | "observationSubstratumResult" | "observations" | "organizationInternalTags" | "organizationUsers" | "organizations" | "participantProjectSpecies" | "plantingSeasonScheduledDates" | "plantingSeasonSpeciesTargets" | "plantingSeasons" | "plantingSiteHistories" | "plantingSitePopulations" | "plantingSites" | "plantings" | "projectAcceleratorDetails" | "projectDeliverables" | "projectInternalUsers" | "projectLandUseModelTypes" | "projectModules" | "projectVariableValues" | "projectVariables" | "projects" | "recordedTrees" | "reports" | "scheduledPlantingDateSpeciesTable" | "species" | "speciesEcosystemTypes" | "speciesGrowthForms" | "speciesPlantMaterialSourcingMethods" | "speciesProblems" | "speciesSuccessionalGroups" | "strata" | "stratumHistories" | "stratumPopulations" | "subLocations" | "substrata" | "substratumHistories" | "substratumPopulations" | "users" | "variableSelectOptions" | "viabilityTestResults" | "viabilityTests" | "withdrawals";
             search?: components["schemas"]["SearchNodePayload"];
             sortOrder?: components["schemas"]["SearchSortOrderElement"][];
         };
@@ -10560,6 +10651,7 @@ export interface components {
             results: {
                 [key: string]: unknown;
             }[];
+            status: components["schemas"]["SuccessOrError"];
         };
         SearchSortOrderElement: {
             field: string;
@@ -10569,6 +10661,7 @@ export interface components {
             results: {
                 [key: string]: components["schemas"]["FieldValuesPayload"];
             };
+            status: components["schemas"]["SuccessOrError"];
         };
         SectionVariablePayload: Omit<WithRequired<components["schemas"]["VariablePayload"], "id" | "internalOnly" | "isList" | "isRequired" | "name" | "stableId" | "type">, "type"> & {
             children: components["schemas"]["SectionVariablePayload"][];
@@ -10709,6 +10802,7 @@ export interface components {
              */
             problemType?: "Name Misspelled" | "Name Not Found" | "Name Is Synonym";
             scientificName: string;
+            status: components["schemas"]["SuccessOrError"];
             /** @description If this is not the accepted name for the species, the name to suggest as an alternative. */
             suggestedScientificName?: string;
         };
@@ -10893,7 +10987,7 @@ export interface components {
              * Format: int32
              * @description Estimated planting density for the stratum based on the observed planting densities of monitoring plots.
              */
-            plantingDensity: number;
+            plantingDensity?: number;
             /** Format: int32 */
             plantingDensityStdDev?: number;
             /** @description Combined list of observed species and their statuses from the latest observation of each substratum. */
@@ -10913,12 +11007,12 @@ export interface components {
              * Format: int32
              * @description Total number of plants recorded from the latest observations of each substratum. Includes all plants, regardless of live/dead status or species.
              */
-            totalPlants: number;
+            totalPlants?: number;
             /**
              * Format: int32
              * @description Total number of species observed, not counting dead plants. Includes plants with Known and Other certainties. In the case of Other, each distinct user-supplied species name is counted as a separate species for purposes of this total.
              */
-            totalSpecies: number;
+            totalSpecies?: number;
         };
         StratumReportedPlantsResponsePayload: {
             /** Format: int64 */
@@ -18691,8 +18785,9 @@ export interface operations {
     };
     listPlantingSeasons: {
         parameters: {
-            query: {
-                plantingSiteId: number;
+            query?: {
+                plantingSiteId?: number;
+                organizationId?: number;
             };
             header?: never;
             path?: never;
@@ -18828,6 +18923,176 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SimpleErrorResponsePayload"];
+                };
+            };
+        };
+    };
+    closePlantingSeason: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The requested operation succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SimpleSuccessResponsePayload"];
+                };
+            };
+            /** @description The requested resource was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SimpleErrorResponsePayload"];
+                };
+            };
+        };
+    };
+    getScheduledPlantingDates: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plantingSeasonId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The requested operation succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListScheduledDatesResponsePayload"];
+                };
+            };
+        };
+    };
+    createScheduledPlantingDate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plantingSeasonId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ScheduledPlantingDateRequestPayload"];
+            };
+        };
+        responses: {
+            /** @description The requested operation succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SimpleSuccessResponsePayload"];
+                };
+            };
+            /** @description The requested resource was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SimpleErrorResponsePayload"];
+                };
+            };
+        };
+    };
+    getSingleScheduledPlantingDate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plantingSeasonId: number;
+                scheduledPlantingDateId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The requested operation succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetScheduledDateResponsePayload"];
+                };
+            };
+        };
+    };
+    updateScheduledPlantingDate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plantingSeasonId: number;
+                scheduledPlantingDateId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ScheduledPlantingDateRequestPayload"];
+            };
+        };
+        responses: {
+            /** @description The requested operation succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SimpleSuccessResponsePayload"];
+                };
+            };
+            /** @description The requested resource was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SimpleErrorResponsePayload"];
+                };
+            };
+        };
+    };
+    deleteScheduledPlantingDate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plantingSeasonId: number;
+                scheduledPlantingDateId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The requested operation succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SimpleSuccessResponsePayload"];
                 };
             };
         };
@@ -19982,30 +20247,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SummarizeAccessionSearchResponsePayload"];
-                };
-            };
-        };
-    };
-    listFieldValues: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ListFieldValuesRequestPayload"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ListFieldValuesResponsePayload"];
                 };
             };
         };

--- a/src/components/NewMap/ObservationPhotoDrawerContent.tsx
+++ b/src/components/NewMap/ObservationPhotoDrawerContent.tsx
@@ -117,11 +117,11 @@ const ObservationPhotoDrawerContent = ({
         },
         {
           key: strings.PLANTS,
-          value: monitoringPlot.totalPlants.toString(),
+          value: monitoringPlot.totalPlants !== undefined ? monitoringPlot.totalPlants.toString() : '',
         },
         {
           key: strings.SPECIES,
-          value: monitoringPlot.totalSpecies.toString(),
+          value: monitoringPlot.totalSpecies !== undefined ? monitoringPlot.totalSpecies.toString() : '',
         },
         {
           key: strings.PLANTING_DENSITY,

--- a/src/queries/generated/activities.ts
+++ b/src/queries/generated/activities.ts
@@ -179,7 +179,7 @@ export type Point = {
     coordinates: number[];
     type: 'Point';
   };
-export type ObservationActivityMediaFilePayload = {
+export type ActivityObservationMediaFilePayload = {
   monitoringPlotNumber: number;
   position?: 'SouthwestCorner' | 'SoutheastCorner' | 'NortheastCorner' | 'NorthwestCorner';
   type: 'Plot' | 'Quadrat' | 'Soil';
@@ -194,8 +194,11 @@ export type ActivityMediaFilePayload = {
   isHiddenOnMap: boolean;
   listPosition: number;
   /** If this file is from an observation, additional observation-specific data about it. */
-  observation?: ObservationActivityMediaFilePayload;
+  observation?: ActivityObservationMediaFilePayload;
   type: 'Photo' | 'Video';
+};
+export type ActivityObservationPayload = {
+  observationId: number;
 };
 export type ActivityPayload = {
   date: string;
@@ -203,6 +206,7 @@ export type ActivityPayload = {
   id: number;
   isHighlight: boolean;
   media: ActivityMediaFilePayload[];
+  observation?: ActivityObservationPayload;
   publishedTime?: string;
   status: 'Not Verified' | 'Verified' | 'Do Not Use';
   type:
@@ -238,6 +242,11 @@ export type CreateActivityRequestPayload = {
     | 'Drone Flight'
     | 'Others';
 };
+export type AdminActivityObservationMediaFilePayload = {
+  monitoringPlotNumber: number;
+  position?: 'SouthwestCorner' | 'SoutheastCorner' | 'NortheastCorner' | 'NorthwestCorner';
+  type: 'Plot' | 'Quadrat' | 'Soil';
+};
 export type AdminActivityMediaFilePayload = {
   caption?: string;
   capturedDate: string;
@@ -249,7 +258,11 @@ export type AdminActivityMediaFilePayload = {
   isCoverPhoto: boolean;
   isHiddenOnMap: boolean;
   listPosition: number;
+  observation?: AdminActivityObservationMediaFilePayload;
   type: 'Photo' | 'Video';
+};
+export type AdminActivityObservationPayload = {
+  observationId: number;
 };
 export type AdminActivityPayload = {
   createdBy: number;
@@ -261,6 +274,7 @@ export type AdminActivityPayload = {
   media: AdminActivityMediaFilePayload[];
   modifiedBy: number;
   modifiedTime: string;
+  observation?: AdminActivityObservationPayload;
   publishedBy?: number;
   publishedTime?: string;
   status: 'Not Verified' | 'Verified' | 'Do Not Use';

--- a/src/queries/generated/funderActivities.ts
+++ b/src/queries/generated/funderActivities.ts
@@ -67,6 +67,11 @@ export type Point = {
     coordinates: number[];
     type: 'Point';
   };
+export type FunderObservationActivityMediaFilePayload = {
+  monitoringPlotNumber: number;
+  position?: 'SouthwestCorner' | 'SoutheastCorner' | 'NortheastCorner' | 'NorthwestCorner';
+  type: 'Plot' | 'Quadrat' | 'Soil';
+};
 export type FunderActivityMediaFilePayload = {
   caption?: string;
   capturedDate: string;
@@ -76,7 +81,14 @@ export type FunderActivityMediaFilePayload = {
   isCoverPhoto: boolean;
   isHiddenOnMap: boolean;
   listPosition: number;
+  observation?: FunderObservationActivityMediaFilePayload;
   type: 'Photo' | 'Video';
+};
+export type FunderActivityObservationPayload = {
+  completedTime: string;
+  livePlants?: number;
+  plantDensity?: number;
+  survivalRate?: number;
 };
 export type FunderActivityPayload = {
   date: string;
@@ -84,6 +96,7 @@ export type FunderActivityPayload = {
   id: number;
   isHighlight: boolean;
   media: FunderActivityMediaFilePayload[];
+  observation?: FunderActivityObservationPayload;
   type:
     | 'Seed Collection'
     | 'Nursery and Propagule Operations'

--- a/src/queries/generated/observations.ts
+++ b/src/queries/generated/observations.ts
@@ -604,7 +604,7 @@ export type ObservationMonitoringPlotMediaPayload = {
 };
 export type ObservationSpeciesResultsPayload = {
   certainty: 'Known' | 'Other' | 'Unknown';
-  /** Number of live plants observed in permanent plots in this observation, not including existing plants. 0 if ths is a plot-level result for a temporary monitoring plot. */
+  /** Number of live plants observed in permanent plots in this observation, not including existing plants. 0 if this is a plot-level result for a temporary monitoring plot. */
   permanentLive: number;
   /** If certainty is Known, the ID of the species. Null if certainty is Other or Unknown. */
   speciesId?: number;
@@ -666,7 +666,7 @@ export type ObservationMonitoringPlotResultsPayload = {
   overlapsWithPlotIds: number[];
   photos: ObservationMonitoringPlotMediaPayload[];
   /** Number of live plants per hectare. */
-  plantingDensity: number;
+  plantingDensity?: number;
   plants?: RecordedPlantPayload[];
   /** Length of each edge of the monitoring plot in meters. */
   sizeMeters: number;
@@ -675,9 +675,9 @@ export type ObservationMonitoringPlotResultsPayload = {
   /** If this is a permanent monitoring plot in this observation, percentage of plants that have survived since t0 data. */
   survivalRate?: number;
   /** Total number of plants recorded. Includes all plants, regardless of live/dead status or species. */
-  totalPlants: number;
+  totalPlants?: number;
   /** Total number of species observed, not counting dead plants. Includes plants with Known and Other certainties. In the case of Other, each distinct user-supplied species name is counted as a separate species for purposes of this total. */
-  totalSpecies: number;
+  totalSpecies?: number;
   /** Information about plants of unknown species, if any were observed. */
   unknownSpecies?: ObservationSpeciesResultsPayload;
 };
@@ -746,7 +746,7 @@ export type ObservationSubstratumResultsPayload = {
   monitoringPlots: ObservationMonitoringPlotResultsPayload[];
   name: string;
   /** Estimated planting density for the substratum based on the observed planting densities of monitoring plots. */
-  plantingDensity: number;
+  plantingDensity?: number;
   plantingDensityStdDev?: number;
   species: ObservationSpeciesResultsPayload[];
   /** ID of the substratum. Absent if the substratum was deleted after the observation. */
@@ -754,9 +754,9 @@ export type ObservationSubstratumResultsPayload = {
   survivalRate?: number;
   survivalRateStdDev?: number;
   /** Total number of plants recorded. Includes all plants, regardless of live/dead status or species. */
-  totalPlants: number;
+  totalPlants?: number;
   /** Total number of species observed, not counting dead plants. Includes plants with Known and Other certainties. In the case of Other, each distinct user-supplied species name is counted as a separate species for purposes of this total. */
-  totalSpecies: number;
+  totalSpecies?: number;
 };
 export type ObservationStratumResultsPayload = {
   /** Area of this stratum in hectares. */
@@ -766,7 +766,7 @@ export type ObservationStratumResultsPayload = {
   estimatedPlants?: number;
   name: string;
   /** Estimated planting density for the stratum based on the observed planting densities of monitoring plots. */
-  plantingDensity: number;
+  plantingDensity?: number;
   plantingDensityStdDev?: number;
   species: ObservationSpeciesResultsPayload[];
   /** ID of the stratum. Absent if the stratum was deleted after the observation. */
@@ -776,9 +776,9 @@ export type ObservationStratumResultsPayload = {
   survivalRate?: number;
   survivalRateStdDev?: number;
   /** Total number of plants recorded. Includes all plants, regardless of live/dead status or species. */
-  totalPlants: number;
+  totalPlants?: number;
   /** Total number of species observed, not counting dead plants. Includes plants with Known and Other certainties. In the case of Other, each distinct user-supplied species name is counted as a separate species for purposes of this total. */
-  totalSpecies: number;
+  totalSpecies?: number;
 };
 export type ObservationResultsPayload = {
   adHocPlot?: ObservationMonitoringPlotResultsPayload;
@@ -791,7 +791,7 @@ export type ObservationResultsPayload = {
   isAdHoc: boolean;
   observationId: number;
   /** Estimated planting density for the site, based on the observed planting densities of monitoring plots. */
-  plantingDensity: number;
+  plantingDensity?: number;
   plantingDensityStdDev?: number;
   plantingSiteHistoryId?: number;
   plantingSiteId: number;
@@ -801,8 +801,8 @@ export type ObservationResultsPayload = {
   strata: ObservationStratumResultsPayload[];
   survivalRate?: number;
   survivalRateStdDev?: number;
-  totalPlants: number;
-  totalSpecies: number;
+  totalPlants?: number;
+  totalSpecies?: number;
   type: 'Monitoring' | 'Biomass Measurements';
 };
 export type ListAdHocObservationResultsResponsePayload = {
@@ -823,7 +823,7 @@ export type StratumObservationSummaryPayload = {
   /** The latest time of the observations used in this summary. */
   latestObservationTime: string;
   /** Estimated planting density for the stratum based on the observed planting densities of monitoring plots. */
-  plantingDensity: number;
+  plantingDensity?: number;
   plantingDensityStdDev?: number;
   /** Combined list of observed species and their statuses from the latest observation of each substratum. */
   species: ObservationSpeciesResultsPayload[];
@@ -834,9 +834,9 @@ export type StratumObservationSummaryPayload = {
   survivalRate?: number;
   survivalRateStdDev?: number;
   /** Total number of plants recorded from the latest observations of each substratum. Includes all plants, regardless of live/dead status or species. */
-  totalPlants: number;
+  totalPlants?: number;
   /** Total number of species observed, not counting dead plants. Includes plants with Known and Other certainties. In the case of Other, each distinct user-supplied species name is counted as a separate species for purposes of this total. */
-  totalSpecies: number;
+  totalSpecies?: number;
 };
 export type PlantingSiteObservationSummaryPayload = {
   /** The earliest time of the observations used in this summary. */
@@ -846,7 +846,7 @@ export type PlantingSiteObservationSummaryPayload = {
   /** The latest time of the observations used in this summary. */
   latestObservationTime: string;
   /** Estimated planting density for the site, based on the observed planting densities of monitoring plots. */
-  plantingDensity: number;
+  plantingDensity?: number;
   plantingDensityStdDev?: number;
   plantingSiteId: number;
   /** Combined list of observed species and their statuses from the latest observation of each substratum within each stratum. */
@@ -856,9 +856,9 @@ export type PlantingSiteObservationSummaryPayload = {
   survivalRate?: number;
   survivalRateStdDev?: number;
   /** Total number of plants recorded from the latest observations of each substratum within each stratum. Includes all plants, regardless of live/dead status or species. */
-  totalPlants: number;
+  totalPlants?: number;
   /** Total number of species observed, not counting dead plants. Includes plants with Known and Other certainties. In the case of Other, each distinct user-supplied species name is counted as a separate species for purposes of this total. */
-  totalSpecies: number;
+  totalSpecies?: number;
 };
 export type ListObservationSummariesResponsePayload = {
   status: SuccessOrError;

--- a/src/queries/generated/plantingSeasons.ts
+++ b/src/queries/generated/plantingSeasons.ts
@@ -6,7 +6,8 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: `/api/v1/planting-seasons`,
         params: {
-          plantingSiteId: queryArg,
+          plantingSiteId: queryArg.plantingSiteId,
+          organizationId: queryArg.organizationId,
         },
       }),
     }),
@@ -24,6 +25,49 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/api/v1/planting-seasons/${queryArg.id}`,
         method: 'PUT',
         body: queryArg.updatePlantingSeasonRequestPayload,
+      }),
+    }),
+    closePlantingSeason: build.mutation<ClosePlantingSeasonApiResponse, ClosePlantingSeasonApiArg>({
+      query: (queryArg) => ({ url: `/api/v1/planting-seasons/${queryArg}/close`, method: 'POST' }),
+    }),
+    getScheduledPlantingDates: build.query<GetScheduledPlantingDatesApiResponse, GetScheduledPlantingDatesApiArg>({
+      query: (queryArg) => ({ url: `/api/v1/planting-seasons/${queryArg}/scheduled-dates` }),
+    }),
+    createScheduledPlantingDate: build.mutation<
+      CreateScheduledPlantingDateApiResponse,
+      CreateScheduledPlantingDateApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/v1/planting-seasons/${queryArg.plantingSeasonId}/scheduled-dates`,
+        method: 'POST',
+        body: queryArg.scheduledPlantingDateRequestPayload,
+      }),
+    }),
+    deleteScheduledPlantingDate: build.mutation<
+      DeleteScheduledPlantingDateApiResponse,
+      DeleteScheduledPlantingDateApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/v1/planting-seasons/${queryArg.plantingSeasonId}/scheduled-dates/${queryArg.scheduledPlantingDateId}`,
+        method: 'DELETE',
+      }),
+    }),
+    getSingleScheduledPlantingDate: build.query<
+      GetSingleScheduledPlantingDateApiResponse,
+      GetSingleScheduledPlantingDateApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/v1/planting-seasons/${queryArg.plantingSeasonId}/scheduled-dates/${queryArg.scheduledPlantingDateId}`,
+      }),
+    }),
+    updateScheduledPlantingDate: build.mutation<
+      UpdateScheduledPlantingDateApiResponse,
+      UpdateScheduledPlantingDateApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/v1/planting-seasons/${queryArg.plantingSeasonId}/scheduled-dates/${queryArg.scheduledPlantingDateId}`,
+        method: 'PUT',
+        body: queryArg.scheduledPlantingDateRequestPayload,
       }),
     }),
     deleteSpeciesTarget: build.mutation<DeleteSpeciesTargetApiResponse, DeleteSpeciesTargetApiArg>({
@@ -52,7 +96,10 @@ const injectedRtkApi = api.injectEndpoints({
 export { injectedRtkApi as api };
 export type ListPlantingSeasonsApiResponse =
   /** status 200 The requested operation succeeded. */ ListPlantingSeasonsResponsePayload;
-export type ListPlantingSeasonsApiArg = number;
+export type ListPlantingSeasonsApiArg = {
+  plantingSiteId?: number;
+  organizationId?: number;
+};
 export type CreatePlantingSeasonApiResponse =
   /** status 200 The requested operation succeeded. */ CreatePlantingSeasonResponsePayload;
 export type CreatePlantingSeasonApiArg = CreatePlantingSeasonRequestPayload;
@@ -67,6 +114,37 @@ export type UpdatePlantingSeasonApiResponse =
 export type UpdatePlantingSeasonApiArg = {
   id: number;
   updatePlantingSeasonRequestPayload: UpdatePlantingSeasonRequestPayload;
+};
+export type ClosePlantingSeasonApiResponse =
+  /** status 200 The requested operation succeeded. */ SimpleSuccessResponsePayload;
+export type ClosePlantingSeasonApiArg = number;
+export type GetScheduledPlantingDatesApiResponse =
+  /** status 200 The requested operation succeeded. */ ListScheduledDatesResponsePayload;
+export type GetScheduledPlantingDatesApiArg = number;
+export type CreateScheduledPlantingDateApiResponse =
+  /** status 200 The requested operation succeeded. */ SimpleSuccessResponsePayload;
+export type CreateScheduledPlantingDateApiArg = {
+  plantingSeasonId: number;
+  scheduledPlantingDateRequestPayload: ScheduledPlantingDateRequestPayload;
+};
+export type DeleteScheduledPlantingDateApiResponse =
+  /** status 200 The requested operation succeeded. */ SimpleSuccessResponsePayload;
+export type DeleteScheduledPlantingDateApiArg = {
+  plantingSeasonId: number;
+  scheduledPlantingDateId: number;
+};
+export type GetSingleScheduledPlantingDateApiResponse =
+  /** status 200 The requested operation succeeded. */ GetScheduledDateResponsePayload;
+export type GetSingleScheduledPlantingDateApiArg = {
+  plantingSeasonId: number;
+  scheduledPlantingDateId: number;
+};
+export type UpdateScheduledPlantingDateApiResponse =
+  /** status 200 The requested operation succeeded. */ SimpleSuccessResponsePayload;
+export type UpdateScheduledPlantingDateApiArg = {
+  plantingSeasonId: number;
+  scheduledPlantingDateId: number;
+  scheduledPlantingDateRequestPayload: ScheduledPlantingDateRequestPayload;
 };
 export type DeleteSpeciesTargetApiResponse =
   /** status 200 The requested operation succeeded. */ SimpleSuccessResponsePayload;
@@ -133,6 +211,28 @@ export type UpdatePlantingSeasonRequestPayload = {
   name: string;
   startDate: string;
 };
+export type ScheduledPlantingDateSpeciesPayload = {
+  quantity: number;
+  speciesId: number;
+  substratumId: number;
+};
+export type ScheduledDatePayload = {
+  date: string;
+  scheduledPlantingDateId: number;
+  species: ScheduledPlantingDateSpeciesPayload[];
+};
+export type ListScheduledDatesResponsePayload = {
+  scheduledDates: ScheduledDatePayload[];
+  status: SuccessOrError;
+};
+export type ScheduledPlantingDateRequestPayload = {
+  date: string;
+  species: ScheduledPlantingDateSpeciesPayload[];
+};
+export type GetScheduledDateResponsePayload = {
+  scheduledDate: ScheduledDatePayload;
+  status: SuccessOrError;
+};
 export type ListSpeciesTargetsResponsePayload = {
   status: SuccessOrError;
   targets: SpeciesTargetPayload[];
@@ -150,6 +250,14 @@ export const {
   useGetPlantingSeasonQuery,
   useLazyGetPlantingSeasonQuery,
   useUpdatePlantingSeasonMutation,
+  useClosePlantingSeasonMutation,
+  useGetScheduledPlantingDatesQuery,
+  useLazyGetScheduledPlantingDatesQuery,
+  useCreateScheduledPlantingDateMutation,
+  useDeleteScheduledPlantingDateMutation,
+  useGetSingleScheduledPlantingDateQuery,
+  useLazyGetSingleScheduledPlantingDateQuery,
+  useUpdateScheduledPlantingDateMutation,
   useDeleteSpeciesTargetMutation,
   useGetSpeciesTargetsQuery,
   useLazyGetSpeciesTargetsQuery,

--- a/src/redux/features/observations/utils.ts
+++ b/src/redux/features/observations/utils.ts
@@ -1,26 +1,16 @@
 import { DropdownItem } from '@terraware/web-components';
-import getDateDisplayValue from '@terraware/web-components/utils/date';
 
 import strings from 'src/strings';
 import {
   AdHocObservationResults,
-  MonitoringPlotStatus,
   ObservationMonitoringPlotResults,
-  ObservationMonitoringPlotResultsPayload,
   ObservationResults,
-  ObservationResultsPayload,
-  ObservationSpeciesResults,
-  ObservationSpeciesResultsPayload,
   ObservationStratumResults,
-  ObservationStratumResultsPayload,
   ObservationSubstratumResults,
-  ObservationSubstratumResultsPayload,
   PlotCondition,
 } from 'src/types/Observations';
-import { Species } from 'src/types/Species';
-import { MultiPolygon, PlantingSite } from 'src/types/Tracking';
+import { MultiPolygon } from 'src/types/Tracking';
 import { getShortDate } from 'src/utils/dateFormatter';
-import { getObservationSpeciesLivePlantsCount } from 'src/utils/observation';
 import { regexMatch } from 'src/utils/search';
 
 // utils
@@ -92,138 +82,10 @@ export const searchPlots = (search: string, observations?: AdHocObservationResul
   );
 };
 
-type SpeciesValue = {
-  commonName?: string;
-  scientificName: string;
-};
-
 export type Value = {
   name: string;
   boundary: MultiPolygon;
   timeZone?: string;
-};
-
-/** Returns a map of site IDs to name, boundary, and timeZone for each site. */
-const sitesReverseMap = (ary: PlantingSite[]): Record<number, Value> =>
-  ary.reduce(
-    (acc, curr) => {
-      const { id, name, boundary, timeZone } = curr;
-      if (boundary) {
-        acc[id] = { name, boundary, timeZone };
-      }
-      return acc;
-    },
-    {} as Record<number, Value>
-  );
-
-// species reverse map
-const speciesReverseMap = (ary: any[]): Record<number, SpeciesValue> =>
-  ary.reduce(
-    (acc, curr) => {
-      const { id, commonName, scientificName } = curr;
-      acc[id] = { commonName, scientificName };
-      return acc;
-    },
-    {} as Record<number, SpeciesValue>
-  );
-
-const StatusWeights: Record<MonitoringPlotStatus, number> = {
-  Completed: 1,
-  Claimed: 2,
-  Unclaimed: 3,
-  'Not Observed': 4,
-};
-
-/** Merges additional data into the results of a stratum observation. */
-const mergeStrata = (
-  stratumObservations: ObservationStratumResultsPayload[],
-  species: Record<number, SpeciesValue>,
-  timeZone?: string
-): ObservationStratumResults[] => {
-  return stratumObservations.map((stratumObservation: ObservationStratumResultsPayload): ObservationStratumResults => {
-    const monitoringPlots: ObservationMonitoringPlotResultsPayload[] = stratumObservation.substrata.flatMap(
-      (substratum: ObservationSubstratumResultsPayload) => substratum.monitoringPlots
-    );
-    const status: MonitoringPlotStatus | undefined = monitoringPlots.reduce(
-      (acc: MonitoringPlotStatus | undefined, mp: ObservationMonitoringPlotResultsPayload) => {
-        if (!acc || StatusWeights[mp.status] > StatusWeights[acc]) {
-          return mp.status;
-        } else {
-          return acc;
-        }
-      },
-      undefined
-    );
-
-    return {
-      ...stratumObservation,
-      stratumName: stratumObservation.name,
-      completedDate: stratumObservation.completedTime
-        ? getDateDisplayValue(stratumObservation.completedTime, timeZone)
-        : undefined,
-      species: mergeSpecies(stratumObservation.species, species),
-      substrata: mergeSubstrata(stratumObservation.substrata, species, timeZone),
-      status,
-      hasObservedPermanentPlots: stratumObservation.substrata.some((substrata) =>
-        substrata.monitoringPlots.some((plot) => plot.isPermanent && plot.completedTime)
-      ),
-      hasObservedTemporaryPlots: stratumObservation.substrata.some((substrata) =>
-        substrata.monitoringPlots.some((plot) => !plot.isPermanent && plot.completedTime)
-      ),
-    };
-  });
-};
-
-// merge substratum
-const mergeSubstrata = (
-  substratumObservations: ObservationSubstratumResultsPayload[],
-  species: Record<number, SpeciesValue>,
-  timeZone?: string
-): ObservationSubstratumResults[] => {
-  return substratumObservations.map(
-    (substratumObservation: ObservationSubstratumResultsPayload): ObservationSubstratumResults => {
-      return {
-        ...substratumObservation,
-        substratumName: substratumObservation.name,
-        monitoringPlots: substratumObservation.monitoringPlots.map(
-          (monitoringPlot: ObservationMonitoringPlotResultsPayload) => {
-            return {
-              ...monitoringPlot,
-              species: mergeSpecies(monitoringPlot.species, species),
-              completedDate: monitoringPlot.completedTime
-                ? getDateDisplayValue(monitoringPlot.completedTime, timeZone)
-                : undefined,
-            };
-          }
-        ),
-      };
-    }
-  );
-};
-
-const mergeSpecies = (
-  speciesObservations: ObservationSpeciesResultsPayload[],
-  species: Record<number, SpeciesValue>
-): ObservationSpeciesResults[] => {
-  return speciesObservations
-    .filter(
-      (speciesObservation: ObservationSpeciesResultsPayload) =>
-        species[speciesObservation.speciesId ?? -1] || speciesObservation.speciesName
-    )
-    .map(
-      (speciesObservation: ObservationSpeciesResultsPayload): ObservationSpeciesResults => ({
-        ...speciesObservation,
-        speciesCommonName:
-          species[speciesObservation.speciesId ?? -1]?.commonName ?? speciesObservation.speciesName ?? '',
-        speciesScientificName: species[speciesObservation.speciesId ?? -1]?.scientificName ?? '',
-      })
-    );
-};
-
-export const has25mPlots = (substrata: ObservationSubstratumResults[] | ObservationSubstratumResultsPayload[]) => {
-  return substrata
-    ?.flatMap((substratum: { monitoringPlots: any[] }) => substratum.monitoringPlots.flatMap((plot) => plot.sizeMeters))
-    .some((size: number) => size.toString() === '25');
 };
 
 export const getConditionString = (

--- a/src/redux/features/observations/utils.ts
+++ b/src/redux/features/observations/utils.ts
@@ -127,43 +127,6 @@ const speciesReverseMap = (ary: any[]): Record<number, SpeciesValue> =>
     {} as Record<number, SpeciesValue>
   );
 
-// merge observation
-export const mergeObservations = (
-  observations: ObservationResultsPayload[],
-  defaultTimeZone: string,
-  plantingSites?: PlantingSite[],
-  speciesData?: Species[]
-): ObservationResults[] => {
-  const sites = sitesReverseMap(plantingSites ?? []);
-  const species = speciesReverseMap(speciesData ?? []);
-
-  return observations
-    .filter((observation) => sites[observation.plantingSiteId])
-    .map((observation: ObservationResultsPayload): ObservationResults => {
-      const { plantingSiteId } = observation;
-      const site = sites[plantingSiteId];
-      const timeZone = site.timeZone ?? defaultTimeZone;
-
-      const mergedStrata = mergeStrata(observation.strata, species, timeZone);
-      const mergedSpecies = mergeSpecies(observation.species, species);
-
-      return {
-        ...observation,
-        plantingSiteName: site.name,
-        boundary: site.boundary,
-        completedDate: observation.completedTime ? getDateDisplayValue(observation.completedTime, site.timeZone) : '',
-        startDate: getDateDisplayValue(observation.startDate, site.timeZone),
-        strata: mergedStrata,
-        species: mergedSpecies,
-        timeZone,
-        totalLive: getObservationSpeciesLivePlantsCount(observation.species),
-        totalPlants: observation.strata.reduce((acc, curr) => acc + curr.totalPlants, 0),
-        hasObservedPermanentPlots: mergedStrata.some((stratum) => stratum.hasObservedPermanentPlots),
-        hasObservedTemporaryPlots: mergedStrata.some((stratum) => stratum.hasObservedTemporaryPlots),
-      };
-    });
-};
-
 const StatusWeights: Record<MonitoringPlotStatus, number> = {
   Completed: 1,
   Claimed: 2,
@@ -261,40 +224,6 @@ export const has25mPlots = (substrata: ObservationSubstratumResults[] | Observat
   return substrata
     ?.flatMap((substratum: { monitoringPlots: any[] }) => substratum.monitoringPlots.flatMap((plot) => plot.sizeMeters))
     .some((size: number) => size.toString() === '25');
-};
-
-export const mergeAdHocObservations = (
-  observations: ObservationResultsPayload[],
-  defaultTimeZone: string,
-  plantingSites?: PlantingSite[]
-): AdHocObservationResults[] => {
-  const sites = sitesReverseMap(plantingSites ?? []);
-
-  return observations
-    .filter((observation) => sites[observation.plantingSiteId])
-    .filter((observation) => observation.adHocPlot)
-    .map((observation: ObservationResultsPayload): AdHocObservationResults => {
-      const { plantingSiteId } = observation;
-      const site = sites[plantingSiteId];
-      const species = speciesReverseMap([]);
-      const adHocPlot = observation.adHocPlot!;
-      const timeZone = site.timeZone ?? defaultTimeZone;
-
-      const mergedStrata = mergeStrata(observation.strata, species, site.timeZone ?? defaultTimeZone);
-
-      return {
-        ...observation,
-        adHocPlot,
-        boundary: site.boundary,
-        plantingSiteName: site.name,
-        strata: mergedStrata,
-        plotName: adHocPlot.monitoringPlotName,
-        plotNumber: adHocPlot.monitoringPlotNumber,
-        timeZone,
-        totalLive: getObservationSpeciesLivePlantsCount(adHocPlot.species),
-        totalPlants: observation.strata.reduce((acc, curr) => acc + curr.totalPlants, 0),
-      };
-    });
 };
 
 export const getConditionString = (

--- a/src/types/Observations.ts
+++ b/src/types/Observations.ts
@@ -49,7 +49,7 @@ export type AdHocObservationResults = Omit<ObservationResultsPayload, 'strata' |
     plotNumber?: number;
     timeZone: string;
     totalLive: number | undefined;
-    totalPlants: number;
+    totalPlants: number | undefined;
   };
 
 export type ObservationResultsWithLastObv = Omit<


### PR DESCRIPTION
Some values in observation payloads that were previously not nullable
are now nullable, which caused types to not match what the application
code expects.

Luckily, most of the problems were in a couple of functions that
aren't used any more; remove them.