### PR TITLE
Add initial script for validating type generation scripts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -86,6 +86,21 @@ steps:
       SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTSECRET: dummy
       SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI: https://auth.staging.terraware.io/realms/terraware
 
+  - label: ':yarn: Validate type generation'
+    key: 'validate-types'
+    depends_on:
+      - step: 'build-and-test'
+      - step: 'e2e-tests'
+    plugins:
+      - *shallow-clone
+      - *load-secrets
+      - cache#v1.11.1:
+          <<: *cache-node-modules-args
+          save:
+            - file
+            - branch
+    command: .buildkite/scripts/validate-types.sh
+
   - label: ':docker: Build and push Docker image'
     key: 'docker'
     depends_on:

--- a/.buildkite/scripts/validate-types.sh
+++ b/.buildkite/scripts/validate-types.sh
@@ -7,7 +7,7 @@ echo "--- :yarn: Generate types"
 yarn generate-types
 
 echo "--- :yarn Generate queries"
-yarn generate-queries
+PUBLIC_TERRAWARE_API=http://localhost:8080 yarn generate-queries
 
 # TODO add validation of generated output here. For now, running the scripts will validate that a dependency update
 # TODO didn't break one of these

--- a/.buildkite/scripts/validate-types.sh
+++ b/.buildkite/scripts/validate-types.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+.buildkite/scripts/install-deps.sh --node --tools
+
+echo "--- :yarn: Generate types"
+yarn generate-types
+
+echo "--- :yarn Generate queries"
+yarn generate-queries
+
+# TODO add validation of generated output here. For now, running the scripts will validate that a dependency update
+# TODO didn't break one of these


### PR DESCRIPTION
We recently had a PR get merged that broke one of the types generation scripts because it updated a dependency. Add a CI step that runs the type generation scripts so that failure to run those will at least keep a PR from being merge-able.

Include a TODO note toadd actual validation instead of just confirming that generation works. 