### PR TITLE
Replace requestSyncActivityMedia thunk with RTK Query hook

### DIFF
--- a/src/components/ActivityLog/ActivityDetailsForm.tsx
+++ b/src/components/ActivityLog/ActivityDetailsForm.tsx
@@ -29,9 +29,7 @@ import {
 } from 'src/queries/generated/activities';
 import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { QueryTagTypes } from 'src/queries/tags';
-import { requestSyncActivityMedia } from 'src/redux/features/activities/activitiesAsyncThunks';
-import { selectSyncActivityMedia } from 'src/redux/features/activities/activitiesSelectors';
-import { useAppDispatch, useAppSelector } from 'src/redux/store';
+import { useAppDispatch } from 'src/redux/store';
 import {
   ACTIVITY_STATUSES,
   ACTIVITY_TYPES,
@@ -67,6 +65,7 @@ import DeleteActivityModal from './DeleteActivityModal';
 import MapSplitView from './MapSplitView';
 import ObservationStatsPanel from './ObservationStatsPanel';
 import { TypedActivity } from './types';
+import useSyncActivityMedia from './useSyncActivityMedia';
 
 const MAX_FILE_SIZE_GB = 5;
 const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_GB * 1024 * 1024 * 1024;
@@ -102,7 +101,6 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
   const [record, setRecord, onChange, onChangeCallback] = useForm<FormRecord>(undefined);
   const [mediaItems, setMediaItems] = useState<ActivityMediaItem[]>([]);
   const [validateFields, setValidateFields] = useState<boolean>(false);
-  const [syncMediaRequestId, setSyncMediaRequestId] = useState('');
   const [busy, setBusy] = useState<boolean>(false);
   const [deleteActivityModalOpen, setDeleteActivityModalOpen] = useState<boolean>(false);
 
@@ -198,7 +196,7 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
     return obsMonthYear ? `${strings.OBSERVATION}: ${obsMonthYear}` : undefined;
   }, [isObsActivity, obsIsAdHoc, obsMonthYear, obsPlotNumber, strings]);
 
-  const syncActivityMediaRequest = useAppSelector(selectSyncActivityMedia(syncMediaRequestId));
+  const { syncActivityMedia } = useSyncActivityMedia();
 
   const [adminCreateActivity] = useAdminCreateActivityMutation();
   const [createActivity] = useCreateActivityMutation();
@@ -313,35 +311,52 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
   }, [isObsActivity, record, mediaItems, snackbar, strings]);
 
   const syncMediaFiles = useCallback(
-    (newActivityId: number) => {
+    async (newActivityId: number) => {
       // Only sync if there are any media operations to perform
       const hasMediaOperations = mediaItems.some(
         (item) => item.type === 'new' || (item.type === 'existing' && (item.isDeleted || item.isModified))
       );
 
-      if (hasMediaOperations) {
-        const request = dispatch(
-          requestSyncActivityMedia({
-            activityId: newActivityId,
-            mediaItems,
-            observationId: activity?.payload.observation?.observationId,
-            plotNumberToIdMap: obsPlotNumberToIdMap,
-          })
-        );
-        setSyncMediaRequestId(request.requestId);
-      } else {
+      if (!hasMediaOperations) {
         // No media operations needed
         setBusy(false);
         navToActivityLog();
+        return;
       }
+
+      const response = await syncActivityMedia({
+        activityId: newActivityId,
+        mediaItems,
+        observationId: activity?.payload.observation?.observationId,
+        plotNumberToIdMap: obsPlotNumberToIdMap,
+      });
+
+      if (!response.allSuccessful) {
+        setBusy(false);
+        snackbar.toastError(strings.GENERIC_ERROR);
+        navToActivityLog();
+        return;
+      }
+
+      dispatch(
+        baseApi.util.invalidateTags([
+          { type: QueryTagTypes.Activities, id: newActivityId },
+          { type: QueryTagTypes.Activities, id: 'LIST' },
+        ])
+      );
+      setBusy(false);
+      navToActivityLog();
     },
     [
+      activity?.payload.observation?.observationId,
       dispatch,
       mediaItems,
-      setBusy,
       navToActivityLog,
-      activity?.payload.observation?.observationId,
       obsPlotNumberToIdMap,
+      setBusy,
+      snackbar,
+      strings.GENERIC_ERROR,
+      syncActivityMedia,
     ]
   );
 
@@ -393,7 +408,7 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
             type: isObsActivity ? activity.payload.type : (record?.type as AdminActivityPayload['type']),
           },
         }).unwrap();
