### PR TITLE
SW-8460: Scroll down to error field when there's an error upon a user saving edits

### DIFF
--- a/src/components/ActivityLog/ActivityDetailsForm.tsx
+++ b/src/components/ActivityLog/ActivityDetailsForm.tsx
@@ -68,6 +68,9 @@ import MapSplitView from './MapSplitView';
 import ObservationStatsPanel from './ObservationStatsPanel';
 import { TypedActivity } from './types';
 
+const MAX_FILE_SIZE_GB = 5;
+const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_GB * 1024 * 1024 * 1024;
+
 interface ActivityDetailsFormProps {
   activityId?: number;
   projectId: number;
@@ -296,8 +299,6 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
     if (isObsActivity && newMediaFiles.some((item) => item.data.monitoringPlotId === undefined)) {
       return false;
     }
-    const MAX_FILE_SIZE_GB = 5;
-    const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_GB * 1024 * 1024 * 1024;
 
     for (const mediaItem of newMediaFiles) {
       const file = mediaItem.data.file;
@@ -344,9 +345,36 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
     ]
   );
 
+  const scrollToFirstError = useCallback(() => {
+    if (!isObsActivity) {
+      if (!record?.type) {
+        scrollToElementById('activity-type-field');
+        return;
+      }
+      if (!record?.date) {
+        scrollToElementById('date');
+        return;
+      }
+      if (!record?.description) {
+        scrollToElementById('description');
+        return;
+      }
+    }
+
+    const firstInvalidIndex = mediaItems.findIndex(
+      (item) =>
+        item.type === 'new' &&
+        ((isObsActivity && item.data.monitoringPlotId === undefined) || item.data.file.size > MAX_FILE_SIZE_BYTES)
+    );
+    if (firstInvalidIndex !== -1) {
+      scrollToElementById(`activity-media-item-new-${firstInvalidIndex}`);
+    }
+  }, [isObsActivity, mediaItems, record, scrollToElementById]);
+
   const saveActivity = useCallback(async () => {
     if (!validateForm()) {
       setValidateFields(true);
+      scrollToFirstError();
       return;
     }
 
@@ -414,6 +442,7 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
     isObsActivity,
     projectId,
     record,
+    scrollToFirstError,
     snackbar,
     strings.GENERIC_ERROR,
     syncMediaFiles,
@@ -726,7 +755,7 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
                 />
               ) : (
                 <Box display='flex' alignItems='center' gap={1}>
-                  <Box flex={1}>
+                  <Box flex={1} id='activity-type-field'>
                     <Dropdown
                       errorText={validateFields && !record?.type && !isObsActivity ? strings.REQUIRED_FIELD : ''}
                       fullWidth

--- a/src/components/ActivityLog/ActivityMediaForm.tsx
+++ b/src/components/ActivityLog/ActivityMediaForm.tsx
@@ -56,6 +56,7 @@ type ActivityPhotoPreviewProps = {
   isAdHoc?: boolean;
   isLast?: boolean;
   isObsActivity: boolean;
+  itemIndex: number;
   maxPosition: number;
   mediaItem: ActivityMediaItem;
   onClick?: () => void;
@@ -76,6 +77,7 @@ const ActivityPhotoPreview = ({
   isAdHoc,
   isLast,
   isObsActivity,
+  itemIndex,
   maxPosition,
   mediaItem,
   onClick,
@@ -246,7 +248,11 @@ const ActivityPhotoPreview = ({
     <Box
       bgcolor={focused ? theme.palette.TwClrBgSecondary : undefined}
       borderBottom={isLast ? 'none' : `1px solid ${theme.palette.TwClrBgSecondary}`}
-      id={mediaItem.type === 'existing' ? `activity-media-item-${mediaItem.data.fileId}` : undefined}
+      id={
+        mediaItem.type === 'existing'
+          ? `activity-media-item-${mediaItem.data.fileId}`
+          : `activity-media-item-new-${itemIndex}`
+      }
       marginBottom='24px'
       onClick={onClick}
       paddingBottom='24px'
@@ -795,6 +801,7 @@ export default function ActivityMediaForm({
               isAdHoc={isAdHoc}
               isLast={visibleIndex === visibleMediaItems.length - 1}
               isObsActivity={isObsActivity}
+              itemIndex={index}
               key={`photo-${index}`}
               maxPosition={visibleMediaItems.length}
               onClick={mediaItem.type === 'existing' ? onClickMediaItem(mediaItem.data.fileId) : undefined}


### PR DESCRIPTION
This PR improves validation by scrolling to the first field with an error when saving activity edits.

## Example

https://github.com/user-attachments/assets/ca42cbb2-601c-40c2-a428-4804deebf171