### PR TITLE
Migrate search projects to rtk query

### DIFF
--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -1,4 +1,4 @@
-import React, { type JSX, useCallback, useEffect, useRef, useState } from 'react';
+import React, { type JSX, useMemo, useRef, useState } from 'react';
 
 import { Box, Grid, useTheme } from '@mui/material';
 
@@ -12,11 +12,11 @@ import { TableColumnType } from 'src/components/common/table/types';
 import { APP_PATHS, DEFAULT_SEARCH_DEBOUNCE_MS } from 'src/constants';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
-import ProjectsService from 'src/services/ProjectsService';
+import { useListProjectsQuery } from 'src/queries/generated/projects';
 import strings from 'src/strings';
-import { Project } from 'src/types/Project';
+import { SearchNodePayload } from 'src/types/Search';
 import { isAdmin } from 'src/utils/organization';
-import { getRequestId, setRequestId } from 'src/utils/requestsId';
+import { searchAndSort } from 'src/utils/searchAndSort';
 import useDebounce from 'src/utils/useDebounce';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 
@@ -33,37 +33,34 @@ export default function ProjectsList(): JSX.Element {
   const navigate = useSyncNavigate();
   const [temporalSearchValue, setTemporalSearchValue] = useState('');
   const debouncedSearchTerm = useDebounce(temporalSearchValue, DEFAULT_SEARCH_DEBOUNCE_MS);
-  const [results, setResults] = useState<Project[]>();
   const { isMobile } = useDeviceInfo();
   const contentRef = useRef(null);
   const { activeLocale } = useLocalization();
 
-  const search = useCallback(
-    async (searchTerm: string) => {
-      if (selectedOrganization) {
-        const projects = await ProjectsService.searchProjects(selectedOrganization.id, searchTerm);
-        if (projects) {
-          return projects;
-        }
-      }
-    },
-    [selectedOrganization]
-  );
+  const { data: projectsData } = useListProjectsQuery(selectedOrganization?.id, {
+    skip: selectedOrganization === undefined,
+  });
 
-  useEffect(() => {
-    const refreshSearch = async () => {
-      const requestId = Math.random().toString();
-      setRequestId('searchProjects', requestId);
-      const projectsResults = await search(debouncedSearchTerm);
-      if (getRequestId('searchProjects') === requestId) {
-        setResults(projectsResults);
-      }
-    };
-
-    if (activeLocale) {
-      void refreshSearch();
+  const results = useMemo(() => {
+    if (!activeLocale || !projectsData?.projects) {
+      return undefined;
     }
-  }, [debouncedSearchTerm, search, activeLocale]);
+
+    const searchNode: SearchNodePayload | undefined = debouncedSearchTerm
+      ? {
+          operation: 'or',
+          children: [
+            { operation: 'field', field: 'name', type: 'Fuzzy', values: [debouncedSearchTerm] },
+            { operation: 'field', field: 'description', type: 'Fuzzy', values: [debouncedSearchTerm] },
+          ],
+        }
+      : undefined;
+
+    return searchAndSort(projectsData.projects, searchNode, {
+      locale: activeLocale,
+      sortOrder: { field: 'name' },
+    });
+  }, [activeLocale, debouncedSearchTerm, projectsData]);
 
   const goToNewProject = () => {
     const newProjectLocation = {

--- a/src/services/ProjectsService.ts
+++ b/src/services/ProjectsService.ts
@@ -1,9 +1,5 @@
 import { components } from 'src/api/types/generated-schema';
 import HttpService from 'src/services/HttpService';
-import SearchService from 'src/services/SearchService';
-import { Project } from 'src/types/Project';
-import { OrNodePayload, SearchRequestPayload } from 'src/types/Search';
-import { parseSearchTerm } from 'src/utils/search';
 
 /**
  * Projects related services
@@ -17,63 +13,6 @@ export type AssignProjectResponsePayload = components['schemas']['SimpleSuccessR
 
 const httpProjects = HttpService.root(PROJECTS_ENDPOINT);
 
-/**
- * Search projects
- */
-const searchProjects = async (organizationId: number, query?: string): Promise<Project[] | null> => {
-  const searchField: OrNodePayload | null = query
-    ? (() => {
-        const { type, values } = parseSearchTerm(query);
-        return {
-          operation: 'or',
-          children: [
-            {
-              operation: 'field',
-              field: 'name',
-              type,
-              values,
-            },
-            {
-              operation: 'field',
-              field: 'description',
-              type,
-              values,
-            },
-          ],
-        };
-      })()
-    : null;
-
-  const searchParams: SearchRequestPayload = {
-    prefix: 'projects',
-    fields: ['name', 'description', 'id', 'organization_id'],
-    search: {
-      operation: 'and',
-      children: [
-        {
-          operation: 'field',
-          field: 'organization_id',
-          type: 'Exact',
-          values: [organizationId],
-        },
-      ],
-    },
-    sortOrder: [
-      {
-        field: 'name',
-      },
-    ],
-    count: 0,
-  };
-
-  if (searchField) {
-    searchParams.search.children.push(searchField);
-  }
-
-  const response = await SearchService.search(searchParams);
-  return response ? (response as Project[]) : null;
-};
-
 const assignProjectToEntities = (projectId: number, entities: AssignProjectRequestPayload) =>
   httpProjects.post2<AssignProjectResponsePayload>({
     url: PROJECT_ASSIGN_ENDPOINT,
@@ -85,7 +24,6 @@ const assignProjectToEntities = (projectId: number, entities: AssignProjectReque
  * Exported functions
  */
 const ProjectsService = {
-  searchProjects,
   assignProjectToEntities,
 };
 


### PR DESCRIPTION
Replace `ProjectsService.searchProjects` usages with rtk query. It was previously a search api call to get the list of projects. This was replaced with a standard `listProjects` rtk query and a `searchAndSort` usage in the FE since orgs don't have many projects. 

Co-authored-by: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)