### PR TITLE
SW-8378 Make Edit Org modal scrollable

### DIFF
--- a/src/components/AddNewOrganizationModal.tsx
+++ b/src/components/AddNewOrganizationModal.tsx
@@ -25,7 +25,7 @@ import { TimeZoneDescription } from 'src/types/TimeZones';
 import useForm from 'src/utils/useForm';
 import useSnackbar from 'src/utils/useSnackbar';
 
-import DialogBox from './common/ScrollableDialogBox';
+import ScrollableDialogBox from './common/ScrollableDialogBox';
 import TextField from './common/Textfield/Textfield';
 
 type LocationTypesSelected = Record<ManagedLocationType, boolean>;
@@ -182,7 +182,7 @@ export default function AddNewOrganizationModal(props: AddNewOrganizationModalPr
   };
 
   return (
-    <DialogBox
+    <ScrollableDialogBox
       onClose={onCancelWrapper}
       open={open}
       title={strings.ADD_ORGANIZATION}
@@ -321,6 +321,6 @@ export default function AddNewOrganizationModal(props: AddNewOrganizationModalPr
           {strings.ADD_NEW_ORGANIZATION_FOOTNOTE}
         </Typography>
       </Grid>
-    </DialogBox>
+    </ScrollableDialogBox>
   );
 }

--- a/src/components/Disclaimer/DisclaimerModal.tsx
+++ b/src/components/Disclaimer/DisclaimerModal.tsx
@@ -5,7 +5,7 @@ import { DialogBoxSize } from '@terraware/web-components/components/DialogBox/Di
 import { useDeviceInfo } from '@terraware/web-components/utils';
 
 import Checkbox from 'src/components/common/Checkbox';
-import DialogBox from 'src/components/common/ScrollableDialogBox';
+import ScrollableDialogBox from 'src/components/common/ScrollableDialogBox';
 import Button from 'src/components/common/button/Button';
 import { useLocalization } from 'src/providers';
 import { useDisclaimerData } from 'src/providers/Disclaimer/Context';
@@ -75,7 +75,7 @@ const DisclaimerModal = ({ open, setOpen, onCancel, onConfirm }: DisclaimerModal
   }, [activeLocale, agreed, onConfirm]);
 
   return (
-    <DialogBox
+    <ScrollableDialogBox
       onClose={onClose}
       open={open}
       title={strings.FUNDER_DISCLAIMER_TITLE}
@@ -104,7 +104,7 @@ const DisclaimerModal = ({ open, setOpen, onCancel, onConfirm }: DisclaimerModal
           />
         </Box>
       )}
-    </DialogBox>
+    </ScrollableDialogBox>
   );
 };
 

--- a/src/components/ProjectView/ProjectEditModal.tsx
+++ b/src/components/ProjectView/ProjectEditModal.tsx
@@ -2,7 +2,7 @@ import React, { type JSX, useEffect, useState } from 'react';
 
 import { Grid } from '@mui/material';
 
-import DialogBox from 'src/components/common/ScrollableDialogBox';
+import ScrollableDialogBox from 'src/components/common/ScrollableDialogBox';
 import TextField from 'src/components/common/Textfield/Textfield';
 import Button from 'src/components/common/button/Button';
 import { useUpdateProjectMutation } from 'src/queries/generated/projects';
@@ -59,7 +59,7 @@ export default function ProjectEditModal({ open, onClose, project, reload }: Pro
   }, [isError, isSuccess, reset, snackbar, project, reload, onClose]);
 
   return (
-    <DialogBox
+    <ScrollableDialogBox
       onClose={onClose}
       open={open}
       title={project?.name ?? strings.EDIT_PROJECT}
@@ -98,6 +98,6 @@ export default function ProjectEditModal({ open, onClose, project, reload }: Pro
           />
         </Grid>
       </Grid>
-    </DialogBox>
+    </ScrollableDialogBox>
   );
 }

--- a/src/components/Variables/VariableHistoryModal.tsx
+++ b/src/components/Variables/VariableHistoryModal.tsx
@@ -1,6 +1,6 @@
 import React, { type JSX, useCallback } from 'react';
 
-import DialogBox from 'src/components/common/ScrollableDialogBox';
+import ScrollableDialogBox from 'src/components/common/ScrollableDialogBox';
 import Button from 'src/components/common/button/Button';
 import strings from 'src/strings';
 
