### PR TITLE
SW-7672 add useLatestSiteObservationResult hook

### DIFF
--- a/src/hooks/observations/index.ts
+++ b/src/hooks/observations/index.ts
@@ -1,3 +1,4 @@
 export { default as useListObservationResults } from './useListObservationResults';
 export { default as useGetOneObservationResults } from './useOneObservationResults';
 export type { ObservationDepth } from './types';
+export { default as useLatestSiteObservationResult } from './useLatestSiteObservationResult';

--- a/src/hooks/observations/useLatestSiteObservationResult.ts
+++ b/src/hooks/observations/useLatestSiteObservationResult.ts
@@ -1,0 +1,28 @@
+import { useMemo } from 'react';
+
+import usePlantingSite from 'src/hooks/usePlantingSite';
+
+import { ObservationDepth } from './types';
+import useGetOneObservationResults from './useOneObservationResults';
+
+/** Resolves a planting site's latest observation and returns that observation's results. */
+const useLatestSiteObservationResult = (plantingSiteId: number | undefined, depth: ObservationDepth = 'Plot') => {
+  const { plantingSite, isLoading: isSiteLoading } = usePlantingSite(plantingSiteId);
+
+  const observationResultsResponse = useGetOneObservationResults({
+    observationId: plantingSite?.latestObservationId,
+    depth,
+  });
+
+  const observation = useMemo(() => {
+    const result = observationResultsResponse.currentData?.observation;
+    return result?.plantingSiteId === plantingSiteId ? result : undefined;
+  }, [observationResultsResponse.currentData?.observation, plantingSiteId]);
+
+  return {
+    observation,
+    isLoading: isSiteLoading || observationResultsResponse.isFetching,
+  };
+};
+
+export default useLatestSiteObservationResult;


### PR DESCRIPTION
Adds a hook that resolves a planting site's latest observation and returns its results via the observation results API, replacing the deprecated observation summaries query for single-site dashboard cards.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>