### PR TITLE
Add friction tracking mixpanel events

### DIFF
--- a/src/components/AddNewOrganizationModal.tsx
+++ b/src/components/AddNewOrganizationModal.tsx
@@ -7,6 +7,7 @@ import RegionSelector from 'src/components/RegionSelector';
 import TimeZoneSelector from 'src/components/TimeZoneSelector';
 import Button from 'src/components/common/button/Button';
 import { useTrackEvent } from 'src/hooks/useTrackEvent';
+import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useLocalization } from 'src/providers/hooks';
 import { OrganizationService } from 'src/services';
@@ -42,6 +43,7 @@ export default function AddNewOrganizationModal(props: AddNewOrganizationModalPr
   const theme = useTheme();
   const snackbar = useSnackbar();
   const trackEvent = useTrackEvent();
+  const markSubmitted = useTrackModalAbandonment('organization_create');
   const [nameError, setNameError] = useState('');
   const [timeZoneError, setTimeZoneError] = useState('');
   const [countryError, setCountryError] = useState('');
@@ -103,36 +105,48 @@ export default function AddNewOrganizationModal(props: AddNewOrganizationModalPr
 
   const saveOrganization = async () => {
     let hasErrors = false;
+    const fieldsWithErrors: string[] = [];
 
     if (newOrganization.name === '') {
       setNameError(strings.REQUIRED_FIELD);
+      fieldsWithErrors.push('name');
       hasErrors = true;
     }
 
     if (!newOrganization.timeZone) {
       setTimeZoneError(strings.REQUIRED_FIELD);
+      fieldsWithErrors.push('timeZone');
       hasErrors = true;
     }
 
     if (!newOrganization.countryCode) {
       setCountryError(strings.REQUIRED_FIELD);
+      fieldsWithErrors.push('countryCode');
       hasErrors = true;
     }
 
     if (hasStates && !newOrganization.countrySubdivisionCode) {
       setStateError(strings.REQUIRED_FIELD);
+      fieldsWithErrors.push('countrySubdivisionCode');
       hasErrors = true;
     }
 
     if (!newOrganization.organizationType) {
       setOrganizationTypeError(strings.REQUIRED_FIELD);
+      fieldsWithErrors.push('organizationType');
       hasErrors = true;
     } else if (newOrganization.organizationType === 'Other' && !newOrganization.organizationTypeDetails?.trim()) {
       setOrganizationTypeDetailsError(strings.REQUIRED_FIELD);
+      fieldsWithErrors.push('organizationTypeDetails');
       hasErrors = true;
     }
 
     if (hasErrors) {
+      trackEvent(MIXPANEL_EVENTS.FORM_VALIDATION_FAILED, {
+        form_name: 'organization_create',
+        error_count: fieldsWithErrors.length,
+        fields_with_errors: fieldsWithErrors,
+      });
       return;
     }
 
@@ -146,8 +160,10 @@ export default function AddNewOrganizationModal(props: AddNewOrganizationModalPr
         has_country_code: !!newOrganization.countryCode,
         num_managed_locations: selectedLocationTypes.length,
       });
+      markSubmitted();
       onSuccess(response.organization);
     } else {
+      trackEvent(MIXPANEL_EVENTS.SAVE_FAILED, { entity_type: 'organization' });
       snackbar.toastError(strings.GENERIC_ERROR, strings.ORGANIZATION_CREATE_FAILED);
     }
     onCancel();

--- a/src/components/BatchWithdrawFlow/index.tsx
+++ b/src/components/BatchWithdrawFlow/index.tsx
@@ -56,6 +56,25 @@ export default function BatchWithdrawFlow(props: BatchWithdrawFlowProps): JSX.El
   const [createBatchWithdrawal] = useCreateBatchWithdrawalMutation();
   const [uploadWithdrawalPhotos] = useUploadWithdrawalPhotoMutation();
 
+  // Funnel anchor: fires once when the flow mounts. Lets us measure overall
+  // funnel entry volume + segment by which page the user came from.
+  useEffect(() => {
+    trackEvent(MIXPANEL_EVENTS.BATCH_WITHDRAWAL_STARTED, {
+      batch_count: batchIds.length,
+      source_page: sourcePage,
+    });
+    // Intentionally empty dep array beyond trackEvent: we want this once per
+    // mount, not on every batchIds/sourcePage re-reference.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [trackEvent]);
+
+  // Funnel step marker: fires on each flowState change (including the initial
+  // 'purpose' on mount). Building a Mixpanel funnel on this event + `step`
+  // property shows drop-off between every step in the multi-step flow.
+  useEffect(() => {
+    trackEvent(MIXPANEL_EVENTS.BATCH_WITHDRAWAL_STEP_REACHED, { step: flowState });
+  }, [flowState, trackEvent]);
+
   useEffect(() => {
     if (selectedOrganization) {
       const populateBatches = async () => {
@@ -124,6 +143,11 @@ export default function BatchWithdrawFlow(props: BatchWithdrawFlowProps): JSX.El
       });
 
     if (record.batchWithdrawals.length === 0) {
+      trackEvent(MIXPANEL_EVENTS.FORM_VALIDATION_FAILED, {
+        form_name: 'batch_withdraw',
+        error_count: 1,
+        fields_with_errors: ['no_batches_selected'],
+      });
       snackbar.toastError(strings.NO_BATCHES_TO_WITHDRAW_FROM); // temporary until we have a solution from design
       return;
     }
@@ -167,6 +191,7 @@ export default function BatchWithdrawFlow(props: BatchWithdrawFlowProps): JSX.El
         onWithdrawSuccess(withdrawal);
       }
     } catch {
+      trackEvent(MIXPANEL_EVENTS.SAVE_FAILED, { entity_type: 'batch_withdrawal' });
       snackbar.toastError();
     }
   };

--- a/src/components/common/ImportModal.tsx
+++ b/src/components/common/ImportModal.tsx
@@ -3,6 +3,7 @@ import React, { type JSX, useEffect, useRef, useState } from 'react';
 import { Box, Typography, useTheme } from '@mui/material';
 
 import Link from 'src/components/common/Link';
+import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { useOrganization } from 'src/providers/hooks';
 import { ImportModuleResponsePayload } from 'src/services/ModuleService';
 import strings from 'src/strings';
@@ -90,6 +91,7 @@ export default function ImportSpeciesModal(props: ImportSpeciesModalProps): JSX.
   const [uploadId, setUploadId] = useState<number>();
   const theme = useTheme();
   const snackbar = useSnackbar();
+  const markSubmitted = useTrackModalAbandonment('import_modal');
 
   const spacingStyles = { marginRight: theme.spacing(2) };
 
@@ -162,6 +164,7 @@ export default function ImportSpeciesModal(props: ImportSpeciesModalProps): JSX.
       if (fileStatus.details.status === 'Invalid') {
         setError(getErrors());
       } else if (fileStatus.details.status === 'Completed') {
+        markSubmitted();
         setCompleted(true);
       }
     } else if (fileStatus?.details.status === 'Awaiting User Action') {
@@ -169,7 +172,7 @@ export default function ImportSpeciesModal(props: ImportSpeciesModalProps): JSX.
       clearUploadInterval();
       setWarning(true);
     }
-  }, [fileStatus, uploadInterval]);
+  }, [fileStatus, uploadInterval, markSubmitted]);
 
   const dropHandler = (event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -221,6 +224,7 @@ export default function ImportSpeciesModal(props: ImportSpeciesModalProps): JSX.
             onClose(false);
           } else {
             setLoading(false);
+            markSubmitted();
             setCompleted(true);
           }
         }

