### PR TITLE
Fixed sticky planting site ID to have strict 'all' | numbers type

### DIFF
--- a/src/hooks/observations/useListObservationResults.ts
+++ b/src/hooks/observations/useListObservationResults.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 
+import { ALL_PLANTING_SITES, type PlantingSiteId } from 'src/hooks/useStickyPlantingSiteId';
 import { useLazyListObservationResultsQuery } from 'src/queries/generated/observations';
 import { ObservationState } from 'src/types/Observations';
 
@@ -7,7 +8,7 @@ import { ObservationDepth } from './types';
 
 type UseListObservationResultsArgs = {
   organizationId: number | undefined;
-  plantingSiteId?: number;
+  plantingSiteId?: PlantingSiteId;
   depth?: ObservationDepth;
   state?: ObservationState[];
   limit?: number;
@@ -22,11 +23,14 @@ const useListObservationResults = ({
 }: UseListObservationResultsArgs) => {
   const [listObservationResults, result] = useLazyListObservationResultsQuery();
 
+  // Listing results for 'all' planting sites means querying with no site filter.
+  const plantingSiteIdFilter = plantingSiteId === ALL_PLANTING_SITES ? undefined : plantingSiteId;
+
   useEffect(() => {
     if (organizationId !== undefined) {
-      void listObservationResults({ organizationId, plantingSiteId, depth, state, limit }, true);
+      void listObservationResults({ organizationId, plantingSiteId: plantingSiteIdFilter, depth, state, limit }, true);
     }
-  }, [depth, limit, listObservationResults, organizationId, plantingSiteId, state]);
+  }, [depth, limit, listObservationResults, organizationId, plantingSiteIdFilter, state]);
 
   return result;
 };

--- a/src/hooks/useStickyPlantingSiteId.ts
+++ b/src/hooks/useStickyPlantingSiteId.ts
@@ -3,31 +3,39 @@ import { useCallback, useEffect, useState } from 'react';
 import { useOrganization } from 'src/providers';
 import { CachedUserService, PreferencesService } from 'src/services';
 
