### PR TITLE
SW-7484 Don't send batch PUT request when nothing has been changed

### DIFF
--- a/src/scenes/InventoryRouter/BatchDetailsModal.tsx
+++ b/src/scenes/InventoryRouter/BatchDetailsModal.tsx
@@ -169,6 +169,11 @@ export default function BatchDetailsModal({ batch, onClose, reload }: BatchDetai
         return;
       }
 
+      if (batch === record) {
+        onCloseHandler();
+        return;
+      }
+
       let responseQuantities = { requestSucceeded: true };
 
       const response = await NurseryBatchService.updateBatch(record);
@@ -189,7 +194,7 @@ export default function BatchDetailsModal({ batch, onClose, reload }: BatchDetai
         snackbar.toastError();
       }
     }
-  }, [record, hasErrors, updatePhotos, reload, onCloseHandler, snackbar, trackEvent, markSubmitted]);
+  }, [record, hasErrors, updatePhotos, reload, onCloseHandler, snackbar, trackEvent, markSubmitted, batch]);
 
   const handleSaveBatch = useCallback(() => {
     void saveBatch();


### PR DESCRIPTION
If a user doesn't change any fields in the Edit Batch Details modal and clicks save, a PUT request is still sent to the BE. Instead of this, close the modal by calling the `onCloseHandler`.