### PR TITLE
SW-8463: Needed to reload page to see caption updates (FOLLOW-UP)

### DIFF
--- a/src/queries/extensions/observations.ts
+++ b/src/queries/extensions/observations.ts
@@ -119,19 +119,35 @@ api.enhanceEndpoints({
       providesTags: (_results, _error, payload) => [{ type: QueryTagTypes.ObservationMedia, id: payload.fileId }],
     },
     uploadOtherPlotMedia: {
-      invalidatesTags: (_results, _error, payload) => [{ type: QueryTagTypes.Observation, id: payload.observationId }],
+      invalidatesTags: (_results, _error, payload) => [
+        { type: QueryTagTypes.Observation, id: payload.observationId },
+        { type: QueryTagTypes.Activities },
+        { type: QueryTagTypes.FunderActivities },
+      ],
     },
     uploadPlotPhoto: {
-      invalidatesTags: (_results, _error, payload) => [{ type: QueryTagTypes.Observation, id: payload.observationId }],
+      invalidatesTags: (_results, _error, payload) => [
+        { type: QueryTagTypes.Observation, id: payload.observationId },
+        { type: QueryTagTypes.Activities },
+        { type: QueryTagTypes.FunderActivities },
+      ],
     },
     deletePlotPhoto: {
-      invalidatesTags: (_results, _error, payload) => [{ type: QueryTagTypes.Observation, id: payload.observationId }],
+      invalidatesTags: (_results, _error, payload) => [
+        { type: QueryTagTypes.Observation, id: payload.observationId },
+        { type: QueryTagTypes.Activities },
+        { type: QueryTagTypes.FunderActivities },
+      ],
     },
     getPlotPhoto: {
       providesTags: (_results, _error, payload) => [{ type: QueryTagTypes.ObservationMedia, id: payload.fileId }],
     },
     updatePlotPhoto: {
-      invalidatesTags: (_results, _error, payload) => [{ type: QueryTagTypes.Observation, id: payload.observationId }],
+      invalidatesTags: (_results, _error, payload) => [
+        { type: QueryTagTypes.Observation, id: payload.observationId },
+        { type: QueryTagTypes.Activities },
+        { type: QueryTagTypes.FunderActivities },
+      ],
     },
     releaseMonitoringPlot: {
       invalidatesTags: (_results, _error, payload) => [{ type: QueryTagTypes.Observation, id: payload.observationId }],

--- a/src/queries/extensions/observations.ts
+++ b/src/queries/extensions/observations.ts
@@ -74,8 +74,8 @@ api.enhanceEndpoints({
       invalidatesTags: (_results, _error, observationId) => [
         { type: QueryTagTypes.Observation, id: observationId },
         { type: QueryTagTypes.Observation, id: 'LIST' },
-        { type: QueryTagTypes.Activities, id: 'LIST' },
-        { type: QueryTagTypes.FunderActivities, id: 'LIST' },
+        { type: QueryTagTypes.Activities },
+        { type: QueryTagTypes.FunderActivities },
       ],
     },
     mergeOtherSpecies: {
@@ -94,22 +94,22 @@ api.enhanceEndpoints({
       invalidatesTags: (_results, _error, payload) => [
         { type: QueryTagTypes.Observation, id: payload.observationId },
         { type: QueryTagTypes.Observation, id: 'LIST' },
-        { type: QueryTagTypes.Activities, id: 'LIST' },
-        { type: QueryTagTypes.FunderActivities, id: 'LIST' },
+        { type: QueryTagTypes.Activities },
+        { type: QueryTagTypes.FunderActivities },
       ],
     },
     completePlotObservation: {
       invalidatesTags: (_results, _error, payload) => [
         { type: QueryTagTypes.Observation, id: payload.observationId },
-        { type: QueryTagTypes.Activities, id: 'LIST' },
-        { type: QueryTagTypes.FunderActivities, id: 'LIST' },
+        { type: QueryTagTypes.Activities },
+        { type: QueryTagTypes.FunderActivities },
       ],
     },
     updatePlotObservation: {
       invalidatesTags: (_results, _error, payload) => [
         { type: QueryTagTypes.Observation, id: payload.observationId },
-        { type: QueryTagTypes.Activities, id: 'LIST' },
-        { type: QueryTagTypes.FunderActivities, id: 'LIST' },
+        { type: QueryTagTypes.Activities },
+        { type: QueryTagTypes.FunderActivities },
       ],
     },
     claimMonitoringPlot: {


### PR DESCRIPTION
This PR fixes an issue that resulted in stale observation photo captions in Activity Log.

Co-authored by Claude Code.

## Context

After editing observation photo captions, the activity log showed stale data until the page was reloaded.

**Root cause:** Observation mutations invalidated `{ type: Activities, id: 'LIST' }`, which only busts the list query. The activity detail view uses `getActivity(id)`, cached under a numeric id tag that `'LIST'` never matches.

**Fix:** Switch to type-only invalidation tags (no `id`) on observation mutations that affect activity data, which invalidates all cached entries for that tag type regardless of id.