### PR TITLE
Migrate biomass observations CSV export to RTK Query

### DIFF
--- a/src/queries/exports/observations.ts
+++ b/src/queries/exports/observations.ts
@@ -140,6 +140,73 @@ const injectedRtkApi = api.injectEndpoints({
       }),
       providesTags: (_results, _errors, observationId) => [{ type: QueryTagTypes.Observation, id: observationId }],
     }),
+    exportBiomassObservationsCsv: build.query<string, ExportBiomassObservationsApiArg>({
+      query: ({ organizationId, plantingSiteId }) => ({
+        url: '/api/v1/search',
+        method: 'POST',
+        headers: {
+          accept: 'text/csv',
+        },
+        body: {
+          prefix: 'observationPlots',
+          fields: [
+            'monitoringPlot_plotNumber',
+            'monitoringPlot_plantingSite_name',
+            'completedTime',
+            'biomassDetails_description',
+            'monitoringPlot_southwestLatitude',
+            'monitoringPlot_southwestLongitude',
+            'monitoringPlot_northwestLatitude',
+            'monitoringPlot_northwestLongitude',
+            'monitoringPlot_southeastLatitude',
+            'monitoringPlot_southeastLongitude',
+            'monitoringPlot_northeastLatitude',
+            'monitoringPlot_northeastLongitude',
+            'biomassDetails_forestType',
+            'biomassDetails_herbaceousCoverPercent',
+            'biomassDetails_ph',
+            'biomassDetails_smallTreesCountLow',
+            'biomassDetails_smallTreesCountHigh',
+            'biomassDetails_salinity',
+            'biomassDetails_soilAssessment',
+            'biomassDetails_tide',
+            'biomassDetails_tideTime',
+            'biomassDetails_waterDepth',
+            'biomassDetails_numPlants',
+            'biomassDetails_numSpecies',
+            'conditions.condition',
+            'notes',
+          ],
+          sortOrder: [{ field: 'monitoringPlot_plotNumber', direction: 'Descending' }],
+          search: {
+            operation: 'and',
+            children: [
+              {
+                operation: 'field',
+                type: 'Exact',
+                field: 'observation_type(raw)',
+                values: ['Biomass Measurements'],
+              },
+              plantingSiteId && plantingSiteId > 0
+                ? {
+                    operation: 'field',
+                    type: 'Exact',
+                    field: 'monitoringPlot_plantingSite_id',
+                    values: [`${plantingSiteId}`],
+                  }
+                : {
+                    operation: 'field',
+                    type: 'Exact',
+                    field: 'monitoringPlot_plantingSite_organization_id',
+                    values: [`${organizationId}`],
+                  },
+            ],
+          },
+          count: 0,
+        },
+        responseHandler: 'text',
+      }),
+    }),
   }),
 });
 
@@ -159,4 +226,6 @@ export const {
   useLazyExportBiomassSpeciesCsvQuery,
   useExportBiomassTreesShrubsCsvQuery,
   useLazyExportBiomassTreesShrubsCsvQuery,
+  useExportBiomassObservationsCsvQuery,
+  useLazyExportBiomassObservationsCsvQuery,
 } = injectedRtkApi;

--- a/src/scenes/ObservationsRouterV2/ListView/BiomassList.tsx
+++ b/src/scenes/ObservationsRouterV2/ListView/BiomassList.tsx
@@ -11,7 +11,6 @@ import {
   MRT_ToggleFullScreenButton,
   MRT_ToggleGlobalFilterButton,
 } from 'material-react-table';
-import sanitize from 'sanitize-filename';
 
 import Card from 'src/components/common/Card';
 import Link from 'src/components/common/Link';
@@ -23,8 +22,6 @@ import { ALL_PLANTING_SITES, type PlantingSiteId } from 'src/hooks/useStickyPlan
 import useTableState from 'src/hooks/useTableState';
 import { useLocalization, useOrganization } from 'src/providers/hooks';
 import { useLazyListObservationResultsQuery } from 'src/queries/generated/observations';
-import { ObservationsService } from 'src/services';
-import { downloadCsv } from 'src/utils/csv';
 import { makeDateRangeFilterFn } from 'src/utils/tableFilters';
 import { useDefaultTimeZone } from 'src/utils/useTimeZoneUtils';
 
@@ -68,6 +65,7 @@ export default function BiomassList({ plantingSiteId }: BiomassListProps): JSX.E
   const { strings } = useLocalization();
   const { selectedOrganization } = useOrganization();
   const defaultTimezone = useDefaultTimeZone().get().id;
