### PR TITLE
Poll survival rate recalculation and auto-refresh observation results

### DIFF
--- a/src/hooks/useSurvivalRateCalculationInProgress.ts
+++ b/src/hooks/useSurvivalRateCalculationInProgress.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { API_PULL_INTERVAL } from 'src/constants';
+import { baseApi } from 'src/queries/baseApi';
+import { useGetSurvivalRateCalculationInProgressQuery } from 'src/queries/generated/plantingSites';
+import { QueryTagTypes } from 'src/queries/tags';
+import { useAppDispatch } from 'src/redux/store';
+
+/**
+ * Polls the lightweight survival rate calculation status endpoint while a recalculation is in
+ * progress for a planting site. When the calculation completes, invalidates that site's
+ * observation results so the displayed survival rates refresh once.
+ */
+const useSurvivalRateCalculationInProgress = (plantingSiteId: number | undefined) => {
+  const dispatch = useAppDispatch();
+  const [isPolling, setIsPolling] = useState(false);
+
+  const { currentData } = useGetSurvivalRateCalculationInProgressQuery(plantingSiteId ?? 0, {
+    skip: plantingSiteId === undefined,
+    pollingInterval: isPolling && !import.meta.env.PUBLIC_DISABLE_RECURRENT_REQUESTS ? API_PULL_INTERVAL : undefined,
+  });
+
+  const inProgress = currentData?.calculationInProgress ?? false;
+
+  // Keep polling alive only while a recalculation is in progress.
+  useEffect(() => {
+    setIsPolling(inProgress);
+  }, [inProgress]);
+
+  // Refresh this site's observation results once, on the in-progress -> done transition.
+  const wasInProgress = useRef(false);
+  useEffect(() => {
+    if (wasInProgress.current && !inProgress && plantingSiteId !== undefined) {
+      dispatch(baseApi.util.invalidateTags([{ type: QueryTagTypes.PlantingSiteSurvivalRate, id: plantingSiteId }]));
+    }
+    wasInProgress.current = inProgress;
+  }, [inProgress, dispatch, plantingSiteId]);
+
+  return { inProgress };
+};
+
+export default useSurvivalRateCalculationInProgress;

--- a/src/scenes/ObservationsRouterV2/ListView/index.tsx
+++ b/src/scenes/ObservationsRouterV2/ListView/index.tsx
@@ -10,6 +10,7 @@ import Card from 'src/components/common/Card';
 import { APP_PATHS } from 'src/constants';
 import useOrganizationPlantingSites from 'src/hooks/useOrganizationPlantingSites';
 import useStickyPlantingSiteId from 'src/hooks/useStickyPlantingSiteId';
+import useSurvivalRateCalculationInProgress from 'src/hooks/useSurvivalRateCalculationInProgress';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
 import { useLazyCountObservationsQuery } from 'src/queries/search/observations';
