### PR TITLE
Add organization and user role context to Mixpanel events

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import BlockingSpinner from 'src/components/common/BlockingSpinner';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import { useAppVersion } from 'src/hooks/useAppVersion';
 import { MixpanelUserProfile } from 'src/mixpanelEvents';
-import { useLocalization, useUser } from 'src/providers';
+import { useLocalization, useOrganization, useUser } from 'src/providers';
 import { store } from 'src/redux/store';
 import AcceleratorRouter from 'src/scenes/AcceleratorRouter';
 import FunderRouter from 'src/scenes/FunderRouter';
@@ -44,6 +44,7 @@ function AppContent() {
   useAppVersion();
   const { isDesktop, type } = useDeviceInfo();
   const { user, isAllowed } = useUser();
+  const { selectedOrganization } = useOrganization();
   const { isAcceleratorRoute } = useAcceleratorConsole();
   const { isApplicationPortal } = useApplicationPortal();
   const { isFunderRoute } = useFunderPortal();
@@ -80,6 +81,21 @@ function AppContent() {
       }
     }
   }, [user, mixpanel]);
+
+  // Keep org context registered as super properties whenever the active
+  // organization changes. Re-registering with new values overwrites the old
+  // ones so every subsequent event (including auto-pageviews, which
+  // `useTrackEvent` can't reach) carries the current org.
+  useEffect(() => {
+    if (user && mixpanel && user.cookiesConsented === true) {
+      mixpanel.register({
+        organization_id: selectedOrganization?.id,
+        organization_role: selectedOrganization?.role,
+        user_type: user.userType,
+        is_internal_user: user.globalRoles.length > 0,
+      });
+    }
+  }, [user, mixpanel, selectedOrganization]);
 
   useEffect(() => {
     if (type === 'mobile' || type === 'tablet') {

--- a/src/mixpanelEvents.ts
+++ b/src/mixpanelEvents.ts
@@ -21,7 +21,6 @@ export enum MIXPANEL_EVENTS {
 
   // --- Planting & plants ---
   PLANTING_SITE_CREATED = 'Planting Site Created',
-  SURVIVAL_RATE_VIEWED = 'Survival Rate Viewed',
 
   // --- Observations ---
   OBSERVATION_SCHEDULED = 'Observation Scheduled',
@@ -118,9 +117,6 @@ export type MixpanelEventPropertyMap = {
     num_strata?: number;
     has_boundary: boolean;
   };
-  [MIXPANEL_EVENTS.SURVIVAL_RATE_VIEWED]: {
-    is_project_view: boolean;
-  };
   [MIXPANEL_EVENTS.OBSERVATION_SCHEDULED]: {
     duration_days?: number;
   };
@@ -139,7 +135,7 @@ export type MixpanelEventPropertyMap = {
     new_role: string;
   };
   [MIXPANEL_EVENTS.REPORT_VIEWED]: {
-    is_funder_view: boolean;
+    viewer_persona: 'accelerator_admin' | 'funder' | 'forester';
   };
   [MIXPANEL_EVENTS.REPORT_DOWNLOADED]: {
     report_type: string;

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportView.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportView.tsx
@@ -53,7 +53,7 @@ const ReportView = () => {
   const trackEvent = useTrackEvent();
 
   useEffect(() => {
-    trackEvent(MIXPANEL_EVENTS.REPORT_VIEWED, { is_funder_view: false });
+    trackEvent(MIXPANEL_EVENTS.REPORT_VIEWED, { viewer_persona: 'accelerator_admin' });
   }, [trackEvent]);
   const [showApproveDialog, , openApprovalDialog, closeApproveDialog] = useBoolean(false);
   const [showRejectDialog, , openRejectDialog, closeRejectDialog] = useBoolean(false);

--- a/src/scenes/FunderReport/FunderReportView.tsx
+++ b/src/scenes/FunderReport/FunderReportView.tsx
@@ -37,7 +37,7 @@ const FunderReportView = ({ selectedProjectId, selectedReport }: FunderReportVie
   // (as a published-preview), that parent already fires REPORT_VIEWED.
   useEffect(() => {
     if (isFunderRoute) {
-      trackEvent(MIXPANEL_EVENTS.REPORT_VIEWED, { is_funder_view: true });
+      trackEvent(MIXPANEL_EVENTS.REPORT_VIEWED, { viewer_persona: 'funder' });
     }
   }, [isFunderRoute, trackEvent]);
 

--- a/src/scenes/PlantsDashboardRouter/components/SurvivalRateCard.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/SurvivalRateCard.tsx
@@ -9,9 +9,7 @@ import FormattedNumber from 'src/components/common/FormattedNumber';
 import Link from 'src/components/common/Link';
 import { APP_PATHS } from 'src/constants';
 import { useLatestSiteObservationResult } from 'src/hooks/observations';
-import { useTrackEvent } from 'src/hooks/useTrackEvent';
 import { useKnowledgeBaseLinks } from 'src/knowledgeBaseLinks';
-import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useLazyGetAggregatedTrackingStatsQuery } from 'src/queries/generated/stats';
 import strings from 'src/strings';
 
@@ -29,12 +27,6 @@ export default function SurvivalRateCard({ plantingSiteId, projectId }: Survival
   const { isDesktop } = useDeviceInfo();
   const isProjectView = !plantingSiteId && typeof projectId === 'number';
   const knowledgeBaseLinks = useKnowledgeBaseLinks();
-  const trackEvent = useTrackEvent();
-
-  useEffect(() => {
-    trackEvent(MIXPANEL_EVENTS.SURVIVAL_RATE_VIEWED, { is_project_view: !!isProjectView });
-  }, [isProjectView, trackEvent]);
-
   const { observation: latestObservationResult, isLoading: isLoadingObservation } = useLatestSiteObservationResult(
     plantingSiteId,
     'Stratum'

--- a/src/scenes/Reports/AcceleratorReportView.tsx
+++ b/src/scenes/Reports/AcceleratorReportView.tsx
@@ -20,6 +20,8 @@ import Card from 'src/components/common/Card';
 import TitleBar from 'src/components/common/TitleBar';
 import { APP_PATHS } from 'src/constants';
 import useNavigateTo from 'src/hooks/useNavigateTo';
+import { useTrackEvent } from 'src/hooks/useTrackEvent';
+import { MIXPANEL_EVENTS } from 'src/mixpanelEvents';
 import { useLocalization } from 'src/providers';
 import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 import { useGetAcceleratorReportQuery, useSubmitAcceleratorReportMutation } from 'src/queries/generated/reports';
@@ -31,6 +33,11 @@ const AcceleratorReportView = () => {
   const { strings } = useLocalization();
   const { currentAcceleratorProject, setCurrentAcceleratorProject } = useParticipantData();
   const theme = useTheme();
+  const trackEvent = useTrackEvent();
+
+  useEffect(() => {
+    trackEvent(MIXPANEL_EVENTS.REPORT_VIEWED, { viewer_persona: 'forester' });
+  }, [trackEvent]);
 
   const { goToAcceleratorReportEdit } = useNavigateTo();
 


### PR DESCRIPTION
Additionally, removed a superfluous survival rate view event which adds nothing beyond page view. And clarify report views by user type.

Co-authored by Claude