### PR TITLE
SW-8469: Editing Photos & Videos in Observations shows additional data in alert

### DIFF
--- a/src/components/ActivityLog/ActivityMediaForm.tsx
+++ b/src/components/ActivityLog/ActivityMediaForm.tsx
@@ -751,7 +751,7 @@ export default function ActivityMediaForm({
           message={
             obsConfirmContext
               ? strings.formatString(
-                  strings.SAVE_OBSERVATION_ACTIVITY_PHOTOS_AND_VIDEOS_DESCRIPTION,
+                  strings.DELETE_OBSERVATION_ACTIVITY_PHOTO_MESSAGE,
                   obsConfirmContext.monthYear,
                   obsConfirmContext.projectName
                 )

--- a/src/components/ActivityLog/ActivityMediaForm.tsx
+++ b/src/components/ActivityLog/ActivityMediaForm.tsx
@@ -751,7 +751,7 @@ export default function ActivityMediaForm({
           message={
             obsConfirmContext
               ? strings.formatString(
-                  strings.SAVE_PHOTOS_AND_VIDEOS_DESCRIPTION,
+                  strings.SAVE_OBSERVATION_ACTIVITY_PHOTOS_AND_VIDEOS_DESCRIPTION,
                   obsConfirmContext.monthYear,
                   obsConfirmContext.projectName
                 )

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -492,6 +492,9 @@ DELETE_FUNDING_ENTITY,Delete Funding Entity,
 DELETE_FUNDING_ENTITY_FUNDERS_MESSAGE,All Funders associated with this Funding Entity will be deleted.,
 DELETE_FUNDING_ENTITY_MESSAGE,You’re about to delete {0}.,
 DELETE_OBSERVATION_PHOTO_MESSAGE,This photo will also be removed from the linked observation. This action cannot be undone.,
+DELETE_OBSERVATION_ACTIVITY_PHOTO_MESSAGE,"You are about to make changes to photos and videos associated with an Observation in {0} for {1}.
+
+Are you sure you want to make these changes?",
 DELETE_OBSERVATION_PHOTO_TITLE,Remove Photo from Observation,
 DELETE_ORGANIZATION,Delete Organization,
 DELETE_ORGANIZATION_MSG,Are you sure you want to delete {0}?,
@@ -1850,9 +1853,7 @@ SAVE_CHANGES,Save Changes,
 SAVE_OBSERVATION_DATA,Save Observation Data,
 SAVE_OBSERVATION_DATA_DESCRIPTION,Your edits will replace any previously entered data. Are you sure you want to make these edits?,
 SAVE_PHOTOS_AND_VIDEOS,Save Photos & Videos,
-SAVE_PHOTOS_AND_VIDEOS_DESCRIPTION,"You are about to make changes to photos and videos associated with an Observation in {0} for {1}.
-
-Are you sure you want to make these changes?",
+SAVE_PHOTOS_AND_VIDEOS_DESCRIPTION,You are making changes to the photos and videos associated with this Observation plot. Are you sure you want to make these changes?,
 SAVE_PLANT_DENSITY,Save Plant Density,
 SAVE_PROJECT_BOUNDARIES,Save Project Boundaries,
 SAVE_VERSION,Save Version,

--- a/src/strings/csv/es.csv
+++ b/src/strings/csv/es.csv
@@ -491,6 +491,9 @@ DELETE_CONFIRMATION_MODAL_MAIN_TEXT,¿Está seguro de que desea eliminar la espe
 DELETE_FUNDING_ENTITY,Eliminar entidad financiadora,7d8a1f95
 DELETE_FUNDING_ENTITY_FUNDERS_MESSAGE,Se eliminarán todos los financiadores asociados a esta entidad financiadora.,cedce711
 DELETE_FUNDING_ENTITY_MESSAGE,Va a eliminar {0}.,4a41e34f
+DELETE_OBSERVATION_ACTIVITY_PHOTO_MESSAGE,"Está a punto de realizar cambios en las fotos y videos asociados a una Observación en {0} para {1}.
+
+¿Está seguro de que desea realizar estos cambios?",b9887b3e
 DELETE_OBSERVATION_PHOTO_MESSAGE,Esta foto también se eliminará de la observación vinculada. Esta acción no se puede deshacer.,cd60484f
 DELETE_OBSERVATION_PHOTO_TITLE,Eliminar foto de la observación,e92e9851
 DELETE_ORGANIZATION,Borrar Organización,91c84420
@@ -1852,9 +1855,7 @@ SAVE_CHANGES,Guardar los cambios,cb5e8c33
 SAVE_OBSERVATION_DATA,Guardar datos de observación,e308c5cd
 SAVE_OBSERVATION_DATA_DESCRIPTION,Sus ediciones reemplazarán cualquier dato ingresado previamente. ¿Está seguro de que desea realizar estos cambios?,b1657c44
 SAVE_PHOTOS_AND_VIDEOS,Guardar fotos y videos,d38ce0cc
-SAVE_PHOTOS_AND_VIDEOS_DESCRIPTION,"Está a punto de realizar cambios en las fotos y videos asociados con una Observación en {0} para {1}.
-
-¿Está seguro de que desea realizar estos cambios?",81b6df07
+SAVE_PHOTOS_AND_VIDEOS_DESCRIPTION,Está realizando cambios en las fotos y videos asociados a esta parcela de Observación. ¿Está seguro de que desea realizar estos cambios?,8cfdcf97
 SAVE_PLANT_DENSITY,Guardar densidad de plantas,73135113
 SAVE_PROJECT_BOUNDARIES,Guardar límites del proyecto,d206ddd9
 SAVE_VERSION,Guardar versión,5afacff0

--- a/src/strings/csv/fr.csv
+++ b/src/strings/csv/fr.csv
@@ -490,6 +490,9 @@ DELETE_CONFIRMATION_MODAL_MAIN_TEXT,Êtes-vous sûr de vouloir supprimer l'espè
 DELETE_FUNDING_ENTITY,Supprimer l’entité de financement,7d8a1f95
 DELETE_FUNDING_ENTITY_FUNDERS_MESSAGE,Tous les financeurs associés à cette entité de financement seront supprimés.,cedce711
 DELETE_FUNDING_ENTITY_MESSAGE,Vous êtes sur le point de supprimer {0}.,4a41e34f
+DELETE_OBSERVATION_ACTIVITY_PHOTO_MESSAGE,"Vous êtes sur le point de modifier les photos et vidéos associées à une Observation dans {0} pour {1}.
+
+Êtes-vous sûr de vouloir effectuer ces modifications ?",b9887b3e
 DELETE_OBSERVATION_PHOTO_MESSAGE,Cette photo sera également supprimée de l'observation associée. Cette action est irréversible.,cd60484f
 DELETE_OBSERVATION_PHOTO_TITLE,Supprimer la photo de l'observation,e92e9851
 DELETE_ORGANIZATION,Supprimer l'organisation,91c84420
@@ -1851,9 +1854,7 @@ SAVE_CHANGES,Sauvegarder les modifications,cb5e8c33
 SAVE_OBSERVATION_DATA,Enregistrer les données d'observation,e308c5cd
 SAVE_OBSERVATION_DATA_DESCRIPTION,Vos modifications remplaceront toutes les données saisies précédemment. Êtes-vous sûr de vouloir effectuer ces modifications ?,b1657c44
 SAVE_PHOTOS_AND_VIDEOS,Enregistrer les photos et vidéos,d38ce0cc
-SAVE_PHOTOS_AND_VIDEOS_DESCRIPTION,"Vous êtes sur le point de modifier les photos et vidéos associées à une Observation dans {0} pour {1}.
-
-Êtes-vous sûr de vouloir effectuer ces modifications ?",81b6df07
+SAVE_PHOTOS_AND_VIDEOS_DESCRIPTION,Vous êtes en train de modifier les photos et vidéos associées à cette parcelle d’Observation. Êtes-vous sûr de vouloir effectuer ces modifications ?,8cfdcf97
 SAVE_PLANT_DENSITY,Enregistrer la densité de plantation,73135113
 SAVE_PROJECT_BOUNDARIES,Sauvegarder les limites du projet,d206ddd9
 SAVE_VERSION,Enregistrer la version,5afacff0


### PR DESCRIPTION
This PR fixes invalid copy in one of the confirmation dialogs.

A [previous PR](https://github.com/terraware/terraware-web/pull/5776) incorrectly modified an existing UI string rather than creating a new one.