### PR TITLE
Fix false-positive modal abandoned events

### DIFF
--- a/src/components/AddNewOrganizationModal.tsx
+++ b/src/components/AddNewOrganizationModal.tsx
@@ -43,7 +43,7 @@ export default function AddNewOrganizationModal(props: AddNewOrganizationModalPr
   const theme = useTheme();
   const snackbar = useSnackbar();
   const trackEvent = useTrackEvent();
-  const markSubmitted = useTrackModalAbandonment('organization_create');
+  const markSubmitted = useTrackModalAbandonment('organization_create', open);
   const [nameError, setNameError] = useState('');
   const [timeZoneError, setTimeZoneError] = useState('');
   const [countryError, setCountryError] = useState('');

--- a/src/components/common/ImportModal.tsx
+++ b/src/components/common/ImportModal.tsx
@@ -91,7 +91,7 @@ export default function ImportSpeciesModal(props: ImportSpeciesModalProps): JSX.
   const [uploadId, setUploadId] = useState<number>();
   const theme = useTheme();
   const snackbar = useSnackbar();
-  const markSubmitted = useTrackModalAbandonment('import_modal');
+  const markSubmitted = useTrackModalAbandonment('import_modal', open);
 
   const spacingStyles = { marginRight: theme.spacing(2) };
 

--- a/src/hooks/useTrackModalAbandonment.ts
+++ b/src/hooks/useTrackModalAbandonment.ts
@@ -4,41 +4,73 @@ import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 
 import { useTrackEvent } from './useTrackEvent';
 
-// Fires MODAL_ABANDONED on the component's unmount unless the returned
-// markSubmitted() has been called first. Call markSubmitted() inside any
-// successful-save path so the resulting close/unmount is not counted as
-// abandonment. Closures of less than a second are skipped to filter out React
-// strict-mode double-mount in dev as well as no-op open/close interactions.
+// Fires MODAL_ABANDONED when the modal was actually visible to the user and
+// then closed (or unmounted while open) without markSubmitted() being called
+// first. Call markSubmitted() inside any successful-save path so a successful
+// close is not counted as abandonment.
+//
+// `isOpen` is REQUIRED because most modals in this codebase stay mounted while
+// their parent route is rendered, with an `open` prop controlling visibility.
+// Without isOpen, the hook would fire false positives on every route
+// navigation that unmounts a modal the user never actually opened. For modals
+// that are conditionally rendered (only mounted while open), pass `true`.
+//
+// Closures shorter than a second are skipped to filter out React strict-mode
+// double-mount in dev and instant open/close interactions.
 //
 // Returns a stable callback safe to include in useCallback/useEffect deps.
-export const useTrackModalAbandonment = (modalName: string): (() => void) => {
+export const useTrackModalAbandonment = (modalName: string, isOpen: boolean): (() => void) => {
   const trackEvent = useTrackEvent();
 
   // Refs so the unmount cleanup reads the latest values regardless of when
   // the effect originally captured them.
-  const wasSubmittedRef = useRef(false);
   const trackEventRef = useRef(trackEvent);
   trackEventRef.current = trackEvent;
   const modalNameRef = useRef(modalName);
   modalNameRef.current = modalName;
 
-  useEffect(() => {
-    const mountTime = Date.now();
-    return () => {
-      if (wasSubmittedRef.current) {
-        return;
-      }
-      const timeOpenSeconds = Math.round((Date.now() - mountTime) / 1000);
-      if (timeOpenSeconds < 1) {
-        return;
-      }
-      trackEventRef.current(MIXPANEL_EVENTS.MODAL_ABANDONED, {
-        modal_name: modalNameRef.current,
-        time_open_seconds: timeOpenSeconds,
-      });
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+  // null = modal is not currently open; number = timestamp of when isOpen became true.
+  const openedAtRef = useRef<number | null>(null);
+  const wasSubmittedRef = useRef(false);
+
+  // Fires the abandonment event if the modal was open and not submitted.
+  // Always clears the session state regardless.
+  const fireAbandonment = useCallback(() => {
+    const openedAt = openedAtRef.current;
+    const wasSubmitted = wasSubmittedRef.current;
+    openedAtRef.current = null;
+    wasSubmittedRef.current = false;
+    if (openedAt === null || wasSubmitted) {
+      return;
+    }
+    const timeOpenSeconds = Math.round((Date.now() - openedAt) / 1000);
+    if (timeOpenSeconds < 1) {
+      return;
+    }
+    trackEventRef.current(MIXPANEL_EVENTS.MODAL_ABANDONED, {
+      modal_name: modalNameRef.current,
+      time_open_seconds: timeOpenSeconds,
+    });
   }, []);
+
+  // Track isOpen transitions. Each false → true starts a "session"; each
+  // true → false ends one and may emit MODAL_ABANDONED.
+  useEffect(() => {
+    if (isOpen && openedAtRef.current === null) {
+      openedAtRef.current = Date.now();
+      wasSubmittedRef.current = false;
+    } else if (!isOpen && openedAtRef.current !== null) {
+      fireAbandonment();
+    }
+  }, [isOpen, fireAbandonment]);
+
+  // Catch-all: fire on unmount if the modal was still open at unmount time
+  // (e.g., user navigated away with the modal open).
+  useEffect(() => {
+    return () => {
+      fireAbandonment();
+    };
+  }, [fireAbandonment]);
 
   return useCallback(() => {
     wasSubmittedRef.current = true;

--- a/src/scenes/AccessionsRouter/edit/Accession2EditModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/Accession2EditModal.tsx
@@ -58,7 +58,7 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
   const [photoFilenamesToRemove, setPhotoFilenamesToRemove] = useState<string[]>([]);
   const [uploadPhoto] = useUploadPhotoMutation();
   const [deletePhoto] = useDeletePhotoMutation();
-  const markSubmitted = useTrackModalAbandonment('accession_edit');
+  const markSubmitted = useTrackModalAbandonment('accession_edit', open);
 
   const onPhotosChanged = (photosList: File[]) => {
     setNewPhotos(photosList);

--- a/src/scenes/AccessionsRouter/edit/EditLocationModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/EditLocationModal.tsx
@@ -36,7 +36,7 @@ export default function EditLocationModal(props: EditLocationModalProps): JSX.El
     : [];
   const [subLocations, setSubLocations] = useState<SubLocation[]>([]);
   const snackbar = useSnackbar();
-  const markSubmitted = useTrackModalAbandonment('accession_edit_location');
+  const markSubmitted = useTrackModalAbandonment('accession_edit_location', open);
 
   const newRecord = {
     facilityId: accession.facilityId || 0,

--- a/src/scenes/AccessionsRouter/edit/EditStateModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/EditStateModal.tsx
@@ -22,7 +22,7 @@ export default function EditStateModal(props: EditStateModalProps): JSX.Element 
   const { onClose, open, accession, reload } = props;
   const [record, setRecord, onChange] = useForm(accession);
   const [editUsedUpStatus] = useState<boolean>(accession.state === 'Used Up');
-  const markSubmitted = useTrackModalAbandonment('accession_edit_state');
+  const markSubmitted = useTrackModalAbandonment('accession_edit_state', open);
 
   useEffect(() => {
     setRecord(accession);

--- a/src/scenes/AccessionsRouter/edit/QuantityModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/QuantityModal.tsx
@@ -68,7 +68,7 @@ export default function QuantityModal(props: QuantityModalProps): JSX.Element {
   const [totalWeightError, setTotalWeightError] = useState('');
   const [remainingQuantityNotes, setRemainingQuantityNotes] = useState<string>('');
   const [remainingQuantityNotesError, setRemainingQuantityNotesError] = useState<boolean>(false);
-  const markSubmitted = useTrackModalAbandonment('accession_edit_quantity');
+  const markSubmitted = useTrackModalAbandonment('accession_edit_quantity', open);
 
   const quantityChanged = useMemo(() => {
     if (!accession.remainingQuantity) {

--- a/src/scenes/AccessionsRouter/edit/ViabilityModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/ViabilityModal.tsx
@@ -30,7 +30,7 @@ export default function ViabilityDialog(props: ViabilityDialogProps): JSX.Elemen
   const [record, setRecord, , onChangeCallback] = useForm(accession);
   const [error, setError] = useForm('');
   const snackbar = useSnackbar();
-  const markSubmitted = useTrackModalAbandonment('viability_edit_legacy');
+  const markSubmitted = useTrackModalAbandonment('viability_edit_legacy', open);
 
   const saveQuantity = async () => {
     if (record.viabilityPercent) {

--- a/src/scenes/AccessionsRouter/viabilityTesting/NewViabilityTestModal.tsx
+++ b/src/scenes/AccessionsRouter/viabilityTesting/NewViabilityTestModal.tsx
@@ -50,7 +50,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
   const { selectedOrganization } = useOrganization();
   const trackEvent = useTrackEvent();
   const { onClose, open, accession, user, reload, viabilityTest } = props;
-  const markSubmitted = useTrackModalAbandonment(viabilityTest ? 'viability_test_edit' : 'viability_test_create');
+  const markSubmitted = useTrackModalAbandonment(viabilityTest ? 'viability_test_edit' : 'viability_test_create', open);
 
   const [record, setRecord, onChange, onChangeCallback] = useForm(viabilityTest);
   const [users, setUsers] = useState<OrganizationUser[]>();

--- a/src/scenes/AccessionsRouter/withdraw/WithdrawModal.tsx
+++ b/src/scenes/AccessionsRouter/withdraw/WithdrawModal.tsx
@@ -43,7 +43,7 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
   const { selectedOrganization } = useOrganization();
   const { onClose, open, accession, reload, user } = props;
   const trackEvent = useTrackEvent();
-  const markSubmitted = useTrackModalAbandonment('accession_withdraw');
+  const markSubmitted = useTrackModalAbandonment('accession_withdraw', open);
 
   const newViabilityTesting: ViabilityTestPostRequest = {
     testType: 'Lab',

--- a/src/scenes/ApplicationRouter/NewApplicationModal.tsx
+++ b/src/scenes/ApplicationRouter/NewApplicationModal.tsx
@@ -45,7 +45,7 @@ const NewApplicationModal = ({ open, onClose }: NewApplicationModalProps): JSX.E
   const dispatch = useAppDispatch();
   const { toastSuccess } = useSnackbar();
   const { goToApplication } = useNavigateTo();
-  const markSubmitted = useTrackModalAbandonment('application_create');
+  const markSubmitted = useTrackModalAbandonment('application_create', open);
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [projectNameError, setProjectNameError] = useState<string>('');

--- a/src/scenes/InventoryRouter/BatchDetailsModal.tsx
+++ b/src/scenes/InventoryRouter/BatchDetailsModal.tsx
@@ -42,7 +42,7 @@ export default function BatchDetailsModal({ batch, onClose, reload }: BatchDetai
   const numberFormatter = useNumberFormatter();
   const snackbar = useSnackbar();
   const trackEvent = useTrackEvent();
-  const markSubmitted = useTrackModalAbandonment('batch_details_edit');
+  const markSubmitted = useTrackModalAbandonment('batch_details_edit', true);
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
 

--- a/src/scenes/InventoryRouter/view/BatchDetailsModal.tsx
+++ b/src/scenes/InventoryRouter/view/BatchDetailsModal.tsx
@@ -24,7 +24,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
 
   const dispatch = useAppDispatch();
   const snackbar = useSnackbar();
-  const markSubmitted = useTrackModalAbandonment('batch_details_view');
+  const markSubmitted = useTrackModalAbandonment('batch_details_view', true);
 
   const [doValidateBatch, setDoValidateBatch] = useState<boolean>(false);
   const [requestId, setRequestId] = useState('');

--- a/src/scenes/InventoryRouter/view/ChangeQuantityModal.tsx
+++ b/src/scenes/InventoryRouter/view/ChangeQuantityModal.tsx
@@ -31,7 +31,7 @@ export default function ChangeQuantityModal({
   const { type } = modalValues;
   const snackbar = useSnackbar();
   const numberFormatter = useNumberFormatter();
-  const markSubmitted = useTrackModalAbandonment('batch_quantity_change');
+  const markSubmitted = useTrackModalAbandonment('batch_quantity_change', true);
 
   const [nextPhase, setNextPhase] = useState<ChangeBatchStatusesRequestPayload['newPhase']>(
     type === 'germinating' ? 'ActiveGrowth' : type === 'active-growth' ? 'HardeningOff' : 'Ready'

--- a/src/scenes/NurseryRouter/PlantingSeasons/AddPlantingSeasonModal.tsx
+++ b/src/scenes/NurseryRouter/PlantingSeasons/AddPlantingSeasonModal.tsx
@@ -35,7 +35,7 @@ const AddPlantingSeasonModal = ({ onClose, initialPlantingSiteId }: AddPlantingS
   const { plantingSites } = useOrganizationPlantingSites({ full: true });
   const snackbar = useSnackbar();
   const [createPlantingSeason, { isLoading }] = useCreatePlantingSeasonMutation();
-  const markSubmitted = useTrackModalAbandonment('planting_season_add');
+  const markSubmitted = useTrackModalAbandonment('planting_season_add', true);
 
   const [record, setRecord, onChange] = useForm<PlantingSeasonForm>({
     plantingSiteId: initialPlantingSiteId && initialPlantingSiteId > 0 ? initialPlantingSiteId : undefined,

--- a/src/scenes/NurseryRouter/PlantingSeasons/EditPlantingSeasonModal.tsx
+++ b/src/scenes/NurseryRouter/PlantingSeasons/EditPlantingSeasonModal.tsx
@@ -38,7 +38,7 @@ const EditPlantingSeasonModal = ({
   const defaultTimeZone = useDefaultTimeZone().get().id;
   const snackbar = useSnackbar();
   const [updatePlantingSeason, { isLoading }] = useUpdatePlantingSeasonMutation();
-  const markSubmitted = useTrackModalAbandonment('planting_season_edit');
+  const markSubmitted = useTrackModalAbandonment('planting_season_edit', true);
 
   const [record, , onChange] = useForm<PlantingSeasonForm>({
     name: plantingSeason.name,


### PR DESCRIPTION
The modal abandonment hook currently fires on every component unmount, which causes spurious events for modals that stay mounted while their parent route is rendered. 

Updated the hook to require an isOpen argument and only count abandonment when the modal is actually visible.

Co-authored by Claude