### PR TITLE
Migrate create project to rtk query

### DIFF
--- a/src/components/ProjectNewView/index.tsx
+++ b/src/components/ProjectNewView/index.tsx
@@ -7,6 +7,7 @@ import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
+import { useCreateProjectMutation } from 'src/queries/generated/projects';
 import { SearchResponseBatches } from 'src/services/NurseryBatchService';
 import ProjectsService from 'src/services/ProjectsService';
 import strings from 'src/strings';
@@ -34,6 +35,8 @@ export default function ProjectNewView({ reloadData }: ProjectNewViewProps): JSX
   const snackbar = useSnackbar();
   const navigate = useSyncNavigate();
 
+  const [createProject, { data: createdProject, isError, isSuccess }] = useCreateProjectMutation();
+
   const [record, setRecord] = useForm<CreateProjectRequest>({
     name: '',
     organizationId: selectedOrganization?.id || -1,
@@ -52,46 +55,58 @@ export default function ProjectNewView({ reloadData }: ProjectNewViewProps): JSX
     navigate({ pathname: APP_PATHS.PROJECTS });
   }, [navigate]);
 
-  const saveProject = useCallback(async () => {
-    // first create the project
-    let projectId = -1;
-    const response = await ProjectsService.createProject(record);
-    if (!response.requestSucceeded || !response.data) {
-      snackbar.toastError();
-      return;
-    } else {
-      projectId = response.data.id;
-    }
+  const saveProject = useCallback(() => {
+    void createProject(record);
+  }, [createProject, record]);
 
-    if (!projectId) {
-      snackbar.toastError();
-      return;
-    }
-
-    await ProjectsService.assignProjectToEntities(projectId, {
-      accessionIds: projectAccessions.map((entity) => Number(entity.id)),
-      batchIds: projectBatches.map((entity) => Number(entity.id)),
-      plantingSiteIds: projectPlantingSites.map((entity) => Number(entity.id)),
-    });
-
-    reloadData();
-
-    // set snackbar with status
-    snackbar.toastSuccess(
-      getFormattedSuccessMessages(record.name, projectAccessions, projectBatches, projectPlantingSites),
-      strings.formatString(strings.PROJECT_ADDED, record.name) as string
-    );
-
-    // redirect to projects
-    goToProjects();
-  }, [goToProjects, projectAccessions, projectBatches, projectPlantingSites, record, reloadData, snackbar]);
-
-  // If we get to the end of the flowState (there are no more valid steps available), save the project and redirect
+  // If we get to the end of the flowState (there are no more valid steps available), create the project
   useEffect(() => {
     if (!flowState) {
-      void saveProject();
+      saveProject();
     }
   }, [flowState, saveProject]);
