### PR TITLE
SW-8506: Observation activity name and data takes 6 seconds to load (much longer than the rest of the page)

### DIFF
--- a/src/components/ActivityLog/ActivityDetailView.tsx
+++ b/src/components/ActivityLog/ActivityDetailView.tsx
@@ -395,8 +395,6 @@ const ActivityDetailView = ({
 
   const obsIsAdHoc = activity.payload.observation?.isAdHoc ?? false;
   const obsPlotNumber = activity.payload.observation?.monitoringPlotNumber;
-  const obsCompletedTime =
-    funderObsPayload !== undefined ? funderObsPayload.completedTime : observationResultsData?.observation.completedTime;
 
   const obsCompletedMonthYear = useMemo(() => {
     const dt = DateTime.fromISO(activity.payload.date);

--- a/src/components/ActivityLog/ActivityDetailView.tsx
+++ b/src/components/ActivityLog/ActivityDetailView.tsx
@@ -399,12 +399,9 @@ const ActivityDetailView = ({
     funderObsPayload !== undefined ? funderObsPayload.completedTime : observationResultsData?.observation.completedTime;
 
   const obsCompletedMonthYear = useMemo(() => {
-    if (!obsCompletedTime) {
-      return undefined;
-    }
-    const dt = DateTime.fromISO(obsCompletedTime);
+    const dt = DateTime.fromISO(activity.payload.date);
     return dt.isValid ? dt.toFormat('LLLL yyyy') : undefined;
-  }, [obsCompletedTime]);
+  }, [activity.payload.date]);
 
   const obsTitle = useMemo(() => {
     if (!showObsPanel) {

--- a/src/components/ActivityLog/ObservationStatsPanel.tsx
+++ b/src/components/ActivityLog/ObservationStatsPanel.tsx
@@ -23,15 +23,21 @@ export default function ObservationStatsPanel({
 
   return (
     <>
-      <Grid item xs={12} sm={4}>
-        <ActivityStatField title={strings.LIVE_PLANTS} contents={(livePlants ?? 0).toString()} isEditing={isEditing} />
-      </Grid>
-      {!!plantDensity && (
+      {typeof livePlants === 'number' && (
+        <Grid item xs={12} sm={4}>
+          <ActivityStatField
+            title={strings.LIVE_PLANTS}
+            contents={(livePlants ?? 0).toString()}
+            isEditing={isEditing}
+          />
+        </Grid>
+      )}
+      {typeof plantDensity === 'number' && (
         <Grid item xs={12} sm={4}>
           <ActivityStatField title={strings.PLANT_DENSITY} contents={plantDensity.toString()} isEditing={isEditing} />
         </Grid>
       )}
-      {survivalRate !== undefined && (
+      {typeof survivalRate === 'number' && (
         <Grid item xs={12} sm={4}>
           <ActivityStatField title={strings.SURVIVAL_RATE} contents={`${survivalRate}%`} isEditing={isEditing} />
         </Grid>


### PR DESCRIPTION
This PR improves the loading UX for observation activities by:

- Derive observation month & year from activity payload to instantly render title (previously month & year were derived from async observation results fetch)
- Hide observation stats until async data is loaded