--- a/src/hooks/useTrackModalAbandonment.ts
+++ b/src/hooks/useTrackModalAbandonment.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
+
+import { useTrackEvent } from './useTrackEvent';
+
+// Fires MODAL_ABANDONED on the component's unmount unless the returned
+// markSubmitted() has been called first. Call markSubmitted() inside any
+// successful-save path so the resulting close/unmount is not counted as
+// abandonment. Closures of less than a second are skipped to filter out React
+// strict-mode double-mount in dev as well as no-op open/close interactions.
+//
+// Returns a stable callback safe to include in useCallback/useEffect deps.
+export const useTrackModalAbandonment = (modalName: string): (() => void) => {
+  const trackEvent = useTrackEvent();
+
+  // Refs so the unmount cleanup reads the latest values regardless of when
+  // the effect originally captured them.
+  const wasSubmittedRef = useRef(false);
+  const trackEventRef = useRef(trackEvent);
+  trackEventRef.current = trackEvent;
+  const modalNameRef = useRef(modalName);
+  modalNameRef.current = modalName;
+
+  useEffect(() => {
+    const mountTime = Date.now();
+    return () => {
+      if (wasSubmittedRef.current) {
+        return;
+      }
+      const timeOpenSeconds = Math.round((Date.now() - mountTime) / 1000);
+      if (timeOpenSeconds < 1) {
+        return;
+      }
+      trackEventRef.current(MIXPANEL_EVENTS.MODAL_ABANDONED, {
+        modal_name: modalNameRef.current,
+        time_open_seconds: timeOpenSeconds,
+      });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return useCallback(() => {
+    wasSubmittedRef.current = true;
+  }, []);
+};

--- a/src/mixpanelEvents.ts
+++ b/src/mixpanelEvents.ts
@@ -14,6 +14,8 @@ export enum MIXPANEL_EVENTS {
 
   // --- Nursery / inventory ---
   BATCH_CREATED = 'Batch Created',
+  BATCH_WITHDRAWAL_STARTED = 'Batch Withdrawal Started',
+  BATCH_WITHDRAWAL_STEP_REACHED = 'Batch Withdrawal Step Reached',
   BATCH_WITHDRAWN = 'Batch Withdrawn',
   BATCH_QUANTITY_EDITED = 'Batch Quantity Edited',
 
@@ -54,6 +56,11 @@ export enum MIXPANEL_EVENTS {
   // --- Generic UI / Navigation ---
   TOP_BAR_HOME_CLICKED = 'Top Bar Home Clicked',
   SETTINGS_TAB_CLICKED = 'Settings Tab Clicked',
+
+  // --- Friction / failure (Phase 2) ---
+  FORM_VALIDATION_FAILED = 'Form Validation Failed',
+  SAVE_FAILED = 'Save Failed',
+  MODAL_ABANDONED = 'Modal Abandoned',
 }
 
 // Shape of the user profile written via mixpanel.people.set(). Keys prefixed with
@@ -95,6 +102,13 @@ export type MixpanelEventPropertyMap = {
     species_id?: number;
     from_accession: boolean;
   };
+  [MIXPANEL_EVENTS.BATCH_WITHDRAWAL_STARTED]: {
+    batch_count: number;
+    source_page?: string;
+  };
+  [MIXPANEL_EVENTS.BATCH_WITHDRAWAL_STEP_REACHED]: {
+    step: string;
+  };
   [MIXPANEL_EVENTS.BATCH_WITHDRAWN]: {
     purpose: string;
     batch_count: number;
@@ -131,5 +145,18 @@ export type MixpanelEventPropertyMap = {
     report_type: string;
     format: string;
     row_count?: number;
+  };
+  [MIXPANEL_EVENTS.FORM_VALIDATION_FAILED]: {
+    form_name: string;
+    error_count: number;
+    fields_with_errors?: string[];
+  };
+  [MIXPANEL_EVENTS.SAVE_FAILED]: {
+    entity_type: string;
+    error_details?: string;
+  };
+  [MIXPANEL_EVENTS.MODAL_ABANDONED]: {
+    modal_name: string;
+    time_open_seconds: number;
   };
 };

--- a/src/scenes/AccessionsRouter/Accession2CreateView.tsx
+++ b/src/scenes/AccessionsRouter/Accession2CreateView.tsx
@@ -147,6 +147,19 @@ export default function CreateAccession(): JSX.Element | null {
 
   const saveAccession = async () => {
     if (hasErrors()) {
+      const missingFields = MANDATORY_FIELDS.filter((field: MandatoryField) => !record[field]);
+      const fieldsWithErrors: string[] = [...missingFields];
+      if (collectedDateError) {
+        fieldsWithErrors.push('collectedDate');
+      }
+      if (receivedDateError) {
+        fieldsWithErrors.push('receivedDate');
+      }
+      trackEvent(MIXPANEL_EVENTS.FORM_VALIDATION_FAILED, {
+        form_name: 'accession_create',
+        error_count: fieldsWithErrors.length,
+        fields_with_errors: fieldsWithErrors,
+      });
       setValidateFields(true);
       return;
     }
@@ -175,6 +188,7 @@ export default function CreateAccession(): JSX.Element | null {
         pathname: APP_PATHS.ACCESSIONS2_ITEM.replace(':accessionId', accessionId.toString()),
       });
     } catch {
+      trackEvent(MIXPANEL_EVENTS.SAVE_FAILED, { entity_type: 'accession' });
       snackbar.toastError();
     } finally {
       setIsSaving(false);

--- a/src/scenes/AccessionsRouter/edit/Accession2EditModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/Accession2EditModal.tsx
@@ -7,6 +7,7 @@ import { useDeviceInfo } from '@terraware/web-components/utils';
 import SelectPhotos from 'src/components/common/Photos/SelectPhotos';
 import ProgressCircle from 'src/components/common/ProgressCircle/ProgressCircle';
 import SpeciesSelector from 'src/components/common/SpeciesSelector';
+import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { useLocalization, useOrganization } from 'src/providers';
 import { useDeletePhotoMutation, useUploadPhotoMutation } from 'src/queries/generated/accessionsV1';
 import AccessionService from 'src/services/AccessionService';
@@ -57,6 +58,7 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
   const [photoFilenamesToRemove, setPhotoFilenamesToRemove] = useState<string[]>([]);
   const [uploadPhoto] = useUploadPhotoMutation();
   const [deletePhoto] = useDeletePhotoMutation();
+  const markSubmitted = useTrackModalAbandonment('accession_edit');
 
   const onPhotosChanged = (photosList: File[]) => {
     setNewPhotos(photosList);
@@ -113,6 +115,7 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
       setLoading(true);
       const response = await AccessionService.updateAccession(record);
       if (response.requestSucceeded && accession) {
+        markSubmitted();
         await updatePhotos();
         reload();
         onCloseHandler();

--- a/src/scenes/AccessionsRouter/edit/EditLocationModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/EditLocationModal.tsx
@@ -4,6 +4,7 @@ import { Grid } from '@mui/material';
 
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
+import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
 import { SubLocationService } from 'src/services';
 import AccessionService from 'src/services/AccessionService';
@@ -35,6 +36,7 @@ export default function EditLocationModal(props: EditLocationModalProps): JSX.El
     : [];
   const [subLocations, setSubLocations] = useState<SubLocation[]>([]);
   const snackbar = useSnackbar();
+  const markSubmitted = useTrackModalAbandonment('accession_edit_location');
 
   const newRecord = {
     facilityId: accession.facilityId || 0,
@@ -68,6 +70,7 @@ export default function EditLocationModal(props: EditLocationModalProps): JSX.El
       ...record,
     });
     if (response.requestSucceeded) {
+      markSubmitted();
       reload();
       onClose();
     } else {

--- a/src/scenes/AccessionsRouter/edit/EditStateModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/EditStateModal.tsx
@@ -2,6 +2,7 @@ import React, { type JSX, useEffect, useState } from 'react';
 
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
+import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import AccessionService from 'src/services/AccessionService';
 import strings from 'src/strings';
 import { Accession } from 'src/types/Accession';
@@ -21,6 +22,7 @@ export default function EditStateModal(props: EditStateModalProps): JSX.Element 
   const { onClose, open, accession, reload } = props;
   const [record, setRecord, onChange] = useForm(accession);
   const [editUsedUpStatus] = useState<boolean>(accession.state === 'Used Up');
+  const markSubmitted = useTrackModalAbandonment('accession_edit_state');
 
   useEffect(() => {
     setRecord(accession);
@@ -30,6 +32,7 @@ export default function EditStateModal(props: EditStateModalProps): JSX.Element 
     if (record) {
       const response = await AccessionService.updateAccession(record);
       if (response.requestSucceeded) {
+        markSubmitted();
         reload();
       }
       onClose();

--- a/src/scenes/AccessionsRouter/edit/QuantityModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/QuantityModal.tsx
@@ -9,6 +9,7 @@ import ConvertedValue from 'src/components/ConvertedValue';
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Link from 'src/components/common/Link';
 import Button from 'src/components/common/button/Button';
+import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { useUser } from 'src/providers';
 import AccessionService from 'src/services/AccessionService';
 import strings from 'src/strings';
@@ -67,6 +68,7 @@ export default function QuantityModal(props: QuantityModalProps): JSX.Element {
   const [totalWeightError, setTotalWeightError] = useState('');
   const [remainingQuantityNotes, setRemainingQuantityNotes] = useState<string>('');
   const [remainingQuantityNotesError, setRemainingQuantityNotesError] = useState<boolean>(false);
+  const markSubmitted = useTrackModalAbandonment('accession_edit_quantity');
 
   const quantityChanged = useMemo(() => {
     if (!accession.remainingQuantity) {
@@ -134,6 +136,7 @@ export default function QuantityModal(props: QuantityModalProps): JSX.Element {
     }
     const response = await AccessionService.updateAccession(record, false, remainingQuantityNotes);
     if (response.requestSucceeded) {
+      markSubmitted();
       reload();
       onCloseHandler();
     } else {

--- a/src/scenes/AccessionsRouter/edit/ViabilityModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/ViabilityModal.tsx
@@ -7,6 +7,7 @@ import { preventDefaultEvent } from '@terraware/web-components/utils';
 import AddLink from 'src/components/common/AddLink';
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
+import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import AccessionService from 'src/services/AccessionService';
 import strings from 'src/strings';
 import { Accession } from 'src/types/Accession';
@@ -29,6 +30,7 @@ export default function ViabilityDialog(props: ViabilityDialogProps): JSX.Elemen
   const [record, setRecord, , onChangeCallback] = useForm(accession);
   const [error, setError] = useForm('');
   const snackbar = useSnackbar();
+  const markSubmitted = useTrackModalAbandonment('viability_edit_legacy');
 
   const saveQuantity = async () => {
     if (record.viabilityPercent) {
@@ -43,6 +45,7 @@ export default function ViabilityDialog(props: ViabilityDialogProps): JSX.Elemen
     setError('');
     const response = await AccessionService.updateAccession(record);
     if (response.requestSucceeded) {
+      markSubmitted();
       reload();
       onCloseHandler();
     } else {

--- a/src/scenes/AccessionsRouter/viabilityTesting/NewViabilityTestModal.tsx
+++ b/src/scenes/AccessionsRouter/viabilityTesting/NewViabilityTestModal.tsx
@@ -17,6 +17,7 @@ import TooltipLearnMoreModal, {
 import AddLink from 'src/components/common/AddLink';
 import DatePicker from 'src/components/common/DatePicker';
 import { useTrackEvent } from 'src/hooks/useTrackEvent';
+import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useOrganization } from 'src/providers/hooks';
 import { OrganizationUserService } from 'src/services';
@@ -49,6 +50,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
   const { selectedOrganization } = useOrganization();
   const trackEvent = useTrackEvent();
   const { onClose, open, accession, user, reload, viabilityTest } = props;
+  const markSubmitted = useTrackModalAbandonment(viabilityTest ? 'viability_test_edit' : 'viability_test_create');
 
   const [record, setRecord, onChange, onChangeCallback] = useForm(viabilityTest);
   const [users, setUsers] = useState<OrganizationUser[]>();
@@ -337,6 +339,10 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
   const saveTest = async () => {
     if (record) {
       if (hasErrors()) {
+        trackEvent(MIXPANEL_EVENTS.FORM_VALIDATION_FAILED, {
+          form_name: record.id === -1 ? 'viability_test_create' : 'viability_test_edit',
+          error_count: 1,
+        });
         setValidateFields(true);
         return;
       }
@@ -360,6 +366,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
             test_type: record.testType,
           });
         }
+        markSubmitted();
         reload();
         onCloseHandler();
         const cutTestEdited =
@@ -373,6 +380,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
           setOpenViabilityResultModal(true);
         }
       } else {
+        trackEvent(MIXPANEL_EVENTS.SAVE_FAILED, { entity_type: 'viability_test' });
         snackbar.toastError();
       }
     }

--- a/src/scenes/AccessionsRouter/withdraw/WithdrawModal.tsx
+++ b/src/scenes/AccessionsRouter/withdraw/WithdrawModal.tsx
@@ -9,6 +9,7 @@ import DatePicker from 'src/components/common/DatePicker';
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
 import { useTrackEvent } from 'src/hooks/useTrackEvent';
+import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
 import CountWithdrawal from 'src/scenes/AccessionsRouter/withdraw/CountWithdrawal';
@@ -42,6 +43,7 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
   const { selectedOrganization } = useOrganization();
   const { onClose, open, accession, reload, user } = props;
   const trackEvent = useTrackEvent();
+  const markSubmitted = useTrackModalAbandonment('accession_withdraw');
 
   const newViabilityTesting: ViabilityTestPostRequest = {
     testType: 'Lab',
@@ -247,10 +249,27 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
       let response;
       if (record) {
         if (isNurseryTransfer && nurseryTransferRecord.destinationFacilityId === -1) {
+          trackEvent(MIXPANEL_EVENTS.FORM_VALIDATION_FAILED, {
+            form_name: 'accession_withdraw',
+            error_count: 1,
+            fields_with_errors: ['destinationFacilityId'],
+          });
           setIndividualError('destinationFacilityId', strings.REQUIRED_FIELD);
           return;
         }
         if (fieldsErrors.date || (isNurseryTransfer && fieldsErrors.readyByDate)) {
+          const errored: string[] = [];
+          if (fieldsErrors.date) {
+            errored.push('date');
+          }
+          if (isNurseryTransfer && fieldsErrors.readyByDate) {
+            errored.push('readyByDate');
+          }
+          trackEvent(MIXPANEL_EVENTS.FORM_VALIDATION_FAILED, {
+            form_name: 'accession_withdraw',
+            error_count: errored.length,
+            fields_with_errors: errored,
+          });
           return;
         }
 
@@ -281,9 +300,11 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
             purpose: isNurseryTransfer ? 'Nursery' : record.purpose || 'Other',
             quantity: estimatedWithdrawalQty,
           });
+          markSubmitted();
           reload();
           onCloseHandler();
         } else {
+          trackEvent(MIXPANEL_EVENTS.SAVE_FAILED, { entity_type: 'accession_withdrawal' });
           snackbar.toastError();
         }
       }
@@ -301,6 +322,7 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
     onCloseHandler,
     record,
     reload,
+    markSubmitted,
     setIndividualError,
     snackbar,
     strings,

--- a/src/scenes/ApplicationRouter/NewApplicationModal.tsx
+++ b/src/scenes/ApplicationRouter/NewApplicationModal.tsx
@@ -8,6 +8,7 @@ import TextField from 'src/components/common/Textfield/Textfield';
 import Button from 'src/components/common/button/Button';
 import useNavigateTo from 'src/hooks/useNavigateTo';
 import { useProjects } from 'src/hooks/useProjects';
+import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { useLocalization, useOrganization } from 'src/providers';
 import {
   requestCreateApplication,
@@ -44,6 +45,7 @@ const NewApplicationModal = ({ open, onClose }: NewApplicationModalProps): JSX.E
   const dispatch = useAppDispatch();
   const { toastSuccess } = useSnackbar();
   const { goToApplication } = useNavigateTo();
+  const markSubmitted = useTrackModalAbandonment('application_create');
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [projectNameError, setProjectNameError] = useState<string>('');
@@ -164,11 +166,12 @@ const NewApplicationModal = ({ open, onClose }: NewApplicationModalProps): JSX.E
   const onApplicationCreated = useCallback(
     (applicationId: number) => {
       if (activeLocale) {
+        markSubmitted();
         toastSuccess(strings.SUCCESS);
       }
       goToApplication(applicationId);
     },
-    [activeLocale, goToApplication, toastSuccess]
+    [activeLocale, goToApplication, markSubmitted, toastSuccess]
   );
 
   useEffect(() => {

--- a/src/scenes/InventoryRouter/BatchDetailsModal.tsx
+++ b/src/scenes/InventoryRouter/BatchDetailsModal.tsx
@@ -8,6 +8,7 @@ import getDateDisplayValue from '@terraware/web-components/utils/date';
 import DatePicker from 'src/components/common/DatePicker';
 import SelectPhotos from 'src/components/common/Photos/SelectPhotos';
 import { useTrackEvent } from 'src/hooks/useTrackEvent';
+import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
 import { NurseryBatchService } from 'src/services';
@@ -41,6 +42,7 @@ export default function BatchDetailsModal({ batch, onClose, reload }: BatchDetai
   const numberFormatter = useNumberFormatter();
   const snackbar = useSnackbar();
   const trackEvent = useTrackEvent();
+  const markSubmitted = useTrackModalAbandonment('batch_details_edit');
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
 
@@ -179,6 +181,7 @@ export default function BatchDetailsModal({ batch, onClose, reload }: BatchDetai
 
       if (response.requestSucceeded && responseQuantities.requestSucceeded) {
         trackEvent(MIXPANEL_EVENTS.BATCH_QUANTITY_EDITED);
+        markSubmitted();
         await updatePhotos();
         reload();
         onCloseHandler();
@@ -186,7 +189,7 @@ export default function BatchDetailsModal({ batch, onClose, reload }: BatchDetai
         snackbar.toastError();
       }
     }
-  }, [record, hasErrors, updatePhotos, reload, onCloseHandler, snackbar, trackEvent]);
+  }, [record, hasErrors, updatePhotos, reload, onCloseHandler, snackbar, trackEvent, markSubmitted]);
 
   const handleSaveBatch = useCallback(() => {
     void saveBatch();

--- a/src/scenes/InventoryRouter/view/BatchDetailsModal.tsx
+++ b/src/scenes/InventoryRouter/view/BatchDetailsModal.tsx
@@ -2,6 +2,7 @@ import React, { type JSX, useCallback, useEffect, useState } from 'react';
 
 import { BusySpinner, Button, DialogBox } from '@terraware/web-components';
 
+import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { OriginPage } from 'src/scenes/InventoryRouter/InventoryBatchView';
 import BatchDetailsForm from 'src/scenes/InventoryRouter/form/BatchDetailsForm';
 import strings from 'src/strings';
@@ -23,6 +24,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
 
   const dispatch = useAppDispatch();
   const snackbar = useSnackbar();
+  const markSubmitted = useTrackModalAbandonment('batch_details_view');
 
   const [doValidateBatch, setDoValidateBatch] = useState<boolean>(false);
   const [requestId, setRequestId] = useState('');
@@ -48,6 +50,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
 
   useEffect(() => {
     if (batchesRequest?.status === 'success') {
+      markSubmitted();
       setBusy(false);
       reload();
       onClose();
@@ -56,7 +59,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
       snackbar.toastError(strings.GENERIC_ERROR);
       setDoValidateBatch(false);
     }
-  }, [batchesRequest, reload, onClose, snackbar]);
+  }, [batchesRequest, reload, onClose, snackbar, markSubmitted]);
 
   return (
     <>

--- a/src/scenes/InventoryRouter/view/ChangeQuantityModal.tsx
+++ b/src/scenes/InventoryRouter/view/ChangeQuantityModal.tsx
@@ -5,6 +5,7 @@ import { BusySpinner, Dropdown, Icon, Textfield } from '@terraware/web-component
 
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
+import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { NurseryBatchService } from 'src/services';
 import { ChangeBatchStatusesRequestPayload } from 'src/services/NurseryBatchService';
 import strings from 'src/strings';
@@ -30,6 +31,7 @@ export default function ChangeQuantityModal({
   const { type } = modalValues;
   const snackbar = useSnackbar();
   const numberFormatter = useNumberFormatter();
+  const markSubmitted = useTrackModalAbandonment('batch_quantity_change');
 
   const [nextPhase, setNextPhase] = useState<ChangeBatchStatusesRequestPayload['newPhase']>(
     type === 'germinating' ? 'ActiveGrowth' : type === 'active-growth' ? 'HardeningOff' : 'Ready'
@@ -109,6 +111,7 @@ export default function ChangeQuantityModal({
     setSaving(false);
 
     if (response.requestSucceeded) {
+      markSubmitted();
       if (reload) {
         reload();
       }
@@ -116,7 +119,7 @@ export default function ChangeQuantityModal({
     } else {
       snackbar.toastError();
     }
-  }, [movedValue, nextPhase, onCloseHandler, record, reload, row, snackbar, type]);
+  }, [markSubmitted, movedValue, nextPhase, onCloseHandler, record, reload, row, snackbar, type]);
 
   const onSave = useCallback(() => {
     void onSubmit();

--- a/src/scenes/NurseryRouter/PlantingSeasons/AddPlantingSeasonModal.tsx
+++ b/src/scenes/NurseryRouter/PlantingSeasons/AddPlantingSeasonModal.tsx
@@ -9,6 +9,7 @@ import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import TextField from 'src/components/common/Textfield/Textfield';
 import Button from 'src/components/common/button/Button';
 import useOrganizationPlantingSites from 'src/hooks/useOrganizationPlantingSites';
+import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { useLocalization, useOrganization } from 'src/providers';
 import {
   CreatePlantingSeasonRequestPayload,
@@ -34,6 +35,7 @@ const AddPlantingSeasonModal = ({ onClose, initialPlantingSiteId }: AddPlantingS
   const { plantingSites } = useOrganizationPlantingSites({ full: true });
   const snackbar = useSnackbar();
   const [createPlantingSeason, { isLoading }] = useCreatePlantingSeasonMutation();
+  const markSubmitted = useTrackModalAbandonment('planting_season_add');
 
   const [record, setRecord, onChange] = useForm<PlantingSeasonForm>({
     plantingSiteId: initialPlantingSiteId && initialPlantingSiteId > 0 ? initialPlantingSiteId : undefined,
@@ -121,6 +123,7 @@ const AddPlantingSeasonModal = ({ onClose, initialPlantingSiteId }: AddPlantingS
         plantingSiteId,
         startDate,
       }).unwrap();
+      markSubmitted();
       onClose();
     } catch (e) {
       snackbar.toastError();

--- a/src/scenes/NurseryRouter/PlantingSeasons/EditPlantingSeasonModal.tsx
+++ b/src/scenes/NurseryRouter/PlantingSeasons/EditPlantingSeasonModal.tsx
@@ -7,6 +7,7 @@ import DatePicker from 'src/components/common/DatePicker';
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import TextField from 'src/components/common/Textfield/Textfield';
 import Button from 'src/components/common/button/Button';
+import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { useOrganization } from 'src/providers';
 import { PlantingSeasonPayload, useUpdatePlantingSeasonMutation } from 'src/queries/generated/plantingSeasons';
 import { PlantingSitePayload } from 'src/queries/generated/plantingSites';
@@ -37,6 +38,7 @@ const EditPlantingSeasonModal = ({
   const defaultTimeZone = useDefaultTimeZone().get().id;
   const snackbar = useSnackbar();
   const [updatePlantingSeason, { isLoading }] = useUpdatePlantingSeasonMutation();
+  const markSubmitted = useTrackModalAbandonment('planting_season_edit');
 
   const [record, , onChange] = useForm<PlantingSeasonForm>({
     name: plantingSeason.name,
@@ -81,6 +83,7 @@ const EditPlantingSeasonModal = ({
           endDate,
         },
       }).unwrap();
+      markSubmitted();
       onClose();
     } catch (e) {
       snackbar.toastError();

--- a/src/scenes/PeopleRouter/NewPersonView.tsx
+++ b/src/scenes/PeopleRouter/NewPersonView.tsx
@@ -79,13 +79,24 @@ export default function PersonView(): JSX.Element {
 
   const saveUser = async () => {
     setPageError(undefined);
+    const formName = personSelectedToEdit ? 'person_edit' : 'person_invite';
 
     if (newPerson.email === '') {
+      trackEvent(MIXPANEL_EVENTS.FORM_VALIDATION_FAILED, {
+        form_name: formName,
+        error_count: 1,
+        fields_with_errors: ['email_empty'],
+      });
       setEmailError(strings.REQUIRED_FIELD);
       return;
     }
 
     if (!EMAIL_REGEX.test(newPerson.email)) {
+      trackEvent(MIXPANEL_EVENTS.FORM_VALIDATION_FAILED, {
+        form_name: formName,
+        error_count: 1,
+        fields_with_errors: ['email_format'],
+      });
       setEmailError(strings.INCORRECT_EMAIL_FORMAT);
       return;
     }
@@ -101,6 +112,8 @@ export default function PersonView(): JSX.Element {
       );
       if (response.requestSucceeded) {
         trackEvent(MIXPANEL_EVENTS.USER_ROLE_UPDATED, { new_role: newPerson.role });
+      } else {
+        trackEvent(MIXPANEL_EVENTS.SAVE_FAILED, { entity_type: 'user_role_update' });
       }
       successMessage = response.requestSucceeded ? strings.CHANGES_SAVED : null;
       userId = newPerson.id;
@@ -109,6 +122,10 @@ export default function PersonView(): JSX.Element {
         ...newPerson,
       });
       if (!response.requestSucceeded) {
+        trackEvent(MIXPANEL_EVENTS.SAVE_FAILED, {
+          entity_type: 'user_invitation',
+          error_details: response.errorDetails,
+        });
         if (response.errorDetails === 'PRE_EXISTING_USER') {
           setRepeatedEmail(newPerson.email);
           setPageError('REPEATED_EMAIL');


### PR DESCRIPTION
Add some Mixpanel instrumentation for behavioral friction signals, including:

- Batch Withdrawal Started & Batch Withdrawal Step Reached.
- Form Validation Failed and Save failures.
- Modal abandonment.

This doesn't include all modals. More will follow in a future PR.

Co-authored by Claude