-const useStickyPlantingSiteId = (preferenceName: string, defaultValue?: number | undefined) => {
+// Selecting 'all' means "all planting sites" (no single site filter).
+export const ALL_PLANTING_SITES = 'all';
+export type PlantingSiteId = number | typeof ALL_PLANTING_SITES;
+
+// The backend historically stored -1 to mean "all planting sites". We now persist 'all', but still
+// translate the legacy -1 value to 'all' when reading existing preferences.
+const LEGACY_ALL_PLANTING_SITES = -1;
+
+const useStickyPlantingSiteId = (preferenceName: string) => {
   const { selectedOrganization } = useOrganization();
 
-  const [selectedPlantingSiteId, setSelectedPlantingSiteId] = useState<number | undefined>(defaultValue);
+  const [selectedPlantingSiteId, setSelectedPlantingSiteId] = useState<PlantingSiteId>(ALL_PLANTING_SITES);
   useEffect(() => {
     if (selectedOrganization) {
       const response = CachedUserService.getUserOrgPreferences(selectedOrganization.id);
       const stickyPlantingSite = response[preferenceName];
       if (stickyPlantingSite) {
-        const lastPlantingSiteId = Number(stickyPlantingSite.plantingSiteId);
-        setSelectedPlantingSiteId(lastPlantingSiteId);
+        const storedPlantingSiteId = stickyPlantingSite.plantingSiteId;
+        const isAllPlantingSites =
+          storedPlantingSiteId === ALL_PLANTING_SITES || Number(storedPlantingSiteId) === LEGACY_ALL_PLANTING_SITES;
+        setSelectedPlantingSiteId(isAllPlantingSites ? ALL_PLANTING_SITES : Number(storedPlantingSiteId));
       }
     }
   }, [selectedOrganization, preferenceName]);
 
   const selectPlantingSite = useCallback(
-    (nextPlantingSiteId: number) => {
+    (nextPlantingSiteId: PlantingSiteId) => {
       setSelectedPlantingSiteId(nextPlantingSiteId);
 
-      if (selectedOrganization) {
-        if (nextPlantingSiteId !== selectedPlantingSiteId) {
-          void PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
-            [preferenceName]: { plantingSiteId: nextPlantingSiteId },
-          });
-        }
+      if (selectedOrganization && nextPlantingSiteId !== selectedPlantingSiteId) {
+        void PreferencesService.updateUserOrgPreferences(selectedOrganization.id, {
+          [preferenceName]: { plantingSiteId: nextPlantingSiteId },
+        });
       }
     },
     [preferenceName, selectedOrganization, selectedPlantingSiteId]

--- a/src/scenes/NurseryRouter/PlantingSeasons/PlantingSeasonsView.tsx
+++ b/src/scenes/NurseryRouter/PlantingSeasons/PlantingSeasonsView.tsx
@@ -8,7 +8,7 @@ import Page from 'src/components/Page';
 import Card from 'src/components/common/Card';
 import useBoolean from 'src/hooks/useBoolean';
 import useOrganizationPlantingSites from 'src/hooks/useOrganizationPlantingSites';
-import useStickyPlantingSiteId from 'src/hooks/useStickyPlantingSiteId';
+import useStickyPlantingSiteId, { ALL_PLANTING_SITES } from 'src/hooks/useStickyPlantingSiteId';
 import { useLocalization, useOrganization } from 'src/providers';
 import { useLazyListPlantingSeasonsQuery } from 'src/queries/generated/plantingSeasons';
 
@@ -22,7 +22,7 @@ const PlantingSeasonsView = (): JSX.Element => {
   const { selectedOrganization } = useOrganization();
 
   const { plantingSites } = useOrganizationPlantingSites({ full: true });
-  const { selectPlantingSite, selectedPlantingSiteId } = useStickyPlantingSiteId('planting-seasons', -1);
+  const { selectPlantingSite, selectedPlantingSiteId } = useStickyPlantingSiteId('planting-seasons');
 
   const [listPlantingSeasons, { data: plantingSeasonsData }] = useLazyListPlantingSeasonsQuery();
 
@@ -37,7 +37,10 @@ const PlantingSeasonsView = (): JSX.Element => {
       .map((site) => ({ label: site.name, value: site.id }))
       .sort((a, b) => a.label.localeCompare(b.label));
 
-    return [{ label: isMobile ? strings.ALL_SITES : strings.ALL_PLANTING_SITES, value: -1 }, ...sitesOptions];
+    return [
+      { label: isMobile ? strings.ALL_SITES : strings.ALL_PLANTING_SITES, value: ALL_PLANTING_SITES },
+      ...sitesOptions,
+    ];
   }, [isMobile, plantingSites, strings]);
 
   const plantingSiteDropdown = (
@@ -46,7 +49,9 @@ const PlantingSeasonsView = (): JSX.Element => {
       required
       selectedValue={selectedPlantingSiteId}
       options={plantingSiteOptions}
-      onChange={(value: any) => selectPlantingSite(Number(value))}
+      onChange={(value: string) =>
+        selectPlantingSite(value === ALL_PLANTING_SITES ? ALL_PLANTING_SITES : Number(value))
+      }
       sx={{ flex: 1, maxWidth: isMobile ? '280px' : '400px' }}
     />
   );
@@ -75,7 +80,9 @@ const PlantingSeasonsView = (): JSX.Element => {
     const sitesById = new Map(plantingSites.map((site) => [site.id, site]));
     const seasons = plantingSeasonsData?.seasons ?? [];
     return seasons
-      .filter((season) => selectedPlantingSiteId === -1 || season.plantingSiteId === selectedPlantingSiteId)
+      .filter(
+        (season) => selectedPlantingSiteId === ALL_PLANTING_SITES || season.plantingSiteId === selectedPlantingSiteId
+      )
       .flatMap((season) => {
         const site = sitesById.get(season.plantingSiteId);
         return site ? [{ site, season }] : [];
@@ -124,7 +131,10 @@ const PlantingSeasonsView = (): JSX.Element => {
       rightComponentGridSize={isMobile ? 0 : undefined}
     >
       {addModalOpen && (
-        <AddPlantingSeasonModal onClose={onCloseAddModal} initialPlantingSiteId={selectedPlantingSiteId} />
+        <AddPlantingSeasonModal
+          onClose={onCloseAddModal}
+          initialPlantingSiteId={selectedPlantingSiteId === ALL_PLANTING_SITES ? undefined : selectedPlantingSiteId}
+        />
       )}
       {seasonRows.length === 0 ? (
         <Card style={{ width: '100%' }} radius={theme.spacing(1)}>

--- a/src/scenes/ObservationsRouterV2/ListView/BiomassList.tsx
+++ b/src/scenes/ObservationsRouterV2/ListView/BiomassList.tsx
@@ -19,6 +19,7 @@ import TableRowPopupMenu from 'src/components/common/table/TableRowPopupMenu';
 import EmptyStateContent from 'src/components/emptyStatePages/EmptyStateContent';
 import { APP_PATHS } from 'src/constants';
 import useOrganizationPlantingSites from 'src/hooks/useOrganizationPlantingSites';
+import { ALL_PLANTING_SITES, type PlantingSiteId } from 'src/hooks/useStickyPlantingSiteId';
 import useTableState from 'src/hooks/useTableState';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
 import { useLazyListObservationResultsQuery } from 'src/queries/generated/observations';
@@ -59,7 +60,7 @@ const BiomassActionsMenuContent = ({ observationId }: { observationId: number })
 };
 
 export type BiomassListProps = {
-  plantingSiteId?: number;
+  plantingSiteId?: PlantingSiteId;
 };
 
 export default function BiomassList({ plantingSiteId }: BiomassListProps): JSX.Element {
@@ -101,7 +102,12 @@ export default function BiomassList({ plantingSiteId }: BiomassListProps): JSX.E
   useEffect(() => {
     if (selectedOrganization) {
       void listAdHocObservationResults(
-        { plantingSiteId, organizationId: selectedOrganization.id, depth: 'Plant', isAdHoc: true },
+        {
+          plantingSiteId: plantingSiteId === ALL_PLANTING_SITES ? undefined : plantingSiteId,
+          organizationId: selectedOrganization.id,
+          depth: 'Plant',
+          isAdHoc: true,
+        },
         true
       );
     }
@@ -228,11 +234,15 @@ export default function BiomassList({ plantingSiteId }: BiomassListProps): JSX.E
     if (!selectedOrganization) {
       return;
     }
-    const content = await ObservationsService.exportBiomassObservationsCsv(selectedOrganization.id, plantingSiteId);
+    const content = await ObservationsService.exportBiomassObservationsCsv(
+      selectedOrganization.id,
+      plantingSiteId === ALL_PLANTING_SITES ? undefined : plantingSiteId
+    );
     if (content !== null) {
-      const siteName = plantingSiteId
-        ? plantingSitesNames[plantingSiteId] ?? strings.ALL_PLANTING_SITES
-        : strings.ALL_PLANTING_SITES;
+      const siteName =
+        typeof plantingSiteId === 'number'
+          ? plantingSitesNames[plantingSiteId] ?? strings.ALL_PLANTING_SITES
+          : strings.ALL_PLANTING_SITES;
       const filename = sanitize(`${siteName}-${strings.BIOMASS_MONITORING}`);
       downloadCsv(filename, content);
     }

--- a/src/scenes/ObservationsRouterV2/ListView/PlantMonitoringList.tsx
+++ b/src/scenes/ObservationsRouterV2/ListView/PlantMonitoringList.tsx
@@ -22,6 +22,7 @@ import EmptyStateContent from 'src/components/emptyStatePages/EmptyStateContent'
 import { APP_PATHS } from 'src/constants';
 import { useListObservationResults } from 'src/hooks/observations';
 import useOrganizationPlantingSites from 'src/hooks/useOrganizationPlantingSites';
+import { ALL_PLANTING_SITES, type PlantingSiteId } from 'src/hooks/useStickyPlantingSiteId';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import useTableState from 'src/hooks/useTableState';
 import { useLocalization, useOrganization } from 'src/providers';
@@ -117,7 +118,7 @@ const PlantMonitoringActionsMenuContent = ({ row }: { row: PlantMonitoringRow })
 };
 
 export type PlantMonitoringListProps = {
-  plantingSiteId?: number;
+  plantingSiteId?: PlantingSiteId;
 };
 
 const PlantMonitoringList = ({ plantingSiteId }: PlantMonitoringListProps) => {
@@ -192,7 +193,7 @@ const PlantMonitoringList = ({ plantingSiteId }: PlantMonitoringListProps) => {
       void listAdHocObservationResults(
         {
           organizationId: selectedOrganization.id,
-          plantingSiteId,
+          plantingSiteId: plantingSiteId === ALL_PLANTING_SITES ? undefined : plantingSiteId,
           depth: 'Plant',
           isAdHoc: true,
         },
@@ -202,7 +203,7 @@ const PlantMonitoringList = ({ plantingSiteId }: PlantMonitoringListProps) => {
   }, [listAdHocObservationResults, selectedPlotSelection, selectedOrganization, plantingSiteId]);
 
   useEffect(() => {
-    if (plantingSiteId) {
+    if (typeof plantingSiteId === 'number') {
       void getT0SiteDataSet(plantingSiteId, true);
       void getPlotsWithObservations(plantingSiteId, true);
     }
@@ -287,7 +288,7 @@ const PlantMonitoringList = ({ plantingSiteId }: PlantMonitoringListProps) => {
   );
 
   const navigateToSurvivalRateSettings = useCallback(() => {
-    if (plantingSiteId) {
+    if (typeof plantingSiteId === 'number') {
       navigate({
         pathname: APP_PATHS.SURVIVAL_RATE_SETTINGS_V2.replace(':plantingSiteId', plantingSiteId.toString()),
       });
@@ -554,7 +555,7 @@ const PlantMonitoringList = ({ plantingSiteId }: PlantMonitoringListProps) => {
       };
     });
 
-    const selectedSite = plantingSiteId ? plantingSitesById[plantingSiteId] : undefined;
+    const selectedSite = typeof plantingSiteId === 'number' ? plantingSitesById[plantingSiteId] : undefined;
     void exportAdHocObservationsResults({ adHocObservationsResults, plantingSite: selectedSite });
   }, [defaultTimezone, listAdHocObservationResultsResponse, plantingSiteId, plantingSitesById]);
 
@@ -579,7 +580,7 @@ const PlantMonitoringList = ({ plantingSiteId }: PlantMonitoringListProps) => {
           fixedMenu
           fullWidth
         />
-        {plantingSiteId && selectedPlotSelection === 'assigned' && rows.length > 0 && (
+        {typeof plantingSiteId === 'number' && selectedPlotSelection === 'assigned' && rows.length > 0 && (
           <Box display='flex' alignItems='center'>
             <Link
               onClick={navigateToSurvivalRateSettings}

--- a/src/scenes/ObservationsRouterV2/ListView/index.tsx
+++ b/src/scenes/ObservationsRouterV2/ListView/index.tsx
@@ -10,7 +10,7 @@ import SurvivalRateRecalculationMessage from 'src/components/SurvivalRate/Surviv
 import Card from 'src/components/common/Card';
 import { APP_PATHS } from 'src/constants';
 import useOrganizationPlantingSites from 'src/hooks/useOrganizationPlantingSites';
-import useStickyPlantingSiteId from 'src/hooks/useStickyPlantingSiteId';
+import useStickyPlantingSiteId, { ALL_PLANTING_SITES } from 'src/hooks/useStickyPlantingSiteId';
 import useSurvivalRateCalculationInProgress from 'src/hooks/useSurvivalRateCalculationInProgress';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
@@ -34,12 +34,14 @@ const ObservationListView = (): JSX.Element => {
 
   const observableSites = useObservablePlantingSites();
   const { plantingSites } = useOrganizationPlantingSites();
-  const { selectPlantingSite, selectedPlantingSiteId } = useStickyPlantingSiteId('observations-list', -1);
+  const { selectPlantingSite, selectedPlantingSiteId } = useStickyPlantingSiteId('observations-list');
+
+  // The data layer treats `undefined` as "all planting sites", so translate the selection for queries.
+  const plantingSiteIdFilter = selectedPlantingSiteId === ALL_PLANTING_SITES ? undefined : selectedPlantingSiteId;
 
   // Poll for survival rate recalculation and refresh observation results when it completes.
-  const { inProgress: survivalRateRecalculationInProgress } = useSurvivalRateCalculationInProgress(
-    selectedPlantingSiteId === -1 ? undefined : selectedPlantingSiteId
-  );
+  const { inProgress: survivalRateRecalculationInProgress } =
+    useSurvivalRateCalculationInProgress(plantingSiteIdFilter);
 
   const [countObservations, countObservationsResult] = useLazyCountObservationsQuery();
   const hasObservationsResults = useMemo(() => !!countObservationsResult.data, [countObservationsResult]);
@@ -57,7 +59,7 @@ const ObservationListView = (): JSX.Element => {
         ? [
             {
               label: strings.ALL_PLANTING_SITES,
-              value: -1,
+              value: ALL_PLANTING_SITES,
             },
           ]
         : [];
@@ -82,7 +84,9 @@ const ObservationListView = (): JSX.Element => {
           required
           selectedValue={selectedPlantingSiteId}
           options={plantingSiteOptions}
-          onChange={(value: any) => selectPlantingSite(Number(value))}
+          onChange={(value: string) =>
+            selectPlantingSite(value === ALL_PLANTING_SITES ? ALL_PLANTING_SITES : Number(value))
+          }
           sx={{ flex: 1, maxWidth: '400px' }}
         />
       </Box>
@@ -90,21 +94,21 @@ const ObservationListView = (): JSX.Element => {
     [isMobile, strings, theme, selectedPlantingSiteId, plantingSiteOptions, selectPlantingSite]
   );
 
-  const tabs = useMemo(() => {
-    const siteId = selectedPlantingSiteId === -1 ? undefined : selectedPlantingSiteId;
-    return [
+  const tabs = useMemo(
+    () => [
       {
         id: 'plantMonitoring',
         label: strings.PLANT_MONITORING,
-        children: <PlantMonitoringList plantingSiteId={siteId} />,
+        children: <PlantMonitoringList plantingSiteId={selectedPlantingSiteId} />,
       },
       {
         id: 'biomassMeasurements',
         label: strings.BIOMASS_MONITORING,
-        children: <BiomassList plantingSiteId={siteId} />,
+        children: <BiomassList plantingSiteId={selectedPlantingSiteId} />,
       },
-    ];
-  }, [selectedPlantingSiteId, strings.BIOMASS_MONITORING, strings.PLANT_MONITORING]);
+    ],
+    [selectedPlantingSiteId, strings.BIOMASS_MONITORING, strings.PLANT_MONITORING]
+  );
 
   const { activeTab, onChangeTab } = useStickyTabs({
     defaultTab: 'plantMonitoring',
@@ -134,14 +138,13 @@ const ObservationListView = (): JSX.Element => {
   }, [navigate, scheduleObservationEnabled, strings.SCHEDULE_OBSERVATION]);
 
   useEffect(() => {
-    const siteId = selectedPlantingSiteId === -1 ? undefined : selectedPlantingSiteId;
     if (selectedOrganization) {
       if (activeTab === 'biomassMeasurements') {
         void countObservations(
           {
             organizationId: selectedOrganization.id,
             observationType: 'Biomass Measurements',
-            plantingSiteId: siteId,
+            plantingSiteId: plantingSiteIdFilter,
             state: ['Abandoned', 'Completed', 'InProgress', 'Overdue'],
           },
           true
@@ -151,14 +154,14 @@ const ObservationListView = (): JSX.Element => {
           {
             organizationId: selectedOrganization.id,
             observationType: 'Monitoring',
-            plantingSiteId: siteId,
+            plantingSiteId: plantingSiteIdFilter,
             state: ['Abandoned', 'Completed', 'InProgress', 'Overdue'],
           },
           true
         );
       }
     }
-  }, [activeTab, countObservations, selectedOrganization, selectedPlantingSiteId]);
+  }, [activeTab, countObservations, selectedOrganization, plantingSiteIdFilter]);
 
   return (
     <Page
@@ -171,9 +174,7 @@ const ObservationListView = (): JSX.Element => {
       <ObservationsEventsNotification />
       {activeTab === 'plantMonitoring' && (
         <>
-          <SurvivalRateMessageV2
-            selectedPlantingSiteId={selectedPlantingSiteId === -1 ? undefined : selectedPlantingSiteId}
-          />
+          <SurvivalRateMessageV2 selectedPlantingSiteId={plantingSiteIdFilter} />
           <SurvivalRateRecalculationMessage inProgress={survivalRateRecalculationInProgress} />
         </>
       )}
@@ -182,7 +183,7 @@ const ObservationListView = (): JSX.Element => {
           <Card radius={'8px'} style={{ marginBottom: theme.spacing(3), width: '100%' }}>
             <ObservationMapWrapper
               isBiomass={isBiomass}
-              plantingSiteId={selectedPlantingSiteId === -1 ? undefined : selectedPlantingSiteId}
+              plantingSiteId={plantingSiteIdFilter}
               selectPlantingSiteId={selectPlantingSite}
             />
           </Card>

--- a/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
+++ b/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
@@ -14,6 +14,7 @@ import { useLatestSiteObservationResult } from 'src/hooks/observations';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import useOrganizationPlantingSites from 'src/hooks/useOrganizationPlantingSites';
 import usePlantingSite from 'src/hooks/usePlantingSite';
+import { ALL_PLANTING_SITES, type PlantingSiteId } from 'src/hooks/useStickyPlantingSiteId';
 import useSurvivalRateCalculationInProgress from 'src/hooks/useSurvivalRateCalculationInProgress';
 import { useLocalization, useOrganization } from 'src/providers';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
@@ -47,7 +48,7 @@ export default function PlantsDashboardView({
 
   const { plantingSiteId: plantingSiteIdParam } = useParams<{ plantingSiteId: string }>();
   const initialPlantingSiteId = plantingSiteIdParam ? Number(plantingSiteIdParam) : undefined;
-  const [selectedPlantingSiteId, setSelectedPlantingSiteId] = useState<number | undefined>(
+  const [selectedPlantingSiteId, setSelectedPlantingSiteId] = useState<PlantingSiteId | undefined>(
     initialPlantingSiteId && !isNaN(initialPlantingSiteId) ? initialPlantingSiteId : undefined
   );
 
@@ -55,7 +56,9 @@ export default function PlantsDashboardView({
   const { plantingSitesWithAllSitesOption } = useOrganizationPlantingSites({
     organizationId: isAcceleratorRoute ? acceleratorOrganizationId : undefined,
   });
-  const { plantingSite } = usePlantingSite(selectedPlantingSiteId);
+  const { plantingSite } = usePlantingSite(
+    selectedPlantingSiteId === ALL_PLANTING_SITES ? undefined : selectedPlantingSiteId
+  );
   const latestObservationResultId = useMemo(() => {
     return plantingSite?.latestObservationId;
   }, [plantingSite]);
@@ -63,7 +66,10 @@ export default function PlantsDashboardView({
     return plantingSite?.latestObservationCompletedTime;
   }, [plantingSite]);
 
-  const { observation: latestObservationResult } = useLatestSiteObservationResult(selectedPlantingSiteId, 'Substratum');
+  const { observation: latestObservationResult } = useLatestSiteObservationResult(
+    selectedPlantingSiteId === ALL_PLANTING_SITES ? undefined : selectedPlantingSiteId,
+    'Substratum'
+  );
 
   // Poll for survival rate recalculation and refresh observation results when it completes.
   const { inProgress: survivalRateRecalculationInProgress } = useSurvivalRateCalculationInProgress(plantingSite?.id);
@@ -206,13 +212,13 @@ export default function PlantsDashboardView({
           }}
         >
           <Typography fontWeight={600} fontSize={'20px'} paddingRight={1}>
-            {selectedPlantingSiteId === -1 ? strings.PROJECT_AREA_TOTALS : strings.PLANTING_SITE_TOTALS}
+            {selectedPlantingSiteId === ALL_PLANTING_SITES ? strings.PROJECT_AREA_TOTALS : strings.PLANTING_SITE_TOTALS}
           </Typography>
         </Box>
       </Grid>
       <Grid item xs={12}>
         <PlantsAndSpeciesCard
-          plantingSiteId={selectedPlantingSiteId !== -1 ? plantingSite?.id : undefined}
+          plantingSiteId={selectedPlantingSiteId !== ALL_PLANTING_SITES ? plantingSite?.id : undefined}
           projectId={projectId}
         />
       </Grid>
@@ -386,7 +392,8 @@ export default function PlantsDashboardView({
   }, [plantingSite, observationDateRange, renderLatestObservationLink, observedHectares, strings]);
 
   const onSelect = useCallback((nextPlantingSiteId: number) => {
-    setSelectedPlantingSiteId(nextPlantingSiteId);
+    // PlantsPrimaryPage represents "all planting sites" with the synthetic site id -1.
+    setSelectedPlantingSiteId(nextPlantingSiteId === -1 ? ALL_PLANTING_SITES : nextPlantingSiteId);
   }, []);
 
   const onSelectProject = useCallback((newProjectId: number) => {
@@ -417,7 +424,7 @@ export default function PlantsDashboardView({
     <PlantsPrimaryPage
       title={isAcceleratorRoute ? '' : strings.PLANTS_DASHBOARD}
       text={
-        selectedPlantingSiteId !== -1
+        selectedPlantingSiteId !== ALL_PLANTING_SITES
           ? plantingSite
             ? latestObservationResultId
               ? getDashboardSubhead()
@@ -448,13 +455,13 @@ export default function PlantsDashboardView({
     >
       <Grid container spacing={3} alignItems='flex-start' height='fit-content'>
         {renderTotalPlantsAndSpecies()}
-        {hasObservationResults && selectedPlantingSiteId !== -1 && renderPlantingSiteTrends()}
-        {selectedPlantingSiteId !== -1 && hasObservationResults && renderPlantingProgressAndDensity()}
-        {((hasObservationResults && selectedPlantingSiteId !== -1) || (!!projectId && !plantingSite)) &&
+        {hasObservationResults && selectedPlantingSiteId !== ALL_PLANTING_SITES && renderPlantingSiteTrends()}
+        {selectedPlantingSiteId !== ALL_PLANTING_SITES && hasObservationResults && renderPlantingProgressAndDensity()}
+        {((hasObservationResults && selectedPlantingSiteId !== ALL_PLANTING_SITES) || (!!projectId && !plantingSite)) &&
           renderSurvivalRate()}
-        {selectedPlantingSiteId !== -1 && hasStrata && renderStratumLevelData()}
-        {selectedPlantingSiteId !== -1 && hasPolygons && !hasStrata && renderSimpleSiteMap()}
-        {(selectedPlantingSiteId === -1 || !plantingSite) && renderMapWithSites()}
+        {selectedPlantingSiteId !== ALL_PLANTING_SITES && hasStrata && renderStratumLevelData()}
+        {selectedPlantingSiteId !== ALL_PLANTING_SITES && hasPolygons && !hasStrata && renderSimpleSiteMap()}
+        {(selectedPlantingSiteId === ALL_PLANTING_SITES || !plantingSite) && renderMapWithSites()}
       </Grid>
     </PlantsPrimaryPage>
   );


### PR DESCRIPTION
Discontinue using `-1` to represent 'All Entites', since it will silently pass typechecks and and lead to API calls with -1 as ID. Instead, use an explicit 'all' string.