### PR TITLE
Sort organization picker options alphabetically

### DIFF
--- a/src/components/OrganizationsDropdown.tsx
+++ b/src/components/OrganizationsDropdown.tsx
@@ -64,8 +64,7 @@ export default function OrganizationsDropdown(): JSX.Element {
         anchor={<p style={{ fontSize: '16px' }}>{selectedOrganization?.name}</p>}
         menuSections={[
           organizations
-            ?.slice()
-            .sort((a, b) => a.name.localeCompare(b.name, activeLocale || undefined))
+            ?.toSorted((a, b) => a.name.localeCompare(b.name, activeLocale || undefined))
             .map((organization) => ({ label: organization.name, value: organization.id.toString() })) || [],
           [{ label: strings.CREATE_NEW_ORGANIZATION, value: '0' }],
         ]}

--- a/src/components/OrganizationsDropdown.tsx
+++ b/src/components/OrganizationsDropdown.tsx
@@ -4,13 +4,14 @@ import { DropdownItem, PopoverMenu } from '@terraware/web-components';
 
 import { APP_PATHS } from 'src/constants';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
-import { useOrganization } from 'src/providers/hooks';
+import { useLocalization, useOrganization } from 'src/providers/hooks';
 import strings from 'src/strings';
 import { Organization } from 'src/types/Organization';
 
 import AddNewOrganizationModal from './AddNewOrganizationModal';
 
 export default function OrganizationsDropdown(): JSX.Element {
+  const { activeLocale } = useLocalization();
   const { selectedOrganization, setSelectedOrganization, organizations, redirectAndNotify, reloadOrganizations } =
     useOrganization();
   const navigate = useSyncNavigate();
@@ -62,7 +63,10 @@ export default function OrganizationsDropdown(): JSX.Element {
       <PopoverMenu
         anchor={<p style={{ fontSize: '16px' }}>{selectedOrganization?.name}</p>}
         menuSections={[
-          organizations?.map((organization) => ({ label: organization.name, value: organization.id.toString() })) || [],
+          organizations
+            ?.slice()
+            .sort((a, b) => a.name.localeCompare(b.name, activeLocale || undefined))
+            .map((organization) => ({ label: organization.name, value: organization.id.toString() })) || [],
           [{ label: strings.CREATE_NEW_ORGANIZATION, value: '0' }],
         ]}
         onClick={changeOrganization}


### PR DESCRIPTION
This PR implements alphabetical sorting of the organization picker options in the site header.

This has been driving my crazy for a while 😬, finally decided to do something about it 😄

## Example

### BEFORE

<img width="2560" height="1680" alt="staging terraware io_home_organizationId=139" src="https://github.com/user-attachments/assets/62fec468-31e1-4057-b1d3-e021c02ada2e" />

### AFTER

<img width="2560" height="1680" alt="localhost_3000_home_organizationId=139" src="https://github.com/user-attachments/assets/d2a21874-558f-4978-a9af-0a1a736b74b7" />
