### PR TITLE
SW-8603 Fix Editing allocated quantity on Inventory Planning page causes console error

### DIFF
--- a/src/queries/search/inventoryPlanning.ts
+++ b/src/queries/search/inventoryPlanning.ts
@@ -106,7 +106,7 @@ const injectedRtkApi = api.injectEndpoints({
       transformResponse: (response: InventoryPlanningSeasonSearchResponse) => response.results,
     }),
 
-    listInventoryPlanningSpeciesAvailable: build.query<Map<number, number>, number>({
+    listInventoryPlanningSpeciesAvailable: build.query<Record<number, number>, number>({
       query: (organizationId) => ({
         url: '/api/v1/search',
         method: 'POST',
@@ -141,14 +141,14 @@ const injectedRtkApi = api.injectEndpoints({
         },
       }),
       providesTags: [{ type: QueryTagTypes.InventoryPlanning, id: 'LIST' }],
-      transformResponse: (response: InventoryPlanningAvailableResponse): Map<number, number> => {
-        const map = new Map<number, number>();
+      transformResponse: (response: InventoryPlanningAvailableResponse): Record<number, number> => {
+        const availableBySpecies: Record<number, number> = {};
         response.results.forEach((s) => {
           const hardening = Number(s.inventory?.['hardeningOffQuantity(raw)'] ?? 0);
           const ready = Number(s.inventory?.['readyQuantity(raw)'] ?? 0);
-          map.set(Number(s.id), hardening + ready);
+          availableBySpecies[Number(s.id)] = hardening + ready;
         });
-        return map;
+        return availableBySpecies;
       },
     }),
   }),
@@ -198,7 +198,7 @@ type InventoryPlanningAvailableResponse = {
 
 export const aggregateInventoryPlanningRows = (
   seasons: InventoryPlanningSeasonSearch[],
-  availableBySpecies: Map<number, number>
+  availableBySpecies: Record<number, number>
 ): InventoryPlanningSpeciesRow[] => {
   type SpeciesAcc = {
     scientificName: string;
@@ -274,7 +274,7 @@ export const aggregateInventoryPlanningRows = (
         speciesId,
         scientificName: acc.scientificName,
         commonName: acc.commonName,
-        available: availableBySpecies.get(speciesId) ?? 0,
+        available: availableBySpecies[speciesId] ?? 0,
         target: totalTarget,
         allocated: totalAllocated,
         seasons: seasonRows,

--- a/src/scenes/InventoryPlanningRouter/InventoryPlanningView.tsx
+++ b/src/scenes/InventoryPlanningRouter/InventoryPlanningView.tsx
@@ -74,7 +74,7 @@ const InventoryPlanningView = (): JSX.Element => {
     if (!seasonsSearchData) {
       return [];
     }
-    const aggregated = aggregateInventoryPlanningRows(seasonsSearchData, availableBySpecies ?? new Map());
+    const aggregated = aggregateInventoryPlanningRows(seasonsSearchData, availableBySpecies ?? {});
     return speciesId === undefined ? aggregated : aggregated.filter((row) => row.speciesId === speciesId);
   }, [seasonsSearchData, availableBySpecies, speciesId]);
 


### PR DESCRIPTION
I asked Claude about the error and it explained and fixed it:

The [Immer] MapSet error (Immer error #18) happens when a Map or Set gets written into Immer-produced state without the enableMapSet() plugin. In this case:

- listInventoryPlanningSpeciesAvailable's transformResponse returned a Map<number, number>.
- RTK Query stores every query result in the Redux store via Immer's producer, and Immer can't handle a Map in state
  by default.
- It surfaced specifically on editing allocated quantity because the upsertAllocatedSpecies mutation invalidates the
  InventoryPlanning tag → that query refetches → RTK Query tries to write the Map back into the store → Immer throws.

The fix

Changed the query to return a plain serializable object (Record<number, number>) instead of a Map, which Immer stores without issue.