### PR TITLE
SW-8466: Disable link to observation if the console user is not in the project Org

### DIFF
--- a/src/components/ActivityLog/ActivityDetailView.tsx
+++ b/src/components/ActivityLog/ActivityDetailView.tsx
@@ -31,7 +31,6 @@ import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { ACTIVITY_MEDIA_FILE_ENDPOINT } from 'src/services/ActivityService';
 import { FUNDER_ACTIVITY_MEDIA_FILE_ENDPOINT } from 'src/services/funder/FunderActivityService';
 import { ActivityMediaFile, activityTypeLabel } from 'src/types/Activity';
-import { userHasOrgAccess } from 'src/utils/acl';
 import { getObsPhotoTypeLabel, isObservationActivity } from 'src/utils/activityUtils';
 import { getObservationSpeciesLivePlantsCount } from 'src/utils/observation';
 import useQuery from 'src/utils/useQuery';
@@ -368,8 +367,13 @@ const ActivityDetailView = ({
   });
 
   const hasOrgAccess = useMemo(
-    () => userHasOrgAccess(isAcceleratorRoute, organizations, projectData?.project.organizationId),
-    [isAcceleratorRoute, organizations, projectData?.project.organizationId]
+    () =>
+      isAllowed('VIEW_ORG_OBSERVATIONS', {
+        organizations,
+        project: projectData?.project,
+        isAcceleratorRoute,
+      }),
+    [isAcceleratorRoute, isAllowed, organizations, projectData?.project]
   );
 
   // Funder activities include observation stats directly on the payload (no observationId or API call needed)

--- a/src/components/ActivityLog/ActivityDetailView.tsx
+++ b/src/components/ActivityLog/ActivityDetailView.tsx
@@ -31,6 +31,7 @@ import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { ACTIVITY_MEDIA_FILE_ENDPOINT } from 'src/services/ActivityService';
 import { FUNDER_ACTIVITY_MEDIA_FILE_ENDPOINT } from 'src/services/funder/FunderActivityService';
 import { ActivityMediaFile, activityTypeLabel } from 'src/types/Activity';
+import { userHasOrgAccess } from 'src/utils/acl';
 import { getObsPhotoTypeLabel, isObservationActivity } from 'src/utils/activityUtils';
 import { getObservationSpeciesLivePlantsCount } from 'src/utils/observation';
 import useQuery from 'src/utils/useQuery';
@@ -366,8 +367,8 @@ const ActivityDetailView = ({
     skip: !isAcceleratorRoute || !isObsActivity,
   });
 