@@ -19,7 +19,7 @@ const VariableHistoryModal = ({ open, projectId, setOpen, variableId }: Variable
   }, [setOpen]);
 
   return (
-    <DialogBox
+    <ScrollableDialogBox
       onClose={onClose}
       open={open}
       title={strings.VARIABLE_HISTORY}
@@ -28,7 +28,7 @@ const VariableHistoryModal = ({ open, projectId, setOpen, variableId }: Variable
       style={{ zIndex: 1301 }}
     >
       <VariableHistoryTable projectId={projectId} variableId={variableId} />
-    </DialogBox>
+    </ScrollableDialogBox>
   );
 };
 

--- a/src/components/common/ScrollableDialogBox.tsx
+++ b/src/components/common/ScrollableDialogBox.tsx
@@ -3,7 +3,11 @@ import React, { type JSX } from 'react';
 import { Box, useTheme } from '@mui/material';
 import DialogBox, { Props as DialogBoxProps } from '@terraware/web-components/components/DialogBox/DialogBox';
 
-export default function ScrollableDialogBox(props: DialogBoxProps): JSX.Element {
+export type ScrollableDialogBoxProps = DialogBoxProps & {
+  maxHeight?: number | string;
+};
+
+export default function ScrollableDialogBox({ maxHeight = 'none', ...props }: ScrollableDialogBoxProps): JSX.Element {
   const theme = useTheme();
   return (
     <Box
@@ -16,7 +20,7 @@ export default function ScrollableDialogBox(props: DialogBoxProps): JSX.Element 
           paddingBottom: theme.spacing(3),
         },
         '& .dialog-box': {
-          maxHeight: 'none',
+          maxHeight,
         },
       }}
     >

--- a/src/scenes/OrganizationRouter/EditOrganizationModal.tsx
+++ b/src/scenes/OrganizationRouter/EditOrganizationModal.tsx
@@ -5,7 +5,7 @@ import { Dropdown } from '@terraware/web-components';
 
 import RegionSelector from 'src/components/RegionSelector';
 import TimeZoneSelector from 'src/components/TimeZoneSelector';
-import DialogBox from 'src/components/common/ScrollableDialogBox';
+import ScrollableDialogBox from 'src/components/common/ScrollableDialogBox';
 import TextField from 'src/components/common/Textfield/Textfield';
 import Button from 'src/components/common/button/Button';
 import { useLocalization, useTimeZones } from 'src/providers';
@@ -121,11 +121,13 @@ export default function EditOrganizationModal({
   };
 
   return (
-    <DialogBox
+    <ScrollableDialogBox
       onClose={onClose}
       open={open}
       title={strings.EDIT_ORGANIZATION}
       size='medium'
+      maxHeight={'calc(100vh - 120px)'}
+      scrolled
       middleButtons={[
         <Button
           id='cancelEditOrg'
@@ -231,6 +233,6 @@ export default function EditOrganizationModal({
           />
         </Grid>
       </Grid>
-    </DialogBox>
+    </ScrollableDialogBox>
   );
 }

--- a/src/scenes/PeopleRouter/PersonModal.tsx
+++ b/src/scenes/PeopleRouter/PersonModal.tsx
@@ -4,7 +4,7 @@ import { Box, Grid, Typography } from '@mui/material';
 import { Dropdown } from '@terraware/web-components';
 
 import ErrorBox from 'src/components/common/ErrorBox/ErrorBox';
-import DialogBox from 'src/components/common/ScrollableDialogBox';
+import ScrollableDialogBox from 'src/components/common/ScrollableDialogBox';
 import TextField from 'src/components/common/Textfield/Textfield';
 import Button from 'src/components/common/button/Button';
 import { APP_PATHS, EMAIL_REGEX } from 'src/constants';
@@ -176,7 +176,7 @@ export default function PersonModal({ open, onClose, person, reload }: PersonMod
   }
 
   return (
-    <DialogBox
+    <ScrollableDialogBox
       onClose={onClose}
       open={open}
       title={person ? person.email : strings.ADD_PERSON}
@@ -266,6 +266,6 @@ export default function PersonModal({ open, onClose, person, reload }: PersonMod
           />
         </Grid>
       </Grid>
-    </DialogBox>
+    </ScrollableDialogBox>
   );
 }


### PR DESCRIPTION
Make Edit Org modal dynamically scrollable so it doesn't overflow on the page. 

Also rename usages of `ScrollableDialogBox` to reduce confusion from the `DialogBox` component.