@@ -33,6 +34,9 @@ const ObservationListView = (): JSX.Element => {
   const observableSites = useObservablePlantingSites();
   const { plantingSites } = useOrganizationPlantingSites();
   const { selectPlantingSite, selectedPlantingSiteId } = useStickyPlantingSiteId('observations-list', -1);
+
+  // Poll for survival rate recalculation and refresh observation results when it completes.
+  useSurvivalRateCalculationInProgress(selectedPlantingSiteId === -1 ? undefined : selectedPlantingSiteId);
 
   const [countObservations, countObservationsResult] = useLazyCountObservationsQuery();
   const hasObservationsResults = useMemo(() => !!countObservationsResult.data, [countObservationsResult]);

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/index.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/MonitoringPlot/index.tsx
@@ -9,6 +9,7 @@ import Page from 'src/components/Page';
 import SurvivalRateMessageV2 from 'src/components/SurvivalRate/SurvivalRateMessageV2';
 import { APP_PATHS } from 'src/constants';
 import { useGetOneObservationResults } from 'src/hooks/observations';
+import useSurvivalRateCalculationInProgress from 'src/hooks/useSurvivalRateCalculationInProgress';
 import { useLocalization } from 'src/providers';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import VirtualWalkthroughModal from 'src/scenes/VirtualWalkthrough/VirtualWalkthroughModal';
@@ -29,6 +30,10 @@ const MonitoringPlotDetails = (): JSX.Element => {
   const [getPlantingSite, getPlantingSiteResult] = useLazyGetPlantingSiteQuery();
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const plantingSite = useMemo(() => getPlantingSiteResult.data?.site, [getPlantingSiteResult.data?.site]);
+
+  // Poll for survival rate recalculation and refresh observation results when it completes.
+  useSurvivalRateCalculationInProgress(results?.plantingSiteId);
+
   const monitoringPlot = useMemo(
     () =>
       results?.isAdHoc

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Site/index.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Site/index.tsx
@@ -12,6 +12,7 @@ import SurvivalRateMessageV2 from 'src/components/SurvivalRate/SurvivalRateMessa
 import Card from 'src/components/common/Card';
 import { APP_PATHS } from 'src/constants';
 import { useGetOneObservationResults } from 'src/hooks/observations';
+import useSurvivalRateCalculationInProgress from 'src/hooks/useSurvivalRateCalculationInProgress';
 import { useLocalization } from 'src/providers';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import ObservationMapWrapper from 'src/scenes/ObservationsRouterV2/Map';
@@ -61,6 +62,9 @@ const SiteDetails = (): JSX.Element => {
 
   const results = useMemo(() => observationResultsResponse?.observation, [observationResultsResponse?.observation]);
   const plantingSite = useMemo(() => getPlantingSiteResult.data?.site, [getPlantingSiteResult.data?.site]);
+
+  // Poll for survival rate recalculation and refresh observation results when it completes.
+  useSurvivalRateCalculationInProgress(results?.plantingSiteId);
 
   useEffect(() => {
     if (results?.plantingSiteId) {

--- a/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/index.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/PlantMonitoring/Stratum/index.tsx
@@ -11,6 +11,7 @@ import SurvivalRateMessageV2 from 'src/components/SurvivalRate/SurvivalRateMessa
 import Card from 'src/components/common/Card';
 import { APP_PATHS } from 'src/constants';
 import { useGetOneObservationResults } from 'src/hooks/observations';
+import useSurvivalRateCalculationInProgress from 'src/hooks/useSurvivalRateCalculationInProgress';
 import { useLocalization } from 'src/providers';
 import { useLazyGetPlantingSiteQuery } from 'src/queries/generated/plantingSites';
 import { getShortDate } from 'src/utils/dateFormatter';
@@ -37,6 +38,9 @@ const StratumDetails = (): JSX.Element => {
     [results?.strata, stratumName]
   );
   const plantingSite = useMemo(() => getPlantingSiteResult.data?.site, [getPlantingSiteResult.data?.site]);
+
+  // Poll for survival rate recalculation and refresh observation results when it completes.
+  useSurvivalRateCalculationInProgress(results?.plantingSiteId);
 
   useEffect(() => {
     if (results) {

--- a/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
+++ b/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
@@ -13,6 +13,7 @@ import { useLatestSiteObservationResult } from 'src/hooks/observations';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import useOrganizationPlantingSites from 'src/hooks/useOrganizationPlantingSites';
 import usePlantingSite from 'src/hooks/usePlantingSite';
+import useSurvivalRateCalculationInProgress from 'src/hooks/useSurvivalRateCalculationInProgress';
 import { useLocalization, useOrganization } from 'src/providers';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import SimplePlantingSiteMap from 'src/scenes/PlantsDashboardRouter/components/SimplePlantingSiteMap';
@@ -62,6 +63,9 @@ export default function PlantsDashboardView({
   }, [plantingSite]);
 
   const { observation: latestObservationResult } = useLatestSiteObservationResult(selectedPlantingSiteId, 'Substratum');
+
+  // Poll for survival rate recalculation and refresh observation results when it completes.
+  useSurvivalRateCalculationInProgress(plantingSite?.id);
   const hasObservationResults = useMemo(() => !!latestObservationResultId, [latestObservationResultId]);
 
   const onPreferences = useCallback(


### PR DESCRIPTION
polls `calculationInProgress` endpoint and invalidate observations once completed.

Co-Authored-By: Claude Opus 4.8 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)