### PR TITLE
Migrate delete project to rtk query

### DIFF
--- a/src/components/ProjectView/index.tsx
+++ b/src/components/ProjectView/index.tsx
@@ -16,18 +16,12 @@ import { APP_PATHS } from 'src/constants';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
 import { useApplicationData } from 'src/providers/Application/Context';
-import { baseApi } from 'src/queries/baseApi';
-import { useGetProjectQuery } from 'src/queries/generated/projects';
-import { QueryTagTypes } from 'src/queries/tags';
-import { requestProjectDelete } from 'src/redux/features/projects/projectsAsyncThunks';
-import { selectProjectRequest } from 'src/redux/features/projects/projectsSelectors';
-import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import { useDeleteProjectMutation, useGetProjectQuery } from 'src/queries/generated/projects';
 import { isAdmin } from 'src/utils/organization';
 import useSnackbar from 'src/utils/useSnackbar';
 import useStateLocation, { getLocation } from 'src/utils/useStateLocation';
 
 export default function ProjectView(): JSX.Element {
-  const dispatch = useAppDispatch();
   const theme = useTheme();
 
   const snackbar = useSnackbar();
@@ -42,10 +36,10 @@ export default function ProjectView(): JSX.Element {
   const { data, refetch } = useGetProjectQuery(projectId, { skip: !projectId || isNaN(projectId) });
   const project = data?.project;
 
+  const [deleteProject, { isError: isDeleteError, isSuccess: isDeleteSuccess }] = useDeleteProjectMutation();
+
   const [isDeleteConfirmationOpen, setIsDeleteConfirmationOpen] = useState<boolean>(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState<boolean>(false);
-  const [requestId, setRequestId] = useState<string>('');
-  const projectDeleteRequest = useAppSelector((state) => selectProjectRequest(state, requestId));
 
   const projectHasApplication = useMemo(() => {
     if (projectId && allApplications !== undefined) {
@@ -63,9 +57,8 @@ export default function ProjectView(): JSX.Element {
 
   const onDeleteConfirmationDialogClose = useCallback(() => setIsDeleteConfirmationOpen(false), []);
   const onDeleteConfirmationDialogSubmit = useCallback(() => {
-    const dispatched = dispatch(requestProjectDelete({ projectId }));
-    setRequestId(dispatched.requestId);
-  }, [dispatch, projectId]);
+    void deleteProject(projectId);
+  }, [deleteProject, projectId]);
 
   const reloadProject = useCallback(() => {
     void refetch();
@@ -74,17 +67,12 @@ export default function ProjectView(): JSX.Element {
   const goToProjects = useCallback(() => navigate(getLocation(APP_PATHS.PROJECTS, location)), [navigate, location]);
 
   useEffect(() => {
-    if (!projectDeleteRequest) {
-      return;
-    }
-
-    if (projectDeleteRequest.status === 'error') {
+    if (isDeleteError) {
       snackbar.toastError();
-    } else if (projectDeleteRequest.status === 'success' && selectedOrganization) {
-      void dispatch(baseApi.util.invalidateTags([{ type: QueryTagTypes.Projects, id: 'LIST' }]));
+    } else if (isDeleteSuccess && selectedOrganization) {
       goToProjects();
     }
-  }, [selectedOrganization, projectDeleteRequest, snackbar, goToProjects, dispatch]);
+  }, [selectedOrganization, isDeleteError, isDeleteSuccess, snackbar, goToProjects]);
 
   const rightComponents = useMemo(
     () =>

--- a/src/queries/extensions/projects.ts
+++ b/src/queries/extensions/projects.ts
@@ -18,5 +18,11 @@ api.enhanceEndpoints({
         { type: QueryTagTypes.Projects, id: 'LIST' },
       ],
     },
+    deleteProject: {
+      invalidatesTags: (_result, _error, projectId) => [
+        { type: QueryTagTypes.Projects, id: projectId },
+        { type: QueryTagTypes.Projects, id: 'LIST' },
+      ],
+    },
   },
 });

--- a/src/redux/features/projects/projectsAsyncThunks.ts
+++ b/src/redux/features/projects/projectsAsyncThunks.ts
@@ -4,22 +4,8 @@ import { Response2 } from 'src/services/HttpService';
 import ProjectsService, {
   AssignProjectRequestPayload,
   AssignProjectResponsePayload,
-  DeleteProjectResponsePayload,
 } from 'src/services/ProjectsService';
 import strings from 'src/strings';
-
-export const requestProjectDelete = createAsyncThunk(
-  'projects/delete',
-  async (request: { projectId: number }, { rejectWithValue }) => {
-    const response: Response2<DeleteProjectResponsePayload> = await ProjectsService.deleteProject(request.projectId);
-
-    if (response !== null && response.requestSucceeded) {
-      return response.data;
-    }
-
-    return rejectWithValue(strings.GENERIC_ERROR);
-  }
-);
 
 export const requestProjectAssign = createAsyncThunk(
   'project/assign',

--- a/src/redux/features/projects/projectsSlice.ts
+++ b/src/redux/features/projects/projectsSlice.ts
@@ -1,10 +1,10 @@
 import { ActionReducerMapBuilder, createSlice } from '@reduxjs/toolkit';
 
 import { StatusT, buildReducers } from 'src/redux/features/asyncUtils';
-import { requestProjectAssign, requestProjectDelete } from 'src/redux/features/projects/projectsAsyncThunks';
-import { DeleteProjectResponsePayload } from 'src/services/ProjectsService';
+import { requestProjectAssign } from 'src/redux/features/projects/projectsAsyncThunks';
+import { AssignProjectResponsePayload } from 'src/services/ProjectsService';
 
-type ProjectsResponsesUnion = DeleteProjectResponsePayload;
+type ProjectsResponsesUnion = AssignProjectResponsePayload;
 type ProjectsRequestsState = Record<string, StatusT<ProjectsResponsesUnion>>;
 
 const initialProjectsRequestsState: ProjectsRequestsState = {};
@@ -14,7 +14,6 @@ export const projectsRequestsSlice = createSlice({
   initialState: initialProjectsRequestsState,
   reducers: {},
   extraReducers: (builder: ActionReducerMapBuilder<ProjectsRequestsState>) => {
-    buildReducers(requestProjectDelete)(builder);
     buildReducers(requestProjectAssign)(builder);
   },
 });

--- a/src/services/ProjectsService.ts
+++ b/src/services/ProjectsService.ts
@@ -10,13 +10,10 @@ import { parseSearchTerm } from 'src/utils/search';
  */
 
 const PROJECTS_ENDPOINT = '/api/v1/projects';
-const PROJECT_ENDPOINT = '/api/v1/projects/{id}';
 const PROJECT_ASSIGN_ENDPOINT = '/api/v1/projects/{id}/assign';
 
 type CreateProjectResponsePayload =
   paths[typeof PROJECTS_ENDPOINT]['post']['responses'][200]['content']['application/json'];
-export type DeleteProjectResponsePayload =
-  paths[typeof PROJECT_ENDPOINT]['delete']['responses'][200]['content']['application/json'];
 
 export type AssignProjectRequestPayload = components['schemas']['AssignProjectRequestPayload'];
 export type AssignProjectResponsePayload = components['schemas']['SimpleSuccessResponsePayload'];
@@ -95,12 +92,6 @@ const assignProjectToEntities = (projectId: number, entities: AssignProjectReque
     entity: entities,
   });
 
-const deleteProject = (projectId: number) =>
-  httpProjects.delete2<DeleteProjectResponsePayload>({
-    url: PROJECT_ENDPOINT,
-    urlReplacements: { '{id}': `${projectId}` },
-  });
-
 /**
  * Exported functions
  */
@@ -108,7 +99,6 @@ const ProjectsService = {
   searchProjects,
   createProject,
   assignProjectToEntities,
-  deleteProject,
 };
 
 export default ProjectsService;


### PR DESCRIPTION
Replace `ProjectsService.deleteProject` usages with rtk query.

Co-authored-by: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)