### PR TITLE
SW-8428: Survival Rate Settings: Species lists not appearing in alphabetical order

### DIFF
--- a/src/scenes/SurvivalRateSettings/PlotT0EditBox.tsx
+++ b/src/scenes/SurvivalRateSettings/PlotT0EditBox.tsx
@@ -73,7 +73,6 @@ const PlotT0EditBox = ({
   }, [t0Plot, withdrawnSpeciesPlot]);
 
   const [newSpeciesRows, setNewSpeciesRows] = useState<AddedSpecies[]>(initialNewSpecies);
-  const [sessionAddedRowIds, setSessionAddedRowIds] = useState<Set<string>>(new Set());
 
   const isEqualObservation = useCallback(
     (a: ObservationSpeciesDensityPayload, b: ObservationSpeciesDensityPayload) => a.observationId === b.observationId,
@@ -115,7 +114,6 @@ const PlotT0EditBox = ({
 
   useEffect(() => {
     setNewSpeciesRows(initialNewSpecies);
-    setSessionAddedRowIds(new Set());
   }, [initialNewSpecies]);
 
   useEffect(() => {
@@ -259,7 +257,6 @@ const PlotT0EditBox = ({
   const onAddNewSpecies = useCallback(() => {
     const newRowId = `new-species-${crypto.randomUUID()}`;
     setNewSpeciesRows((prev) => [...prev, { id: newRowId, density: '' }]);
-    setSessionAddedRowIds((prev) => new Set([...prev, newRowId]));
   }, []);
 
   const onNewSpeciesChange = useCallback(
@@ -369,16 +366,18 @@ const PlotT0EditBox = ({
     });
   }, [activeLocale, withdrawnSpeciesPlot?.species, speciesById]);
 
+  const initialNewSpeciesIds = useMemo(() => new Set(initialNewSpecies.map((row) => row.id)), [initialNewSpecies]);
+
   const sortedNewSpeciesRows = useMemo(() => {
-    const preExisting = newSpeciesRows.filter((row) => !sessionAddedRowIds.has(row.id));
-    const sessionAdded = newSpeciesRows.filter((row) => sessionAddedRowIds.has(row.id));
+    const preExisting = newSpeciesRows.filter((row) => initialNewSpeciesIds.has(row.id));
+    const sessionAdded = newSpeciesRows.filter((row) => !initialNewSpeciesIds.has(row.id));
     const sorted = [...preExisting].sort((a, b) => {
       const nameA = a.speciesId !== undefined ? speciesById[a.speciesId]?.scientificName ?? '' : '\uffff';
       const nameB = b.speciesId !== undefined ? speciesById[b.speciesId]?.scientificName ?? '' : '\uffff';
       return nameA.localeCompare(nameB, activeLocale ?? undefined);
     });
     return [...sorted, ...sessionAdded];
-  }, [activeLocale, newSpeciesRows, sessionAddedRowIds, speciesById]);
+  }, [activeLocale, initialNewSpeciesIds, newSpeciesRows, speciesById]);
 
   return (
     <>

--- a/src/scenes/SurvivalRateSettings/PlotT0EditBox.tsx
+++ b/src/scenes/SurvivalRateSettings/PlotT0EditBox.tsx
@@ -73,6 +73,7 @@ const PlotT0EditBox = ({
   }, [t0Plot, withdrawnSpeciesPlot]);
 
   const [newSpeciesRows, setNewSpeciesRows] = useState<AddedSpecies[]>(initialNewSpecies);
+  const [sessionAddedRowIds, setSessionAddedRowIds] = useState<Set<string>>(new Set());
 
   const isEqualObservation = useCallback(
     (a: ObservationSpeciesDensityPayload, b: ObservationSpeciesDensityPayload) => a.observationId === b.observationId,
@@ -114,6 +115,7 @@ const PlotT0EditBox = ({
 
   useEffect(() => {
     setNewSpeciesRows(initialNewSpecies);
+    setSessionAddedRowIds(new Set());
   }, [initialNewSpecies]);
 
   useEffect(() => {
@@ -257,6 +259,7 @@ const PlotT0EditBox = ({
   const onAddNewSpecies = useCallback(() => {
     const newRowId = `new-species-${crypto.randomUUID()}`;
     setNewSpeciesRows((prev) => [...prev, { id: newRowId, density: '' }]);
+    setSessionAddedRowIds((prev) => new Set([...prev, newRowId]));
   }, []);
 
   const onNewSpeciesChange = useCallback(
@@ -367,12 +370,15 @@ const PlotT0EditBox = ({
   }, [activeLocale, withdrawnSpeciesPlot?.species, speciesById]);
 
   const sortedNewSpeciesRows = useMemo(() => {
-    return [...newSpeciesRows].sort((a, b) => {
+    const preExisting = newSpeciesRows.filter((row) => !sessionAddedRowIds.has(row.id));
+    const sessionAdded = newSpeciesRows.filter((row) => sessionAddedRowIds.has(row.id));
+    const sorted = [...preExisting].sort((a, b) => {
       const nameA = a.speciesId !== undefined ? speciesById[a.speciesId]?.scientificName ?? '' : '\uffff';
       const nameB = b.speciesId !== undefined ? speciesById[b.speciesId]?.scientificName ?? '' : '\uffff';
       return nameA.localeCompare(nameB, activeLocale ?? undefined);
     });
-  }, [activeLocale, newSpeciesRows, speciesById]);
+    return [...sorted, ...sessionAdded];
+  }, [activeLocale, newSpeciesRows, sessionAddedRowIds, speciesById]);
 
   return (
     <>

--- a/src/scenes/SurvivalRateSettings/StratumT0EditBox.tsx
+++ b/src/scenes/SurvivalRateSettings/StratumT0EditBox.tsx
@@ -66,12 +66,10 @@ const StratumT0EditBox = ({
   }, [allWithdrawnSpecies, stratumData]);
 
   const [newSpeciesRows, setNewSpeciesRows] = useState<AddedSpecies[]>(initialNewSpecies);
-  const [sessionAddedRowIds, setSessionAddedRowIds] = useState<Set<string>>(new Set());
 
   const onAddNewSpecies = useCallback(() => {
     const newRowId = `new-species-${crypto.randomUUID()}`;
     setNewSpeciesRows((prev) => [...prev, { id: newRowId, density: '' }]);
-    setSessionAddedRowIds((prev) => new Set([...prev, newRowId]));
   }, []);
 
   const availableSpecies = useMemo(() => {
@@ -279,16 +277,18 @@ const StratumT0EditBox = ({
     });
   }, [activeLocale, allWithdrawnSpecies, speciesById]);
 
+  const initialNewSpeciesIds = useMemo(() => new Set(initialNewSpecies.map((row) => row.id)), [initialNewSpecies]);
+
   const sortedNewSpeciesRows = useMemo(() => {
-    const preExisting = newSpeciesRows.filter((row) => !sessionAddedRowIds.has(row.id));
-    const sessionAdded = newSpeciesRows.filter((row) => sessionAddedRowIds.has(row.id));
+    const preExisting = newSpeciesRows.filter((row) => initialNewSpeciesIds.has(row.id));
+    const sessionAdded = newSpeciesRows.filter((row) => !initialNewSpeciesIds.has(row.id));
     const sorted = [...preExisting].sort((a, b) => {
       const nameA = a.speciesId !== undefined ? speciesById[a.speciesId]?.scientificName ?? '' : '\uffff';
       const nameB = b.speciesId !== undefined ? speciesById[b.speciesId]?.scientificName ?? '' : '\uffff';
       return nameA.localeCompare(nameB, activeLocale ?? undefined);
     });
     return [...sorted, ...sessionAdded];
-  }, [activeLocale, newSpeciesRows, sessionAddedRowIds, speciesById]);
+  }, [activeLocale, initialNewSpeciesIds, newSpeciesRows, speciesById]);
 
   return (
     <>

--- a/src/scenes/SurvivalRateSettings/StratumT0EditBox.tsx
+++ b/src/scenes/SurvivalRateSettings/StratumT0EditBox.tsx
@@ -66,10 +66,12 @@ const StratumT0EditBox = ({
   }, [allWithdrawnSpecies, stratumData]);
 
   const [newSpeciesRows, setNewSpeciesRows] = useState<AddedSpecies[]>(initialNewSpecies);
+  const [sessionAddedRowIds, setSessionAddedRowIds] = useState<Set<string>>(new Set());
 
   const onAddNewSpecies = useCallback(() => {
     const newRowId = `new-species-${crypto.randomUUID()}`;
     setNewSpeciesRows((prev) => [...prev, { id: newRowId, density: '' }]);
+    setSessionAddedRowIds((prev) => new Set([...prev, newRowId]));
   }, []);
 
   const availableSpecies = useMemo(() => {
@@ -278,12 +280,15 @@ const StratumT0EditBox = ({
   }, [activeLocale, allWithdrawnSpecies, speciesById]);
 
   const sortedNewSpeciesRows = useMemo(() => {
-    return [...newSpeciesRows].sort((a, b) => {
+    const preExisting = newSpeciesRows.filter((row) => !sessionAddedRowIds.has(row.id));
+    const sessionAdded = newSpeciesRows.filter((row) => sessionAddedRowIds.has(row.id));
+    const sorted = [...preExisting].sort((a, b) => {
       const nameA = a.speciesId !== undefined ? speciesById[a.speciesId]?.scientificName ?? '' : '\uffff';
       const nameB = b.speciesId !== undefined ? speciesById[b.speciesId]?.scientificName ?? '' : '\uffff';
       return nameA.localeCompare(nameB, activeLocale ?? undefined);
     });
-  }, [activeLocale, newSpeciesRows, speciesById]);
+    return [...sorted, ...sessionAdded];
+  }, [activeLocale, newSpeciesRows, sessionAddedRowIds, speciesById]);
 
   return (
     <>


### PR DESCRIPTION
This PR adjusts species sorting in survival rate settings, so newly added species are not sorted, and are instead appended to the bottom of the list.