### PR TITLE
Revert "Update dependency js-yaml to v5"

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
     "brace-expansion": "^2.0.3",
     "fork-ts-checker-webpack-plugin": "^9.0.0",
     "immutable": "^5.1.5",
-    "js-yaml": "5.1.0",
+    "js-yaml": "4.2.0",
     "picomatch": "^4.0.4",
     "serialize-javascript": "^7.0.5",
     "simple-git": "^3.32.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13067,10 +13067,10 @@ js-tokens@^10.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.1, js-yaml@5.1.0, js-yaml@^3.13.1, js-yaml@^4.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-5.1.0.tgz#c084ac880197833810a69e9c7e51eae12ff35448"
-  integrity sha512-s8VA5jkR8f22S3NAXmhKPFqGUduqZGlsufabVOgN14iTdw/RXcym7bKkbwjxLK9Yw2lEvvmJjFp119+KPeo8Kg==
+js-yaml@4.1.1, js-yaml@4.2.0, js-yaml@^3.13.1, js-yaml@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
+  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
Reverts terraware/terraware-web#5964

**NOTE: The `js-yaml` update from v4 to v5 broke API types generation. Reverting this change fixes it.**

A recent dependency update added "js-yaml": "5.1.0" to the resolutions field in `package.json`, which forces `js-yaml` 5.x on all packages in the dependency tree — including `@redocly/openapi-core` (a transitive dependency of `openapi-typescript`, used by the `generate-types` script). `js-yaml` 5.x is a breaking API rewrite that removed the types export (e.g. `types.merge`, `types.binary`), which `@redocly/openapi-core` relies on. Even the latest `@redocly/openapi-core@1.34.6` still requires `js-yaml@^4.1.0`, so there is no upstream fix available yet.

Fix: Revert the resolution from "js-yaml": "5.1.0" back to "js-yaml": "^4.1.0". The project does not import `js-yaml` directly anywhere in source, so this has no impact on application code — it only affects how the version is resolved for transitive dependencies.