+
+  // Once the project is created, assign the selected entities and redirect to the projects list
+  useEffect(() => {
+    if (isError) {
+      snackbar.toastError();
+      return;
+    }
+
+    if (!isSuccess || !createdProject) {
+      return;
+    }
+
+    const assignAndRedirect = async () => {
+      await ProjectsService.assignProjectToEntities(createdProject.id, {
+        accessionIds: projectAccessions.map((entity) => Number(entity.id)),
+        batchIds: projectBatches.map((entity) => Number(entity.id)),
+        plantingSiteIds: projectPlantingSites.map((entity) => Number(entity.id)),
+      });
+
+      reloadData();
+
+      snackbar.toastSuccess(
+        getFormattedSuccessMessages(record.name, projectAccessions, projectBatches, projectPlantingSites),
+        strings.formatString(strings.PROJECT_ADDED, record.name) as string
+      );
+
+      goToProjects();
+    };
+
+    void assignAndRedirect();
+  }, [
+    createdProject,
+    goToProjects,
+    isError,
+    isSuccess,
+    projectAccessions,
+    projectBatches,
+    projectPlantingSites,
+    record,
+    reloadData,
+    snackbar,
+  ]);
 
   useEffect(() => {
     setSaveText(getSaveText(flowState, hasAccessions, hasBatches, hasPlantingSites));

--- a/src/queries/extensions/projects.ts
+++ b/src/queries/extensions/projects.ts
@@ -12,6 +12,9 @@ api.enhanceEndpoints({
     getProject: {
       providesTags: (_result, _error, projectId) => [{ type: QueryTagTypes.Projects, id: projectId }],
     },
+    createProject: {
+      invalidatesTags: [{ type: QueryTagTypes.Projects, id: 'LIST' }],
+    },
     updateProject: {
       invalidatesTags: (_result, _error, payload) => [
         { type: QueryTagTypes.Projects, id: payload.id },

--- a/src/redux/features/application/applicationAsyncThunks.ts
+++ b/src/redux/features/application/applicationAsyncThunks.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
+import { api as projectsApi } from 'src/queries/generated/projects';
 import ApplicationService from 'src/services/ApplicationService';
 import strings from 'src/strings';
 import { Application, ApplicationReview } from 'src/types/Application';
@@ -24,13 +25,21 @@ export const requestCreateApplication = createAsyncThunk(
 
 export const requestCreateProjectApplication = createAsyncThunk(
   'applications/createProject',
-  async (request: { projectName: string; organizationId: number }, { rejectWithValue }) => {
+  async (request: { projectName: string; organizationId: number }, { dispatch, rejectWithValue }) => {
     const { projectName, organizationId } = request;
 
-    const response = await ApplicationService.createProjectApplication(projectName, organizationId);
+    try {
+      const project = await dispatch(
+        projectsApi.endpoints.createProject.initiate({ name: projectName, organizationId })
+      ).unwrap();
 
-    if (response.requestSucceeded && response.data) {
-      return response.data.id;
+      const response = await ApplicationService.createApplication(project.id);
+
+      if (response.requestSucceeded && response.data) {
+        return response.data.id;
+      }
+    } catch {
+      return rejectWithValue(strings.GENERIC_ERROR);
     }
 
     return rejectWithValue(strings.GENERIC_ERROR);

--- a/src/services/ApplicationService.ts
+++ b/src/services/ApplicationService.ts
@@ -4,7 +4,6 @@ import { SearchNodePayload, SearchSortOrder } from 'src/types/Search';
 import { SearchAndSortFn, SearchOrderConfig, searchAndSort as genericSearchAndSort } from 'src/utils/searchAndSort';
 
 import HttpService, { Params, Response, Response2 } from './HttpService';
-import ProjectsService from './ProjectsService';
 
 /**
  * Service for application related functionality
@@ -80,19 +79,6 @@ const createApplication = async (projectId: number): Promise<Response2<CreateApp
   return HttpService.root(APPLICATIONS_ENDPOINT).post2<CreateApplicationResponsePayload>({
     entity: { projectId },
   });
-};
-
-const createProjectApplication = async (
-  projectName: string,
-  organizationId: number
-): Promise<Response2<CreateApplicationResponsePayload>> => {
-  const projectRequest = await ProjectsService.createProject({ name: projectName, organizationId });
-
-  if (projectRequest.requestSucceeded && projectRequest.data) {
-    return createApplication(projectRequest.data.id);
-  } else {
-    return { ...projectRequest, data: undefined };
-  }
 };
 
 const exportBoundary = async (applicationId: number): Promise<Response2<any>> => {
@@ -185,7 +171,6 @@ const uploadBoundary = async (applicationId: number, file: File): Promise<Respon
  */
 const ApplicationService = {
   createApplication,
-  createProjectApplication,
   exportBoundary,
   getApplication,
   listApplications,

--- a/src/services/ProjectsService.ts
+++ b/src/services/ProjectsService.ts
@@ -1,7 +1,7 @@
-import { components, paths } from 'src/api/types/generated-schema';
-import HttpService, { Response2 } from 'src/services/HttpService';
+import { components } from 'src/api/types/generated-schema';
+import HttpService from 'src/services/HttpService';
 import SearchService from 'src/services/SearchService';
-import { CreateProjectRequest, Project } from 'src/types/Project';
+import { Project } from 'src/types/Project';
 import { OrNodePayload, SearchRequestPayload } from 'src/types/Search';
 import { parseSearchTerm } from 'src/utils/search';
 
@@ -11,9 +11,6 @@ import { parseSearchTerm } from 'src/utils/search';
 
 const PROJECTS_ENDPOINT = '/api/v1/projects';
 const PROJECT_ASSIGN_ENDPOINT = '/api/v1/projects/{id}/assign';
-
-type CreateProjectResponsePayload =
-  paths[typeof PROJECTS_ENDPOINT]['post']['responses'][200]['content']['application/json'];
 
 export type AssignProjectRequestPayload = components['schemas']['AssignProjectRequestPayload'];
 export type AssignProjectResponsePayload = components['schemas']['SimpleSuccessResponsePayload'];
@@ -77,14 +74,6 @@ const searchProjects = async (organizationId: number, query?: string): Promise<P
   return response ? (response as Project[]) : null;
 };
 
-/**
- * Create a project
- */
-const createProject = (project: CreateProjectRequest): Promise<Response2<CreateProjectResponsePayload>> =>
-  httpProjects.post2({
-    entity: project,
-  });
-
 const assignProjectToEntities = (projectId: number, entities: AssignProjectRequestPayload) =>
   httpProjects.post2<AssignProjectResponsePayload>({
     url: PROJECT_ASSIGN_ENDPOINT,
@@ -97,7 +86,6 @@ const assignProjectToEntities = (projectId: number, entities: AssignProjectReque
  */
 const ProjectsService = {
   searchProjects,
-  createProject,
   assignProjectToEntities,
 };
 


### PR DESCRIPTION
Replace `ProjectsService.createProject` usages with rtk query. This includes the create call when creating a new application. 

Co-authored-by: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)