-  const userHasOrgAccess = useMemo(
-    () => !isAcceleratorRoute || organizations.some((org) => org.id === projectData?.project.organizationId),
+  const hasOrgAccess = useMemo(
+    () => userHasOrgAccess(isAcceleratorRoute, organizations, projectData?.project.organizationId),
     [isAcceleratorRoute, organizations, projectData?.project.organizationId]
   );
 
@@ -382,10 +383,10 @@ const ActivityDetailView = ({
 
   const observationUrl = useMemo(
     () =>
-      isObsActivity && activity.payload.observation?.observationId && userHasOrgAccess
+      isObsActivity && activity.payload.observation?.observationId && hasOrgAccess
         ? APP_PATHS.OBSERVATION_DETAILS_V2.replace(':observationId', String(activity.payload.observation.observationId))
         : undefined,
-    [activity.payload.observation?.observationId, isObsActivity, userHasOrgAccess]
+    [activity.payload.observation?.observationId, isObsActivity, hasOrgAccess]
   );
 
   const obsIsAdHoc = activity.payload.observation?.isAdHoc ?? false;

--- a/src/components/ActivityLog/ActivityDetailView.tsx
+++ b/src/components/ActivityLog/ActivityDetailView.tsx
@@ -24,6 +24,7 @@ import {
   useLazyGetActivityMediaStreamQuery,
 } from 'src/queries/generated/funderActivities';
 import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
+import { useGetProjectQuery } from 'src/queries/generated/projects';
 import { requestGetUser } from 'src/redux/features/user/usersAsyncThunks';
 import { selectUser } from 'src/redux/features/user/usersSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
@@ -350,7 +351,7 @@ const ActivityDetailView = ({
   const location = useStateLocation();
   const theme = useTheme();
   const { goToAcceleratorActivityEdit, goToActivityEdit } = useNavigateTo();
-  const { selectedOrganization } = useOrganization();
+  const { selectedOrganization, organizations } = useOrganization();
 
   const verifiedByUser = useAppSelector(
     selectUser(activity.type === 'admin' ? activity.payload.verifiedBy : undefined)
@@ -360,6 +361,15 @@ const ActivityDetailView = ({
     : isAllowed('EDIT_ACTIVITIES', { organization: selectedOrganization });
 
   const isObsActivity = useMemo(() => isObservationActivity(activity.payload), [activity.payload]);
+
+  const { data: projectData } = useGetProjectQuery(projectId, {
+    skip: !isAcceleratorRoute || !isObsActivity,
+  });
+
+  const userHasOrgAccess = useMemo(
+    () => !isAcceleratorRoute || organizations.some((org) => org.id === projectData?.project.organizationId),
+    [isAcceleratorRoute, organizations, projectData?.project.organizationId]
+  );
 
   // Funder activities include observation stats directly on the payload (no observationId or API call needed)
   const funderObsPayload = activity.type === 'funder' ? activity.payload.observation : undefined;
@@ -372,10 +382,10 @@ const ActivityDetailView = ({
 
   const observationUrl = useMemo(
     () =>
-      isObsActivity && activity.payload.observation?.observationId
+      isObsActivity && activity.payload.observation?.observationId && userHasOrgAccess
         ? APP_PATHS.OBSERVATION_DETAILS_V2.replace(':observationId', String(activity.payload.observation.observationId))
         : undefined,
-    [activity.payload.observation?.observationId, isObsActivity]
+    [activity.payload.observation?.observationId, isObsActivity, userHasOrgAccess]
   );
 
   const obsIsAdHoc = activity.payload.observation?.isAdHoc ?? false;

--- a/src/utils/acl.test.ts
+++ b/src/utils/acl.test.ts
@@ -1,7 +1,8 @@
 import { User } from 'src/types/User';
-import { isAllowed, userHasOrgAccess } from './acl';
+import { isAllowed } from './acl';
 import { GLOBAL_ROLE_ACCELERATOR_ADMIN, GLOBAL_ROLE_READ_ONLY, GLOBAL_ROLE_SUPER_ADMIN, GLOBAL_ROLE_TF_EXPERT } from 'src/types/GlobalRoles';
 import { Organization } from 'src/types/Organization';
+import { ProjectPayload } from 'src/queries/generated/projects';
 
 describe('isAllowed', () => {
   it('has the correct permissions for a user with the Super Admin global role', () => {
@@ -99,30 +100,26 @@ describe('isAllowed', () => {
     expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_TF_EXPERT })).toBeFalsy();
     expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_READ_ONLY })).toBeFalsy();
   });
-});
 
-describe('userHasOrgAccess', () => {
-  const org = (id: number): Organization => ({ id, name: `Org ${id}`, totalUsers: 1 });
+  it('has the correct permissions for VIEW_ORG_OBSERVATIONS', () => {
+    const noRolesUser: User = {
+      id: 1,
+      emailNotificationsEnabled: false,
+      email: 'mock@email.com',
+      globalRoles: [],
+      userType: 'Individual',
+    };
+    const org = (id: number): Organization => ({ id, name: `Org ${id}`, totalUsers: 1 });
+    const project = (organizationId: number) => ({ id: 1, name: 'Project', organizationId } as ProjectPayload);
 
-  it('returns true when not in an accelerator route, regardless of org membership', () => {
-    expect(userHasOrgAccess(false, [], 42)).toBeTruthy();
-    expect(userHasOrgAccess(false, [], undefined)).toBeTruthy();
-    expect(userHasOrgAccess(false, [org(1)], 99)).toBeTruthy();
-  });
+    // Non-accelerator route: always allowed regardless of org membership
+    expect(isAllowed(noRolesUser, 'VIEW_ORG_OBSERVATIONS', { organizations: [], project: undefined, isAcceleratorRoute: false })).toBeTruthy();
+    expect(isAllowed(noRolesUser, 'VIEW_ORG_OBSERVATIONS', { organizations: [org(1)], project: project(1), isAcceleratorRoute: false })).toBeTruthy();
 
-  it('returns true in an accelerator route when the user belongs to the org', () => {
-    expect(userHasOrgAccess(true, [org(1), org(2)], 2)).toBeTruthy();
-  });
-
-  it('returns false in an accelerator route when the user does not belong to the org', () => {
-    expect(userHasOrgAccess(true, [org(1), org(2)], 3)).toBeFalsy();
-  });
-
-  it('returns false in an accelerator route when the user has no orgs', () => {
-    expect(userHasOrgAccess(true, [], 1)).toBeFalsy();
-  });
-
-  it('returns false in an accelerator route when organizationId is undefined', () => {
-    expect(userHasOrgAccess(true, [org(1)], undefined)).toBeFalsy();
+    // Accelerator route: allowed only when the project's org is in the user's orgs
+    expect(isAllowed(noRolesUser, 'VIEW_ORG_OBSERVATIONS', { organizations: [org(1), org(2)], project: project(2), isAcceleratorRoute: true })).toBeTruthy();
+    expect(isAllowed(noRolesUser, 'VIEW_ORG_OBSERVATIONS', { organizations: [org(1), org(2)], project: project(3), isAcceleratorRoute: true })).toBeFalsy();
+    expect(isAllowed(noRolesUser, 'VIEW_ORG_OBSERVATIONS', { organizations: [], project: project(1), isAcceleratorRoute: true })).toBeFalsy();
+    expect(isAllowed(noRolesUser, 'VIEW_ORG_OBSERVATIONS', { organizations: [org(1)], project: undefined, isAcceleratorRoute: true })).toBeFalsy();
   });
 });

--- a/src/utils/acl.test.ts
+++ b/src/utils/acl.test.ts
@@ -1,6 +1,7 @@
 import { User } from 'src/types/User';
-import { isAllowed } from './acl';
+import { isAllowed, userHasOrgAccess } from './acl';
 import { GLOBAL_ROLE_ACCELERATOR_ADMIN, GLOBAL_ROLE_READ_ONLY, GLOBAL_ROLE_SUPER_ADMIN, GLOBAL_ROLE_TF_EXPERT } from 'src/types/GlobalRoles';
+import { Organization } from 'src/types/Organization';
 
 describe('isAllowed', () => {
   it('has the correct permissions for a user with the Super Admin global role', () => {
@@ -97,5 +98,31 @@ describe('isAllowed', () => {
     expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_ACCELERATOR_ADMIN })).toBeFalsy();
     expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_TF_EXPERT })).toBeFalsy();
     expect(isAllowed(user, 'ASSIGN_GLOBAL_ROLE_TO_USER', { roleToSet: GLOBAL_ROLE_READ_ONLY })).toBeFalsy();
+  });
+});
+
+describe('userHasOrgAccess', () => {
+  const org = (id: number): Organization => ({ id, name: `Org ${id}`, totalUsers: 1 });
+
+  it('returns true when not in an accelerator route, regardless of org membership', () => {
+    expect(userHasOrgAccess(false, [], 42)).toBeTruthy();
+    expect(userHasOrgAccess(false, [], undefined)).toBeTruthy();
+    expect(userHasOrgAccess(false, [org(1)], 99)).toBeTruthy();
+  });
+
+  it('returns true in an accelerator route when the user belongs to the org', () => {
+    expect(userHasOrgAccess(true, [org(1), org(2)], 2)).toBeTruthy();
+  });
+
+  it('returns false in an accelerator route when the user does not belong to the org', () => {
+    expect(userHasOrgAccess(true, [org(1), org(2)], 3)).toBeFalsy();
+  });
+
+  it('returns false in an accelerator route when the user has no orgs', () => {
+    expect(userHasOrgAccess(true, [], 1)).toBeFalsy();
+  });
+
+  it('returns false in an accelerator route when organizationId is undefined', () => {
+    expect(userHasOrgAccess(true, [org(1)], undefined)).toBeFalsy();
   });
 });

--- a/src/utils/acl.ts
+++ b/src/utils/acl.ts
@@ -1,3 +1,4 @@
+import { ProjectPayload } from 'src/queries/generated/projects';
 import {
   GLOBAL_ROLE_ACCELERATOR_ADMIN,
   GLOBAL_ROLE_READ_ONLY,
@@ -33,7 +34,8 @@ type PermissionActivities =
   | 'DELETE_ACTIVITIES_NON_PUBLISHED'
   | 'DELETE_ACTIVITIES_PUBLISHED'
   | 'EDIT_ACTIVITIES'
-  | 'READ_ACTIVITIES';
+  | 'READ_ACTIVITIES'
+  | 'VIEW_ORG_OBSERVATIONS';
 type PermissionApplication =
   | 'READ_ALL_APPLICATIONS'
   | 'UPDATE_APPLICATION_INTERNAL_COMMENTS'
@@ -220,6 +222,25 @@ const isAllowedManageFundingEntities: PermissionCheckFn = (user: User): boolean 
 };
 
 /**
+ * Function related to org access for viewing activities, since the permission also applies to
+ * org roles, we need to check the passed-in organization. The caller is responsible for resolving
+ * the organization object from their list before passing it as metadata.
+ */
+type ViewOrgObservationsMetadata = {
+  isAcceleratorRoute: boolean;
+  organizations: Organization[] | undefined;
+  project: ProjectPayload | undefined;
+};
+const isAllowedViewOrgObservations: PermissionCheckFn<ViewOrgObservationsMetadata> = (
+  _user: User,
+  __: GlobalRolePermission,
+  metadata?: ViewOrgObservationsMetadata
+): boolean => {
+  const organization = metadata?.organizations?.find((org) => org.id === metadata?.project?.organizationId);
+  return !metadata?.isAcceleratorRoute || isMember(organization);
+};
+
+/**
  * Function related to reading activities, since the permission also applies to
  * org roles, we need to check the passed-in organization
  */
@@ -325,6 +346,7 @@ const ACL: Record<GlobalRolePermission, UserGlobalRoles | PermissionCheckFn> = {
   UPDATE_SUBMISSION_STATUS: TFExpertPlus,
   VIEW_CONSOLE: ReadOnlyPlus,
   VIEW_ACCELERATOR_PROJECT_SCORING_VOTING: TFExpertPlus,
+  VIEW_ORG_OBSERVATIONS: isAllowedViewOrgObservations,
   FREE_FLY_VIRTUAL_WALKTHROUGH: SuperAdminPlus,
 };
 
@@ -351,14 +373,3 @@ export const isAllowed: PermissionCheckFn = (
     return acl(user, permission, metadata);
   }
 };
-
-/**
- * Returns true if the user is a member of the given organization (by ID).
- * In non-accelerator contexts, access is always granted since the user is already
- * scoped to their own organization.
- */
-export const userHasOrgAccess = (
-  isAcceleratorRoute: boolean,
-  organizations: Organization[],
-  organizationId: number | undefined
-): boolean => !isAcceleratorRoute || organizations.some((org) => org.id === organizationId);

--- a/src/utils/acl.ts
+++ b/src/utils/acl.ts
@@ -222,7 +222,7 @@ const isAllowedManageFundingEntities: PermissionCheckFn = (user: User): boolean 
 };
 
 /**
- * Function related to org access for viewing activities, since the permission also applies to
+ * Function related to org access for viewing observations, since the permission also applies to
  * org roles, we need to check the passed-in organization. The caller is responsible for resolving
  * the organization object from their list before passing it as metadata.
  */

--- a/src/utils/acl.ts
+++ b/src/utils/acl.ts
@@ -351,3 +351,14 @@ export const isAllowed: PermissionCheckFn = (
     return acl(user, permission, metadata);
   }
 };
+
+/**
+ * Returns true if the user is a member of the given organization (by ID).
+ * In non-accelerator contexts, access is always granted since the user is already
+ * scoped to their own organization.
+ */
+export const userHasOrgAccess = (
+  isAcceleratorRoute: boolean,
+  organizations: Organization[],
+  organizationId: number | undefined
+): boolean => !isAcceleratorRoute || organizations.some((org) => org.id === organizationId);


### PR DESCRIPTION
This PR includes a change to only enable a link to an observation from an observation activity, when the user is a member of the project org.

Co-authored by Claude.