### PR TITLE
Migrate list projects and get project to rtk query

### DIFF
--- a/src/components/BatchWithdrawFlow/flow/SelectPurposeForm.tsx
+++ b/src/components/BatchWithdrawFlow/flow/SelectPurposeForm.tsx
@@ -21,10 +21,9 @@ import Divisor from 'src/components/common/Divisor';
 import PageForm from 'src/components/common/PageForm';
 import { APP_PATHS } from 'src/constants';
 import useOrganizationPlantingSites from 'src/hooks/useOrganizationPlantingSites';
+import { useProjects } from 'src/hooks/useProjects';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import { useOrganization } from 'src/providers/hooks';
-import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
-import { useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 import { BatchWithdrawalPayload, NurseryWithdrawalPurposes, NurseryWithdrawalRequest } from 'src/types/Batch';
 import { Facility } from 'src/types/Facility';
@@ -60,7 +59,7 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
   const { plantingSites, isLoading } = useOrganizationPlantingSites({ full: true });
 
   const { species } = useSpeciesData();
-  const projects = useAppSelector(selectProjects);
+  const { availableProjects: projects } = useProjects();
 
   const [isNurseryTransfer, setIsNurseryTransfer] = useState(contributor ? true : false);
   const [isOutplant, setIsOutplant] = useState(nurseryWithdrawal.purpose === OUTPLANT);

--- a/src/components/ProjectNewView/flow/ProjectEntitySearch.tsx
+++ b/src/components/ProjectNewView/flow/ProjectEntitySearch.tsx
@@ -1,4 +1,4 @@
-import React, { type JSX, useCallback, useEffect, useMemo } from 'react';
+import React, { type JSX, useCallback, useMemo } from 'react';
 
 import { Box, Grid, useTheme } from '@mui/material';
 import { PillListItem, Textfield } from '@terraware/web-components';
@@ -8,10 +8,7 @@ import ProjectEntityFilter, {
   EntitySpecificFilterConfig,
 } from 'src/components/ProjectNewView/flow/ProjectEntityFilter';
 import { ProjectEntityFilters } from 'src/components/ProjectNewView/flow/useProjectEntitySelection';
-import { useLocalization, useOrganization } from 'src/providers';
-import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
-import { requestProjects } from 'src/redux/features/projects/projectsThunks';
-import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import { useProjects } from 'src/hooks/useProjects';
 import strings from 'src/strings';
 
 interface ProjectEntitySearchProps {
@@ -27,12 +24,9 @@ export type PillListItemWithEmptyValue = PillListItem<string> & { emptyValue: un
 export default function ProjectEntitySearch(props: ProjectEntitySearchProps): JSX.Element | null {
   const { searchValue, onSearch, entitySpecificFilterConfigs, filters, setFilters } = props;
 
-  const dispatch = useAppDispatch();
   const theme = useTheme();
-  const { selectedOrganization } = useOrganization();
-  const { activeLocale } = useLocalization();
 
-  const projects = useAppSelector(selectProjects);
+  const { availableProjects: projects } = useProjects();
 
   const projectEntityFilterConfig: EntitySpecificFilterConfig | undefined = useMemo(
     () =>
@@ -85,12 +79,6 @@ export default function ProjectEntitySearch(props: ProjectEntitySearchProps): JS
     },
     [filterPillData, setFilters]
   );
-
-  useEffect(() => {
-    if (selectedOrganization) {
-      void dispatch(requestProjects(selectedOrganization.id, activeLocale || undefined));
-    }
-  }, [activeLocale, dispatch, selectedOrganization]);
 
   return (
     <Grid container>

--- a/src/components/ProjectOverviewItemCard/index.tsx
+++ b/src/components/ProjectOverviewItemCard/index.tsx
@@ -6,9 +6,8 @@ import { Icon } from '@terraware/web-components';
 import ProjectAssignModal from 'src/components/ProjectAssignModal';
 import Link from 'src/components/common/Link';
 import OverviewItemCard from 'src/components/common/OverviewItemCard';
+import { useProjects } from 'src/hooks/useProjects';
 import { useOrganization } from 'src/providers';
-import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
-import { useAppSelector } from 'src/redux/store';
 import { AssignProjectRequestPayload } from 'src/services/ProjectsService';
 import strings from 'src/strings';
 import { isMember } from 'src/utils/organization';
@@ -30,7 +29,7 @@ const ProjectOverviewItemCard = <T extends { id: number; projectId?: number }>({
   const userCanEdit = isMember(selectedOrganization);
   const theme = useTheme();
 
-  const projects = useAppSelector(selectProjects);
+  const { availableProjects: projects } = useProjects();
   const entityProject = projects?.find((project) => project.id === entity?.projectId);
 
   const [isProjectAssignModalOpen, setIsProjectAssignModalOpen] = useState<boolean>(false);

--- a/src/components/ProjectView/ProjectEditModal.tsx
+++ b/src/components/ProjectView/ProjectEditModal.tsx
@@ -5,6 +5,8 @@ import { Grid } from '@mui/material';
 import DialogBox from 'src/components/common/ScrollableDialogBox';
 import TextField from 'src/components/common/Textfield/Textfield';
 import Button from 'src/components/common/button/Button';
+import { baseApi } from 'src/queries/baseApi';
+import { QueryTagTypes } from 'src/queries/tags';
 import { requestProjectUpdate } from 'src/redux/features/projects/projectsAsyncThunks';
 import { selectProjectRequest } from 'src/redux/features/projects/projectsSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
@@ -62,10 +64,11 @@ export default function ProjectEditModal({ open, onClose, project, reload }: Pro
     } else if (projectUpdateRequest.status === 'success' && project) {
       setRequestId('');
       snackbar.toastSuccess(strings.CHANGES_SAVED, strings.SAVED);
+      void dispatch(baseApi.util.invalidateTags([{ type: QueryTagTypes.Projects, id: 'LIST' }]));
       reload();
       onClose();
     }
-  }, [projectUpdateRequest, snackbar, project, reload, onClose]);
+  }, [dispatch, projectUpdateRequest, snackbar, project, reload, onClose]);
 
   return (
     <DialogBox

--- a/src/components/ProjectView/index.tsx
+++ b/src/components/ProjectView/index.tsx
@@ -16,9 +16,11 @@ import { APP_PATHS } from 'src/constants';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
 import { useApplicationData } from 'src/providers/Application/Context';
+import { baseApi } from 'src/queries/baseApi';
+import { QueryTagTypes } from 'src/queries/tags';
 import { requestProjectDelete } from 'src/redux/features/projects/projectsAsyncThunks';
 import { selectProject, selectProjectRequest } from 'src/redux/features/projects/projectsSelectors';
-import { requestProject, requestProjects } from 'src/redux/features/projects/projectsThunks';
+import { requestProject } from 'src/redux/features/projects/projectsThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { isAdmin } from 'src/utils/organization';
 import useSnackbar from 'src/utils/useSnackbar';
@@ -84,7 +86,7 @@ export default function ProjectView(): JSX.Element {
     if (projectDeleteRequest.status === 'error') {
       snackbar.toastError();
     } else if (projectDeleteRequest.status === 'success' && selectedOrganization) {
-      void dispatch(requestProjects(selectedOrganization.id));
+      void dispatch(baseApi.util.invalidateTags([{ type: QueryTagTypes.Projects, id: 'LIST' }]));
       goToProjects();
     }
   }, [selectedOrganization, projectDeleteRequest, snackbar, goToProjects, dispatch]);

--- a/src/components/SeedFundReports/ReportSettingsEditFormFields.tsx
+++ b/src/components/SeedFundReports/ReportSettingsEditFormFields.tsx
@@ -1,13 +1,11 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 import { Button, Checkbox } from '@terraware/web-components';
 
+import { useProjects } from 'src/hooks/useProjects';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers';
-import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
-import { requestProjects } from 'src/redux/features/projects/projectsThunks';
-import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { ReportsSettings } from 'src/services/ReportSettingsService';
 import strings from 'src/strings';
 import { Project } from 'src/types/Project';
@@ -28,18 +26,11 @@ interface ReportsSettingsCheckboxConfig {
 }
 
 const ReportSettingsEditFormFields = ({ isEditing, onChange, reportsSettings }: ReportSettingsEditFormFieldsProps) => {
-  const dispatch = useAppDispatch();
   const theme = useTheme();
   const navigate = useSyncNavigate();
   const { selectedOrganization } = useOrganization();
 
-  const projects = useAppSelector(selectProjects);
-
-  useEffect(() => {
-    if (!projects && selectedOrganization) {
-      void dispatch(requestProjects(selectedOrganization.id));
-    }
-  }, [dispatch, projects, selectedOrganization]);
+  const { availableProjects: projects } = useProjects();
 
   const renderCheckbox = useCallback(
     ({ label, key, value, index }: ReportsSettingsCheckboxConfig) => {

--- a/src/components/seeds/database/AccessionsBySpeciesTable.tsx
+++ b/src/components/seeds/database/AccessionsBySpeciesTable.tsx
@@ -14,10 +14,9 @@ import {
 import Card from 'src/components/common/Card';
 import Link from 'src/components/common/Link';
 import { APP_PATHS } from 'src/constants';
+import { useProjects } from 'src/hooks/useProjects';
 import useTableState from 'src/hooks/useTableState';
 import { useLocalization } from 'src/providers/hooks';
-import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
-import { useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 import { Project } from 'src/types/Project';
 import { SearchResponseElementWithId } from 'src/types/Search';
@@ -46,7 +45,7 @@ export default function AccessionsBySpeciesTable({ searchResults }: AccessionsBy
   const { activeLocale } = useLocalization();
   const theme = useTheme();
   const numberFormatter = useNumberFormatter();
-  const projects = useAppSelector(selectProjects);
+  const { availableProjects: projects } = useProjects();
 
   const uniqueProjectNames = useMemo(
     () =>

--- a/src/components/seeds/database/index.tsx
+++ b/src/components/seeds/database/index.tsx
@@ -12,13 +12,11 @@ import TfMain from 'src/components/common/TfMain';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS } from 'src/constants';
 import useNavigateTo from 'src/hooks/useNavigateTo';
+import { useProjects } from 'src/hooks/useProjects';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization, useUser } from 'src/providers/hooks';
 import { useLazyGetAccessionsListUploadTemplateQuery } from 'src/queries/generated/accessionsV2';
 import { useLazyGetPendingAccessionsQuery, useLazySearchAccessionsQuery } from 'src/queries/search/accessions';
-import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
-import { requestProjects } from 'src/redux/features/projects/projectsThunks';
-import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 import { Facility } from 'src/types/Facility';
 import { SearchResponseElementWithId } from 'src/types/Search';
@@ -84,19 +82,12 @@ export default function Database(props: DatabaseProps): JSX.Element {
   const theme = useTheme();
   const navigate = useSyncNavigate();
   const { goToNewAccession } = useNavigateTo();
-  const dispatch = useAppDispatch();
-  const projects = useAppSelector(selectProjects);
+  const { availableProjects: projects } = useProjects();
   const contentRef = useRef(null);
 
   const [selectedFacility, setSelectedFacility] = useState<Facility | undefined>();
   const [selectSeedBankForImportModalOpen, setSelectSeedBankForImportModalOpen] = useState(false);
   const [openImportModal, setOpenImportModal] = useState(false);
-
-  useEffect(() => {
-    if (selectedOrganization) {
-      void dispatch(requestProjects(selectedOrganization.id, activeLocale || undefined));
-    }
-  }, [activeLocale, dispatch, selectedOrganization]);
 
   const [fetchAccessions, searchAccessionsResult] = useLazySearchAccessionsQuery();
   useEffect(() => {

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -1,19 +1,28 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
-import { useOrganization } from 'src/providers';
-import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
-import { requestProjects } from 'src/redux/features/projects/projectsThunks';
-import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import { useLocalization, useOrganization } from 'src/providers';
+import { useListProjectsQuery } from 'src/queries/generated/projects';
 import { Project } from 'src/types/Project';
 
 import useAcceleratorConsole from './useAcceleratorConsole';
 
 export const useProjects = (record?: { projectId?: number }) => {
-  const dispatch = useAppDispatch();
+  const { activeLocale } = useLocalization();
   const { selectedOrganization } = useOrganization();
   const { isAcceleratorRoute } = useAcceleratorConsole();
 
-  const availableProjects = useAppSelector(selectProjects);
+  const organizationId = isAcceleratorRoute ? undefined : selectedOrganization?.id;
+  const { data } = useListProjectsQuery(organizationId, {
+    skip: !isAcceleratorRoute && selectedOrganization === undefined,
+  });
+
+  const availableProjects = useMemo<Project[] | undefined>(
+    () =>
+      data?.projects
+        ? [...data.projects].sort((a, b) => a.name.localeCompare(b.name, activeLocale || undefined))
+        : undefined,
+    [activeLocale, data]
+  );
 
   const getProjectName = useCallback(
     (projectId: number) => (availableProjects?.find((project: Project) => project.id === projectId) || {}).name || '',
@@ -28,19 +37,6 @@ export const useProjects = (record?: { projectId?: number }) => {
         : undefined,
     [availableProjects, recordProjectId]
   );
-
-  useEffect(() => {
-    if (selectedOrganization) {
-      void dispatch(requestProjects(selectedOrganization.id));
-    }
-  }, [dispatch, selectedOrganization]);
-
-  // fetch all projects in the accelerator route
-  useEffect(() => {
-    if (isAcceleratorRoute) {
-      void dispatch(requestProjects());
-    }
-  }, [isAcceleratorRoute, dispatch]);
 
   return { availableProjects, getProjectName, selectedProject };
 };

--- a/src/providers/Participant/ParticipantProvider.tsx
+++ b/src/providers/Participant/ParticipantProvider.tsx
@@ -1,11 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import useListProjectModules from 'src/hooks/useListProjectModules';
+import { useProjects } from 'src/hooks/useProjects';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
 import { requestListOrgProjectsAndModules } from 'src/redux/features/modules/modulesAsyncThunks';
 import { selectModuleOrgProjects } from 'src/redux/features/modules/modulesSelectors';
-import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
-import { requestProjects } from 'src/redux/features/projects/projectsThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { Project } from 'src/types/Project';
 
@@ -29,7 +28,7 @@ const ParticipantProvider = ({ children }: Props) => {
   const [listModuleProjectsRequestId, setListModuleProjectsRequestId] = useState<string>('');
 
   const moduleProjectsListRequest = useAppSelector(selectModuleOrgProjects(listModuleProjectsRequestId));
-  const projects = useAppSelector(selectProjects);
+  const { availableProjects: projects } = useProjects();
 
   const { listProjectModules, projectModules, isLoading: listModulesIsLoading } = useListProjectModules();
 
@@ -71,9 +70,8 @@ const ParticipantProvider = ({ children }: Props) => {
       setOrgHasModules(undefined);
       setOrgHasParticipants(undefined);
       setAcceleratorProjects([]);
-      void dispatch(requestProjects(selectedOrganization.id, activeLocale));
     }
-  }, [activeLocale, dispatch, selectedOrganization]);
+  }, [activeLocale, selectedOrganization]);
 
   useEffect(() => {
     const nextAcceleratorProjects = (projects || []).filter((project) => !!project.phase);

--- a/src/queries/extensions/projects.ts
+++ b/src/queries/extensions/projects.ts
@@ -3,6 +3,12 @@ import { QueryTagTypes } from '../tags';
 
 api.enhanceEndpoints({
   endpoints: {
+    listProjects: {
+      providesTags: (results) => [
+        ...(results ? results.projects.map((project) => ({ type: QueryTagTypes.Projects, id: project.id })) : []),
+        { type: QueryTagTypes.Projects, id: 'LIST' },
+      ],
+    },
     getProject: {
       providesTags: (_result, _error, projectId) => [{ type: QueryTagTypes.Projects, id: projectId }],
     },

--- a/src/redux/features/projects/projectsSelectors.ts
+++ b/src/redux/features/projects/projectsSelectors.ts
@@ -1,8 +1,6 @@
 import { RootState } from 'src/redux/rootReducer';
 import { Project } from 'src/types/Project';
 
-export const selectProjects = (state: RootState) => state.projects.projects;
-
 export const selectProject =
   (projectId: number) =>
   (state: RootState): Project | undefined =>

--- a/src/redux/features/projects/projectsSlice.ts
+++ b/src/redux/features/projects/projectsSlice.ts
@@ -22,11 +22,6 @@ export const projectsSlice = createSlice({
   name: 'projectsSlice',
   initialState,
   reducers: {
-    setProjectsAction: (state, action: PayloadAction<Data>) => {
-      const data: Data = action.payload;
-      state.error = data.error;
-      state.projects = data.projects;
-    },
     setProjectAction: (state, action: PayloadAction<Data>) => {
       const data: Data = action.payload;
       const payloadProjects = data.projects || [];
@@ -42,7 +37,7 @@ export const projectsSlice = createSlice({
   },
 });
 
-export const { setProjectsAction, setProjectAction } = projectsSlice.actions;
+export const { setProjectAction } = projectsSlice.actions;
 
 type ProjectsResponsesUnion = UpdateProjectResponsePayload;
 type ProjectsRequestsState = Record<string, StatusT<ProjectsResponsesUnion>>;

--- a/src/redux/features/projects/projectsThunks.ts
+++ b/src/redux/features/projects/projectsThunks.ts
@@ -1,36 +1,8 @@
 import { Dispatch } from 'redux';
 
-import { setProjectAction, setProjectsAction } from 'src/redux/features/projects/projectsSlice';
+import { setProjectAction } from 'src/redux/features/projects/projectsSlice';
 import { RootState } from 'src/redux/rootReducer';
 import ProjectsService from 'src/services/ProjectsService';
-
-const inFlightRequests = new Map<number | undefined, Promise<void>>();
-
-export const requestProjects = (organizationId?: number, locale?: string | null) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  return async (dispatch: Dispatch, _getState: () => RootState) => {
-    if (inFlightRequests.has(organizationId)) {
-      return inFlightRequests.get(organizationId);
-    }
-
-    const request = (async () => {
-      try {
-        const response = await ProjectsService.listProjects(organizationId, locale);
-        const { error, projects } = response;
-        dispatch(setProjectsAction({ error, projects }));
-      } catch (e) {
-        // should not happen, the response above captures any http request errors
-        // eslint-disable-next-line no-console
-        console.error('Error dispatching projects', e);
-      } finally {
-        inFlightRequests.delete(organizationId);
-      }
-    })();
-
-    inFlightRequests.set(organizationId, request);
-    return request;
-  };
-};
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const requestProject = (projectId: number) => async (dispatch: Dispatch, _getState: () => RootState) => {

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/Voting/VotingProvider.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/Voting/VotingProvider.tsx
@@ -2,8 +2,8 @@ import React, { type JSX, useCallback, useEffect, useMemo, useState } from 'reac
 import { useParams } from 'react-router';
 
 import { APP_PATHS } from 'src/constants';
+import { useProjects } from 'src/hooks/useProjects';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
-import { selectProject } from 'src/redux/features/projects/projectsSelectors';
 import { requestProjectVotesGet } from 'src/redux/features/votes/votesAsyncThunks';
 import { selectProjectVotes } from 'src/redux/features/votes/votesSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
@@ -25,7 +25,7 @@ const VotingProvider = ({ children }: Props): JSX.Element => {
 
   const pathParams = useParams<{ projectId: string }>();
   const projectId = Number(pathParams.projectId);
-  const project = useAppSelector(selectProject(projectId));
+  const { selectedProject: project } = useProjects({ projectId });
 
   const phase: Phase = (query.get('phase') as Phase) || project?.phase || 'Phase 1 - Feasibility Study'; // default to phase 1?
 

--- a/src/scenes/InventoryRouter/Search.tsx
+++ b/src/scenes/InventoryRouter/Search.tsx
@@ -7,10 +7,9 @@ import { PillList } from '@terraware/web-components';
 
 import FilterGroup, { FilterField } from 'src/components/common/FilterGroup';
 import TableSettingsButton from 'src/components/common/table/TableSettingsButton';
+import { useProjects } from 'src/hooks/useProjects';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
-import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
-import { requestProjects } from 'src/redux/features/projects/projectsThunks';
 import { selectSubLocations } from 'src/redux/features/subLocations/subLocationsSelectors';
 import { requestSubLocations } from 'src/redux/features/subLocations/subLocationsThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
@@ -89,7 +88,7 @@ export default function Search(props: SearchProps): JSX.Element | null {
   const origin = props.origin || 'Species';
 
   const { species } = useSpeciesData();
-  const projects = useAppSelector(selectProjects);
+  const { availableProjects: projects } = useProjects();
   const nurseries = useMemo<Facility[]>(
     () => (selectedOrganization ? getAllNurseries(selectedOrganization) : []),
     [selectedOrganization]
@@ -99,12 +98,6 @@ export default function Search(props: SearchProps): JSX.Element | null {
   useEffect(() => {
     void dispatch(requestSubLocations(filters.facilityIds ?? []));
   }, [filters.facilityIds, dispatch]);
-
-  useEffect(() => {
-    if (selectedOrganization) {
-      void dispatch(requestProjects(selectedOrganization.id, activeLocale || undefined));
-    }
-  }, [dispatch, activeLocale, selectedOrganization]);
 
   useEffect(() => {
     if (origin !== 'Nursery' || !species.length) {

--- a/src/scenes/InventoryRouter/view/InventorySeedlingsTable.tsx
+++ b/src/scenes/InventoryRouter/view/InventorySeedlingsTable.tsx
@@ -17,12 +17,10 @@ import ProjectAssignTopBarButton from 'src/components/ProjectAssignTopBarButton'
 import Link from 'src/components/common/Link';
 import { APP_PATHS } from 'src/constants';
 import isEnabled from 'src/features';
+import { useProjects } from 'src/hooks/useProjects';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import useTableState from 'src/hooks/useTableState';
 import { useLocalization, useOrganization } from 'src/providers';
-import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
-import { requestProjects } from 'src/redux/features/projects/projectsThunks';
-import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import { isBatchEmpty } from 'src/scenes/InventoryRouter/FilterUtils';
 import { InventoryFiltersUnion } from 'src/scenes/InventoryRouter/InventoryFilter';
 import { NurseryBatchService } from 'src/services';
@@ -76,8 +74,7 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
 
   const { activeLocale, strings } = useLocalization();
   const { selectedOrganization } = useOrganization();
-  const dispatch = useAppDispatch();
-  const projects = useAppSelector(selectProjects);
+  const { availableProjects: projects } = useProjects();
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
   const snackbar = useSnackbar();
@@ -103,12 +100,6 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
         .filter((row): row is SearchResponseElement => row !== undefined),
     [rowSelection, filteredBatches]
   );
-
-  useEffect(() => {
-    if (selectedOrganization) {
-      void dispatch(requestProjects(selectedOrganization.id, activeLocale || undefined));
-    }
-  }, [dispatch, selectedOrganization, activeLocale]);
 
   useEffect(() => {
     if (

--- a/src/scenes/ModulesRouter/ModuleViewTitle.tsx
+++ b/src/scenes/ModulesRouter/ModuleViewTitle.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 
 import { Box, Typography } from '@mui/material';
 
-import { selectProject } from 'src/redux/features/projects/projectsSelectors';
-import { useAppSelector } from 'src/redux/store';
+import { useProjects } from 'src/hooks/useProjects';
 import { ProjectModule } from 'src/types/Module';
 import { getDateRangeString } from 'src/utils/dateFormatter';
 
@@ -13,7 +12,7 @@ type ModulePageTitleProps = {
 };
 
 const ModuleViewTitle = ({ module, projectId }: ModulePageTitleProps) => {
-  const project = useAppSelector(selectProject(projectId));
+  const { selectedProject: project } = useProjects({ projectId });
 
   return (
     <Box alignItems='center' display='flex' flexDirection='row' flexWrap='wrap' marginTop='16px' width='100%'>

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsTable.tsx
@@ -17,6 +17,7 @@ import {
 
 import TextTruncated from 'src/components/common/TextTruncated';
 import { APP_PATHS, DEFAULT_SEARCH_DEBOUNCE_MS } from 'src/constants';
+import { useProjects } from 'src/hooks/useProjects';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import useTableState from 'src/hooks/useTableState';
 import { useLocalization, useOrganization } from 'src/providers';
@@ -28,8 +29,6 @@ import {
   useLazySearchNurseryWithdrawalsFilterOptionsQuery,
   useLazySearchNurseryWithdrawalsQuery,
 } from 'src/queries/search/nurseries';
-import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
-import { useAppSelector } from 'src/redux/store';
 import UndoWithdrawalModal from 'src/scenes/NurseryRouter/UndoWithdrawalModal';
 import WithdrawalHistoryMenu from 'src/scenes/NurseryRouter/WithdrawalHistoryMenu';
 import { exportNurseryWithdrawalResults } from 'src/scenes/NurseryRouter/exportNurseryData';
@@ -90,7 +89,7 @@ export default function NurseryWithdrawalsTable(): JSX.Element {
   const location = useStateLocation();
   const query = useQuery();
 
-  const projects = useAppSelector(selectProjects);
+  const { availableProjects: projects } = useProjects();
 
   const [undoModalRow, setUndoModalRow] = useState<SearchNurseryWithdrawalPayload>();
   const [searchFilterOptions, searchFilterOptionsResponse] = useLazySearchNurseryWithdrawalsFilterOptionsQuery();

--- a/src/scenes/NurseryRouter/PlantingProgressList.tsx
+++ b/src/scenes/NurseryRouter/PlantingProgressList.tsx
@@ -16,12 +16,11 @@ import FormattedNumber from 'src/components/common/FormattedNumber';
 import Link from 'src/components/common/Link';
 import { APP_PATHS } from 'src/constants';
 import useOrganizationPlantingSites from 'src/hooks/useOrganizationPlantingSites';
+import { useProjects } from 'src/hooks/useProjects';
 import useTableState from 'src/hooks/useTableState';
 import { useOrganization } from 'src/providers';
 import { useLazyListPlantingSiteReportedPlantsQuery } from 'src/queries/generated/plantingSites';
 import { useUpdateSubstrataMutation } from 'src/queries/generated/substrata';
-import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
-import { useAppSelector } from 'src/redux/store';
 import { exportNurseryPlantingProgress } from 'src/scenes/NurseryRouter/exportNurseryData';
 import strings from 'src/strings';
 import { PlantingProgressType } from 'src/types/PlantingSite';
@@ -33,7 +32,7 @@ export default function PlantingProgressList(): JSX.Element {
   const [rowSelection, setRowSelection] = useState({});
   const { selectedOrganization } = useOrganization();
 
-  const projects = useAppSelector(selectProjects);
+  const { availableProjects: projects } = useProjects();
   const { plantingSites } = useOrganizationPlantingSites({ full: true });
   const [listReportedPlants, listReportedPlantsResponse] = useLazyListPlantingSiteReportedPlantsQuery();
   const [updateSubstratum, { isLoading }] = useUpdateSubstrataMutation();

--- a/src/scenes/OrgRouter/index.tsx
+++ b/src/scenes/OrgRouter/index.tsx
@@ -10,16 +10,17 @@ import BlockingSpinner from 'src/components/common/BlockingSpinner';
 import { APP_PATHS } from 'src/constants';
 import isEnabled from 'src/features';
 import useOrganizationFeatures from 'src/hooks/useOrganizationFeatures';
-import { useLocalization, useOrganization, useUser } from 'src/providers';
+import { useProjects } from 'src/hooks/useProjects';
+import { useOrganization, useUser } from 'src/providers';
 import ApplicationProvider from 'src/providers/Application';
 import ParticipantProvider from 'src/providers/Participant/ParticipantProvider';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import SpeciesProvider from 'src/providers/Species/SpeciesProvider';
+import { baseApi } from 'src/queries/baseApi';
 import { useLazyCountObservationsQuery } from 'src/queries/search/observations';
 import { useLazyCountPlantingSitesQuery } from 'src/queries/search/plantingSites';
-import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
-import { requestProjects } from 'src/redux/features/projects/projectsThunks';
-import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import { QueryTagTypes } from 'src/queries/tags';
+import { useAppDispatch } from 'src/redux/store';
 import AccessionsRouter from 'src/scenes/AccessionsRouter';
 import ApplicationRouter from 'src/scenes/ApplicationRouter';
 import BatchBulkWithdrawView from 'src/scenes/BatchBulkWithdrawView';
@@ -49,7 +50,6 @@ import SettingsLayout from 'src/scenes/Settings/SettingsLayout';
 import SettingsRedirect from 'src/scenes/Settings/SettingsRedirect';
 import SpeciesRouter from 'src/scenes/Species';
 import VirtualWalkthroughsView from 'src/scenes/VirtualWalkthrough/VirtualWalkthroughsView';
-import { Project } from 'src/types/Project';
 import { getRgbaFromHex } from 'src/utils/color';
 import { isPlaceholderOrg, selectedOrgHasFacilityType } from 'src/utils/organization';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
@@ -65,7 +65,6 @@ interface OrgRouterProps {
 
 const OrgRouter = ({ showNavBar, setShowNavBar }: OrgRouterProps) => {
   const dispatch = useAppDispatch();
-  const { activeLocale } = useLocalization();
   const { type } = useDeviceInfo();
   const { isProduction } = useEnvironment();
   const { reloadUserPreferences: reloadPreferences } = useUser();
@@ -73,7 +72,7 @@ const OrgRouter = ({ showNavBar, setShowNavBar }: OrgRouterProps) => {
   const { selectedOrganization } = useOrganization();
   const theme = useTheme();
   const { species } = useSpeciesData();
-  const projects: Project[] | undefined = useAppSelector(selectProjects);
+  const { availableProjects: projects } = useProjects();
 
   const [countPlantingSites, countPlantingSitesResult] = useLazyCountPlantingSitesQuery();
   const [countObservations, countObservationsResult] = useLazyCountObservationsQuery();
@@ -118,17 +117,8 @@ const OrgRouter = ({ showNavBar, setShowNavBar }: OrgRouterProps) => {
   };
 
   const reloadProjects = useCallback(() => {
-    const populateProjects = () => {
-      if (selectedOrganization && !isPlaceholderOrg(selectedOrganization.id)) {
-        void dispatch(requestProjects(selectedOrganization.id, activeLocale || undefined));
-      }
-    };
-    populateProjects();
-  }, [selectedOrganization, dispatch, activeLocale]);
-
-  useEffect(() => {
-    reloadProjects();
-  }, [reloadProjects]);
+    void dispatch(baseApi.util.invalidateTags([{ type: QueryTagTypes.Projects, id: 'LIST' }]));
+  }, [dispatch]);
 
   const selectedOrgHasSpecies = useCallback((): boolean => species.length > 0, [species]);
 

--- a/src/scenes/PlantingSitesRouter/view/PlantingSitesTable.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSitesTable.tsx
@@ -8,10 +8,9 @@ import FilterMultiSelectContainer from 'src/components/common/FilterMultiSelectC
 import Table from 'src/components/common/table';
 import TableSettingsButton from 'src/components/common/table/TableSettingsButton';
 import { SortOrder } from 'src/components/common/table/sort';
+import { useProjects } from 'src/hooks/useProjects';
 import { SearchSortOrderElement } from 'src/queries/generated/search';
 import { PlantingSiteSummary } from 'src/queries/search/plantingSites';
-import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
-import { useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 import { PlantingSitesFilters } from 'src/types/PlantingSite';
 import { Project } from 'src/types/Project';
@@ -58,7 +57,7 @@ export default function PlantingSitesTable(props: PlantingSitesTableProps): JSX.
 
   const theme = useTheme();
 
-  const projects = useAppSelector(selectProjects);
+  const { availableProjects: projects } = useProjects();
 
   const [isPresorted, setIsPresorted] = useState<boolean>(true);
 

--- a/src/scenes/Species/SpeciesProjectsTable.tsx
+++ b/src/scenes/Species/SpeciesProjectsTable.tsx
@@ -6,11 +6,10 @@ import { TableColumnType } from '@terraware/web-components/components/table/type
 
 import TooltipButton from 'src/components/common/button/TooltipButton';
 import Table from 'src/components/common/table';
+import { useProjects } from 'src/hooks/useProjects';
 import { useLocalization, useOrganization } from 'src/providers';
 import { requestGetProjectsForSpecies } from 'src/redux/features/acceleratorProjectSpecies/acceleratorProjectSpeciesAsyncThunks';
 import { selectProjectsForSpeciesRequest } from 'src/redux/features/acceleratorProjectSpecies/acceleratorProjectSpeciesSelectors';
-import { selectProjects } from 'src/redux/features/projects/projectsSelectors';
-import { requestProjects } from 'src/redux/features/projects/projectsThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 import { AcceleratorProjectForSpecies } from 'src/types/AcceleratorProjectSpecies';
@@ -59,7 +58,7 @@ export default function SpeciesProjectsTable({
   const dispatch = useAppDispatch();
   const snackbar = useSnackbar();
   const { selectedOrganization } = useOrganization();
-  const allProjects = useAppSelector(selectProjects);
+  const { availableProjects: allProjects } = useProjects();
 
   const [requestId, setRequestId] = useState('');
   const projectsForSpeciesRequest = useAppSelector(selectProjectsForSpeciesRequest(requestId));
@@ -69,12 +68,6 @@ export default function SpeciesProjectsTable({
   const [showRemoveDialog, setShowRemoveDialog] = useState(false);
   const [reload, setReload] = useState(false);
   const [openedAddToProjectModal, setOpenedAddToProjectModal] = useState(false);
-
-  useEffect(() => {
-    if (selectedOrganization) {
-      void dispatch(requestProjects(selectedOrganization.id));
-    }
-  }, [dispatch, selectedOrganization]);
 
   useEffect(() => {
     const request = dispatch(requestGetProjectsForSpecies({ speciesId }));

--- a/src/services/ProjectsService.ts
+++ b/src/services/ProjectsService.ts
@@ -1,5 +1,5 @@
 import { components, paths } from 'src/api/types/generated-schema';
-import HttpService, { Response, Response2 } from 'src/services/HttpService';
+import HttpService, { Response2 } from 'src/services/HttpService';
 import SearchService from 'src/services/SearchService';
 import { CreateProjectRequest, Project, UpdateProjectRequest } from 'src/types/Project';
 import { OrNodePayload, SearchRequestPayload } from 'src/types/Search';
@@ -13,9 +13,6 @@ const PROJECTS_ENDPOINT = '/api/v1/projects';
 const PROJECT_ENDPOINT = '/api/v1/projects/{id}';
 const PROJECT_ASSIGN_ENDPOINT = '/api/v1/projects/{id}/assign';
 
-type ListProjectsResponsePayload =
-  paths[typeof PROJECTS_ENDPOINT]['get']['responses'][200]['content']['application/json'];
-
 type CreateProjectResponsePayload =
   paths[typeof PROJECTS_ENDPOINT]['post']['responses'][200]['content']['application/json'];
 type GetProjectResponsePayload = paths[typeof PROJECT_ENDPOINT]['get']['responses'][200]['content']['application/json'];
@@ -27,35 +24,7 @@ export type DeleteProjectResponsePayload =
 export type AssignProjectRequestPayload = components['schemas']['AssignProjectRequestPayload'];
 export type AssignProjectResponsePayload = components['schemas']['SimpleSuccessResponsePayload'];
 
-/**
- * exported type
- */
-export type ProjectsData = {
-  projects?: Project[];
-};
-
 const httpProjects = HttpService.root(PROJECTS_ENDPOINT);
-
-/**
- * List all projects
- */
-const listProjects = async (organizationId?: number, locale?: string | null): Promise<ProjectsData & Response> => {
-  const params: { organizationId?: string } = {};
-  if (typeof organizationId === 'number') {
-    params.organizationId = organizationId.toString();
-  }
-
-  const response: ProjectsData & Response = await httpProjects.get<ListProjectsResponsePayload, ProjectsData>(
-    {
-      params,
-    },
-    (data) => ({
-      projects: data?.projects.sort((a, b) => a.name.localeCompare(b.name, locale || undefined)),
-    })
-  );
-
-  return response;
-};
 
 /**
  * Search projects
@@ -155,7 +124,6 @@ const deleteProject = (projectId: number) =>
  * Exported functions
  */
 const ProjectsService = {
-  listProjects,
   searchProjects,
   createProject,
   assignProjectToEntities,


### PR DESCRIPTION
The redux `selectProject` was just finding a project by id from the `listProjects` response. Replace `listProjects` with rtk query. Replace the `selectProject` usage in `VotingProvider` and `ModuleViewTitle` with the existing `useProjects` hook (which now uses the rtk query `listProjects` under the hood).

Co-authored-by: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)