-        syncMediaFiles(activity.payload.id);
+        await syncMediaFiles(activity.payload.id);
       } else if (isEditing && !isAcceleratorRoute && activity) {
         // update activity
         await updateActivity({
@@ -405,7 +420,7 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
             type: isObsActivity ? activity.payload.type : (record?.type as ActivityPayload['type']),
           },
         }).unwrap();
-        syncMediaFiles(activity.payload.id);
+        await syncMediaFiles(activity.payload.id);
       } else if (!isEditing && isAcceleratorRoute) {
         // admin create activity
         const result = await adminCreateActivity({
@@ -416,7 +431,7 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
           status: record?.status as AdminCreateActivityRequestPayload['status'],
           type: record?.type as AdminCreateActivityRequestPayload['type'],
         }).unwrap();
-        syncMediaFiles(result.activity.id);
+        await syncMediaFiles(result.activity.id);
       } else {
         // create activity
         const result = await createActivity({
@@ -425,7 +440,7 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
           projectId,
           type: record?.type as CreateActivityRequestPayload['type'],
         }).unwrap();
-        syncMediaFiles(result.activity.id);
+        await syncMediaFiles(result.activity.id);
       }
     } catch {
       setBusy(false);
@@ -503,26 +518,6 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
       setMediaItems(existingMediaItems);
     }
   }, [isEditing, activity]);
