### PR TITLE
SW-8476 In Add Season dialog, when copying past season, selector should include season names, not date ranges

### DIFF
--- a/src/scenes/NurseryRouter/PlantingSeasons/AddPlantingSeasonModal.tsx
+++ b/src/scenes/NurseryRouter/PlantingSeasons/AddPlantingSeasonModal.tsx
@@ -94,7 +94,7 @@ const AddPlantingSeasonModal = ({ onClose, initialPlantingSiteId }: AddPlantingS
   const seasonToCopyOptions = useMemo<DropdownItem[]>(
     () =>
       seasonsForSelectedSite.map((season) => ({
-        label: strings.formatString(strings.DATE_RANGE, season.startDate, season.endDate).toString(),
+        label: season.name,
         value: season.id,
       })),
     [seasonsForSelectedSite]


### PR DESCRIPTION
I did that when the season name was not available and forgot to update it later