+  const { downloadBiomassObservations } = useObservationExports();
 
   const {
     columnFilters,
@@ -231,28 +229,12 @@ export default function BiomassList({ plantingSiteId }: BiomassListProps): JSX.E
   );
 
   const onExportBiomassObservations = useCallback(async () => {
-    if (!selectedOrganization) {
-      return;
-    }
-    const content = await ObservationsService.exportBiomassObservationsCsv(
-      selectedOrganization.id,
-      plantingSiteId === ALL_PLANTING_SITES ? undefined : plantingSiteId
-    );
-    if (content !== null) {
-      const siteName =
-        typeof plantingSiteId === 'number'
-          ? plantingSitesNames[plantingSiteId] ?? strings.ALL_PLANTING_SITES
-          : strings.ALL_PLANTING_SITES;
-      const filename = sanitize(`${siteName}-${strings.BIOMASS_MONITORING}`);
-      downloadCsv(filename, content);
-    }
-  }, [
-    plantingSiteId,
-    plantingSitesNames,
-    selectedOrganization,
-    strings.ALL_PLANTING_SITES,
-    strings.BIOMASS_MONITORING,
-  ]);
+    const siteName =
+      typeof plantingSiteId === 'number'
+        ? plantingSitesNames[plantingSiteId] ?? strings.ALL_PLANTING_SITES
+        : strings.ALL_PLANTING_SITES;
+    await downloadBiomassObservations(siteName, plantingSiteId === ALL_PLANTING_SITES ? undefined : plantingSiteId);
+  }, [downloadBiomassObservations, plantingSiteId, plantingSitesNames, strings.ALL_PLANTING_SITES]);
 
   const handleExportClick = useCallback(() => {
     void onExportBiomassObservations();

--- a/src/scenes/ObservationsRouterV2/ListView/BiomassList.tsx
+++ b/src/scenes/ObservationsRouterV2/ListView/BiomassList.tsx
@@ -65,7 +65,7 @@ export default function BiomassList({ plantingSiteId }: BiomassListProps): JSX.E
   const { strings } = useLocalization();
   const { selectedOrganization } = useOrganization();
   const defaultTimezone = useDefaultTimeZone().get().id;
-  const { downloadBiomassObservations } = useObservationExports();
+  const { downloadBiomassObservationsCsv } = useObservationExports();
 
   const {
     columnFilters,
@@ -233,8 +233,8 @@ export default function BiomassList({ plantingSiteId }: BiomassListProps): JSX.E
       typeof plantingSiteId === 'number'
         ? plantingSitesNames[plantingSiteId] ?? strings.ALL_PLANTING_SITES
         : strings.ALL_PLANTING_SITES;
-    await downloadBiomassObservations(siteName, plantingSiteId === ALL_PLANTING_SITES ? undefined : plantingSiteId);
-  }, [downloadBiomassObservations, plantingSiteId, plantingSitesNames, strings.ALL_PLANTING_SITES]);
+    await downloadBiomassObservationsCsv(siteName, plantingSiteId === ALL_PLANTING_SITES ? undefined : plantingSiteId);
+  }, [downloadBiomassObservationsCsv, plantingSiteId, plantingSitesNames, strings.ALL_PLANTING_SITES]);
 
   const handleExportClick = useCallback(() => {
     void onExportBiomassObservations();

--- a/src/scenes/ObservationsRouterV2/useObservationExports.ts
+++ b/src/scenes/ObservationsRouterV2/useObservationExports.ts
@@ -7,6 +7,7 @@ import { APP_PATHS } from 'src/constants';
 import { useLocalization, useOrganization } from 'src/providers';
 import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import {
+  useLazyExportBiomassObservationsCsvQuery,
   useLazyExportBiomassPlotsCsvQuery,
   useLazyExportBiomassSpeciesCsvQuery,
   useLazyExportBiomassTreesShrubsCsvQuery,
@@ -29,6 +30,7 @@ const useObservationExports = () => {
   const [exportBiomassPlots] = useLazyExportBiomassPlotsCsvQuery();
   const [exportBiomassSpecies] = useLazyExportBiomassSpeciesCsvQuery();
   const [exportBiomassTreesShrubs] = useLazyExportBiomassTreesShrubsCsvQuery();
+  const [exportBiomassObservations] = useLazyExportBiomassObservationsCsvQuery();
   const [exportObservationGpx] = useLazyExportObservationGpxQuery();
   const [getPlantingSite] = useLazyGetPlantingSiteQuery();
 
@@ -463,11 +465,29 @@ const useObservationExports = () => {
     ]
   );
 
+  const downloadBiomassObservations = useCallback(
+    async (siteName: string, plantingSiteId?: number) => {
+      if (!selectedOrganization) {
+        return;
+      }
+
+      const content = await exportBiomassObservations(
+        { organizationId: selectedOrganization.id, plantingSiteId },
+        true
+      ).unwrap();
+
+      const fileName = sanitize(`${siteName}-${strings.BIOMASS_MONITORING}`);
+      downloadCsv(fileName, content);
+    },
+    [exportBiomassObservations, selectedOrganization, strings.BIOMASS_MONITORING]
+  );
+
   return {
     downloadObservationResults,
     downloadObservationCsv,
     downloadObservationGpx,
     downloadBiomassObservationDetails,
+    downloadBiomassObservations,
   };
 };
 

--- a/src/scenes/ObservationsRouterV2/useObservationExports.ts
+++ b/src/scenes/ObservationsRouterV2/useObservationExports.ts
@@ -465,7 +465,7 @@ const useObservationExports = () => {
     ]
   );
 
-  const downloadBiomassObservations = useCallback(
+  const downloadBiomassObservationsCsv = useCallback(
     async (siteName: string, plantingSiteId?: number) => {
       if (!selectedOrganization) {
         return;
@@ -487,7 +487,7 @@ const useObservationExports = () => {
     downloadObservationCsv,
     downloadObservationGpx,
     downloadBiomassObservationDetails,
-    downloadBiomassObservations,
+    downloadBiomassObservationsCsv,
   };
 };
 


### PR DESCRIPTION
Add an exportBiomassObservationsCsv RTK Query endpoint and a
downloadBiomassObservations helper in useObservationExports, then switch
BiomassList off ObservationsService.exportBiomassObservationsCsv.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>