### PR TITLE
Migrate accessions to RTK Query and fetch via useAccession

### DIFF
--- a/src/hooks/useAccession.ts
+++ b/src/hooks/useAccession.ts
@@ -1,10 +1,6 @@
 import { useGetAccessionQuery } from 'src/queries/generated/accessionsV2';
 import { Accession } from 'src/types/Accession';
 
-/**
- * Fetches a single accession via RTK Query. The query is cache-keyed by id, so multiple components
- * requesting the same accession share one cached result (no duplicate requests).
- */
 const useAccession = (accessionId: number) => {
   const { currentData, isFetching, isSuccess, refetch } = useGetAccessionQuery(accessionId, {
     skip: !accessionId,

--- a/src/hooks/useAccession.ts
+++ b/src/hooks/useAccession.ts
@@ -1,0 +1,18 @@
+import { useGetAccessionQuery } from 'src/queries/generated/accessionsV2';
+import { Accession } from 'src/types/Accession';
+
+/**
+ * Fetches a single accession via RTK Query. The query is cache-keyed by id, so multiple components
+ * requesting the same accession share one cached result (no duplicate requests).
+ */
+const useAccession = (accessionId: number) => {
+  const { currentData, isFetching, isSuccess, refetch } = useGetAccessionQuery(accessionId, {
+    skip: !accessionId,
+  });
+
+  const accession: Accession | undefined = currentData?.accession;
+
+  return { accession, refetch, isLoading: isFetching, isSuccess };
+};
+
+export default useAccession;

--- a/src/scenes/AccessionsRouter/Accession2View.tsx
+++ b/src/scenes/AccessionsRouter/Accession2View.tsx
@@ -109,6 +109,7 @@ export default function Accession2View(): JSX.Element {
     return tz.id;
   }, [accession?.facilityId, selectedOrganization, locationTimeZone]);
 
+  // TODO: Remove this hook once project assign endpoint correctly invalidates accession
   const reloadData = useCallback(() => {
     if (accessionId) {
       void refetchAccession();

--- a/src/scenes/AccessionsRouter/Accession2View.tsx
+++ b/src/scenes/AccessionsRouter/Accession2View.tsx
@@ -3,7 +3,6 @@ import { useParams } from 'react-router';
 
 import { Box, Grid, Link as LinkMUI, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem, Icon, Tabs } from '@terraware/web-components';
-import _ from 'lodash';
 import { DateTime } from 'luxon';
 
 import ConvertedValue from 'src/components/ConvertedValue';
@@ -15,9 +14,12 @@ import OverviewItemCard from 'src/components/common/OverviewItemCard';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import useAccession from 'src/hooks/useAccession';
 import { useLocalization, useUser } from 'src/providers';
 import { useOrganization } from 'src/providers/hooks';
-import { AccessionService, FacilityService } from 'src/services';
+import { useCheckInMutation } from 'src/queries/generated/accessionsV1';
+import { useUpdateAccessionMutation } from 'src/queries/generated/accessionsV2';
+import { FacilityService } from 'src/services';
 import strings from 'src/strings';
 import { Accession } from 'src/types/Accession';
 import { ViabilityTest } from 'src/types/Accession';
@@ -48,14 +50,13 @@ export default function Accession2View(): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const { userPreferences } = useUser();
   const { accessionId } = useParams<{ accessionId: string }>();
-  const [accession, setAccession] = useState<Accession>();
+  const { accession, refetch: refetchAccession } = useAccession(Number(accessionId));
   const [openEditLocationModal, setOpenEditLocationModal] = useState(false);
   const [openEditStateModal, setOpenEditStateModal] = useState(false);
   const [openEndDryingReminderModal, setOpenEndDryingReminderModal] = useState(false);
   const [openDeleteAccession, setOpenDeleteAccession] = useState(false);
   const [openWithdrawModal, setOpenWithdrawModal] = useState(false);
   const [openQuantityModal, setOpenQuantityModal] = useState(false);
-  const [hasPendingTests, setHasPendingTests] = useState(false);
   const [openViabilityModal, setOpenViabilityModal] = useState(false);
   const [openNewViabilityTest, setOpenNewViabilityTest] = useState(false);
   const [openViewViabilityTestModal, setOpenViewViabilityTestModal] = useState(false);
@@ -71,6 +72,13 @@ export default function Accession2View(): JSX.Element {
   const { activeLocale } = useLocalization();
   const locationTimeZone = useLocationTimeZone();
   const numberFormatter = useNumberFormatter();
+  const [updateAccession] = useUpdateAccessionMutation();
+  const [checkIn] = useCheckInMutation();
+
+  const hasPendingTests = useMemo(
+    () => accession?.viabilityTests?.some((test) => test.testType !== 'Cut' && !test.endDate) || false,
+    [accession]
+  );
 
   const fullSizeButtonStyles = {
     width: '100%',
@@ -102,41 +110,25 @@ export default function Accession2View(): JSX.Element {
   }, [accession?.facilityId, selectedOrganization, locationTimeZone]);
 
   const reloadData = useCallback(() => {
-    const populateAccession = async () => {
-      if (accessionId) {
-        const response = await AccessionService.getAccession(parseInt(accessionId, 10));
-        if (response.requestSucceeded) {
-          if (!_.isEqual(response.accession, accession)) {
-            setAccession(response.accession);
-            setHasPendingTests(
-              response.accession?.viabilityTests?.some((test) => test.testType !== 'Cut' && !test.endDate) || false
-            );
-          }
-        } else {
-          snackbar.toastError();
-        }
-      }
-    };
-
-    if (accessionId !== undefined) {
-      void populateAccession();
-    } else {
-      setAccession(undefined);
+    if (accessionId) {
+      void refetchAccession();
     }
-  }, [accessionId, accession, snackbar]);
+  }, [accessionId, refetchAccession]);
 
   const onProjectUnAssign = useCallback(async () => {
-    const response = await AccessionService.updateAccession({ ...accession, projectId: undefined } as Accession);
-    if (response.requestSucceeded) {
-      void reloadData();
-    } else {
+    if (!accession) {
+      return;
+    }
+    const updatedAccession = { ...accession, projectId: undefined };
+    try {
+      await updateAccession({
+        id: accession.id,
+        updateAccessionRequestPayloadV2: updatedAccession,
+      }).unwrap();
+    } catch {
       snackbar.toastError();
     }
-  }, [accession, reloadData, snackbar]);
-
-  useEffect(() => {
-    reloadData();
-  }, [accessionId, reloadData]);
+  }, [accession, snackbar, updateAccession]);
 
   useEffect(() => {
     if (activeLocale) {
@@ -185,8 +177,7 @@ export default function Accession2View(): JSX.Element {
   const checkInAccession = async () => {
     if (accession) {
       try {
-        await AccessionService.checkInAccession(accession.id);
-        reloadData();
+        await checkIn(accession.id).unwrap();
         snackbar.toastSuccess(
           strings.formatString(strings.ACCESSION_NUMBER_CHECKED_IN, accession.accessionNumber.toString())
         );
@@ -334,7 +325,7 @@ export default function Accession2View(): JSX.Element {
               padding: themeObj.spacing(3),
             }}
           >
-            <DetailPanel accession={accession} reload={reloadData} />
+            <DetailPanel />
           </Box>
         ),
       },
@@ -361,7 +352,7 @@ export default function Accession2View(): JSX.Element {
                 : {},
             }}
           >
-            {accession && <Accession2History accession={accession} />}
+            <Accession2History />
           </Box>
         ),
       },
@@ -376,21 +367,17 @@ export default function Accession2View(): JSX.Element {
               padding: themeObj.spacing(3),
             }}
           >
-            {accession && (
-              <ViabilityTestingPanel
-                accession={accession}
-                reload={reloadData}
-                canAddTest={viabilityEditable}
-                setNewViabilityTestOpened={setOpenNewViabilityTest}
-                setViewViabilityTestModalOpened={setOpenViewViabilityTestModal}
-                setSelectedTest={setSelectedTest}
-              />
-            )}
+            <ViabilityTestingPanel
+              canAddTest={viabilityEditable}
+              setNewViabilityTestOpened={setOpenNewViabilityTest}
+              setViewViabilityTestModalOpened={setOpenViewViabilityTestModal}
+              setSelectedTest={setSelectedTest}
+            />
           </Box>
         ),
       },
     ];
-  }, [accession, reloadData, activeLocale, themeObj, viabilityEditable, isMobile, hasPendingTests]);
+  }, [activeLocale, themeObj, viabilityEditable, isMobile, hasPendingTests]);
 
   const { activeTab, onChangeTab, setActiveTab } = useStickyTabs({
     defaultTab: 'detail',
@@ -405,7 +392,6 @@ export default function Accession2View(): JSX.Element {
           {selectedTest && (
             <ViewViabilityTestModal
               open={openViewViabilityTestModal}
-              accession={accession}
               isEditable={userCanEdit}
               viabilityTest={selectedTest}
               onClose={() => {
@@ -413,15 +399,12 @@ export default function Accession2View(): JSX.Element {
                 setSelectedTest(undefined);
               }}
               onEdit={() => setOpenNewViabilityTest(true)}
-              reload={reloadData}
             />
           )}
 
           {user && (
             <NewViabilityTestModal
               open={openNewViabilityTest}
-              reload={reloadData}
-              accession={accession}
               onClose={() => {
                 setOpenNewViabilityTest(false);
                 setSelectedTest(undefined);
@@ -432,58 +415,32 @@ export default function Accession2View(): JSX.Element {
           )}
 
           {openEditLocationModal && (
-            <EditLocationModal
-              open={openEditLocationModal}
-              onClose={() => setOpenEditLocationModal(false)}
-              accession={accession}
-              reload={reloadData}
-            />
+            <EditLocationModal open={openEditLocationModal} onClose={() => setOpenEditLocationModal(false)} />
           )}
           {openEditStateModal && (
-            <EditStateModal
-              open={openEditStateModal}
-              onClose={() => setOpenEditStateModal(false)}
-              accession={accession}
-              reload={reloadData}
-            />
+            <EditStateModal open={openEditStateModal} onClose={() => setOpenEditStateModal(false)} />
           )}
           {openEndDryingReminderModal && (
             <EndDryingReminderModal
               open={openEndDryingReminderModal}
               onClose={() => setOpenEndDryingReminderModal(false)}
-              accession={accession}
-              reload={reloadData}
             />
           )}
           {openDeleteAccession && (
-            <DeleteAccessionModal
-              open={openDeleteAccession}
-              onClose={() => setOpenDeleteAccession(false)}
-              accession={accession}
-            />
+            <DeleteAccessionModal open={openDeleteAccession} onClose={() => setOpenDeleteAccession(false)} />
           )}
           {user && openWithdrawModal && (
-            <WithdrawModal
-              open={openWithdrawModal}
-              onClose={() => setOpenWithdrawModal(false)}
-              accession={accession}
-              reload={reloadData}
-              user={user}
-            />
+            <WithdrawModal open={openWithdrawModal} onClose={() => setOpenWithdrawModal(false)} user={user} />
           )}
           <QuantityModal
             open={openQuantityModal}
             onClose={() => setOpenQuantityModal(false)}
-            accession={accession}
-            reload={reloadData}
             title={accession?.remainingQuantity?.quantity !== undefined ? strings.EDIT_QUANTITY : strings.ADD_QUANTITY}
           />
           {openViabilityModal && (
             <ViabilityModal
               open={openViabilityModal}
               onClose={() => setOpenViabilityModal(false)}
-              accession={accession}
-              reload={reloadData}
               setNewViabilityTestOpened={setOpenNewViabilityTest}
               changeTab={setActiveTab}
               title={accession?.viabilityPercent?.toString() ? strings.EDIT_VIABILITY : strings.ADD_VIABILITY}

--- a/src/scenes/AccessionsRouter/edit/Accession2EditModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/Accession2EditModal.tsx
@@ -1,4 +1,5 @@
 import React, { type JSX, useCallback, useEffect, useState } from 'react';
+import { useParams } from 'react-router';
 
 import { Box, Container, Grid, Typography, useTheme } from '@mui/material';
 import { Button, DialogBox, Textfield } from '@terraware/web-components';
@@ -7,12 +8,13 @@ import { useDeviceInfo } from '@terraware/web-components/utils';
 import SelectPhotos from 'src/components/common/Photos/SelectPhotos';
 import ProgressCircle from 'src/components/common/ProgressCircle/ProgressCircle';
 import SpeciesSelector from 'src/components/common/SpeciesSelector';
+import useAccession from 'src/hooks/useAccession';
 import { useTrackEvent } from 'src/hooks/useTrackEvent';
 import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useLocalization, useOrganization } from 'src/providers';
 import { useDeletePhotoMutation, useUploadPhotoMutation } from 'src/queries/generated/accessionsV1';
-import AccessionService from 'src/services/AccessionService';
+import { useUpdateAccessionMutation } from 'src/queries/generated/accessionsV2';
 import strings from 'src/strings';
 import { Accession } from 'src/types/Accession';
 import { getSeedBank } from 'src/utils/organization';
@@ -32,17 +34,31 @@ import CollectionSiteName from '../properties/CollectionSiteName';
 
 export interface Accession2EditModalProps {
   open: boolean;
-  accession: Accession;
   onClose: () => void;
-  reload: () => void;
 }
 
 const MANDATORY_FIELDS = ['speciesId', 'collectedDate'] as const;
 
 type MandatoryField = (typeof MANDATORY_FIELDS)[number];
 
-export default function Accession2EditModal(props: Accession2EditModalProps): JSX.Element | null {
-  const { onClose, open, accession, reload } = props;
+export default function Accession2EditModal({ open, onClose }: Accession2EditModalProps): JSX.Element | null {
+  const { accessionId } = useParams<{ accessionId: string }>();
+  const { accession } = useAccession(Number(accessionId));
+
+  if (!accession) {
+    return null;
+  }
+
+  return <Accession2EditModalForm accession={accession} open={open} onClose={onClose} />;
+}
+
+interface Accession2EditModalFormProps {
+  open: boolean;
+  accession: Accession;
+  onClose: () => void;
+}
+
+function Accession2EditModalForm({ accession, open, onClose }: Accession2EditModalFormProps): JSX.Element | null {
   const { activeLocale } = useLocalization();
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
@@ -60,6 +76,7 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
   const [photoFilenamesToRemove, setPhotoFilenamesToRemove] = useState<string[]>([]);
   const [uploadPhoto] = useUploadPhotoMutation();
   const [deletePhoto] = useDeletePhotoMutation();
+  const [updateAccession] = useUpdateAccessionMutation();
   const markSubmitted = useTrackModalAbandonment('accession_edit', open);
   const trackEvent = useTrackEvent();
 
@@ -122,23 +139,20 @@ export default function Accession2EditModal(props: Accession2EditModalProps): JS
           return;
         }
         setLoading(true);
-        const response = await AccessionService.updateAccession(record);
-        if (response.requestSucceeded && accession) {
-          markSubmitted();
-          await updatePhotos();
-          reload();
-          onCloseHandler();
-        } else {
-          snackbar.toastError();
-          onCloseHandler();
-        }
+        await updateAccession({
+          id: record.id,
+          updateAccessionRequestPayloadV2: record,
+        }).unwrap();
+        markSubmitted();
+        await updatePhotos();
+        onCloseHandler();
       } catch {
         trackEvent(MIXPANEL_EVENTS.SAVE_FAILED, { entity_type: 'accession' });
         snackbar.toastError();
         onCloseHandler();
       }
     }
-  }, [accession, hasErrors, markSubmitted, onCloseHandler, record, reload, snackbar, trackEvent, updatePhotos]);
+  }, [hasErrors, markSubmitted, onCloseHandler, record, snackbar, trackEvent, updateAccession, updatePhotos]);
 
   return !activeLocale ? null : (
     <DialogBox

--- a/src/scenes/AccessionsRouter/edit/DeleteAccessionModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/DeleteAccessionModal.tsx
@@ -1,32 +1,39 @@
 import React, { type JSX } from 'react';
+import { useParams } from 'react-router';
 
 import { Typography } from '@mui/material';
 
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
+import useAccession from 'src/hooks/useAccession';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
-import AccessionService from 'src/services/AccessionService';
+import { useDeleteApiV1SeedbankAccessionsByIdMutation } from 'src/queries/generated/accessionsV1';
 import strings from 'src/strings';
-import { Accession } from 'src/types/Accession';
 import useSnackbar from 'src/utils/useSnackbar';
 
 export interface DeleteAccessionModalProps {
   open: boolean;
-  accession: Accession;
   onClose: () => void;
 }
 
-export default function DeleteAccessionModal(props: DeleteAccessionModalProps): JSX.Element {
-  const { onClose, open, accession } = props;
+export default function DeleteAccessionModal(props: DeleteAccessionModalProps): JSX.Element | null {
+  const { onClose, open } = props;
+  const { accessionId } = useParams<{ accessionId: string }>();
+  const { accession } = useAccession(Number(accessionId));
   const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
+  const [deleteAccession] = useDeleteApiV1SeedbankAccessionsByIdMutation();
+
+  if (!accession) {
+    return null;
+  }
 
   const deleteHandler = async () => {
-    const response = await AccessionService.deleteAccession(accession.id);
-    if (response.requestSucceeded) {
+    try {
+      await deleteAccession(accession.id).unwrap();
       navigate(APP_PATHS.ACCESSIONS);
-    } else {
+    } catch {
       snackbar.toastError();
     }
   };

--- a/src/scenes/AccessionsRouter/edit/EditLocationModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/EditLocationModal.tsx
@@ -1,13 +1,15 @@
 import React, { type JSX, useEffect, useState } from 'react';
+import { useParams } from 'react-router';
 
 import { Grid } from '@mui/material';
 
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
+import useAccession from 'src/hooks/useAccession';
 import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
+import { useUpdateAccessionMutation } from 'src/queries/generated/accessionsV2';
 import { SubLocationService } from 'src/services';
-import AccessionService from 'src/services/AccessionService';
 import strings from 'src/strings';
 import theme from 'src/theme';
 import { Accession } from 'src/types/Accession';
@@ -20,15 +22,29 @@ import { FacilitySelector, SubLocationSelector } from '../properties';
 
 export interface EditLocationModalProps {
   open: boolean;
-  accession: Accession;
   onClose: () => void;
-  reload: () => void;
 }
 
-export default function EditLocationModal(props: EditLocationModalProps): JSX.Element {
+export default function EditLocationModal({ open, onClose }: EditLocationModalProps): JSX.Element | null {
+  const { accessionId } = useParams<{ accessionId: string }>();
+  const { accession } = useAccession(Number(accessionId));
+
+  if (!accession) {
+    return null;
+  }
+
+  return <EditLocationModalForm accession={accession} open={open} onClose={onClose} />;
+}
+
+interface EditLocationModalFormProps {
+  open: boolean;
+  accession: Accession;
+  onClose: () => void;
+}
+
+function EditLocationModalForm({ accession, open, onClose }: EditLocationModalFormProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const { activeLocale } = useLocalization();
-  const { onClose, open, accession, reload } = props;
   const seedBanks: Facility[] = selectedOrganization
     ? selectedOrganization
       ? getAllSeedBanks(selectedOrganization)
@@ -37,6 +53,7 @@ export default function EditLocationModal(props: EditLocationModalProps): JSX.El
   const [subLocations, setSubLocations] = useState<SubLocation[]>([]);
   const snackbar = useSnackbar();
   const markSubmitted = useTrackModalAbandonment('accession_edit_location', open);
+  const [updateAccession] = useUpdateAccessionMutation();
 
   const newRecord = {
     facilityId: accession.facilityId || 0,
@@ -65,15 +82,15 @@ export default function EditLocationModal(props: EditLocationModalProps): JSX.El
   }, [activeLocale, record.facilityId]);
 
   const saveLocation = async () => {
-    const response = await AccessionService.updateAccession({
-      ...accession,
-      ...record,
-    });
-    if (response.requestSucceeded) {
+    const updatedAccession = { ...accession, facilityId: record.facilityId, subLocation: record.subLocation };
+    try {
+      await updateAccession({
+        id: accession.id,
+        updateAccessionRequestPayloadV2: updatedAccession,
+      }).unwrap();
       markSubmitted();
-      reload();
       onClose();
-    } else {
+    } catch {
       snackbar.toastError();
     }
   };

--- a/src/scenes/AccessionsRouter/edit/EditStateModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/EditStateModal.tsx
@@ -1,28 +1,47 @@
 import React, { type JSX, useEffect, useState } from 'react';
+import { useParams } from 'react-router';
 
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
+import useAccession from 'src/hooks/useAccession';
 import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
-import AccessionService from 'src/services/AccessionService';
+import { useUpdateAccessionMutation } from 'src/queries/generated/accessionsV2';
 import strings from 'src/strings';
 import { Accession } from 'src/types/Accession';
 import useForm from 'src/utils/useForm';
+import useSnackbar from 'src/utils/useSnackbar';
 
 import EditState from './EditState';
 import QuantityModal from './QuantityModal';
 
 export interface EditStateModalProps {
   open: boolean;
-  accession: Accession;
   onClose: () => void;
-  reload: () => void;
 }
 
-export default function EditStateModal(props: EditStateModalProps): JSX.Element {
-  const { onClose, open, accession, reload } = props;
+export default function EditStateModal({ open, onClose }: EditStateModalProps): JSX.Element | null {
+  const { accessionId } = useParams<{ accessionId: string }>();
+  const { accession } = useAccession(Number(accessionId));
+
+  if (!accession) {
+    return null;
+  }
+
+  return <EditStateModalForm accession={accession} open={open} onClose={onClose} />;
+}
+
+interface EditStateModalFormProps {
+  open: boolean;
+  accession: Accession;
+  onClose: () => void;
+}
+
+function EditStateModalForm({ accession, open, onClose }: EditStateModalFormProps): JSX.Element {
   const [record, setRecord, onChange] = useForm(accession);
   const [editUsedUpStatus] = useState<boolean>(accession.state === 'Used Up');
   const markSubmitted = useTrackModalAbandonment('accession_edit_state', open);
+  const snackbar = useSnackbar();
+  const [updateAccession] = useUpdateAccessionMutation();
 
   useEffect(() => {
     setRecord(accession);
@@ -30,26 +49,21 @@ export default function EditStateModal(props: EditStateModalProps): JSX.Element 
 
   const saveState = async () => {
     if (record) {
-      const response = await AccessionService.updateAccession(record);
-      if (response.requestSucceeded) {
+      try {
+        await updateAccession({
+          id: record.id,
+          updateAccessionRequestPayloadV2: record,
+        }).unwrap();
         markSubmitted();
-        reload();
+      } catch {
+        snackbar.toastError();
       }
       onClose();
     }
   };
 
   if (editUsedUpStatus) {
-    return (
-      <QuantityModal
-        open={editUsedUpStatus}
-        onClose={onClose}
-        accession={accession}
-        reload={reload}
-        statusEdit={true}
-        title={strings.EDIT_STATUS}
-      />
-    );
+    return <QuantityModal open={editUsedUpStatus} onClose={onClose} statusEdit={true} title={strings.EDIT_STATUS} />;
   }
 
   return (

--- a/src/scenes/AccessionsRouter/edit/EndDryingReminderModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/EndDryingReminderModal.tsx
@@ -1,4 +1,5 @@
 import React, { type JSX, useEffect, useState } from 'react';
+import { useParams } from 'react-router';
 
 import { Grid } from '@mui/material';
 import getDateDisplayValue, { isInTheFuture } from '@terraware/web-components/utils/date';
@@ -6,8 +7,9 @@ import getDateDisplayValue, { isInTheFuture } from '@terraware/web-components/ut
 import DatePicker from 'src/components/common/DatePicker';
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
+import useAccession from 'src/hooks/useAccession';
 import { useOrganization } from 'src/providers';
-import AccessionService from 'src/services/AccessionService';
+import { useUpdateAccessionMutation } from 'src/queries/generated/accessionsV2';
 import strings from 'src/strings';
 import { Accession } from 'src/types/Accession';
 import { getSeedBank } from 'src/utils/organization';
@@ -17,17 +19,32 @@ import { useLocationTimeZone } from 'src/utils/useTimeZoneUtils';
 
 export interface EndDryingReminderModalProps {
   open: boolean;
-  accession: Accession;
   onClose: () => void;
-  reload: () => void;
 }
 
-export default function EndDryingReminderModal(props: EndDryingReminderModalProps): JSX.Element {
-  const { onClose, open, accession, reload } = props;
+export default function EndDryingReminderModal({ open, onClose }: EndDryingReminderModalProps): JSX.Element | null {
+  const { accessionId } = useParams<{ accessionId: string }>();
+  const { accession } = useAccession(Number(accessionId));
+
+  if (!accession) {
+    return null;
+  }
+
+  return <EndDryingReminderModalForm accession={accession} open={open} onClose={onClose} />;
+}
+
+interface EndDryingReminderModalFormProps {
+  open: boolean;
+  accession: Accession;
+  onClose: () => void;
+}
+
+function EndDryingReminderModalForm({ accession, open, onClose }: EndDryingReminderModalFormProps): JSX.Element {
   const [date, setDate] = useState<string | undefined>(accession.dryingEndDate);
   const [dateError, setDateError] = useState<string>('');
   const [record, setRecord, onChange] = useForm(accession);
   const snackbar = useSnackbar();
+  const [updateAccession] = useUpdateAccessionMutation();
   const { selectedOrganization } = useOrganization();
   const timeZoneId = useLocationTimeZone().get(
     selectedOrganization ? getSeedBank(selectedOrganization, accession.facilityId) : undefined
@@ -49,11 +66,13 @@ export default function EndDryingReminderModal(props: EndDryingReminderModalProp
       return;
     }
     if (record) {
-      const response = await AccessionService.updateAccession(record);
-      if (response.requestSucceeded) {
-        reload();
+      try {
+        await updateAccession({
+          id: record.id,
+          updateAccessionRequestPayloadV2: record,
+        }).unwrap();
         onClose();
-      } else {
+      } catch {
         snackbar.toastError();
       }
     }

--- a/src/scenes/AccessionsRouter/edit/QuantityModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/QuantityModal.tsx
@@ -1,4 +1,5 @@
 import React, { type JSX, useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router';
 
 import { Box, FormControlLabel, Grid, Radio, RadioGroup, Typography, useTheme } from '@mui/material';
 import { Dropdown, Icon, Textfield } from '@terraware/web-components';
@@ -9,9 +10,10 @@ import ConvertedValue from 'src/components/ConvertedValue';
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Link from 'src/components/common/Link';
 import Button from 'src/components/common/button/Button';
+import useAccession from 'src/hooks/useAccession';
 import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { useUser } from 'src/providers';
-import AccessionService from 'src/services/AccessionService';
+import { useUpdateAccessionMutation } from 'src/queries/generated/accessionsV2';
 import strings from 'src/strings';
 import { Accession } from 'src/types/Accession';
 import { Unit, isUnitInPreferredSystem, usePreferredWeightUnits } from 'src/units';
@@ -23,9 +25,7 @@ import EditState from './EditState';
 
 export interface QuantityModalProps {
   open: boolean;
-  accession: Accession;
   onClose: () => void;
-  reload: () => void;
   statusEdit?: boolean;
   title: string;
 }
@@ -51,8 +51,29 @@ function UnitsSelector(props: UnitsSelectorProps): JSX.Element {
   );
 }
 
-export default function QuantityModal(props: QuantityModalProps): JSX.Element {
-  const { onClose, open, accession, reload, statusEdit } = props;
+export default function QuantityModal({ open, onClose, statusEdit, title }: QuantityModalProps): JSX.Element | null {
+  const { accessionId } = useParams<{ accessionId: string }>();
+  const { accession } = useAccession(Number(accessionId));
+
+  if (!accession) {
+    return null;
+  }
+
+  return (
+    <QuantityModalForm accession={accession} open={open} onClose={onClose} statusEdit={statusEdit} title={title} />
+  );
+}
+
+interface QuantityModalFormProps {
+  open: boolean;
+  accession: Accession;
+  onClose: () => void;
+  statusEdit?: boolean;
+  title: string;
+}
+
+function QuantityModalForm(props: QuantityModalFormProps): JSX.Element {
+  const { onClose, open, accession, statusEdit } = props;
 
   const [record, setRecord, onChange] = useForm(accession);
   const [isSubsetOpen, setIsSubsetOpen] = useState(false);
@@ -69,6 +90,7 @@ export default function QuantityModal(props: QuantityModalProps): JSX.Element {
   const [remainingQuantityNotes, setRemainingQuantityNotes] = useState<string>('');
   const [remainingQuantityNotesError, setRemainingQuantityNotesError] = useState<boolean>(false);
   const markSubmitted = useTrackModalAbandonment('accession_edit_quantity', open);
+  const [updateAccession] = useUpdateAccessionMutation();
 
   const quantityChanged = useMemo(() => {
     if (!accession.remainingQuantity) {
@@ -92,7 +114,7 @@ export default function QuantityModal(props: QuantityModalProps): JSX.Element {
   const validate = () => {
     let hasErrors = false;
 
-    const quantity = parseFloat(record.remainingQuantity?.quantity as unknown as string);
+    const quantity = parseFloat(String(record.remainingQuantity?.quantity ?? ''));
     if (isNaN(quantity) || quantity < 0) {
       setQuantityError(true);
       hasErrors = true;
@@ -134,12 +156,16 @@ export default function QuantityModal(props: QuantityModalProps): JSX.Element {
     if (!validate()) {
       return;
     }
-    const response = await AccessionService.updateAccession(record, false, remainingQuantityNotes);
-    if (response.requestSucceeded) {
+    const payload = { ...record, remainingQuantityNotes };
+    try {
+      await updateAccession({
+        id: record.id,
+        simulate: false,
+        updateAccessionRequestPayloadV2: payload,
+      }).unwrap();
       markSubmitted();
-      reload();
       onCloseHandler();
-    } else {
+    } catch {
       snackbar.toastError();
     }
   };

--- a/src/scenes/AccessionsRouter/edit/ViabilityModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/ViabilityModal.tsx
@@ -1,4 +1,5 @@
 import React, { type JSX, useEffect } from 'react';
+import { useParams } from 'react-router';
 
 import { Box, Grid, Typography } from '@mui/material';
 import { Textfield } from '@terraware/web-components';
@@ -7,8 +8,9 @@ import { preventDefaultEvent } from '@terraware/web-components/utils';
 import AddLink from 'src/components/common/AddLink';
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
+import useAccession from 'src/hooks/useAccession';
 import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
-import AccessionService from 'src/services/AccessionService';
+import { useUpdateAccessionMutation } from 'src/queries/generated/accessionsV2';
 import strings from 'src/strings';
 import { Accession } from 'src/types/Accession';
 import useForm from 'src/utils/useForm';
@@ -16,21 +18,35 @@ import useSnackbar from 'src/utils/useSnackbar';
 
 export interface ViabilityDialogProps {
   open: boolean;
-  accession: Accession;
   onClose: () => void;
-  reload: () => void;
   setNewViabilityTestOpened: React.Dispatch<React.SetStateAction<boolean>>;
   changeTab: (newValue: string) => void;
   title: string;
 }
 
-export default function ViabilityDialog(props: ViabilityDialogProps): JSX.Element {
-  const { onClose, open, accession, reload, setNewViabilityTestOpened, changeTab } = props;
+export default function ViabilityDialog(props: ViabilityDialogProps): JSX.Element | null {
+  const { accessionId } = useParams<{ accessionId: string }>();
+  const { accession } = useAccession(Number(accessionId));
+
+  if (!accession) {
+    return null;
+  }
+
+  return <ViabilityDialogForm {...props} accession={accession} />;
+}
+
+interface ViabilityDialogFormProps extends ViabilityDialogProps {
+  accession: Accession;
+}
+
+function ViabilityDialogForm(props: ViabilityDialogFormProps): JSX.Element {
+  const { onClose, open, accession, setNewViabilityTestOpened, changeTab } = props;
 
   const [record, setRecord, , onChangeCallback] = useForm(accession);
   const [error, setError] = useForm('');
   const snackbar = useSnackbar();
   const markSubmitted = useTrackModalAbandonment('viability_edit_legacy', open);
+  const [updateAccession] = useUpdateAccessionMutation();
 
   const saveQuantity = async () => {
     if (record.viabilityPercent) {
@@ -43,12 +59,14 @@ export default function ViabilityDialog(props: ViabilityDialogProps): JSX.Elemen
       return;
     }
     setError('');
-    const response = await AccessionService.updateAccession(record);
-    if (response.requestSucceeded) {
+    try {
+      await updateAccession({
+        id: record.id,
+        updateAccessionRequestPayloadV2: record,
+      }).unwrap();
       markSubmitted();
-      reload();
       onCloseHandler();
-    } else {
+    } catch {
       snackbar.toastError();
     }
   };

--- a/src/scenes/AccessionsRouter/history/Accession2History.tsx
+++ b/src/scenes/AccessionsRouter/history/Accession2History.tsx
@@ -1,41 +1,28 @@
-import React, { type JSX, useEffect, useState } from 'react';
+import React, { type JSX, useEffect } from 'react';
+import { useParams } from 'react-router';
 
 import { Box, CircularProgress, Typography, useTheme } from '@mui/material';
-import _ from 'lodash';
 
 import Link from 'src/components/common/Link';
 import { APP_PATHS } from 'src/constants';
-import { useLocalization } from 'src/providers/hooks';
-import AccessionService, { AccessionHistoryEntry } from 'src/services/AccessionService';
+import { useGetAccessionHistoryQuery } from 'src/queries/generated/accessionsV1';
+import { AccessionHistoryEntry } from 'src/services/AccessionService';
 import strings from 'src/strings';
-import { Accession } from 'src/types/Accession';
 import useSnackbar from 'src/utils/useSnackbar';
 
-interface Accession2HistoryProps {
-  accession: Accession;
-}
-
-export default function Accession2History(props: Accession2HistoryProps): JSX.Element {
-  const { activeLocale } = useLocalization();
-  const { accession } = props;
-  const [history, setHistory] = useState<AccessionHistoryEntry[]>();
+export default function Accession2History(): JSX.Element {
+  const { accessionId } = useParams<{ accessionId: string }>();
   const theme = useTheme();
   const snackbar = useSnackbar();
 
+  const { currentData, isError } = useGetAccessionHistoryQuery(Number(accessionId), { skip: !accessionId });
+  const history: AccessionHistoryEntry[] | undefined = isError ? [] : currentData?.history;
+
   useEffect(() => {
-    const loadHistory = async () => {
-      const response = await AccessionService.getAccessionHistory(accession.id);
-      if (response.requestSucceeded) {
-        if (!_.isEqual(history, response.history)) {
-          setHistory(response.history);
-        }
-      } else {
-        setHistory([]);
-        snackbar.toastError();
-      }
-    };
-    void loadHistory();
-  }, [accession, activeLocale, snackbar, history]);
+    if (isError) {
+      snackbar.toastError();
+    }
+  }, [isError, snackbar]);
 
   const HistoryText = (item: AccessionHistoryEntry) => (
     <Typography fontWeight={500}>

--- a/src/scenes/AccessionsRouter/viabilityTesting/DeleteViabilityTestModal.tsx
+++ b/src/scenes/AccessionsRouter/viabilityTesting/DeleteViabilityTestModal.tsx
@@ -1,32 +1,39 @@
 import React, { type JSX } from 'react';
+import { useParams } from 'react-router';
 
 import { Typography } from '@mui/material';
 
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
-import { AccessionService } from 'src/services';
+import useAccession from 'src/hooks/useAccession';
+import { useDeleteViabilityTestMutation } from 'src/queries/generated/accessionsV2';
 import strings from 'src/strings';
-import { Accession } from 'src/types/Accession';
 import { ViabilityTest } from 'src/types/Accession';
 import useSnackbar from 'src/utils/useSnackbar';
 
 export interface DeleteViabilityTestModalProps {
   open: boolean;
-  accession: Accession;
   viabilityTest: ViabilityTest;
   onCancel: () => void;
   onDone: () => void;
 }
 
-export default function DeleteViabilityTestModal(props: DeleteViabilityTestModalProps): JSX.Element {
-  const { onCancel, open, accession, viabilityTest, onDone } = props;
+export default function DeleteViabilityTestModal(props: DeleteViabilityTestModalProps): JSX.Element | null {
+  const { onCancel, open, viabilityTest, onDone } = props;
+  const { accessionId } = useParams<{ accessionId: string }>();
+  const { accession } = useAccession(Number(accessionId));
   const snackbar = useSnackbar();
+  const [deleteViabilityTest] = useDeleteViabilityTestMutation();
+
+  if (!accession) {
+    return null;
+  }
 
   const deleteHandler = async () => {
-    const response = await AccessionService.deleteViabilityTest(accession.id, viabilityTest.id);
-    if (response.requestSucceeded) {
+    try {
+      await deleteViabilityTest({ accessionId: accession.id, viabilityTestId: viabilityTest.id }).unwrap();
       onDone();
-    } else {
+    } catch {
       snackbar.toastError();
     }
   };

--- a/src/scenes/AccessionsRouter/viabilityTesting/NewViabilityTestModal.tsx
+++ b/src/scenes/AccessionsRouter/viabilityTesting/NewViabilityTestModal.tsx
@@ -1,4 +1,5 @@
 import React, { type JSX, useEffect, useState } from 'react';
+import { useParams } from 'react-router';
 
 import { Close } from '@mui/icons-material';
 import { Box, Grid, IconButton, Typography, useTheme } from '@mui/material';
@@ -16,12 +17,14 @@ import TooltipLearnMoreModal, {
 } from 'src/components/TooltipLearnMoreModal';
 import AddLink from 'src/components/common/AddLink';
 import DatePicker from 'src/components/common/DatePicker';
+import useAccession from 'src/hooks/useAccession';
 import { useTrackEvent } from 'src/hooks/useTrackEvent';
 import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useOrganization } from 'src/providers/hooks';
+import { useCreateViabilityTestMutation, useUpdateViabilityTestMutation } from 'src/queries/generated/accessionsV2';
 import { OrganizationUserService } from 'src/services';
-import AccessionService, { ViabilityTestPostRequest } from 'src/services/AccessionService';
+import { ViabilityTestPostRequest } from 'src/services/AccessionService';
 import strings from 'src/strings';
 import { Accession } from 'src/types/Accession';
 import { TEST_TYPES, seedTypes, testMethods, treatments } from 'src/types/Accession';
@@ -39,18 +42,33 @@ import ViabilityResultModal from './ViabilityResultModal';
 
 export interface NewViabilityTestModalProps {
   open: boolean;
-  accession: Accession;
   onClose: () => void;
-  reload: () => void;
   user: User;
   viabilityTest: ViabilityTest | undefined;
 }
 
-export default function NewViabilityTestModal(props: NewViabilityTestModalProps): JSX.Element {
+export default function NewViabilityTestModal(props: NewViabilityTestModalProps): JSX.Element | null {
+  const { accessionId } = useParams<{ accessionId: string }>();
+  const { accession } = useAccession(Number(accessionId));
+
+  if (!accession) {
+    return null;
+  }
+
+  return <NewViabilityTestModalForm {...props} accession={accession} />;
+}
+
+interface NewViabilityTestModalFormProps extends NewViabilityTestModalProps {
+  accession: Accession;
+}
+
+function NewViabilityTestModalForm(props: NewViabilityTestModalFormProps): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const trackEvent = useTrackEvent();
-  const { onClose, open, accession, user, reload, viabilityTest } = props;
+  const { onClose, open, accession, user, viabilityTest } = props;
   const markSubmitted = useTrackModalAbandonment(viabilityTest ? 'viability_test_edit' : 'viability_test_create', open);
+  const [createViabilityTest] = useCreateViabilityTestMutation();
+  const [updateViabilityTest] = useUpdateViabilityTestMutation();
 
   const [record, setRecord, onChange, onChangeCallback] = useForm(viabilityTest);
   const [users, setUsers] = useState<OrganizationUser[]>();
@@ -353,21 +371,24 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
       if (!validSubstrates.find((substrate) => substrate.value === record.substrate)) {
         record.substrate = undefined;
       }
-      let response;
       const isCreate = record.id === -1;
-      if (isCreate) {
-        response = await AccessionService.createViabilityTest(record, accession.id);
-      } else {
-        response = await AccessionService.updateViabilityTest(record, accession.id, record.id);
-      }
-      if (response.requestSucceeded) {
+      try {
         if (isCreate) {
+          await createViabilityTest({
+            accessionId: accession.id,
+            createViabilityTestRequestPayload: record,
+          }).unwrap();
           trackEvent(MIXPANEL_EVENTS.ACCESSION_VIABILITY_TEST_RECORDED, {
             test_type: record.testType,
           });
+        } else {
+          await updateViabilityTest({
+            accessionId: accession.id,
+            viabilityTestId: record.id,
+            updateViabilityTestRequestPayload: record,
+          }).unwrap();
         }
         markSubmitted();
-        reload();
         onCloseHandler();
         const cutTestEdited =
           record.testType === 'Cut' &&
@@ -379,7 +400,7 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
           setSavedRecord({ ...record });
           setOpenViabilityResultModal(true);
         }
-      } else {
+      } catch {
         trackEvent(MIXPANEL_EVENTS.SAVE_FAILED, { entity_type: 'viability_test' });
         snackbar.toastError();
       }
@@ -498,8 +519,6 @@ export default function NewViabilityTestModal(props: NewViabilityTestModalProps)
       {openViabilityResultModal && savedRecord && (
         <ViabilityResultModal
           open={openViabilityResultModal}
-          reload={reload}
-          accession={accession}
           onClose={() => {
             setOpenViabilityResultModal(false);
           }}

--- a/src/scenes/AccessionsRouter/viabilityTesting/ViabilityResultModal.tsx
+++ b/src/scenes/AccessionsRouter/viabilityTesting/ViabilityResultModal.tsx
@@ -1,11 +1,12 @@
 import React, { type JSX } from 'react';
+import { useParams } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Button, DialogBox } from '@terraware/web-components';
 
-import AccessionService from 'src/services/AccessionService';
+import useAccession from 'src/hooks/useAccession';
+import { useUpdateAccessionMutation } from 'src/queries/generated/accessionsV2';
 import strings from 'src/strings';
-import { Accession } from 'src/types/Accession';
 import { ViabilityTest } from 'src/types/Accession';
 import useSnackbar from 'src/utils/useSnackbar';
 
@@ -13,27 +14,29 @@ import { getCutTestViabilityPercent } from './utils';
 
 export interface ViabilityResultModalProps {
   open: boolean;
-  accession: Accession;
   onClose: () => void;
-  reload: () => void;
   viabilityTest: ViabilityTest;
 }
 
 export default function ViabilityResultModal(props: ViabilityResultModalProps): JSX.Element {
-  const { onClose, open, accession, reload, viabilityTest } = props;
+  const { onClose, open, viabilityTest } = props;
   const theme = useTheme();
+  const { accessionId } = useParams<{ accessionId: string }>();
+  const { accession } = useAccession(Number(accessionId));
 
   const snackbar = useSnackbar();
+  const [updateAccession] = useUpdateAccessionMutation();
 
   const saveResult = async () => {
     if (accession) {
       const newAccession = { ...accession, viabilityPercent: getViabilityPercent() };
-      const response = await AccessionService.updateAccession(newAccession);
-
-      if (response.requestSucceeded) {
-        reload();
+      try {
+        await updateAccession({
+          id: newAccession.id,
+          updateAccessionRequestPayloadV2: newAccession,
+        }).unwrap();
         onClose();
-      } else {
+      } catch {
         snackbar.toastError();
       }
     }

--- a/src/scenes/AccessionsRouter/viabilityTesting/ViabilityTestingPanel.tsx
+++ b/src/scenes/AccessionsRouter/viabilityTesting/ViabilityTestingPanel.tsx
@@ -1,26 +1,27 @@
 import React, { type JSX } from 'react';
+import { useParams } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
 import { Button, Icon } from '@terraware/web-components';
 import { useDeviceInfo } from '@terraware/web-components/utils';
 
+import useAccession from 'src/hooks/useAccession';
 import strings from 'src/strings';
-import { Accession } from 'src/types/Accession';
 import { ViabilityTest } from 'src/types/Accession';
 
 import ViabilityTestingDatabase from './ViabilityTestingDatabase';
 
 type ViabilityTestingPanelProps = {
-  accession: Accession;
   canAddTest: boolean;
-  reload: () => void;
   setNewViabilityTestOpened: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedTest: React.Dispatch<React.SetStateAction<ViabilityTest | undefined>>;
   setViewViabilityTestModalOpened: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export default function ViabilityTestingPanel(props: ViabilityTestingPanelProps): JSX.Element {
-  const { accession, canAddTest, setNewViabilityTestOpened, setSelectedTest, setViewViabilityTestModalOpened } = props;
+  const { canAddTest, setNewViabilityTestOpened, setSelectedTest, setViewViabilityTestModalOpened } = props;
+  const { accessionId } = useParams<{ accessionId: string }>();
+  const { accession } = useAccession(Number(accessionId));
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
 
@@ -31,7 +32,7 @@ export default function ViabilityTestingPanel(props: ViabilityTestingPanelProps)
 
   return (
     <>
-      {accession?.viabilityTests ? (
+      {accession && accession.viabilityTests ? (
         <Box>
           <ViabilityTestingDatabase
             accession={accession}

--- a/src/scenes/AccessionsRouter/viabilityTesting/ViewViabilityTestModal.tsx
+++ b/src/scenes/AccessionsRouter/viabilityTesting/ViewViabilityTestModal.tsx
@@ -13,7 +13,6 @@ import TooltipLearnMoreModal, {
   TooltipLearnMoreModalData,
 } from 'src/components/TooltipLearnMoreModal';
 import strings from 'src/strings';
-import { Accession } from 'src/types/Accession';
 import { ViabilityTest } from 'src/types/Accession';
 import { useNumberFormatter } from 'src/utils/useNumberFormatter';
 import { getFullTestType } from 'src/utils/viabilityTest';
@@ -23,17 +22,15 @@ import ObservationsChart from './ObservationsChart';
 
 export interface ViewViabilityTestModalProps {
   open: boolean;
-  accession: Accession;
   isEditable: boolean;
   onClose: () => void;
   viabilityTest: ViabilityTest;
   onEdit: () => void;
-  reload: () => void;
 }
 
 export default function ViewViabilityTestModal(props: ViewViabilityTestModalProps): JSX.Element {
   const theme = useTheme();
-  const { onClose, open, accession, isEditable, viabilityTest, onEdit, reload } = props;
+  const { onClose, open, isEditable, viabilityTest, onEdit } = props;
   const [openDeleteModal, setOpenDeleteModal] = useState<boolean>(false);
   const { isMobile } = useDeviceInfo();
   const numberFormatter = useNumberFormatter();
@@ -68,11 +65,9 @@ export default function ViewViabilityTestModal(props: ViewViabilityTestModalProp
     return (
       <DeleteViabilityTestModal
         open={openDeleteModal}
-        accession={accession}
         viabilityTest={viabilityTest}
         onCancel={() => setOpenDeleteModal(false)}
         onDone={() => {
-          reload();
           onCloseHandler();
         }}
       />

--- a/src/scenes/AccessionsRouter/view/DetailPanel.tsx
+++ b/src/scenes/AccessionsRouter/view/DetailPanel.tsx
@@ -1,26 +1,24 @@
 import React, { type JSX, useMemo, useState } from 'react';
+import { useParams } from 'react-router';
 
 import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Button, Icon } from '@terraware/web-components';
 
 import PhotosList from 'src/components/common/PhotosList';
+import useAccession from 'src/hooks/useAccession';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
 import strings from 'src/strings';
-import { Accession } from 'src/types/Accession';
 import { getCountryByCode, getSubdivisionByCode } from 'src/utils/country';
 import { isContributor } from 'src/utils/organization';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 
 import Accession2EditModal from '../edit/Accession2EditModal';
 
-type DetailPanelProps = {
-  accession?: Accession;
-  reload: () => void;
-};
-export default function DetailPanel(props: DetailPanelProps): JSX.Element {
+export default function DetailPanel(): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const { countries } = useLocalization();
-  const { accession, reload } = props;
+  const { accessionId: accessionIdParam } = useParams<{ accessionId: string }>();
+  const { accession } = useAccession(Number(accessionIdParam));
   const userCanEdit = !isContributor(selectedOrganization);
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
@@ -104,12 +102,7 @@ export default function DetailPanel(props: DetailPanelProps): JSX.Element {
   return accession ? (
     <>
       {openEditAccessionModal && (
-        <Accession2EditModal
-          accession={accession}
-          open={openEditAccessionModal}
-          onClose={() => setOpenEditAccessionModal(false)}
-          reload={reload}
-        />
+        <Accession2EditModal open={openEditAccessionModal} onClose={() => setOpenEditAccessionModal(false)} />
       )}
       <Grid container>
         <Grid item xs={9}>

--- a/src/scenes/AccessionsRouter/withdraw/WithdrawModal.tsx
+++ b/src/scenes/AccessionsRouter/withdraw/WithdrawModal.tsx
@@ -1,4 +1,5 @@
 import React, { type JSX, useCallback, useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router';
 
 import { Box, FormControlLabel, Grid, Radio, RadioGroup, Typography, useTheme } from '@mui/material';
 import { Dropdown, SelectT, Textfield } from '@terraware/web-components';
@@ -8,15 +9,21 @@ import AddLink from 'src/components/common/AddLink';
 import DatePicker from 'src/components/common/DatePicker';
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
+import useAccession from 'src/hooks/useAccession';
 import { useTrackEvent } from 'src/hooks/useTrackEvent';
 import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
+import {
+  useCreateNurseryTransferWithdrawalMutation,
+  useCreateViabilityTestMutation,
+  useCreateWithdrawalMutation,
+} from 'src/queries/generated/accessionsV2';
 import CountWithdrawal from 'src/scenes/AccessionsRouter/withdraw/CountWithdrawal';
 import WeightWithdrawal from 'src/scenes/AccessionsRouter/withdraw/WeightWithdrawal';
 import WithdrawDateWarningModal from 'src/scenes/AccessionsRouter/withdraw/WithdrawDateWarningModal';
 import { OrganizationUserService } from 'src/services';
-import AccessionService, { ViabilityTestPostRequest } from 'src/services/AccessionService';
+import { ViabilityTestPostRequest } from 'src/services/AccessionService';
 import { Accession, Withdrawal, treatments, withdrawalTypes } from 'src/types/Accession';
 import { NurseryTransfer } from 'src/types/Batch';
 import { Facility } from 'src/types/Facility';
@@ -32,18 +39,34 @@ import { withdrawalPurposes } from 'src/utils/withdrawalPurposes';
 
 export interface WithdrawDialogProps {
   open: boolean;
-  accession: Accession;
   onClose: () => void;
-  reload: () => void;
   user: User;
 }
 
-export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element {
+export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element | null {
+  const { accessionId } = useParams<{ accessionId: string }>();
+  const { accession } = useAccession(Number(accessionId));
+
+  if (!accession) {
+    return null;
+  }
+
+  return <WithdrawDialogForm {...props} accession={accession} />;
+}
+
+interface WithdrawDialogFormProps extends WithdrawDialogProps {
+  accession: Accession;
+}
+
+function WithdrawDialogForm(props: WithdrawDialogFormProps): JSX.Element {
   const { strings } = useLocalization();
   const { selectedOrganization } = useOrganization();
-  const { onClose, open, accession, reload, user } = props;
+  const { onClose, open, accession, user } = props;
   const trackEvent = useTrackEvent();
   const markSubmitted = useTrackModalAbandonment('accession_withdraw', open);
+  const [createNurseryTransferWithdrawal] = useCreateNurseryTransferWithdrawalMutation();
+  const [createViabilityTest] = useCreateViabilityTestMutation();
+  const [createWithdrawal] = useCreateWithdrawalMutation();
 
   const newViabilityTesting: ViabilityTestPostRequest = {
     testType: 'Lab',
@@ -246,7 +269,6 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
   const saveWithdrawalHandler = useCallback(async () => {
     setWithdrawalButtonEnabled(false);
     try {
-      let response;
       if (record) {
         if (isNurseryTransfer && nurseryTransferRecord.destinationFacilityId === -1) {
           trackEvent(MIXPANEL_EVENTS.FORM_VALIDATION_FAILED, {
@@ -273,37 +295,45 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
           return;
         }
 
-        if (isNurseryTransfer) {
-          nurseryTransferRecord.germinatingQuantity = estimatedWithdrawalQty;
-          response = await AccessionService.transferToNursery(nurseryTransferRecord, accession.id);
-        } else if (record.purpose === 'Viability Testing') {
-          viabilityTesting.seedsTested = estimatedWithdrawalQty;
-          viabilityTesting.startDate = record.date;
-          response = await AccessionService.createViabilityTest(viabilityTesting, accession.id);
-        } else {
-          let units: UnitType;
-          if (isByWeight) {
-            if (accession.remainingQuantity?.units === 'Seeds') {
-              units = 'Grams';
-            } else {
-              units = accession.remainingQuantity?.units || 'Grams';
-            }
+        try {
+          if (isNurseryTransfer) {
+            nurseryTransferRecord.germinatingQuantity = estimatedWithdrawalQty;
+            await createNurseryTransferWithdrawal({
+              accessionId: accession.id,
+              createNurseryTransferRequestPayload: nurseryTransferRecord,
+            }).unwrap();
+          } else if (record.purpose === 'Viability Testing') {
+            viabilityTesting.seedsTested = estimatedWithdrawalQty;
+            viabilityTesting.startDate = record.date;
+            await createViabilityTest({
+              accessionId: accession.id,
+              createViabilityTestRequestPayload: viabilityTesting,
+            }).unwrap();
           } else {
-            units = 'Seeds';
+            let units: UnitType;
+            if (isByWeight) {
+              if (accession.remainingQuantity?.units === 'Seeds') {
+                units = 'Grams';
+              } else {
+                units = accession.remainingQuantity?.units || 'Grams';
+              }
+            } else {
+              units = 'Seeds';
+            }
+            record.withdrawnQuantity = { quantity: withdrawalQty, units };
+            await createWithdrawal({
+              accessionId: accession.id,
+              createWithdrawalRequestPayload: record,
+            }).unwrap();
           }
-          record.withdrawnQuantity = { quantity: withdrawalQty, units };
-          response = await AccessionService.createWithdrawal(record, accession.id);
-        }
 
-        if (response.requestSucceeded) {
           trackEvent(MIXPANEL_EVENTS.ACCESSION_WITHDRAWN, {
             purpose: isNurseryTransfer ? 'Nursery' : record.purpose || 'Other',
             quantity: estimatedWithdrawalQty,
           });
           markSubmitted();
-          reload();
           onCloseHandler();
-        } else {
+        } catch {
           trackEvent(MIXPANEL_EVENTS.SAVE_FAILED, { entity_type: 'accession_withdrawal' });
           snackbar.toastError();
         }
@@ -314,6 +344,9 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
   }, [
     accession.id,
     accession.remainingQuantity?.units,
+    createNurseryTransferWithdrawal,
+    createViabilityTest,
+    createWithdrawal,
     estimatedWithdrawalQty,
     fieldsErrors,
     isByWeight,
@@ -321,7 +354,6 @@ export default function WithdrawDialog(props: WithdrawDialogProps): JSX.Element 
     nurseryTransferRecord,
     onCloseHandler,
     record,
-    reload,
     markSubmitted,
     setIndividualError,
     snackbar,

--- a/src/scenes/CheckIn/index.tsx
+++ b/src/scenes/CheckIn/index.tsx
@@ -11,8 +11,8 @@ import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
+import { useCheckInMutation } from 'src/queries/generated/accessionsV1';
 import { useLazyGetPendingAccessionsQuery } from 'src/queries/search/accessions';
-import { AccessionService } from 'src/services';
 import strings from 'src/strings';
 import { Accession } from 'src/types/Accession';
 import { SearchResponseElement } from 'src/types/Search';
@@ -37,6 +37,7 @@ export default function CheckIn(): JSX.Element {
   const userCanEdit = !isContributor(selectedOrganization);
 
   const [fetchPendingAccessions] = useLazyGetPendingAccessionsQuery();
+  const [checkIn] = useCheckInMutation();
   const reloadData = useCallback(() => {
     const populatePendingAccessions = async () => {
       if (selectedOrganization) {
@@ -58,7 +59,7 @@ export default function CheckIn(): JSX.Element {
   const checkInAccession = async (accession: Accession) => {
     if (accession) {
       try {
-        await AccessionService.checkInAccession(accession.id);
+        await checkIn(accession.id).unwrap();
         reloadData();
         snackbar.toastSuccess(
           strings.formatString(strings.ACCESSION_NUMBER_CHECKED_IN, accession.accessionNumber.toString())
@@ -74,9 +75,7 @@ export default function CheckIn(): JSX.Element {
     if (pendingAccessions) {
       try {
         setBusy(true);
-        await Promise.all(
-          (pendingAccessions || []).map((accession) => AccessionService.checkInAccession(Number(accession.id)))
-        );
+        await Promise.all((pendingAccessions || []).map((accession) => checkIn(Number(accession.id)).unwrap()));
         setBusy(false);
         reloadData();
         setCheckInAllConfirmationDialogOpen(false);

--- a/src/services/AccessionService.ts
+++ b/src/services/AccessionService.ts
@@ -1,25 +1,17 @@
 import Coordinates from 'coordinate-parser';
 
-import { components, paths } from 'src/api/types/generated-schema';
-import { ACCESSION_2_STATES, Accession, AccessionState, Geolocation } from 'src/types/Accession';
+import { paths } from 'src/api/types/generated-schema';
+import { ACCESSION_2_STATES, AccessionState, Geolocation } from 'src/types/Accession';
 
-import HttpService, { Response, Response2 } from './HttpService';
+import HttpService, { Response2 } from './HttpService';
 
 /**
  * Service for accessions related functionality
  */
 
-const ACCESSION_ENDPOINT = '/api/v2/seedbank/accessions/{id}';
-const ACCESSION_DELETE_ENDPOINT = '/api/v1/seedbank/accessions/{id}';
 const ACCESSION_HISTORY_ENDPOINT = '/api/v1/seedbank/accessions/{id}/history';
-const ACCESSION_CHECKIN_ENDPOINT = '/api/v1/seedbank/accessions/{id}/checkIn';
 const VIABILITY_TESTS_ENDPOINT = '/api/v2/seedbank/accessions/{accessionId}/viabilityTests';
-const VIABILITY_TEST_ENDPOINT = '/api/v2/seedbank/accessions/{accessionId}/viabilityTests/{viabilityTestId}';
-const WITHDRAWALS_ENDPOINT = '/api/v2/seedbank/accessions/{accessionId}/withdrawals';
 const TRANSFER_TO_NURSERY_ENDPOINT = '/api/v2/seedbank/accessions/{accessionId}/transfers/nursery';
-
-type AccessionGetResponsePayload =
-  paths[typeof ACCESSION_ENDPOINT]['get']['responses'][200]['content']['application/json'];
 
 type GetAccessionHistoryResponsePayload =
   paths[typeof ACCESSION_HISTORY_ENDPOINT]['get']['responses'][200]['content']['application/json'];
@@ -28,164 +20,19 @@ type AccessionHistory = GetAccessionHistoryResponsePayload['history'];
 
 export type AccessionHistoryEntry = Required<AccessionHistory>[0];
 
-export type AccessionData = { accession?: Accession };
-export type AccessionResponse = Response & AccessionData;
-export type HistoryData = { history?: AccessionHistoryEntry[] };
-export type AccessionHistoryResponse = Response & HistoryData;
-
-export type UpdateAccession = components['schemas']['UpdateAccessionRequestPayloadV2'] & { id: number };
-
 export type ViabilityTestPostRequest =
   paths[typeof VIABILITY_TESTS_ENDPOINT]['post']['requestBody']['content']['application/json'];
-
-export type ViabilityTestUpdateRequest =
-  paths[typeof VIABILITY_TEST_ENDPOINT]['put']['requestBody']['content']['application/json'];
-
-type WithdrawalsPostRequest = paths[typeof WITHDRAWALS_ENDPOINT]['post']['requestBody']['content']['application/json'];
 
 type TransferToNurseryRequestBody =
   paths[typeof TRANSFER_TO_NURSERY_ENDPOINT]['post']['requestBody']['content']['application/json'];
 type TransferToNurseryResponseBody =
   paths[typeof TRANSFER_TO_NURSERY_ENDPOINT]['post']['responses'][200]['content']['application/json'];
 
-const httpAccession = HttpService.root(ACCESSION_ENDPOINT);
-const httpAccessionHistory = HttpService.root(ACCESSION_HISTORY_ENDPOINT);
-const httpAccessionCheckin = HttpService.root(ACCESSION_CHECKIN_ENDPOINT);
-const httpViabilityTests = HttpService.root(VIABILITY_TESTS_ENDPOINT);
-const httpViabilityTest = HttpService.root(VIABILITY_TEST_ENDPOINT);
-const httpWithdrawals = HttpService.root(WITHDRAWALS_ENDPOINT);
 const httpNurseryTransfer = HttpService.root(TRANSFER_TO_NURSERY_ENDPOINT);
-
-/**
- * Get an accession by id
- */
-const getAccession = async (accessionId: number): Promise<AccessionResponse> => {
-  const response: AccessionResponse = await httpAccession.get<AccessionGetResponsePayload, AccessionData>(
-    {
-      urlReplacements: { '{id}': accessionId.toString() },
-    },
-    (data) => ({ accession: data?.accession })
-  );
-
-  return response;
-};
-
-/**
- * Update an accession by id
- */
-const updateAccession = async (
-  entity: Accession,
-  simulate?: boolean,
-  remainingQuantityNotes?: string
-): Promise<AccessionResponse> => {
-  const params = { simulate: simulate !== undefined ? simulate.toString() : 'false' };
-  const serverResponse: Response = await httpAccession.put({
-    entity: { ...entity, remainingQuantityNotes },
-    params,
-    urlReplacements: { '{id}': entity.id.toString() },
-  });
-  const response: AccessionResponse = { ...serverResponse, accession: serverResponse?.data?.accession };
-
-  return response;
-};
-
-/**
- * Accessions history
- */
-const getAccessionHistory = async (accessionId: number): Promise<AccessionHistoryResponse> => {
-  const response: Response = await httpAccessionHistory.get<GetAccessionHistoryResponsePayload, HistoryData>(
-    {
-      urlReplacements: { '{id}': accessionId.toString() },
-    },
-    (data) => ({ history: data?.history })
-  );
-
-  return response;
-};
-
-/**
- * Check-in an accession
- */
-const checkInAccession = async (accessionId: number): Promise<Response> => {
-  return await httpAccessionCheckin.post({
-    urlReplacements: { '{id}': accessionId.toString() },
-  });
-};
-
-/**
- * Delete an accession
- */
-const deleteAccession = async (accessionId: number): Promise<Response> => {
-  return await HttpService.root(ACCESSION_DELETE_ENDPOINT).delete({
-    urlReplacements: { '{id}': accessionId.toString() },
-  });
-};
-
-/**
- * Viability Tests
- */
-
-/**
- * Create a viability test
- */
-const createViabilityTest = async (viabilityTest: ViabilityTestPostRequest, accessionId: number): Promise<Response> => {
-  return await httpViabilityTests.post({
-    entity: viabilityTest,
-    urlReplacements: {
-      '{accessionId}': accessionId.toString(),
-    },
-  });
-};
-
-/**
- * Update a viability test
- */
-const updateViabilityTest = async (
-  viabilityTest: ViabilityTestUpdateRequest,
-  accessionId: number,
-  viabilityTestId: number
-): Promise<Response> => {
-  return await httpViabilityTest.put({
-    entity: viabilityTest,
-    urlReplacements: {
-      '{accessionId}': accessionId.toString(),
-      '{viabilityTestId}': viabilityTestId.toString(),
-    },
-  });
-};
-
-/**
- * Delete a viability test
- */
-const deleteViabilityTest = async (accessionId: number, viabilityTestId: number): Promise<Response> => {
-  return await httpViabilityTest.delete({
-    urlReplacements: {
-      '{accessionId}': accessionId.toString(),
-      '{viabilityTestId}': viabilityTestId.toString(),
-    },
-  });
-};
-
-/**
- * Accession withdrawals
- */
-
-/**
- * Create a withdrawal
- */
-const createWithdrawal = async (withdrawal: WithdrawalsPostRequest, accessionId: number): Promise<Response> => {
-  return await httpWithdrawals.post({
-    entity: withdrawal,
-    urlReplacements: {
-      '{accessionId}': accessionId.toString(),
-    },
-  });
-};
 
 /**
  * Create a nursery withdrawal/transfer
  */
-
 const transferToNursery = async (
   entity: TransferToNurseryRequestBody,
   accessionId: number
@@ -241,15 +88,6 @@ const getParsedCoords = (coordsStr: string[]): Geolocation[] => {
  * Exported functions
  */
 const AccessionService = {
-  getAccession,
-  getAccessionHistory,
-  checkInAccession,
-  updateAccession,
-  deleteAccession,
-  createViabilityTest,
-  updateViabilityTest,
-  deleteViabilityTest,
-  createWithdrawal,
   transferToNursery,
   getTransitionToStates,
   getParsedCoords,


### PR DESCRIPTION
Replace the remaining AccessionService calls in the accessions component
tree with the generated RTK Query hooks (accessionsV1/V2). Mutations use the
generated hooks with .unwrap() + try/catch; reads use auto-firing queries.

Add a shared useAccession hook so the modals/panels fetch the accession via
RTK Query (cache-keyed by id, so no duplicate requests) instead of having it
prop-drilled down from Accession2View. Drop the now-redundant reload prop —
mutations invalidate the Accessions cache tag, so the shared query
auto-refetches.

Remove the now-unused AccessionService functions, keeping only the pure
utilities (getTransitionToStates, getParsedCoords) and transferToNursery,
which is still used by the batches Redux thunk.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>