### PR TITLE
SW-8408 First cluster click opens drawer, second click fits bounds

### DIFF
--- a/src/components/ActivityLog/MapSplitView.tsx
+++ b/src/components/ActivityLog/MapSplitView.tsx
@@ -204,6 +204,7 @@ export default function MapSplitView({
       {topComponent}
 
       <MapComponent
+        clusterMaxZoom={20}
         containerStyle={
           isDesktop
             ? {

--- a/src/components/NewMap/MapBox.tsx
+++ b/src/components/NewMap/MapBox.tsx
@@ -497,14 +497,25 @@ const MapBox = (props: MapBoxProps): JSX.Element | null => {
         return;
       }
 
+      // Clusters without a drawer handler keep the original behavior: zoom in
+      // one level per click to progressively decluster the markers.
+      if (!cluster.onClick) {
+        map.easeTo({
+          center: { lat: cluster.latitude, lon: cluster.longitude },
+          zoom: map.getZoom() + 1,
+          duration: 500,
+        });
+        return;
+      }
+
       // First click on a not-yet-selected cluster opens the paginated drawer.
-      if (cluster.onClick && !cluster.selected) {
+      if (!cluster.selected) {
         cluster.onClick();
         return;
       }
 
-      // Second click (cluster already selected) or a cluster with no drawer
-      // handler: fit the map to just this cluster's markers so they spread apart.
+      // Second click (cluster already selected): fit the map to just this
+      // cluster's markers so they spread apart.
       const bounds = getBoundingBoxFromPoints(
         cluster.markers.map((marker) => ({ lat: marker.latitude, lng: marker.longitude }))
       );

--- a/src/components/NewMap/MapBox.tsx
+++ b/src/components/NewMap/MapBox.tsx
@@ -32,6 +32,7 @@ import {
   stylesUrl,
 } from './types';
 import { useMaintainLayerOrder } from './useMaintainLayerOrder';
+import { getBoundingBoxFromPoints, isBoundsValid } from './utils';
 
 export type MapBoxProps = {
   additionalComponent?: React.ReactNode;
@@ -109,7 +110,6 @@ const MapBox = (props: MapBoxProps): JSX.Element | null => {
   const { isDesktop } = useDeviceInfo();
   const [cursor, setCursor] = useState<MapCursor>('auto');
   const [hoverFeatureId, setHoverFeatureId] = useState<string>();
-  const [zoom, setZoom] = useState<number>();
   const [focused, setFocused] = useState<boolean>(false);
 
   const loadImages = useCallback(
@@ -131,7 +131,6 @@ const MapBox = (props: MapBoxProps): JSX.Element | null => {
     (map: MapRef | null) => {
       if (map !== null) {
         mapRef.current = map;
-        setZoom(map.getZoom());
         loadImages(map);
         onMapLoad?.();
 
@@ -146,7 +145,6 @@ const MapBox = (props: MapBoxProps): JSX.Element | null => {
 
   const onMove = useCallback(
     (view: ViewStateChangeEvent) => {
-      setZoom(view.viewState.zoom);
       onMapMove?.(view);
     },
     [onMapMove]
@@ -492,24 +490,39 @@ const MapBox = (props: MapBoxProps): JSX.Element | null => {
   );
 
   const onMarkerClusterClick = useCallback(
-    (latitude: number, longitude: number, onClusterClick?: () => void) => (event: MarkerEvent<MouseEvent>) => {
+    (cluster: MapMarkerCluster) => (event: MarkerEvent<MouseEvent>) => {
+      event.originalEvent.stopPropagation();
       const map = mapRef.current;
-      if (map && zoom) {
-        if (clusterMaxZoom && onClusterClick && zoom >= clusterMaxZoom) {
-          // On max zoom
-          onClusterClick();
-          event.originalEvent.stopPropagation();
-        } else {
-          mapRef.current?.easeTo({
-            center: { lat: latitude, lon: longitude },
-            zoom: (zoom ?? 10) + 1,
+      if (!map) {
+        return;
+      }
+
+      // First click on a not-yet-selected cluster opens the paginated drawer.
+      if (cluster.onClick && !cluster.selected) {
+        cluster.onClick();
+        return;
+      }
+
+      // Second click (cluster already selected) or a cluster with no drawer
+      // handler: fit the map to just this cluster's markers so they spread apart.
+      const bounds = getBoundingBoxFromPoints(
+        cluster.markers.map((marker) => ({ lat: marker.latitude, lng: marker.longitude }))
+      );
+      if (isBoundsValid(bounds)) {
+        map.fitBounds(
+          [
+            { lat: bounds.minLat, lng: bounds.minLng },
+            { lat: bounds.maxLat, lng: bounds.maxLng },
+          ],
+          {
+            maxZoom: clusterMaxZoom,
+            padding: 50,
             duration: 500,
-          });
-          event.originalEvent.stopPropagation();
-        }
+          }
+        );
       }
     },
-    [clusterMaxZoom, mapRef, zoom]
+    [clusterMaxZoom, mapRef]
   );
 
   const markersComponents = useMemo(() => {
@@ -549,7 +562,7 @@ const MapBox = (props: MapBoxProps): JSX.Element | null => {
               longitude={cluster.longitude}
               latitude={cluster.latitude}
               anchor='center'
-              onClick={onMarkerClusterClick(cluster.latitude, cluster.longitude, cluster.onClick)}
+              onClick={onMarkerClusterClick(cluster)}
               style={{ backgroundColor: cluster.selected ? markerGroup.style.iconColor : theme.palette.TwClrBg }}
             >
               <p className='count'>{cluster.size}</p>

--- a/src/components/NewMap/MapBox.tsx
+++ b/src/components/NewMap/MapBox.tsx
@@ -497,25 +497,14 @@ const MapBox = (props: MapBoxProps): JSX.Element | null => {
         return;
       }
 
-      // Clusters without a drawer handler keep the original behavior: zoom in
-      // one level per click to progressively decluster the markers.
-      if (!cluster.onClick) {
-        map.easeTo({
-          center: { lat: cluster.latitude, lon: cluster.longitude },
-          zoom: map.getZoom() + 1,
-          duration: 500,
-        });
-        return;
-      }
-
       // First click on a not-yet-selected cluster opens the paginated drawer.
-      if (!cluster.selected) {
+      if (cluster.onClick && !cluster.selected) {
         cluster.onClick();
         return;
       }
 
-      // Second click (cluster already selected): fit the map to just this
-      // cluster's markers so they spread apart.
+      // Second click (cluster already selected) or a cluster with no drawer
+      // handler: fit the map to just this cluster's markers so they spread apart.
       const bounds = getBoundingBoxFromPoints(
         cluster.markers.map((marker) => ({ lat: marker.latitude, lng: marker.longitude }))
       );

--- a/src/scenes/VirtualWalkthrough/VirtualWalkthroughsMap.tsx
+++ b/src/scenes/VirtualWalkthrough/VirtualWalkthroughsMap.tsx
@@ -208,6 +208,14 @@ export default function VirtualWalkthroughsMap({
     []
   );
 
+  const handleDrawerOpenChange = useCallback((open: boolean) => {
+    setDrawerOpen(open);
+    if (!open) {
+      setSelectedFiles([]);
+      setSelectedFileIndex(0);
+    }
+  }, []);
+
   const handleClusterClick = useCallback((clusteredMarkers: MapMarker[]) => {
     const files = clusteredMarkers
       .map((m) => m.properties?.file as OrganizationVirtualWalkthrough | undefined)
@@ -408,7 +416,7 @@ export default function VirtualWalkthroughsMap({
         drawerSize='medium'
         drawerHeader={drawerHeader}
         drawerChildren={drawerContent}
-        setDrawerOpen={setDrawerOpen}
+        setDrawerOpen={handleDrawerOpenChange}
         additionalComponent={draggableMarker}
       />
     </>


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.8 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)