### PR TITLE
SW-7792: Biomass Monitoring Observations: Add field for Crown Diameter for mangrove trees (FOLLOW-UP)

### DIFF
--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/TreesAndShrubsEditableTable.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/TreesAndShrubsEditableTable.tsx
@@ -209,6 +209,7 @@ export default function TreesAndShrubsEditableTable(): JSX.Element {
         id: 'shrubDiameter',
         accessorKey: 'shrubDiameter',
         header: isAdditionalBiomassFieldsEnabled ? strings.SHRUB_CROWN_DIAMETER_CM : strings.CROWN_DIAMETER_CM,
+        enableEditing: (row) => row.original.treeGrowthForm === 'Shrub' && forestType === 'Terrestrial',
         editConfig: {
           onSave: (row, value) => saveRecordedTree('shrubDiameter', row, value),
         },


### PR DESCRIPTION
This PR includes a follow-up change to disable table cell edits for shrub diameter unless growth form is shrub and forest type is terrestrial. Product requested the UX change since the edits are ignored by the BE.