### PR TITLE
Sort organization picker options alphabetically (mobile)

### DIFF
--- a/src/components/OrganizationsDropdown.tsx
+++ b/src/components/OrganizationsDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { type JSX, useCallback, useState } from 'react';
+import React, { type JSX, useCallback, useMemo, useState } from 'react';
 
 import { DropdownItem, PopoverMenu } from '@terraware/web-components';
 
@@ -16,6 +16,16 @@ export default function OrganizationsDropdown(): JSX.Element {
     useOrganization();
   const navigate = useSyncNavigate();
   const [newOrganizationModalOpened, setNewOrganizationModalOpened] = useState(false);
+
+  const menuSections = useMemo(() => {
+    const orgSections = organizations
+      ?.toSorted((a, b) => a.name.localeCompare(b.name, activeLocale || undefined))
+      ?.map((organization) => ({
+        label: organization.name,
+        value: organization.id.toString(),
+      }));
+    return [orgSections || [], [{ label: strings.CREATE_NEW_ORGANIZATION, value: '0' }]];
+  }, [activeLocale, organizations]);
 
   const selectOrganization = (newlySelectedOrg: Organization) => {
     setSelectedOrganization((currentlySelectedOrg: Organization | undefined) => {
@@ -62,12 +72,7 @@ export default function OrganizationsDropdown(): JSX.Element {
       />
       <PopoverMenu
         anchor={<p style={{ fontSize: '16px' }}>{selectedOrganization?.name}</p>}
-        menuSections={[
-          organizations
-            ?.toSorted((a, b) => a.name.localeCompare(b.name, activeLocale || undefined))
-            .map((organization) => ({ label: organization.name, value: organization.id.toString() })) || [],
-          [{ label: strings.CREATE_NEW_ORGANIZATION, value: '0' }],
-        ]}
+        menuSections={menuSections}
         onClick={changeOrganization}
       />
     </div>

--- a/src/components/SmallDeviceUserMenu.tsx
+++ b/src/components/SmallDeviceUserMenu.tsx
@@ -20,7 +20,7 @@ import { APP_PATHS } from 'src/constants';
 import { useDocLinks } from 'src/docLinks';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useUser } from 'src/providers';
-import { useOrganization } from 'src/providers/hooks';
+import { useLocalization, useOrganization } from 'src/providers/hooks';
 import strings from 'src/strings';
 import { Organization } from 'src/types/Organization';
 import { getRgbaFromHex } from 'src/utils/color';
@@ -37,6 +37,7 @@ export default function SmallDeviceUserMenu({
   onLogout,
   hasOrganizations,
 }: SmallDeviceUserMenuProps): JSX.Element | null {
+  const { activeLocale } = useLocalization();
   const { selectedOrganization, setSelectedOrganization, organizations, redirectAndNotify, reloadOrganizations } =
     useOrganization();
   const { user } = useUser();
@@ -281,25 +282,27 @@ export default function SmallDeviceUserMenu({
                       </Typography>
                       {hasOrganizations ? (
                         <div>
-                          {organizations?.map((org, index) => {
-                            return (
-                              <MenuItem
-                                onClick={(e) => {
-                                  selectOrganization(org);
-                                  handleClose(e);
-                                }}
-                                key={`item-${index}`}
-                                sx={[
-                                  menuItemStyles,
-                                  selectedOrganization?.id === org.id && {
-                                    backgroundColor: theme.palette.TwClrBgGhostActive,
-                                  },
-                                ]}
-                              >
-                                {org.name}
-                              </MenuItem>
-                            );
-                          })}
+                          {organizations
+                            ?.toSorted((a, b) => a.name.localeCompare(b.name, activeLocale || undefined))
+                            .map((org, index) => {
+                              return (
+                                <MenuItem
+                                  onClick={(e) => {
+                                    selectOrganization(org);
+                                    handleClose(e);
+                                  }}
+                                  key={`item-${index}`}
+                                  sx={[
+                                    menuItemStyles,
+                                    selectedOrganization?.id === org.id && {
+                                      backgroundColor: theme.palette.TwClrBgGhostActive,
+                                    },
+                                  ]}
+                                >
+                                  {org.name}
+                                </MenuItem>
+                              );
+                            })}
                         </div>
                       ) : null}
                       <MenuItem

--- a/src/components/SmallDeviceUserMenu.tsx
+++ b/src/components/SmallDeviceUserMenu.tsx
@@ -50,6 +50,11 @@ export default function SmallDeviceUserMenu({
   const { isProduction } = useEnvironment();
   const iconLetter = user?.firstName?.charAt(0) || user?.lastName?.charAt(0) || user?.email?.charAt(0);
 
+  const sortedOrganizations = useMemo(
+    () => organizations?.toSorted((a, b) => a.name.localeCompare(b.name, activeLocale || undefined)),
+    [organizations, activeLocale]
+  );
+
   const iconStyles = {
     alignItems: 'center',
     backgroundColor: '#F1F0EC',
@@ -282,27 +287,25 @@ export default function SmallDeviceUserMenu({
                       </Typography>
                       {hasOrganizations ? (
                         <div>
-                          {organizations
-                            ?.toSorted((a, b) => a.name.localeCompare(b.name, activeLocale || undefined))
-                            .map((org, index) => {
-                              return (
-                                <MenuItem
-                                  onClick={(e) => {
-                                    selectOrganization(org);
-                                    handleClose(e);
-                                  }}
-                                  key={`item-${index}`}
-                                  sx={[
-                                    menuItemStyles,
-                                    selectedOrganization?.id === org.id && {
-                                      backgroundColor: theme.palette.TwClrBgGhostActive,
-                                    },
-                                  ]}
-                                >
-                                  {org.name}
-                                </MenuItem>
-                              );
-                            })}
+                          {sortedOrganizations?.map((org, index) => {
+                            return (
+                              <MenuItem
+                                onClick={(e) => {
+                                  selectOrganization(org);
+                                  handleClose(e);
+                                }}
+                                key={`item-${index}`}
+                                sx={[
+                                  menuItemStyles,
+                                  selectedOrganization?.id === org.id && {
+                                    backgroundColor: theme.palette.TwClrBgGhostActive,
+                                  },
+                                ]}
+                              >
+                                {org.name}
+                              </MenuItem>
+                            );
+                          })}
                         </div>
                       ) : null}
                       <MenuItem


### PR DESCRIPTION
This PR includes a change that was missed in a [previous PR](https://github.com/terraware/terraware-web/pull/5832): alphabetically sort organization picker options on mobile.

Note: This PR also includes a change to memoize organization sorting for the non-mobile menu.