### PR TITLE
Add PlantingSiteObservations cache tag to observation results

### DIFF
--- a/src/queries/extensions/observations.ts
+++ b/src/queries/extensions/observations.ts
@@ -30,10 +30,10 @@ api.enhanceEndpoints({
       keepUnusedDataFor: 0,
       providesTags: (results) => [
         ...(results
-          ? results.observations.map((observation) => ({
-              type: QueryTagTypes.Observation,
-              id: observation.observationId,
-            }))
+          ? results.observations.flatMap((observation) => [
+              { type: QueryTagTypes.Observation, id: observation.observationId },
+              { type: QueryTagTypes.PlantingSiteSurvivalRate, id: observation.plantingSiteId },
+            ])
           : []),
         { type: QueryTagTypes.Observation, id: 'LIST' },
       ],
@@ -136,7 +136,10 @@ api.enhanceEndpoints({
     getObservationResults: {
       providesTags: (observationResults) =>
         observationResults
-          ? [{ type: QueryTagTypes.Observation, id: observationResults.observation.observationId }]
+          ? [
+              { type: QueryTagTypes.Observation, id: observationResults.observation.observationId },
+              { type: QueryTagTypes.PlantingSiteSurvivalRate, id: observationResults.observation.plantingSiteId },
+            ]
           : [],
     },
   },

--- a/src/queries/tags.ts
+++ b/src/queries/tags.ts
@@ -24,6 +24,7 @@ export enum QueryTagTypes {
   PlantingDateRequests = 'PlantingDateRequests',
   PlantingSeasonDates = 'PlantingSeasonDates',
   PlantingSeasons = 'PlantingSeasons',
+  PlantingSiteSurvivalRate = 'PlantingSiteSurvivalRate',
   PlantingSites = 'PlantingSites',
   ProjectInternalUsers = 'ProjectInternalUsers',
   ProjectModules = 'ProjectModules',


### PR DESCRIPTION
Adds a per-planting-site cache tag and provides it on both
getObservationResults and listObservationResults so observation
results can be invalidated by planting site.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>