-
-  // handle sync media responses
-  useEffect(() => {
-    if (syncActivityMediaRequest?.status === 'error') {
-      setBusy(false);
-      snackbar.toastError(strings.GENERIC_ERROR);
-      navToActivityLog();
-    } else if (syncActivityMediaRequest?.status === 'success') {
-      if (activityId !== undefined) {
-        dispatch(
-          baseApi.util.invalidateTags([
-            { type: QueryTagTypes.Activities, id: activityId },
-            { type: QueryTagTypes.Activities, id: 'LIST' },
-          ])
-        );
-      }
-      setBusy(false);
-      navToActivityLog();
-    }
-  }, [activityId, dispatch, navToActivityLog, snackbar, strings.GENERIC_ERROR, syncActivityMediaRequest]);
 
   const activityTypeOptions = useMemo(() => {
     return ACTIVITY_TYPES.map((activityType: ActivityType) => ({

--- a/src/components/ActivityLog/ActivityDetailsForm.tsx
+++ b/src/components/ActivityLog/ActivityDetailsForm.tsx
@@ -17,7 +17,6 @@ import useNavigateTo from 'src/hooks/useNavigateTo';
 import { useProjects } from 'src/hooks/useProjects';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization, useUser } from 'src/providers/hooks';
-import { baseApi } from 'src/queries/baseApi';
 import {
   useAdminCreateActivityMutation,
   useAdminUpdateActivityMutation,
@@ -28,8 +27,6 @@ import {
   useUpdateActivityMutation,
 } from 'src/queries/generated/activities';
 import { useGetObservationResultsQuery } from 'src/queries/generated/observations';
-import { QueryTagTypes } from 'src/queries/tags';
-import { useAppDispatch } from 'src/redux/store';
 import {
   ACTIVITY_STATUSES,
   ACTIVITY_TYPES,
@@ -84,7 +81,6 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
   const { isAllowed } = useUser();
 
   const userTimeZone = useUserTimeZone();
-  const dispatch = useAppDispatch();
   const snackbar = useSnackbar();
   const { isMobile } = useDeviceInfo();
   const { selectedOrganization } = useOrganization();
@@ -196,7 +192,7 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
     return obsMonthYear ? `${strings.OBSERVATION}: ${obsMonthYear}` : undefined;
   }, [isObsActivity, obsIsAdHoc, obsMonthYear, obsPlotNumber, strings]);
 
-  const { syncActivityMedia } = useSyncActivityMedia();
+  const syncActivityMedia = useSyncActivityMedia();
 
   const [adminCreateActivity] = useAdminCreateActivityMutation();
   const [createActivity] = useCreateActivityMutation();
@@ -337,19 +333,11 @@ export default function ActivityDetailsForm({ activityId, projectId }: ActivityD
         navToActivityLog();
         return;
       }
-
-      dispatch(
-        baseApi.util.invalidateTags([
-          { type: QueryTagTypes.Activities, id: newActivityId },
-          { type: QueryTagTypes.Activities, id: 'LIST' },
-        ])
-      );
       setBusy(false);
       navToActivityLog();
     },
     [
       activity?.payload.observation?.observationId,
-      dispatch,
       mediaItems,
       navToActivityLog,
       obsPlotNumberToIdMap,

--- a/src/components/ActivityLog/useSyncActivityMedia.ts
+++ b/src/components/ActivityLog/useSyncActivityMedia.ts
@@ -1,12 +1,15 @@
 import { useCallback } from 'react';
 
 import { ActivityMediaItem } from 'src/components/ActivityLog/ActivityMediaForm';
+import { baseApi } from 'src/queries/baseApi';
 import {
   useDeleteActivityMediaMutation,
   useUpdateActivityMediaMutation,
   useUploadActivityMediaMutation,
 } from 'src/queries/generated/activities';
 import { useDeletePlotPhotoMutation, useUploadOtherPlotMediaMutation } from 'src/queries/generated/observations';
+import { QueryTagTypes } from 'src/queries/tags';
+import { useAppDispatch } from 'src/redux/store';
 
 export type SyncActivityMediaResult = {
   error?: string;
@@ -31,13 +34,15 @@ export type SyncActivityMediaRequest = {
 };
 
 const useSyncActivityMedia = () => {
+  const dispatch = useAppDispatch();
+
   const [deleteActivityMedia] = useDeleteActivityMediaMutation();
   const [updateActivityMedia] = useUpdateActivityMediaMutation();
   const [uploadActivityMedia] = useUploadActivityMediaMutation();
   const [deletePlotPhoto] = useDeletePlotPhotoMutation();
   const [uploadOtherPlotMedia] = useUploadOtherPlotMediaMutation();
 
-  const syncActivityMedia = useCallback(
+  return useCallback(
     async ({
       activityId,
       mediaItems,
@@ -158,6 +163,13 @@ const useSyncActivityMedia = () => {
               operation: 'upload',
               success: false,
             });
+          } finally {
+            dispatch(
+              baseApi.util.invalidateTags([
+                { type: QueryTagTypes.Activities, id: activityId },
+                { type: QueryTagTypes.Activities, id: 'LIST' },
+              ])
+            );
           }
         }
       }
@@ -170,10 +182,8 @@ const useSyncActivityMedia = () => {
         uploadedCount: results.filter((result) => result.success && result.operation === 'upload').length,
       };
     },
-    [deleteActivityMedia, deletePlotPhoto, updateActivityMedia, uploadActivityMedia, uploadOtherPlotMedia]
+    [deleteActivityMedia, deletePlotPhoto, dispatch, updateActivityMedia, uploadActivityMedia, uploadOtherPlotMedia]
   );
-
-  return { syncActivityMedia };
 };
 
 export default useSyncActivityMedia;

--- a/src/components/ActivityLog/useSyncActivityMedia.ts
+++ b/src/components/ActivityLog/useSyncActivityMedia.ts
@@ -1,0 +1,179 @@
+import { useCallback } from 'react';
+
+import { ActivityMediaItem } from 'src/components/ActivityLog/ActivityMediaForm';
+import {
+  useDeleteActivityMediaMutation,
+  useUpdateActivityMediaMutation,
+  useUploadActivityMediaMutation,
+} from 'src/queries/generated/activities';
+import { useDeletePlotPhotoMutation, useUploadOtherPlotMediaMutation } from 'src/queries/generated/observations';
+
+export type SyncActivityMediaResult = {
+  error?: string;
+  fileId?: number;
+  operation: 'delete' | 'update' | 'upload';
+  success: boolean;
+};
+
+export type SyncActivityMediaResponse = {
+  allSuccessful: boolean;
+  deletedCount: number;
+  results: SyncActivityMediaResult[];
+  updatedCount: number;
+  uploadedCount: number;
+};
+
+export type SyncActivityMediaRequest = {
+  activityId: number;
+  mediaItems: ActivityMediaItem[];
+  observationId?: number;
+  plotNumberToIdMap?: Record<number, number>;
+};
+
+const useSyncActivityMedia = () => {
+  const [deleteActivityMedia] = useDeleteActivityMediaMutation();
+  const [updateActivityMedia] = useUpdateActivityMediaMutation();
+  const [uploadActivityMedia] = useUploadActivityMediaMutation();
+  const [deletePlotPhoto] = useDeletePlotPhotoMutation();
+  const [uploadOtherPlotMedia] = useUploadOtherPlotMediaMutation();
+
+  const syncActivityMedia = useCallback(
+    async ({
+      activityId,
+      mediaItems,
+      observationId,
+      plotNumberToIdMap,
+    }: SyncActivityMediaRequest): Promise<SyncActivityMediaResponse> => {
+      const results: SyncActivityMediaResult[] = [];
+
+      // delete existing media items marked for deletion
+      const itemsToDelete = mediaItems.filter((item) => item.type === 'existing' && item.isDeleted);
+
+      for (const item of itemsToDelete) {
+        if (item.type === 'existing') {
+          try {
+            let deletedViaObservation = false;
+
+            if (
+              observationId !== undefined &&
+              plotNumberToIdMap !== undefined &&
+              item.data.observation?.monitoringPlotNumber !== undefined
+            ) {
+              // Observation activity: delete via the observation endpoint.
+              const plotId = plotNumberToIdMap[item.data.observation.monitoringPlotNumber];
+              if (plotId !== undefined) {
+                await deletePlotPhoto({ observationId, plotId, fileId: item.data.fileId }).unwrap();
+                deletedViaObservation = true;
+              }
+            }
+
+            if (!deletedViaObservation) {
+              // Non-observation activity or plot ID could not be resolved: fall back to activity endpoint.
+              await deleteActivityMedia({ activityId, fileId: item.data.fileId }).unwrap();
+            }
+
+            results.push({ fileId: item.data.fileId, operation: 'delete', success: true });
+          } catch (error) {
+            results.push({
+              error: error instanceof Error ? error.message : 'Delete request failed',
+              fileId: item.data.fileId,
+              operation: 'delete',
+              success: false,
+            });
+          }
+        }
+      }
+
+      // update metadata of existing media items marked as modified
+      const itemsToUpdate = mediaItems.filter((item) => item.type === 'existing' && item.isModified && !item.isDeleted);
+
+      for (const item of itemsToUpdate) {
+        if (item.type === 'existing') {
+          try {
+            await updateActivityMedia({
+              activityId,
+              fileId: item.data.fileId,
+              updateActivityMediaRequestPayload: {
+                caption: item.data.caption,
+                isCoverPhoto: item.data.isCoverPhoto,
+                isHiddenOnMap: item.data.isHiddenOnMap,
+                listPosition: item.data.listPosition,
+              },
+            }).unwrap();
+
+            results.push({ fileId: item.data.fileId, operation: 'update', success: true });
+          } catch (error) {
+            results.push({
+              error: error instanceof Error ? error.message : 'Update request failed',
+              fileId: item.data.fileId,
+              operation: 'update',
+              success: false,
+            });
+          }
+        }
+      }
+
+      // upload new media files and update their metadata
+      const itemsToUpload = mediaItems.filter((item) => item.type === 'new');
+
+      for (const item of itemsToUpload) {
+        if (item.type === 'new') {
+          try {
+            let uploadedFileId: number;
+
+            if (observationId !== undefined && item.data.monitoringPlotId !== undefined) {
+              // Observation activity: upload via observation endpoint so the file is
+              // associated with the observation (it will appear in the activity automatically).
+              const obsUploadResponse = await uploadOtherPlotMedia({
+                observationId,
+                plotId: item.data.monitoringPlotId,
+                body: { file: item.data.file, payload: {} },
+              }).unwrap();
+              uploadedFileId = obsUploadResponse.fileId;
+            } else {
+              // Non-observation activity: upload directly to the activity endpoint.
+              const actUploadResponse = await uploadActivityMedia({
+                activityId,
+                body: { file: item.data.file },
+              }).unwrap();
+              uploadedFileId = actUploadResponse.fileId;
+            }
+
+            // update the metadata
+            await updateActivityMedia({
+              activityId,
+              fileId: uploadedFileId,
+              updateActivityMediaRequestPayload: {
+                caption: item.data.caption,
+                isCoverPhoto: item.data.isCoverPhoto,
+                isHiddenOnMap: item.data.isHiddenOnMap,
+                listPosition: item.data.listPosition,
+              },
+            }).unwrap();
+
+            results.push({ fileId: uploadedFileId, operation: 'upload', success: true });
+          } catch (error) {
+            results.push({
+              error: error instanceof Error ? error.message : 'File upload failed',
+              operation: 'upload',
+              success: false,
+            });
+          }
+        }
+      }
+
+      return {
+        allSuccessful: results.every((result) => result.success),
+        deletedCount: results.filter((result) => result.success && result.operation === 'delete').length,
+        results,
+        updatedCount: results.filter((result) => result.success && result.operation === 'update').length,
+        uploadedCount: results.filter((result) => result.success && result.operation === 'upload').length,
+      };
+    },
+    [deleteActivityMedia, deletePlotPhoto, updateActivityMedia, uploadActivityMedia, uploadOtherPlotMedia]
+  );
+
+  return { syncActivityMedia };
+};
+
+export default useSyncActivityMedia;


### PR DESCRIPTION
Add useSyncActivityMedia, which orchestrates the delete/update/upload
media operations via the generated activity and observation media
mutations, and wire ActivityDetailsForm to await it directly instead of
dispatching the redux thunk and tracking the request through a selector.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>