### PR TITLE
SW-8459: Photo title for required photos should show up above the photo

### DIFF
--- a/src/components/ActivityLog/ActivityDetailView.tsx
+++ b/src/components/ActivityLog/ActivityDetailView.tsx
@@ -30,8 +30,7 @@ import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { ACTIVITY_MEDIA_FILE_ENDPOINT } from 'src/services/ActivityService';
 import { FUNDER_ACTIVITY_MEDIA_FILE_ENDPOINT } from 'src/services/funder/FunderActivityService';
 import { ActivityMediaFile, activityTypeLabel } from 'src/types/Activity';
-import { getPositionLabel, getQuadratLabel } from 'src/types/Observations';
-import { isObservationActivity, isUndeletableObservationPhoto } from 'src/utils/activityUtils';
+import { getObsPhotoTypeLabel, isObservationActivity } from 'src/utils/activityUtils';
 import { getObservationSpeciesLivePlantsCount } from 'src/utils/observation';
 import useQuery from 'src/utils/useQuery';
 import useSnackbar from 'src/utils/useSnackbar';
@@ -208,23 +207,7 @@ const ActivityMediaItem = ({
     [mediaFile.fileId, setLightboxImageId]
   );
 
-  const obsPhotoTypeLabel = useMemo(() => {
-    const obs = mediaFile.observation;
-    if (!obs || !isUndeletableObservationPhoto(mediaFile)) {
-      return undefined;
-    }
-    const plotPrefix = `${obs.monitoringPlotNumber} `;
-    if (obs.type === 'Plot' && obs.position) {
-      return `${plotPrefix}${getPositionLabel(obs.position)}`;
-    }
-    if (obs.type === 'Quadrat' && obs.position) {
-      return `${plotPrefix}${getQuadratLabel(obs.position)}`;
-    }
-    if (obs.type === 'Soil') {
-      return `${plotPrefix}${strings.SOIL}`;
-    }
-    return undefined;
-  }, [mediaFile, strings]);
+  const obsPhotoTypeLabel = useMemo(() => getObsPhotoTypeLabel(mediaFile, strings), [mediaFile, strings]);
 
   const handleImageError = useCallback(async () => {
     // only check for 412 error if this is a video

--- a/src/components/ActivityLog/ActivityMediaForm.tsx
+++ b/src/components/ActivityLog/ActivityMediaForm.tsx
@@ -18,6 +18,7 @@ import { useLocalization } from 'src/providers/hooks';
 import { ACTIVITY_MEDIA_FILE_ENDPOINT } from 'src/services/ActivityService';
 import { ActivityMediaFile, AdminActivityMediaFile } from 'src/types/Activity';
 import {
+  getObsPhotoTypeLabel,
   isCaptionReadOnly,
   isCornerPhoto,
   isObservationMedia,
@@ -163,6 +164,11 @@ const ActivityPhotoPreview = ({
     return strings.OBSERVATION_PHOTO_CANNOT_DELETE_INFO;
   }, [isUndeletable, mediaItem, strings]);
 
+  const obsPhotoTypeLabel = useMemo(
+    () => (isUndeletable && mediaItem.type === 'existing' ? getObsPhotoTypeLabel(mediaItem.data, strings) : undefined),
+    [isUndeletable, mediaItem, strings]
+  );
+
   const isCaptionRO = useMemo(
     () => isObsMedia && mediaItem.type === 'existing' && isCaptionReadOnly(mediaItem.data),
     [isObsMedia, mediaItem]
@@ -252,6 +258,11 @@ const ActivityPhotoPreview = ({
       paddingBottom='24px'
       width='100%'
     >
+      {obsPhotoTypeLabel && (
+        <Typography fontSize='16px' fontWeight={500} marginBottom={theme.spacing(2)}>
+          {obsPhotoTypeLabel}
+        </Typography>
+      )}
       <Grid container spacing={2} textAlign='left'>
         <Grid item sm='auto' xs={12}>
           <Box position='relative'>

--- a/src/scenes/ObservationsRouterV2/ListView/PlantMonitoringList.tsx
+++ b/src/scenes/ObservationsRouterV2/ListView/PlantMonitoringList.tsx
@@ -269,7 +269,7 @@ const PlantMonitoringList = ({ plantingSiteId }: PlantMonitoringListProps) => {
           completedDate,
         };
       }),
-    [observationResults, plantingSitesById, selectedPlotSelection]
+    [observationResults, plantingSitesById, selectedPlotSelection, strings]
   );
 
   const uniqueStatuses = useMemo(

--- a/src/scenes/ObservationsRouterV2/ListView/PlantMonitoringList.tsx
+++ b/src/scenes/ObservationsRouterV2/ListView/PlantMonitoringList.tsx
@@ -258,7 +258,7 @@ const PlantMonitoringList = ({ plantingSiteId }: PlantMonitoringListProps) => {
           observationId: observationResult.observationId,
           observationDate,
           observationState: observationResult.state,
-          state: getStatus(observationResult.state),
+          state: getStatus(observationResult.state, strings),
           plantingSiteName: plantingSite?.name,
           strata: strataNames.join('\r'),
           totalLive,

--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/QuadratComponent.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/QuadratComponent.tsx
@@ -28,7 +28,7 @@ const QuadratComponent = ({ position }: QuadratComponentProps) => {
   return (
     <Box>
       <Typography fontSize='20px' lineHeight='28px' fontWeight={600} color={theme.palette.TwClrTxt} paddingBottom={2}>
-        {getQuadratLabel(position)}
+        {getQuadratLabel(position, strings)}
       </Typography>
       <Box display={'flex'}>
         <MonitoringPlotPhotos

--- a/src/scenes/ObservationsRouterV2/SingleView/MonitoringPlotPhotoPreview.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/MonitoringPlotPhotoPreview.tsx
@@ -83,12 +83,12 @@ const MonitoringPlotPhotoPreview = ({
     >
       {mediaItem.data.type === 'Plot' && mediaItem.data.position && (
         <Typography marginBottom={3} color={theme.palette.TwClrBaseBlack}>
-          {monitoringPlotName} {getPositionLabel(mediaItem.data.position)}
+          {monitoringPlotName} {getPositionLabel(mediaItem.data.position, strings)}
         </Typography>
       )}
       {mediaItem.data.type === 'Quadrat' && mediaItem.data.position && (
         <Typography marginBottom={3} color={theme.palette.TwClrBaseBlack}>
-          {getQuadratLabel(mediaItem.data.position)}
+          {getQuadratLabel(mediaItem.data.position, strings)}
         </Typography>
       )}
       <Box display='flex' flexDirection='column' gap={2}>

--- a/src/scenes/ObservationsRouterV2/SingleView/MonitoringPlotPhotosWithActions.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/MonitoringPlotPhotosWithActions.tsx
@@ -6,11 +6,11 @@ import { Button } from '@terraware/web-components';
 import ImageLightbox from 'src/components/common/ImageLightbox';
 import MediaItem, { MediaFile } from 'src/components/common/MediaItem';
 import useOrganizationFeatures from 'src/hooks/useOrganizationFeatures';
+import { useLocalization } from 'src/providers/hooks';
 import {
   useGenerateObservationSplatFileMutation,
   useListObservationSplatsQuery,
 } from 'src/queries/generated/observationSplats';
-import strings from 'src/strings';
 import { ObservationMonitoringPlotPhoto, getPositionLabel, getQuadratLabel } from 'src/types/Observations';
 import useSnackbar from 'src/utils/useSnackbar';
 
@@ -32,6 +32,7 @@ export default function MonitoringPlotPhotosWithActions({
   plantingSiteName,
   photos,
 }: MonitoringPlotPhotosWithActionsProps): JSX.Element {
+  const { strings } = useLocalization();
   const theme = useTheme();
   const orgFeatures = useOrganizationFeatures();
   const [lightboxFileId, setLightboxFileId] = useState<number | undefined>(undefined);
@@ -130,11 +131,13 @@ export default function MonitoringPlotPhotosWithActions({
             <Box key={mediaFile.fileId} position='relative'>
               {!!monitoringPlotName && mediaFile.position && (
                 <Typography color={theme.palette.TwClrBaseBlack}>
-                  {monitoringPlotName} {getPositionLabel(mediaFile.position)}
+                  {monitoringPlotName} {getPositionLabel(mediaFile.position, strings)}
                 </Typography>
               )}
               {mediaFile.isQuadrat && (
-                <Typography color={theme.palette.TwClrBaseBlack}>{getQuadratLabel(mediaFile.position)}</Typography>
+                <Typography color={theme.palette.TwClrBaseBlack}>
+                  {getQuadratLabel(mediaFile.position, strings)}
+                </Typography>
               )}
               <MediaItem
                 mediaFile={mediaFile}

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Site/StratumCellRenderer.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Site/StratumCellRenderer.tsx
@@ -4,11 +4,13 @@ import Link from 'src/components/common/Link';
 import CellRenderer, { TableRowType } from 'src/components/common/table/TableCellRenderer';
 import { RendererProps } from 'src/components/common/table/types';
 import { APP_PATHS } from 'src/constants';
+import { useLocalization } from 'src/providers';
 import { MonitoringPlotStatus, getPlotStatus } from 'src/types/Observations';
 
 export default function StratumCellRenderer(props: RendererProps<TableRowType>): JSX.Element {
   const NO_DATA_FIELDS = ['totalPlants', 'totalSpecies'];
   const { column, row, value } = props;
+  const { strings } = useLocalization();
   const observationId = row.observationId as number;
   const stratumName = row.stratumName as string;
   if (column.key === 'stratumName') {
@@ -38,7 +40,7 @@ export default function StratumCellRenderer(props: RendererProps<TableRowType>):
   }
 
   if (column.key === 'status') {
-    return <CellRenderer {...props} value={getPlotStatus(value as MonitoringPlotStatus)} />;
+    return <CellRenderer {...props} value={getPlotStatus(value as MonitoringPlotStatus, strings)} />;
   }
 
   return <CellRenderer {...props} />;

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/MonitoringPlotCellRenderer.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/MonitoringPlotCellRenderer.tsx
@@ -56,7 +56,7 @@ export default function MonitoringPlotCellRenderer(props: RendererProps<TableRow
   }
 
   if (column.key === 'status') {
-    return <CellRenderer {...props} value={getPlotStatus(value as MonitoringPlotStatus)} />;
+    return <CellRenderer {...props} value={getPlotStatus(value as MonitoringPlotStatus, strings)} />;
   }
 
   if (column.key === 'isPermanent') {

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/MonitoringPlotList.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/MonitoringPlotList.tsx
@@ -144,7 +144,7 @@ export default function MonitoringPlotList(): JSX.Element {
     } else {
       return [];
     }
-  }, [observationId, observationResult, stratumResult]);
+  }, [observationId, observationResult, stratumResult, strings]);
 
   const hasSmallPlots = useMemo(() => rows.some((row) => row.sizeMeters === 25), [rows]);
 

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/MonitoringPlotList.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/MonitoringPlotList.tsx
@@ -130,7 +130,7 @@ export default function MonitoringPlotList(): JSX.Element {
             stratumName: stratumResult.name,
             substratumName: substratum.name,
             completedDate: plot.completedTime,
-            status: getPlotStatus(plot.status),
+            status: getPlotStatus(plot.status, strings),
             isPermanent: plot.isPermanent,
             sizeMeters: plot.sizeMeters,
             totalLive,

--- a/src/scenes/ObservationsRouterV2/useObservationExports.ts
+++ b/src/scenes/ObservationsRouterV2/useObservationExports.ts
@@ -208,7 +208,7 @@ const useObservationExports = () => {
               southeastLongitude: plotCoordinates[1][0],
               southwestLatitude: plotCoordinates[0][1],
               southwestLongitude: plotCoordinates[0][0],
-              status: getPlotStatus(monitoringPlot.status),
+              status: getPlotStatus(monitoringPlot.status, strings),
               substratumName: substratum.name,
               survivalRate: monitoringPlot.survivalRate,
               totalDead,

--- a/src/types/Observations.ts
+++ b/src/types/Observations.ts
@@ -1,6 +1,6 @@
 import { components } from 'src/api/types/generated-schema';
 import { ObservationMonitoringPlotMediaPayload } from 'src/queries/generated/observations';
-import strings from 'src/strings';
+import defaultStrings from 'src/strings';
 
 import { MultiPolygon } from './Tracking';
 
@@ -117,7 +117,7 @@ export type ObservationSpeciesResults = ObservationSpeciesResultsPayload & {
   speciesScientificName: string;
 };
 
-export const getStatus = (state: ObservationState): string => {
+export const getStatus = (state: ObservationState, strings: typeof defaultStrings): string => {
   switch (state) {
     case 'Completed':
       return strings.COMPLETED;
@@ -132,7 +132,7 @@ export const getStatus = (state: ObservationState): string => {
   }
 };
 
-export const getPlotStatus = (status?: MonitoringPlotStatus): string => {
+export const getPlotStatus = (status: MonitoringPlotStatus | undefined, strings: typeof defaultStrings): string => {
   switch (status) {
     case 'Completed':
       return strings.COMPLETED;
@@ -147,7 +147,10 @@ export const getPlotStatus = (status?: MonitoringPlotStatus): string => {
   }
 };
 
-export const getReplaceObservationPlotDuration = (duration: ReplaceObservationPlotDuration): string => {
+export const getReplaceObservationPlotDuration = (
+  duration: ReplaceObservationPlotDuration,
+  strings: typeof defaultStrings
+): string => {
   switch (duration) {
     case 'Temporary':
       return strings.TEMPORARY;
@@ -194,7 +197,10 @@ export type ExistingMonitoringPlotMediaItem = {
 
 export type MonitoringPlotMediaItem = NewMonitoringPlotMediaItem | ExistingMonitoringPlotMediaItem;
 
-export const getPositionLabel = (position: ObservationMonitoringPlotPosition): string => {
+export const getPositionLabel = (
+  position: ObservationMonitoringPlotPosition,
+  strings: typeof defaultStrings
+): string => {
   switch (position) {
     case 'NortheastCorner':
       return strings.NORTHEAST_CORNER;
@@ -209,7 +215,10 @@ export const getPositionLabel = (position: ObservationMonitoringPlotPosition): s
   }
 };
 
-export const getQuadratLabel = (position: ObservationMonitoringPlotPosition): string => {
+export const getQuadratLabel = (
+  position: ObservationMonitoringPlotPosition,
+  strings: typeof defaultStrings
+): string => {
   switch (position) {
     case 'NortheastCorner':
       return strings.PHOTO_NORTHEAST_QUADRAT;

--- a/src/utils/activityUtils.test.ts
+++ b/src/utils/activityUtils.test.ts
@@ -1,4 +1,5 @@
 import {
+  getObsPhotoTypeLabel,
   isCaptionReadOnly,
   isCornerPhoto,
   isObservationActivity,
@@ -95,5 +96,59 @@ describe('isCaptionReadOnly', () => {
 
   test('returns false when observation is absent', () => {
     expect(isCaptionReadOnly({})).toBe(false);
+  });
+});
+
+describe('getObsPhotoTypeLabel', () => {
+  const strings = {
+    NORTHEAST_CORNER: 'Northeast corner',
+    NORTHWEST_CORNER: 'Northwest corner',
+    SOUTHEAST_CORNER: 'Southeast corner',
+    SOUTHWEST_CORNER: 'Southwest corner',
+    PHOTO_NORTHEAST_QUADRAT: 'Northeast Quadrat',
+    PHOTO_NORTHWEST_QUADRAT: 'Northwest Quadrat',
+    PHOTO_SOUTHEAST_QUADRAT: 'Southeast Quadrat',
+    PHOTO_SOUTHWEST_QUADRAT: 'Southwest Quadrat',
+    SOIL: 'Soil',
+  } as Parameters<typeof getObsPhotoTypeLabel>[1];
+
+  test('returns undefined when observation is absent', () => {
+    expect(getObsPhotoTypeLabel({}, strings)).toBeUndefined();
+  });
+
+  test('returns undefined for a deletable plot photo (no position)', () => {
+    expect(getObsPhotoTypeLabel({ observation: { monitoringPlotNumber: 3, type: 'Plot' } }, strings)).toBeUndefined();
+  });
+
+  test.each([
+    ['NortheastCorner', '5 Northeast corner'],
+    ['NorthwestCorner', '5 Northwest corner'],
+    ['SoutheastCorner', '5 Southeast corner'],
+    ['SouthwestCorner', '5 Southwest corner'],
+  ] as const)('returns plot prefix + corner label for position %s', (position, expected) => {
+    expect(
+      getObsPhotoTypeLabel({ observation: { monitoringPlotNumber: 5, type: 'Plot', position } }, strings)
+    ).toBe(expected);
+  });
+
+  test.each([
+    ['NortheastCorner', '2 Northeast Quadrat'],
+    ['NorthwestCorner', '2 Northwest Quadrat'],
+    ['SoutheastCorner', '2 Southeast Quadrat'],
+    ['SouthwestCorner', '2 Southwest Quadrat'],
+  ] as const)('returns plot prefix + quadrat label for quadrat position %s', (position, expected) => {
+    expect(
+      getObsPhotoTypeLabel({ observation: { monitoringPlotNumber: 2, type: 'Quadrat', position } }, strings)
+    ).toBe(expected);
+  });
+
+  test('returns undefined for quadrat photo without a position', () => {
+    expect(
+      getObsPhotoTypeLabel({ observation: { monitoringPlotNumber: 2, type: 'Quadrat' } }, strings)
+    ).toBeUndefined();
+  });
+
+  test('returns plot prefix + Soil for soil photos', () => {
+    expect(getObsPhotoTypeLabel({ observation: { monitoringPlotNumber: 7, type: 'Soil' } }, strings)).toBe('7 Soil');
   });
 });

--- a/src/utils/activityUtils.ts
+++ b/src/utils/activityUtils.ts
@@ -116,10 +116,10 @@ export const getObsPhotoTypeLabel = (
   }
   const plotPrefix = `${obs.monitoringPlotNumber} `;
   if (obs.type === 'Plot' && obs.position) {
-    return `${plotPrefix}${getPositionLabel(obs.position)}`;
+    return `${plotPrefix}${getPositionLabel(obs.position, strings)}`;
   }
   if (obs.type === 'Quadrat' && obs.position) {
-    return `${plotPrefix}${getQuadratLabel(obs.position)}`;
+    return `${plotPrefix}${getQuadratLabel(obs.position, strings)}`;
   }
   if (obs.type === 'Soil') {
     return `${plotPrefix}${strings.SOIL}`;

--- a/src/utils/activityUtils.ts
+++ b/src/utils/activityUtils.ts
@@ -1,6 +1,7 @@
 import { components } from 'src/api/types/generated-schema';
 import { TypedActivity } from 'src/components/ActivityLog/types';
 import defaultStrings from 'src/strings';
+import { getPositionLabel, getQuadratLabel } from 'src/types/Observations';
 
 export type GroupedActivities = {
   quarter: string;
@@ -103,4 +104,25 @@ export const isCaptionReadOnly = (media: { observation?: ObservationActivityMedi
     return false;
   }
   return media.observation.position !== undefined || media.observation.type === 'Quadrat';
+};
+
+export const getObsPhotoTypeLabel = (
+  media: { observation?: ObservationActivityMedia },
+  strings: typeof defaultStrings
+): string | undefined => {
+  const obs = media.observation;
+  if (!obs || !isUndeletableObservationPhoto(media)) {
+    return undefined;
+  }
+  const plotPrefix = `${obs.monitoringPlotNumber} `;
+  if (obs.type === 'Plot' && obs.position) {
+    return `${plotPrefix}${getPositionLabel(obs.position)}`;
+  }
+  if (obs.type === 'Quadrat' && obs.position) {
+    return `${plotPrefix}${getQuadratLabel(obs.position)}`;
+  }
+  if (obs.type === 'Soil') {
+    return `${plotPrefix}${strings.SOIL}`;
+  }
+  return undefined;
 };


### PR DESCRIPTION
This PR adds photo titles above required observation photos.

It also updates some utility functions to accept `strings` as an argument instead of importing them directly, ensuring locale changes correctly update displayed copy.