### PR TITLE
Cleanup Mixpanel instrumentation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import React, { type JSX, useEffect, useMemo, useState } from 'react';
-import { MixpanelProvider } from 'react-mixpanel-browser';
-import { useMixpanel } from 'react-mixpanel-browser';
+import { MixpanelProvider, useMixpanel } from 'react-mixpanel-browser';
 import { Provider } from 'react-redux';
 
 import { Box, CssBaseline, StyledEngineProvider, useTheme } from '@mui/material';
@@ -13,6 +12,7 @@ import TopBarContent from 'src/components/TopBar/TopBarContent';
 import BlockingSpinner from 'src/components/common/BlockingSpinner';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import { useAppVersion } from 'src/hooks/useAppVersion';
+import { MixpanelUserProfile } from 'src/mixpanelEvents';
 import { useLocalization, useUser } from 'src/providers';
 import { store } from 'src/redux/store';
 import AcceleratorRouter from 'src/scenes/AcceleratorRouter';
@@ -27,6 +27,11 @@ import DisclaimerProvider from './providers/Disclaimer/Provider';
 import ApplicationPortalRouter from './scenes/ApplicationRouter/portal';
 
 // Mixpanel setup
+// The SDK initializes opted-out (no cookies, no localStorage, no network) until
+// the consent effect below flips it on. The track_pageview config auto-tracks
+// SPA route changes; the first pageview after consent is captured by an explicit
+// track_pageview() call once we opt in (the auto-pageview that fired during
+// init itself was dropped because we were still opted out at the time).
 const MIXPANEL_TOKEN = import.meta.env.PUBLIC_MIXPANEL_TOKEN;
 const MIXPANEL_CONFIG = {
   opt_out_persistence_by_default: true,
@@ -50,16 +55,28 @@ function AppContent() {
   useEffect(() => {
     if (user && mixpanel) {
       if (user.cookiesConsented === true) {
+        const profile: MixpanelUserProfile = {
+          $email: user.email,
+          $first_name: user.firstName,
+          $last_name: user.lastName,
+          $country_code: user.countryCode,
+          $timezone: user.timeZone,
+          locale: user.locale,
+          email_notifs_enabled: user.emailNotificationsEnabled,
+          user_type: user.userType,
+          global_roles: user.globalRoles,
+          is_internal_user: user.globalRoles.length > 0,
+        };
         mixpanel.opt_in_tracking();
         mixpanel.identify(user.id);
-        mixpanel.people.set({
-          $email: user.email,
-          $locale: user.locale,
-          $emailNotifsEnabled: user.emailNotificationsEnabled,
-          $countryCode: user.countryCode,
-        });
+        mixpanel.people.set(profile);
+        // Capture the current page: the auto-pageview from SDK init was dropped
+        // because we were opted out at the time. Subsequent SPA route changes
+        // are picked up by the track_pageview config now that we're opted in.
+        mixpanel.track_pageview();
       } else {
         mixpanel.opt_out_tracking();
+        mixpanel.reset();
       }
     }
   }, [user, mixpanel]);

--- a/src/hooks/useTrackEvent.ts
+++ b/src/hooks/useTrackEvent.ts
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+import { useMixpanel } from 'react-mixpanel-browser';
+
+import { MIXPANEL_EVENTS, MixpanelEventPropertyMap } from 'src/mixpanelEvents';
+import { useOrganization } from 'src/providers';
+
+// For events listed in MixpanelEventPropertyMap, properties are required and
+// type-checked against the event's declared shape. For events not listed there
+// (legacy events, or events whose shape is still being designed), properties are
+// optional and untyped.
+export type TrackEventFn = <E extends MIXPANEL_EVENTS>(
+  ...args: E extends keyof MixpanelEventPropertyMap
+    ? [event: E, properties: MixpanelEventPropertyMap[E]]
+    : [event: E, properties?: Record<string, unknown>]
+) => void;
+
+// Wraps mixpanel.track() with the organization context every event should carry,
+// so call sites only need to pass event-specific properties. Returns a stable
+// callback safe to include in useEffect / useCallback dependency arrays.
+//
+// Returns a no-op when the user has not consented to analytics cookies — the
+// underlying mixpanel instance is undefined in that case (see App.tsx consent
+// gate). Call sites do not need to guard.
+export const useTrackEvent = (): TrackEventFn => {
+  const mixpanel = useMixpanel();
+  const { selectedOrganization } = useOrganization();
+
+  return useCallback(
+    (event: MIXPANEL_EVENTS, properties?: Record<string, unknown>) => {
+      mixpanel?.track(event, {
+        organization_id: selectedOrganization?.id,
+        organization_role: selectedOrganization?.role,
+        ...properties,
+      });
+    },
+    [mixpanel, selectedOrganization]
+  ) as TrackEventFn;
+};

--- a/src/mixpanelEvents.ts
+++ b/src/mixpanelEvents.ts
@@ -1,4 +1,17 @@
+import { User } from 'src/types/User';
+
+// Event names follow the convention "<Domain> <Object> <Past-tense Verb>" for new
+// entries (e.g. "Accession Created", "Batch Withdrawn"). Past-tense encodes that
+// the action completed; the domain prefix groups events in the Mixpanel sidebar.
+//
+// Prefer adding new events to the Phase 1 section below over extending the legacy
+// section. Legacy events are kept to preserve historical data continuity.
+
 export enum MIXPANEL_EVENTS {
+  // ===========================================================================
+  // Legacy events (pre-convention) — Accelerator program, nav clicks, etc.
+  // Do not extend; add new events in the Phase 1 section below.
+  // ===========================================================================
   PART_EX_TO_DO_UPCOMING_VIEW_EVENT = 'To-Do/Upcoming View Event',
   PART_EX_TO_DO_UPCOMING_VIEW_DELIVERABLE = 'To-Do/Upcoming View Deliverable',
   TOP_BAR_HOME = 'Top Bar Home',
@@ -12,4 +25,69 @@ export enum MIXPANEL_EVENTS {
   PART_EX_DELIVERABLES_LIST_FILTER = 'Participant Deliverables List Filter Applied',
   CONSOLE_DELIVERABLES_LIST_FILTER = 'Console Deliverables List Filter Applied',
   SETTINGS_TAB = 'Settings Tab Click',
+
+  // ===========================================================================
+  // Phase 1 events — core Terraware workflows.
+  // Fire from successful API response paths (post-mutation), not from click handlers.
+  // ===========================================================================
+
+  // --- Seed bank ---
+  ACCESSION_CREATED = 'Accession Created',
+  ACCESSION_VIABILITY_TEST_RECORDED = 'Accession Viability Test Recorded',
+  ACCESSION_WITHDRAWN = 'Accession Withdrawn',
+
+  // --- Nursery / inventory ---
+  BATCH_CREATED = 'Batch Created',
+  BATCH_WITHDRAWN = 'Batch Withdrawn',
+  BATCH_QUANTITY_EDITED = 'Batch Quantity Edited',
+
+  // --- Planting & plants ---
+  PLANTING_SITE_CREATED = 'Planting Site Created',
+  PLANTING_SITE_PUBLISHED = 'Planting Site Published',
+  DELIVERY_RECORDED = 'Delivery Recorded',
+  SURVIVAL_RATE_VIEWED = 'Survival Rate Viewed',
+
+  // --- Observations ---
+  OBSERVATION_SCHEDULED = 'Observation Scheduled',
+  OBSERVATION_SUBMITTED = 'Observation Submitted',
+  SPECIES_MERGED = 'Species Merged',
+
+  // --- Organization & people ---
+  ORGANIZATION_CREATED = 'Organization Created',
+  USER_INVITED = 'User Invited',
+  USER_ROLE_UPDATED = 'User Role Updated',
+
+  // --- Reporting & exports ---
+  REPORT_VIEWED = 'Report Viewed',
+  REPORT_DOWNLOADED = 'Report Downloaded',
 }
+
+// Shape of the user profile written via mixpanel.people.set(). Keys prefixed with
+// `$` are Mixpanel reserved properties (they populate built-in profile fields,
+// filters, and dashboards); unprefixed keys are our custom properties.
+export type MixpanelUserProfile = {
+  $email: User['email'];
+  $first_name?: User['firstName'];
+  $last_name?: User['lastName'];
+  $country_code?: User['countryCode'];
+  $timezone?: User['timeZone'];
+  locale?: User['locale'];
+  email_notifs_enabled: User['emailNotificationsEnabled'];
+  user_type: User['userType'];
+  global_roles: User['globalRoles'];
+  is_internal_user: boolean;
+};
+
+// Per-event property shapes. Each event added here gets compile-time checking of
+// its property names + types at every track call site. Events NOT listed here
+// accept any Record<string, unknown> — useful for legacy events and as a fallback
+// while a new event is being designed. When instrumenting a Phase 1 event for the
+// first time, add its shape to this map.
+export type MixpanelEventPropertyMap = {
+  [MIXPANEL_EVENTS.ACCESSION_CREATED]: {
+    species_id?: number;
+    initial_state?: string;
+    has_photos: boolean;
+    has_project_assigned: boolean;
+  };
+};

--- a/src/scenes/AccessionsRouter/Accession2CreateView.tsx
+++ b/src/scenes/AccessionsRouter/Accession2CreateView.tsx
@@ -13,6 +13,8 @@ import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
 import { useProjects } from 'src/hooks/useProjects';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
+import { useTrackEvent } from 'src/hooks/useTrackEvent';
+import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useLocalization, useOrganization } from 'src/providers';
 import SeedBankService, { AccessionPostRequestBody } from 'src/services/SeedBankService';
 import strings from 'src/strings';
@@ -60,6 +62,7 @@ export default function CreateAccession(): JSX.Element | null {
   const [receivedDateError, setReceivedDateError] = useState<string>();
   const [photos, setPhotos] = useState<File[]>([]);
   const [isSaving, setIsSaving] = useState<boolean>(false);
+  const trackEvent = useTrackEvent();
 
   const onPhotosChanged = (photosList: File[]) => {
     setPhotos(photosList);
@@ -146,6 +149,13 @@ export default function CreateAccession(): JSX.Element | null {
     setIsSaving(true);
     const response = await SeedBankService.createAccession(record);
     if (response.requestSucceeded) {
+      trackEvent(MIXPANEL_EVENTS.ACCESSION_CREATED, {
+        species_id: record.speciesId,
+        initial_state: record.state,
+        has_photos: photos.length > 0,
+        has_project_assigned: record.projectId !== null && record.projectId !== undefined,
+      });
+
       if (photos.length) {
         // upload photos
         await SeedBankService.uploadAccessionPhotos(response.id, photos);


### PR DESCRIPTION
Fix broken user profile attributes and add additional params to the profile. Add useTrackEvent hook to be able to include some context with every event and add type security.

So far only one event is wired up using the new hook/properties. We will test with this event on staging and then add additional events if things look good.

co-authored by Claude