### PR TITLE
Rename old Mixpanel events and use new hook

### DIFF
--- a/src/components/DeliverablesTable/index.tsx
+++ b/src/components/DeliverablesTable/index.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useMixpanel } from 'react-mixpanel-browser';
 
 import { TableColumnType } from '@terraware/web-components';
 
 import { FilterConfig, FilterConfigWithValues } from 'src/components/common/SearchFiltersWrapperV2';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
+import { useTrackEvent } from 'src/hooks/useTrackEvent';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useLocalization, useOrganization, useUser } from 'src/providers';
 import { requestListDeliverables } from 'src/redux/features/deliverables/deliverablesAsyncThunks';
@@ -130,7 +130,7 @@ const DeliverablesTable = ({
   const projectParam = query.get('projectId');
   const navigate = useSyncNavigate();
   const location = useStateLocation();
-  const mixpanel = useMixpanel();
+  const trackEvent = useTrackEvent();
 
   const fuzzySearchColumns = useMemo(
     () => (isAcceleratorRoute ? ['name', 'projectDealName'] : ['name', 'projectName']),
@@ -255,14 +255,14 @@ const DeliverablesTable = ({
   const ofFilterAppliedHandler = (filter?: string, values?: (string | number | null)[]) => {
     if (values && values.length) {
       if ((filter === 'status' || filter === 'category') && isAcceleratorRoute) {
-        mixpanel?.track(MIXPANEL_EVENTS.CONSOLE_DELIVERABLES_LIST_FILTER, {
+        trackEvent(MIXPANEL_EVENTS.CONSOLE_DELIVERABLES_FILTER_APPLIED, {
           filter,
           values,
         });
         return;
       }
       if (!isAcceleratorRoute) {
-        mixpanel?.track(MIXPANEL_EVENTS.PART_EX_DELIVERABLES_LIST_FILTER, {
+        trackEvent(MIXPANEL_EVENTS.PARTICIPANT_DELIVERABLES_FILTER_APPLIED, {
           filter,
           values,
         });

--- a/src/components/ModuleDetailsCard/index.tsx
+++ b/src/components/ModuleDetailsCard/index.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode, useMemo } from 'react';
-import { useMixpanel } from 'react-mixpanel-browser';
 
 import { Box, Card, Grid, Typography, useTheme } from '@mui/material';
 import { Button } from '@terraware/web-components';
@@ -8,6 +7,7 @@ import { DateTime } from 'luxon';
 
 import Link from 'src/components/common/Link';
 import useNavigateTo from 'src/hooks/useNavigateTo';
+import { useTrackEvent } from 'src/hooks/useTrackEvent';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useLocalization } from 'src/providers';
 import strings from 'src/strings';
@@ -107,7 +107,7 @@ const ModuleDetailsCard = ({
 }: ModuleDetailsCardProp) => {
   const { activeLocale } = useLocalization();
   const theme = useTheme();
-  const mixpanel = useMixpanel();
+  const trackEvent = useTrackEvent();
 
   const { goToModuleContent } = useNavigateTo();
 
@@ -267,7 +267,7 @@ const ModuleDetailsCard = ({
               <Link
                 fontSize='16px'
                 onClick={() => {
-                  mixpanel?.track(MIXPANEL_EVENTS.ACCELERATOR_MDDULE_ADDITIONAL_LINK, {
+                  trackEvent(MIXPANEL_EVENTS.ACCELERATOR_MODULE_ADDITIONAL_LINK_CLICKED, {
                     type: content.type,
                     moduleId: module.id,
                   });

--- a/src/components/TopBar/TopBarContent.tsx
+++ b/src/components/TopBar/TopBarContent.tsx
@@ -18,6 +18,7 @@ import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import useApplicationPortal from 'src/hooks/useApplicationPortal';
 import useFunderPortal from 'src/hooks/useFunderPortal';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
+import { useTrackEvent } from 'src/hooks/useTrackEvent';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useOrganization, useUser, useUserFundingEntity } from 'src/providers/hooks';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
@@ -40,6 +41,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
   const { isApplicationPortal } = useApplicationPortal();
   const { isFunderRoute } = useFunderPortal();
   const mixpanel = useMixpanel();
+  const trackEvent = useTrackEvent();
 
   const logoStyles = {
     width: 137,
@@ -71,7 +73,7 @@ export default function TopBarContent(props: TopBarProps): JSX.Element | null {
   };
 
   const handleTopBarClick = () => {
-    mixpanel?.track(MIXPANEL_EVENTS.TOP_BAR_HOME);
+    trackEvent(MIXPANEL_EVENTS.TOP_BAR_HOME_CLICKED);
     navigate(APP_PATHS.HOME);
   };
 

--- a/src/mixpanelEvents.ts
+++ b/src/mixpanelEvents.ts
@@ -1,36 +1,12 @@
 import { User } from 'src/types/User';
 
-// Event names follow the convention "<Domain> <Object> <Past-tense Verb>" for new
-// entries (e.g. "Accession Created", "Batch Withdrawn"). Past-tense encodes that
-// the action completed; the domain prefix groups events in the Mixpanel sidebar.
-//
-// Prefer adding new events to the Phase 1 section below over extending the legacy
-// section. Legacy events are kept to preserve historical data continuity.
+// Event names follow the convention "<Domain> <Object> <Past-tense Verb>"
+// (e.g. "Accession Created", "Batch Withdrawn"). Past-tense encodes that the
+// action completed; the domain prefix groups events in the Mixpanel sidebar.
+// Fire events from successful API response paths or completed user actions,
+// not from click handlers that may not result in a meaningful state change.
 
 export enum MIXPANEL_EVENTS {
-  // ===========================================================================
-  // Legacy events (pre-convention) — Accelerator program, nav clicks, etc.
-  // Do not extend; add new events in the Phase 1 section below.
-  // ===========================================================================
-  PART_EX_TO_DO_UPCOMING_VIEW_EVENT = 'To-Do/Upcoming View Event',
-  PART_EX_TO_DO_UPCOMING_VIEW_DELIVERABLE = 'To-Do/Upcoming View Deliverable',
-  TOP_BAR_HOME = 'Top Bar Home',
-  PART_EX_LEFT_NAV_DELIVERABLES = 'Participant Deliverables Nav Click',
-  PART_EX_LEFT_NAV_MODULES = 'Participant Modules Nav Click',
-  CONSOLE_LEFT_NAV_DELIVERABLES = 'Console Deliverables Nav Click',
-  ACCELERATOR_MDDULE_SESSION_EVENT_LINK = 'Accelerator Module Session Event Click',
-  ACCELERATOR_MDDULE_ADDITIONAL_LINK = 'Accelerator Modules Additional Link Click',
-  HOME_ACCELERATOR_APPLY_BUTTON = 'Apply to Accelerator Click',
-  HOME_ACCELERATOR_TF_LINK = 'Accelerator TF Link Click',
-  PART_EX_DELIVERABLES_LIST_FILTER = 'Participant Deliverables List Filter Applied',
-  CONSOLE_DELIVERABLES_LIST_FILTER = 'Console Deliverables List Filter Applied',
-  SETTINGS_TAB = 'Settings Tab Click',
-
-  // ===========================================================================
-  // Phase 1 events — core Terraware workflows.
-  // Fire from successful API response paths (post-mutation), not from click handlers.
-  // ===========================================================================
-
   // --- Seed bank ---
   ACCESSION_CREATED = 'Accession Created',
   ACCESSION_VIABILITY_TEST_RECORDED = 'Accession Viability Test Recorded',
@@ -60,6 +36,27 @@ export enum MIXPANEL_EVENTS {
   // --- Reporting & exports ---
   REPORT_VIEWED = 'Report Viewed',
   REPORT_DOWNLOADED = 'Report Downloaded',
+
+  // --- Accelerator program (top-level CTAs and module interactions) ---
+  ACCELERATOR_APPLY_BUTTON_CLICKED = 'Accelerator Apply Button Clicked',
+  ACCELERATOR_TF_LINK_CLICKED = 'Accelerator TF Link Clicked',
+  ACCELERATOR_MODULE_SESSION_EVENT_LINK_CLICKED = 'Accelerator Module Session Event Link Clicked',
+  ACCELERATOR_MODULE_ADDITIONAL_LINK_CLICKED = 'Accelerator Module Additional Link Clicked',
+
+  // --- Accelerator: Participant (forester) views ---
+  PARTICIPANT_TODO_EVENT_VIEWED = 'Participant To-Do Event Viewed',
+  PARTICIPANT_TODO_DELIVERABLE_VIEWED = 'Participant To-Do Deliverable Viewed',
+  PARTICIPANT_DELIVERABLES_NAV_CLICKED = 'Participant Deliverables Nav Clicked',
+  PARTICIPANT_MODULES_NAV_CLICKED = 'Participant Modules Nav Clicked',
+  PARTICIPANT_DELIVERABLES_FILTER_APPLIED = 'Participant Deliverables Filter Applied',
+
+  // --- Accelerator: Console (admin) views ---
+  CONSOLE_DELIVERABLES_NAV_CLICKED = 'Console Deliverables Nav Clicked',
+  CONSOLE_DELIVERABLES_FILTER_APPLIED = 'Console Deliverables Filter Applied',
+
+  // --- Generic UI / Navigation ---
+  TOP_BAR_HOME_CLICKED = 'Top Bar Home Clicked',
+  SETTINGS_TAB_CLICKED = 'Settings Tab Clicked',
 }
 
 // Shape of the user profile written via mixpanel.people.set(). Keys prefixed with

--- a/src/scenes/AcceleratorRouter/NavBar.tsx
+++ b/src/scenes/AcceleratorRouter/NavBar.tsx
@@ -1,5 +1,4 @@
 import React, { type JSX } from 'react';
-import { useMixpanel } from 'react-mixpanel-browser';
 import { useMatch } from 'react-router';
 
 import { NavSection } from '@terraware/web-components';
@@ -10,6 +9,7 @@ import NavItem from 'src/components/common/Navbar/NavItem';
 import Navbar from 'src/components/common/Navbar/Navbar';
 import { APP_PATHS } from 'src/constants';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
+import { useTrackEvent } from 'src/hooks/useTrackEvent';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useUser } from 'src/providers';
 import strings from 'src/strings';
@@ -23,7 +23,7 @@ export default function NavBar({ backgroundTransparent, setShowNavBar }: NavBarP
   const { isDesktop } = useDeviceInfo();
   const navigate = useSyncNavigate();
   const { isAllowed } = useUser();
-  const mixpanel = useMixpanel();
+  const trackEvent = useTrackEvent();
 
   const isActivityLogRoute = useMatch({ path: APP_PATHS.ACCELERATOR_ACTIVITY_LOG + '/', end: false });
   const isApplicationRoute = useMatch({ path: APP_PATHS.ACCELERATOR_APPLICATIONS, end: false });
@@ -85,7 +85,7 @@ export default function NavBar({ backgroundTransparent, setShowNavBar }: NavBarP
         id='deliverables'
         label={strings.DELIVERABLES}
         onClick={() => {
-          mixpanel?.track(MIXPANEL_EVENTS.CONSOLE_LEFT_NAV_DELIVERABLES);
+          trackEvent(MIXPANEL_EVENTS.CONSOLE_DELIVERABLES_NAV_CLICKED);
           closeAndNavigateTo(APP_PATHS.ACCELERATOR_DELIVERABLES);
         }}
         selected={!!isDeliverablesRoute}

--- a/src/scenes/Home/OnboardingHomeView/index.tsx
+++ b/src/scenes/Home/OnboardingHomeView/index.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useMixpanel } from 'react-mixpanel-browser';
 
 import { Box, Container, Grid, Typography } from '@mui/material';
 import { IconName } from '@terraware/web-components';
@@ -10,6 +9,7 @@ import Link from 'src/components/common/Link';
 import TfMain from 'src/components/common/TfMain';
 import { ACCELERATOR_LINK, APP_PATHS } from 'src/constants';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
+import { useTrackEvent } from 'src/hooks/useTrackEvent';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useOrganization, useUser } from 'src/providers';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
@@ -27,7 +27,7 @@ const OnboardingHomeView = () => {
   const { user } = useUser();
   const { selectedOrganization, orgPreferences, reloadOrgPreferences } = useOrganization();
   const { isMobile, isDesktop } = useDeviceInfo();
-  const mixpanel = useMixpanel();
+  const trackEvent = useTrackEvent();
   const navigate = useSyncNavigate();
   const [people, setPeople] = useState<OrganizationUser[]>();
   const showAcceleratorCard = orgPreferences.showAcceleratorCard !== false;
@@ -185,7 +185,7 @@ const OnboardingHomeView = () => {
                                 fontWeight={400}
                                 target='_blank'
                                 onClick={() => {
-                                  mixpanel?.track(MIXPANEL_EVENTS.HOME_ACCELERATOR_TF_LINK);
+                                  trackEvent(MIXPANEL_EVENTS.ACCELERATOR_TF_LINK_CLICKED);
                                   window.open(ACCELERATOR_LINK, '_blank');
                                 }}
                                 style={{ verticalAlign: 'baseline' }}
@@ -203,7 +203,7 @@ const OnboardingHomeView = () => {
                       primaryButtonProps={{
                         label: strings.APPLY_TO_ACCELERATOR,
                         onClick: () => {
-                          mixpanel?.track(MIXPANEL_EVENTS.HOME_ACCELERATOR_APPLY_BUTTON);
+                          trackEvent(MIXPANEL_EVENTS.ACCELERATOR_APPLY_BUTTON_CLICKED);
                           setIsNewApplicationModalOpen(true);
                         },
                         type: 'productive',

--- a/src/scenes/Home/ParticipantHomeView/CurrentModule.tsx
+++ b/src/scenes/Home/ParticipantHomeView/CurrentModule.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo } from 'react';
-import { useMixpanel } from 'react-mixpanel-browser';
 
 import { DateTime } from 'luxon';
 
@@ -9,6 +8,7 @@ import useListProjectModules from 'src/hooks/useListProjectModules';
 import useNavigateTo from 'src/hooks/useNavigateTo';
 import useProjectModuleDeliverables from 'src/hooks/useProjectModuleDeliverables';
 import useProjectModuleEvents from 'src/hooks/useProjectModuleEvents';
+import { useTrackEvent } from 'src/hooks/useTrackEvent';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useLocalization } from 'src/providers';
 import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
@@ -27,7 +27,7 @@ const ModuleDetailsCardWrapper = ({ moduleId, project }: ModuleDetailsCardWrappe
   const { getProjectModule, projectModule } = useGetProjectModule();
   const { deliverables, listProjectModuleDeliverables } = useProjectModuleDeliverables();
   const { events, listProjectModuleEvents } = useProjectModuleEvents();
-  const mixpanel = useMixpanel();
+  const trackEvent = useTrackEvent();
 
   useEffect(() => {
     if (project.id) {
@@ -52,14 +52,14 @@ const ModuleDetailsCardWrapper = ({ moduleId, project }: ModuleDetailsCardWrappe
       events?.map((event) => ({
         ...event,
         onClick: () => {
-          mixpanel?.track(MIXPANEL_EVENTS.ACCELERATOR_MDDULE_SESSION_EVENT_LINK, {
+          trackEvent(MIXPANEL_EVENTS.ACCELERATOR_MODULE_SESSION_EVENT_LINK_CLICKED, {
             eventId: event.id,
             type: event.type,
           });
           goToModuleEventSession(project.id, moduleId, event.id);
         },
       })),
-    [events, goToModuleEventSession, project, moduleId, mixpanel]
+    [events, goToModuleEventSession, project, moduleId, trackEvent]
   );
 
   const moduleDetails = useMemo(

--- a/src/scenes/Home/ParticipantHomeView/ToDoCta.tsx
+++ b/src/scenes/Home/ParticipantHomeView/ToDoCta.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { useCallback } from 'react';
-import { useMixpanel } from 'react-mixpanel-browser';
 
 import { Button } from '@terraware/web-components';
 import { useDeviceInfo } from '@terraware/web-components/utils';
 
 import useNavigateTo from 'src/hooks/useNavigateTo';
+import { useTrackEvent } from 'src/hooks/useTrackEvent';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import strings from 'src/strings';
 import { DeliverableToDoItem } from 'src/types/DeliverableToDoItem';
@@ -21,7 +21,7 @@ const ToDoCta = ({ toDo }: ToDoCtaProps) => {
   const { projectId } = useToDoData();
   const { goToDeliverable, goToModuleEventSession } = useNavigateTo();
   const { isMobile } = useDeviceInfo();
-  const mixpanel = useMixpanel();
+  const trackEvent = useTrackEvent();
 
   const handleOnClick = useCallback(() => {
     if (projectId === -1) {
@@ -34,7 +34,7 @@ const ToDoCta = ({ toDo }: ToDoCtaProps) => {
       case 'Recorded Session': {
         const event = toDo as EventToDoItem;
 
-        mixpanel?.track(MIXPANEL_EVENTS.PART_EX_TO_DO_UPCOMING_VIEW_EVENT, {
+        trackEvent(MIXPANEL_EVENTS.PARTICIPANT_TODO_EVENT_VIEWED, {
           id: event.id,
           type: event.type,
           status: event.status,
@@ -44,7 +44,7 @@ const ToDoCta = ({ toDo }: ToDoCtaProps) => {
       }
       case 'Deliverable': {
         const deliverable = toDo as DeliverableToDoItem;
-        mixpanel?.track(MIXPANEL_EVENTS.PART_EX_TO_DO_UPCOMING_VIEW_DELIVERABLE, {
+        trackEvent(MIXPANEL_EVENTS.PARTICIPANT_TODO_DELIVERABLE_VIEWED, {
           id: deliverable.id,
           type: deliverable.type,
           category: deliverable.category,
@@ -54,7 +54,7 @@ const ToDoCta = ({ toDo }: ToDoCtaProps) => {
         return goToDeliverable(deliverable.id, deliverable.projectId);
       }
     }
-  }, [goToDeliverable, goToModuleEventSession, projectId, toDo, mixpanel]);
+  }, [goToDeliverable, goToModuleEventSession, projectId, toDo, trackEvent]);
 
   return (
     <Button

--- a/src/scenes/Home/TerrawareHomeView/index.tsx
+++ b/src/scenes/Home/TerrawareHomeView/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useMixpanel } from 'react-mixpanel-browser';
 
 import { Box, Container, Grid, Typography } from '@mui/material';
 import { IconName } from '@terraware/web-components';
@@ -15,6 +14,7 @@ import { useOrgNurserySummary } from 'src/hooks/useOrgNurserySummary';
 import useOrganizationFeatures from 'src/hooks/useOrganizationFeatures';
 import { useSeedBankSummary } from 'src/hooks/useSeedBankSummary';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
+import { useTrackEvent } from 'src/hooks/useTrackEvent';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useLocalization, useOrganization, useUser } from 'src/providers';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
@@ -37,7 +37,7 @@ const TerrawareHomeView = () => {
   const { user } = useUser();
   const { selectedOrganization, orgPreferences, reloadOrgPreferences } = useOrganization();
   const { isTablet, isMobile, isDesktop } = useDeviceInfo();
-  const mixpanel = useMixpanel();
+  const trackEvent = useTrackEvent();
   const navigate = useSyncNavigate();
   const { goToNewAccession } = useNavigateTo();
   const { species } = useSpeciesData();
@@ -304,7 +304,7 @@ const TerrawareHomeView = () => {
                                 fontWeight={400}
                                 target='_blank'
                                 onClick={() => {
-                                  mixpanel?.track(MIXPANEL_EVENTS.HOME_ACCELERATOR_TF_LINK);
+                                  trackEvent(MIXPANEL_EVENTS.ACCELERATOR_TF_LINK_CLICKED);
                                   window.open(ACCELERATOR_LINK, '_blank');
                                 }}
                                 style={{ verticalAlign: 'baseline' }}
@@ -322,7 +322,7 @@ const TerrawareHomeView = () => {
                       primaryButtonProps={{
                         label: strings.APPLY_TO_ACCELERATOR,
                         onClick: () => {
-                          mixpanel?.track(MIXPANEL_EVENTS.HOME_ACCELERATOR_APPLY_BUTTON);
+                          trackEvent(MIXPANEL_EVENTS.ACCELERATOR_APPLY_BUTTON_CLICKED);
                           setIsNewApplicationModalOpen(true);
                         },
                         type: 'productive',
@@ -402,7 +402,7 @@ const TerrawareHomeView = () => {
                           fontSize='16px'
                           target='_blank'
                           onClick={() => {
-                            mixpanel?.track(MIXPANEL_EVENTS.HOME_ACCELERATOR_TF_LINK);
+                            trackEvent(MIXPANEL_EVENTS.ACCELERATOR_TF_LINK_CLICKED);
                             window.open(ACCELERATOR_LINK, '_blank');
                           }}
                         >
@@ -413,7 +413,7 @@ const TerrawareHomeView = () => {
                       linkText={strings.START_NEW_APPLICATION}
                       linkStyle={'button-primary'}
                       onClick={() => {
-                        mixpanel?.track(MIXPANEL_EVENTS.HOME_ACCELERATOR_APPLY_BUTTON);
+                        trackEvent(MIXPANEL_EVENTS.ACCELERATOR_APPLY_BUTTON_CLICKED);
                         setIsNewApplicationModalOpen(true);
                       }}
                     />

--- a/src/scenes/ModulesRouter/ModuleView.tsx
+++ b/src/scenes/ModulesRouter/ModuleView.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo } from 'react';
-import { useMixpanel } from 'react-mixpanel-browser';
 import { useParams } from 'react-router';
 
 import { DateTime } from 'luxon';
@@ -12,6 +11,7 @@ import useGetProjectModule from 'src/hooks/useGetProjectModule';
 import useNavigateTo from 'src/hooks/useNavigateTo';
 import useProjectModuleDeliverables from 'src/hooks/useProjectModuleDeliverables';
 import useProjectModuleEvents from 'src/hooks/useProjectModuleEvents';
+import { useTrackEvent } from 'src/hooks/useTrackEvent';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useLocalization } from 'src/providers';
 import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
@@ -27,7 +27,7 @@ const ModuleView = () => {
   const pathParams = useParams<{ sessionId: string; moduleId: string; projectId: string }>();
   const projectId = Number(pathParams.projectId);
   const moduleId = Number(pathParams.moduleId);
-  const mixpanel = useMixpanel();
+  const trackEvent = useTrackEvent();
 
   useEffect(() => {
     if (projectId) {
@@ -62,14 +62,14 @@ const ModuleView = () => {
       events?.map((event) => ({
         ...event,
         onClick: () => {
-          mixpanel?.track(MIXPANEL_EVENTS.ACCELERATOR_MDDULE_SESSION_EVENT_LINK, {
+          trackEvent(MIXPANEL_EVENTS.ACCELERATOR_MODULE_SESSION_EVENT_LINK_CLICKED, {
             eventId: event.id,
             type: event.type,
           });
           goToModuleEventSession(projectId, moduleId, event.id);
         },
       })),
-    [events, goToModuleEventSession, projectId, mixpanel, moduleId]
+    [events, goToModuleEventSession, projectId, trackEvent, moduleId]
   );
 
   const moduleDetails = useMemo(

--- a/src/scenes/OrgRouter/NavBar.tsx
+++ b/src/scenes/OrgRouter/NavBar.tsx
@@ -1,5 +1,4 @@
 import React, { type JSX, useCallback, useEffect, useMemo } from 'react';
-import { useMixpanel } from 'react-mixpanel-browser';
 import { useMatch } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
@@ -17,6 +16,7 @@ import isEnabled from 'src/features';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import useOrganizationFeatures from 'src/hooks/useOrganizationFeatures';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
+import { useTrackEvent } from 'src/hooks/useTrackEvent';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 import { useLocalization, useOrganization, useUser } from 'src/providers/hooks';
@@ -40,7 +40,7 @@ export default function NavBar({
   const theme = useTheme();
   const { isDesktop, isMobile } = useDeviceInfo();
   const navigate = useSyncNavigate();
-  const mixpanel = useMixpanel();
+  const trackEvent = useTrackEvent();
 
   const orgFeatures = useOrganizationFeatures();
 
@@ -149,7 +149,7 @@ export default function NavBar({
           icon='iconSubmit'
           selected={!!isDeliverablesRoute}
           onClick={() => {
-            mixpanel?.track(MIXPANEL_EVENTS.PART_EX_LEFT_NAV_DELIVERABLES);
+            trackEvent(MIXPANEL_EVENTS.PARTICIPANT_DELIVERABLES_NAV_CLICKED);
             closeAndNavigateTo(isDeliverablesRoute && !isDeliverableViewRoute ? '' : APP_PATHS.DELIVERABLES);
           }}
           id='deliverables'
@@ -159,7 +159,7 @@ export default function NavBar({
       orgFeatures?.deliverables?.enabled,
       strings.DELIVERABLES,
       isDeliverablesRoute,
-      mixpanel,
+      trackEvent,
       closeAndNavigateTo,
       isDeliverableViewRoute,
     ]
@@ -215,7 +215,7 @@ export default function NavBar({
           label={strings.MODULES}
           selected={!!isProjectModulesRoute}
           onClick={() => {
-            mixpanel?.track(MIXPANEL_EVENTS.PART_EX_LEFT_NAV_MODULES);
+            trackEvent(MIXPANEL_EVENTS.PARTICIPANT_MODULES_NAV_CLICKED);
             closeAndNavigateTo(
               APP_PATHS.PROJECT_MODULES.replace(':projectId', currentAcceleratorProject.id.toString())
             );
@@ -227,7 +227,7 @@ export default function NavBar({
       closeAndNavigateTo,
       currentAcceleratorProject,
       isProjectModulesRoute,
-      mixpanel,
+      trackEvent,
       orgFeatures,
       selectedOrganization,
       strings.MODULES,

--- a/src/scenes/Settings/SettingsPage.tsx
+++ b/src/scenes/Settings/SettingsPage.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { useMixpanel } from 'react-mixpanel-browser';
 
 import { Box, useTheme } from '@mui/material';
 import { Button, DropdownItem, Tabs } from '@terraware/web-components';
@@ -10,6 +9,7 @@ import Page from 'src/components/Page';
 import OptionsMenu from 'src/components/common/OptionsMenu';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import TitleDescription from 'src/components/common/TitleDescription';
+import { useTrackEvent } from 'src/hooks/useTrackEvent';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useLocalization, useUser, useUserFundingEntity } from 'src/providers';
 import MyAccountForm from 'src/scenes/MyAccountRouter/MyAccountForm';
@@ -17,7 +17,7 @@ import useStickyTabs from 'src/utils/useStickyTabs';
 
 const SettingsPage = () => {
   const { activeLocale, strings } = useLocalization();
-  const mixpanel = useMixpanel();
+  const trackEvent = useTrackEvent();
   const theme = useTheme();
   const { user, reloadUser } = useUser();
   const { userFundingEntity } = useUserFundingEntity();
@@ -90,14 +90,14 @@ const SettingsPage = () => {
   const onChangeTabHandler = useCallback(
     (tab: string) => {
       if (tab !== 'my-account') {
-        mixpanel?.track(MIXPANEL_EVENTS.SETTINGS_TAB, {
+        trackEvent(MIXPANEL_EVENTS.SETTINGS_TAB_CLICKED, {
           tab,
         });
       }
       setIsEditingAccount(false);
       onChangeTab(tab);
     },
-    [mixpanel, onChangeTab]
+    [trackEvent, onChangeTab]
   );
 
   const onOptionItemClick = useCallback((optionItem: DropdownItem) => {


### PR DESCRIPTION
This brings our existing Mixpanel events up to speed with the cleanup in progress

co-authored by Claude