### PR TITLE
Migrate /api/v1/users/me endpoints to RTK Query

### DIFF
--- a/rtk-codegen.config.ts
+++ b/rtk-codegen.config.ts
@@ -20,6 +20,12 @@ const config: ConfigFile = {
     './src/queries/generated/disclaimer.ts': {
       filterEndpoints: (_, operation) => operation.path.startsWith('/api/v1/disclaimer'),
     },
+    './src/queries/generated/users.ts': {
+      filterEndpoints: (_, operation) =>
+        operation.path === '/api/v1/users' ||
+        operation.path === '/api/v1/users/me' ||
+        operation.path === '/api/v1/users/{userId}',
+    },
     './src/queries/generated/draftPlantingSites.ts': {
       filterEndpoints: (_, operation) => operation.path.startsWith('/api/v1/tracking/draftSites'),
     },

--- a/src/components/LocaleSelector.tsx
+++ b/src/components/LocaleSelector.tsx
@@ -3,7 +3,7 @@ import React, { type JSX } from 'react';
 import { useTheme } from '@mui/material';
 import { Dropdown, DropdownItem, PopoverMenu } from '@terraware/web-components';
 
-import { UserService } from 'src/services';
+import useUpdateCurrentUser from 'src/hooks/useUpdateCurrentUser';
 import strings from 'src/strings';
 
 import { useUser } from '../providers';
@@ -23,7 +23,8 @@ export default function LocaleSelector({
   localeSelected,
   fullWidth,
 }: LocaleSelectorProps): JSX.Element {
-  const { user, reloadUser } = useUser();
+  const { user } = useUser();
+  const updateCurrentUser = useUpdateCurrentUser();
   const supportedLocales = useSupportedLocales();
   const localeItems: DropdownItem[] = supportedLocales.map((supportedLocale) => ({
     value: supportedLocale.id,
@@ -42,8 +43,7 @@ export default function LocaleSelector({
 
           if (user && user.locale !== newValue) {
             const updateUserLocale = async () => {
-              await UserService.updateUser({ ...user, locale: newValue });
-              reloadUser();
+              await updateCurrentUser({ ...user, locale: newValue });
             };
 
             void updateUserLocale();

--- a/src/hooks/useUpdateCurrentUser.ts
+++ b/src/hooks/useUpdateCurrentUser.ts
@@ -1,0 +1,53 @@
+import { useCallback } from 'react';
+
+import { UpdateUserRequestPayload, api, useUpdateMyselfMutation } from 'src/queries/generated/users';
+import { QueryTagTypes } from 'src/queries/tags';
+import { useAppDispatch } from 'src/redux/store';
+import { PreferencesService } from 'src/services';
+import { User } from 'src/types/User';
+
+export type UpdateCurrentUserOptions = {
+  skipAcknowledgeTimeZone?: boolean;
+};
+
+const useUpdateCurrentUser = () => {
+  const dispatch = useAppDispatch();
+  const [updateMyself] = useUpdateMyselfMutation();
+
+  return useCallback(
+    async (user: User, options: UpdateCurrentUserOptions = {}): Promise<boolean> => {
+      const payload: UpdateUserRequestPayload = {
+        firstName: user.firstName || '',
+        lastName: user.lastName || '',
+        timeZone: user.timeZone,
+        locale: user.locale,
+        countryCode: user.countryCode,
+      };
+      if (user.emailNotificationsEnabled !== undefined) {
+        payload.emailNotificationsEnabled = user.emailNotificationsEnabled;
+      }
+
+      const result = await updateMyself(payload);
+      const succeeded = !('error' in result);
+
+      if (succeeded) {
+        // updateMyself invalidates { Users, id: 'ME' }; also invalidate the concrete user id so any
+        // getUser(myId) subscriptions elsewhere refetch after a self-update.
+        dispatch(api.util.invalidateTags([{ type: QueryTagTypes.Users, id: user.id }]));
+      }
+
+      if (succeeded && typeof user.cookiesConsented === 'boolean') {
+        await PreferencesService.updateUserCookieConsentPreferences({ cookiesConsented: user.cookiesConsented });
+      }
+
+      if (succeeded && user.timeZone && !options.skipAcknowledgeTimeZone) {
+        await PreferencesService.updateUserPreferences({ timeZoneAcknowledgedOnMs: Date.now() });
+      }
+
+      return succeeded;
+    },
+    [dispatch, updateMyself]
+  );
+};
+
+export default useUpdateCurrentUser;

--- a/src/providers/UserProvider.tsx
+++ b/src/providers/UserProvider.tsx
@@ -1,6 +1,8 @@
 import React, { type JSX, useCallback, useEffect, useMemo, useState } from 'react';
 
+import { baseApi } from 'src/queries/baseApi';
 import { useGetMyselfQuery } from 'src/queries/generated/users';
+import { QueryTagTypes } from 'src/queries/tags';
 import { selectUserAnalytics } from 'src/redux/features/user/userAnalyticsSelectors';
 import { updateGtmInstrumented } from 'src/redux/features/user/userAnalyticsSlice';
 import { requestUserCookieConsentUpdate } from 'src/redux/features/user/usersAsyncThunks';
@@ -23,13 +25,13 @@ export default function UserProvider({ children }: UserProviderProps): JSX.Eleme
   const dispatch = useAppDispatch();
 
   const { currentData, refetch } = useGetMyselfQuery();
-  // Latch the user into local state so it survives the RESET_APP store wipe that OrganizationProvider
-  // dispatches on org change (which clears the RTK Query cache). Only populated, never cleared here —
-  // effectively "only a logout/reload resets the user", matching the pre-RTK behavior.
+
+  // Persist user after an AppReset due to organization change
   const [user, setUser] = useState<User>();
 
   useEffect(() => {
     if (currentData?.user) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setUser(currentData.user);
     }
   }, [currentData]);
@@ -60,9 +62,9 @@ export default function UserProvider({ children }: UserProviderProps): JSX.Eleme
   const updateUserCookieConsent = useCallback(
     async (consent: boolean) => {
       await dispatch(requestUserCookieConsentUpdate({ cookiesConsented: consent }));
-      reloadUser();
+      dispatch(baseApi.util.invalidateTags([{ type: QueryTagTypes.Users, id: 'ME' }]));
     },
-    [dispatch, reloadUser]
+    [dispatch]
   );
 
   const isAllowed = useCallback(

--- a/src/providers/UserProvider.tsx
+++ b/src/providers/UserProvider.tsx
@@ -1,10 +1,11 @@
 import React, { type JSX, useCallback, useEffect, useMemo, useState } from 'react';
 
+import { useGetMyselfQuery } from 'src/queries/generated/users';
 import { selectUserAnalytics } from 'src/redux/features/user/userAnalyticsSelectors';
 import { updateGtmInstrumented } from 'src/redux/features/user/userAnalyticsSlice';
 import { requestUserCookieConsentUpdate } from 'src/redux/features/user/usersAsyncThunks';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
-import { PreferencesService, UserService } from 'src/services';
+import { CachedUserService, PreferencesService } from 'src/services';
 import { User } from 'src/types/User';
 import { GlobalRolePermission, isAllowed as isAllowedACL } from 'src/utils/acl';
 import { isTerraformationEmail } from 'src/utils/user';
@@ -17,10 +18,21 @@ export type UserProviderProps = {
 };
 
 export default function UserProvider({ children }: UserProviderProps): JSX.Element {
-  const [user, setUser] = useState<User>();
   const [userPreferences, setUserPreferences] = useState<PreferencesType>();
   const userAnalyticsState = useAppSelector(selectUserAnalytics);
   const dispatch = useAppDispatch();
+
+  const { currentData, refetch } = useGetMyselfQuery();
+  // Latch the user into local state so it survives the RESET_APP store wipe that OrganizationProvider
+  // dispatches on org change (which clears the RTK Query cache). Only populated, never cleared here —
+  // effectively "only a logout/reload resets the user", matching the pre-RTK behavior.
+  const [user, setUser] = useState<User>();
+
+  useEffect(() => {
+    if (currentData?.user) {
+      setUser(currentData.user);
+    }
+  }, [currentData]);
 
   const updateUserPreferences = useCallback(async (preferences: PreferencesType) => {
     const response = await PreferencesService.updateUserPreferences(preferences);
@@ -42,33 +54,8 @@ export default function UserProvider({ children }: UserProviderProps): JSX.Eleme
   }, [setUserPreferences]);
 
   const reloadUser = useCallback(() => {
-    const populateUser = async () => {
-      const response = await UserService.getUser();
-
-      if (response.requestSucceeded) {
-        setUser(response.user);
-        if (response.user && !userAnalyticsState?.gtmInstrumented && (window as any).INIT_GTAG) {
-          dispatch(updateGtmInstrumented({ gtmInstrumented: true }));
-
-          // Put the language in the "lang" attribute of the <html> tag before initializing Google
-          // Analytics because the cookie consent UI code will look there to determine which
-          // language to use for the consent UI. This needs to happen before the call to INIT_GTAG,
-          // so it lives here instead of in LocalizationProvider.
-          const locale = response.user.locale;
-          if (locale) {
-            document.documentElement.setAttribute('lang', locale);
-          }
-
-          (window as any).INIT_GTAG(
-            response.user.id.toString(),
-            isTerraformationEmail(response.user.email) ? 'true' : 'false'
-          );
-        }
-      }
-    };
-
-    void populateUser();
-  }, [setUser, userAnalyticsState?.gtmInstrumented, dispatch]);
+    void refetch();
+  }, [refetch]);
 
   const updateUserCookieConsent = useCallback(
     async (consent: boolean) => {
@@ -116,10 +103,27 @@ export default function UserProvider({ children }: UserProviderProps): JSX.Eleme
   }, [reloadUserPreferences]);
 
   useEffect(() => {
-    if (!user) {
-      reloadUser();
+    if (user) {
+      CachedUserService.setUser(user);
     }
-  }, [user, reloadUser]);
+  }, [user]);
+
+  useEffect(() => {
+    if (user && !userAnalyticsState?.gtmInstrumented && (window as any).INIT_GTAG) {
+      dispatch(updateGtmInstrumented({ gtmInstrumented: true }));
+
+      // Put the language in the "lang" attribute of the <html> tag before initializing Google
+      // Analytics because the cookie consent UI code will look there to determine which
+      // language to use for the consent UI. This needs to happen before the call to INIT_GTAG,
+      // so it lives here instead of in LocalizationProvider.
+      const locale = user.locale;
+      if (locale) {
+        document.documentElement.setAttribute('lang', locale);
+      }
+
+      (window as any).INIT_GTAG(user.id.toString(), isTerraformationEmail(user.email) ? 'true' : 'false');
+    }
+  }, [user, userAnalyticsState?.gtmInstrumented, dispatch]);
 
   return <UserContext.Provider value={userData}>{children}</UserContext.Provider>;
 }

--- a/src/queries/extensions/users.ts
+++ b/src/queries/extensions/users.ts
@@ -1,0 +1,28 @@
+import { api } from '../generated/users';
+import { QueryTagTypes } from '../tags';
+
+api.enhanceEndpoints({
+  endpoints: {
+    getMyself: {
+      providesTags: (result) =>
+        result?.user
+          ? [
+              { type: QueryTagTypes.Users, id: 'ME' },
+              { type: QueryTagTypes.Users, id: result.user.id },
+            ]
+          : [{ type: QueryTagTypes.Users, id: 'ME' }],
+    },
+    updateMyself: {
+      invalidatesTags: [{ type: QueryTagTypes.Users, id: 'ME' }],
+    },
+    deleteMyself: {
+      invalidatesTags: [{ type: QueryTagTypes.Users, id: 'ME' }],
+    },
+    getUser: {
+      providesTags: (result) => (result?.user ? [{ type: QueryTagTypes.Users, id: result.user.id }] : []),
+    },
+    searchUsers: {
+      providesTags: (result) => (result?.user ? [{ type: QueryTagTypes.Users, id: result.user.id }] : []),
+    },
+  },
+});

--- a/src/queries/generated/users.ts
+++ b/src/queries/generated/users.ts
@@ -1,0 +1,97 @@
+import { baseApi as api } from '../baseApi';
+
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    searchUsers: build.query<SearchUsersApiResponse, SearchUsersApiArg>({
+      query: (queryArg) => ({
+        url: `/api/v1/users`,
+        params: {
+          email: queryArg,
+        },
+      }),
+    }),
+    deleteMyself: build.mutation<DeleteMyselfApiResponse, DeleteMyselfApiArg>({
+      query: () => ({ url: `/api/v1/users/me`, method: 'DELETE' }),
+    }),
+    getMyself: build.query<GetMyselfApiResponse, GetMyselfApiArg>({
+      query: () => ({ url: `/api/v1/users/me` }),
+    }),
+    updateMyself: build.mutation<UpdateMyselfApiResponse, UpdateMyselfApiArg>({
+      query: (queryArg) => ({ url: `/api/v1/users/me`, method: 'PUT', body: queryArg }),
+    }),
+    getUser: build.query<GetUserApiResponse, GetUserApiArg>({
+      query: (queryArg) => ({ url: `/api/v1/users/${queryArg}` }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as api };
+export type SearchUsersApiResponse = /** status 200 The requested operation succeeded. */ GetUserResponsePayload;
+export type SearchUsersApiArg = /** The email to use when searching for a user */ string;
+export type DeleteMyselfApiResponse = /** status 200 OK */ SimpleSuccessResponsePayload;
+export type DeleteMyselfApiArg = void;
+export type GetMyselfApiResponse = /** status 200 OK */ GetUserResponsePayload;
+export type GetMyselfApiArg = void;
+export type UpdateMyselfApiResponse = /** status 200 OK */ SimpleSuccessResponsePayload;
+export type UpdateMyselfApiArg = UpdateUserRequestPayload;
+export type GetUserApiResponse = /** status 200 The requested operation succeeded. */ GetUserResponsePayload;
+export type GetUserApiArg = number;
+export type SuccessOrError = 'ok' | 'error';
+export type UserProfilePayload = {
+  /** If true, the user has consented to the use of analytics cookies. If false, the user has declined. If null, the user has not made a consent selection yet. */
+  cookiesConsented?: boolean;
+  /** If the user has selected whether or not to consent to analytics cookies, the date and time of the selection. */
+  cookiesConsentedTime?: string;
+  /** Two-letter code of the user's country. */
+  countryCode?: string;
+  email: string;
+  /** If true, the user wants to receive all the notifications for their organizations via email. This does not apply to certain kinds of notifications such as "You've been added to a new organization." */
+  emailNotificationsEnabled: boolean;
+  firstName?: string;
+  globalRoles: ('Super-Admin' | 'Accelerator Admin' | 'TF Expert' | 'Read Only')[];
+  /** User's unique ID. This should not be shown to the user, but is a required input to some API endpoints. */
+  id: number;
+  lastName?: string;
+  /** IETF locale code containing user's preferred language. */
+  locale?: string;
+  /** Time zone name in IANA tz database format */
+  timeZone?: string;
+  /** Type of User. Could be Individual, Funder or DeviceManager */
+  userType: 'Individual' | 'Device Manager' | 'System' | 'Funder';
+};
+export type GetUserResponsePayload = {
+  status: SuccessOrError;
+  user: UserProfilePayload;
+};
+export type ErrorDetails = {
+  message: string;
+};
+export type SimpleErrorResponsePayload = {
+  error: ErrorDetails;
+  status: SuccessOrError;
+};
+export type SimpleSuccessResponsePayload = {
+  status: SuccessOrError;
+};
+export type UpdateUserRequestPayload = {
+  /** Two-letter code of the user's country. */
+  countryCode?: string;
+  /** If true, the user wants to receive all the notifications for their organizations via email. This does not apply to certain kinds of notifications such as "You've been added to a new organization." If null, leave the existing value as-is. */
+  emailNotificationsEnabled?: boolean;
+  firstName: string;
+  lastName: string;
+  /** IETF locale code containing user's preferred language. */
+  locale?: string;
+  /** Time zone name in IANA tz database format */
+  timeZone?: string;
+};
+export const {
+  useSearchUsersQuery,
+  useLazySearchUsersQuery,
+  useDeleteMyselfMutation,
+  useGetMyselfQuery,
+  useLazyGetMyselfQuery,
+  useUpdateMyselfMutation,
+  useGetUserQuery,
+  useLazyGetUserQuery,
+} = injectedRtkApi;

--- a/src/queries/tags.ts
+++ b/src/queries/tags.ts
@@ -37,6 +37,7 @@ export enum QueryTagTypes {
   Reports = 'Reports',
   T0 = 'T0',
   TrackingStats = 'TrackingStats',
+  Users = 'Users',
   ViabilityTests = 'ViabilityTests',
 }
 

--- a/src/scenes/MyAccountRouter/DeleteAccountModal.tsx
+++ b/src/scenes/MyAccountRouter/DeleteAccountModal.tsx
@@ -5,7 +5,7 @@ import { BusySpinner } from '@terraware/web-components';
 
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
-import { UserService } from 'src/services';
+import { useDeleteMyselfMutation } from 'src/queries/generated/users';
 import strings from 'src/strings';
 import useSnackbar from 'src/utils/useSnackbar';
 
@@ -17,11 +17,12 @@ export default function DeleteAccountModal({ onCancel }: DeleteAccountModalProps
   const [busy, setBusy] = useState<boolean>(false);
   const snackbar = useSnackbar();
   const mixpanel = useMixpanel();
+  const [deleteMyself] = useDeleteMyselfMutation();
 
   const deleteUser = async () => {
     setBusy(true);
-    const response = await UserService.deleteUser();
-    if (response.requestSucceeded) {
+    const result = await deleteMyself();
+    if (!('error' in result)) {
       mixpanel?.reset();
       window.location.href = '/sso/logout';
     } else {

--- a/src/scenes/MyAccountRouter/MyAccountForm.tsx
+++ b/src/scenes/MyAccountRouter/MyAccountForm.tsx
@@ -22,9 +22,10 @@ import { TableColumnType } from 'src/components/common/table/types';
 import { APP_PATHS } from 'src/constants';
 import { useDocLinks } from 'src/docLinks';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
+import useUpdateCurrentUser from 'src/hooks/useUpdateCurrentUser';
 import { useLocalization, useTimeZones, useUser } from 'src/providers';
 import { useGetDisclaimerQuery } from 'src/queries/generated/disclaimer';
-import { OrganizationService, OrganizationUserService, PreferencesService, UserService } from 'src/services';
+import { OrganizationService, OrganizationUserService, PreferencesService } from 'src/services';
 import strings from 'src/strings';
 import { findLocaleDetails, useSupportedLocales } from 'src/strings/locales';
 import { Organization, roleName } from 'src/types/Organization';
@@ -92,6 +93,7 @@ const MyAccountForm = ({
   desktopOffset,
 }: MyAccountFormProps): JSX.Element => {
   const { isMobile } = useDeviceInfo();
+  const updateCurrentUser = useUpdateCurrentUser();
   const supportedLocales = useSupportedLocales();
   const theme = useTheme();
   const { currentData: disclaimerData } = useGetDisclaimerQuery(undefined, { skip: user?.userType !== 'Funder' });
@@ -218,9 +220,8 @@ const MyAccountForm = ({
 
       const lastLocale = selectedLocale;
       setSelectedLocale(localeSelected);
-      const updateUserResponse = await saveProfileChanges();
-      if (updateUserResponse.requestSucceeded) {
-        reloadUser();
+      const succeeded = await saveProfileChanges();
+      if (succeeded) {
         snackbar.toastSuccess(strings.CHANGES_SAVED);
       } else {
         setSelectedLocale(lastLocale);
@@ -237,12 +238,12 @@ const MyAccountForm = ({
   const saveProfileChanges = async () => {
     // Save the currently-selected locale, even if it differs from the locale in the profile data we
     // fetched from the server.
-    const updateUserResponse = await UserService.updateUser({
+    const succeeded = await updateCurrentUser({
       ...record,
       countryCode: countryCodeSelected,
       locale: localeSelected,
     });
-    return updateUserResponse;
+    return succeeded;
   };
 
   const openDeleteOrgModal = () => {
@@ -251,7 +252,7 @@ const MyAccountForm = ({
   };
 
   const leaveOrgHandler = async () => {
-    const updateUserResponse = await saveProfileChanges();
+    const succeeded = await saveProfileChanges();
     let leaveOrgResponse = {
       requestSucceeded: true,
     };
@@ -268,7 +269,7 @@ const MyAccountForm = ({
         leaveOrgResponse = await OrganizationUserService.deleteOrganizationUser(removedOrg.id, user.id);
       }
     }
-    if (updateUserResponse.requestSucceeded && leaveOrgResponse.requestSucceeded) {
+    if (succeeded && leaveOrgResponse.requestSucceeded) {
       if (reloadData) {
         reloadData();
       }
@@ -288,8 +289,8 @@ const MyAccountForm = ({
   const deleteOrgHandler = async () => {
     if (removedOrg) {
       const deleterOrgReponse = await OrganizationService.deleteOrganization(removedOrg.id);
-      const updateUserResponse = await saveProfileChanges();
-      if (updateUserResponse.requestSucceeded && deleterOrgReponse.requestSucceeded) {
+      const succeeded = await saveProfileChanges();
+      if (succeeded && deleterOrgReponse.requestSucceeded) {
         if (reloadData) {
           reloadData();
         }

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -35,7 +35,6 @@ const CURRENT_USER_ENDPOINT = '/api/v1/users/me';
 const ENDPOINT_USER = '/api/v1/users/{userId}';
 const ENDPOINT_USERS = '/api/v1/users';
 
-type UserServerResponse = paths[typeof CURRENT_USER_ENDPOINT]['get']['responses'][200]['content']['application/json'];
 type UpdateUserPayloadType = paths[typeof CURRENT_USER_ENDPOINT]['put']['requestBody']['content']['application/json'];
 
 type GetUserResponsePayload = paths[typeof ENDPOINT_USER]['get']['responses'][200]['content']['application/json'];
@@ -49,38 +48,6 @@ const cachedTimeZone: CachedTimeZone = {
   cachedOn: 0,
   promise: null,
   updated: false,
-};
-
-/**
- * get current/active user
- */
-const getUser = async (): Promise<UserResponse> => {
-  const response: UserResponse = await httpCurrentUser.get<UserServerResponse, UserData>({}, (data) => {
-    return {
-      user: data?.user
-        ? {
-            cookiesConsented: data.user.cookiesConsented,
-            cookiesConsentedTime: data.user.cookiesConsentedTime,
-            countryCode: data.user.countryCode,
-            email: data.user.email,
-            emailNotificationsEnabled: data.user.emailNotificationsEnabled,
-            firstName: data.user.firstName,
-            globalRoles: data.user.globalRoles,
-            id: data.user.id,
-            lastName: data.user.lastName,
-            locale: data.user.locale,
-            timeZone: data.user.timeZone,
-            userType: data.user.userType,
-          }
-        : undefined,
-    };
-  });
-
-  if (response.user) {
-    CachedUserService.setUser(response.user);
-  }
-
-  return response;
 };
 
 const get = async (userId: number): Promise<UserResponse> =>
@@ -121,19 +88,12 @@ const updateUser = async (user: User, options: UpdateOptions = {}): Promise<Resp
     await PreferencesService.updateUserCookieConsentPreferences({ cookiesConsented: user.cookiesConsented });
   }
 
-  void getUser();
-
   if (user.timeZone && !options.skipAcknowledgeTimeZone) {
     await PreferencesService.updateUserPreferences({ timeZoneAcknowledgedOnMs: Date.now() });
   }
 
   return response;
 };
-
-/**
- * Delete current user
- */
-const deleteUser = async (): Promise<Response> => await httpCurrentUser.delete({});
 
 /**
  * initialize user time zone
@@ -211,12 +171,10 @@ const initializeUnits = async (units: string): Promise<InitializedUnits> => {
 const UserService = {
   get,
   getInitializedTimeZone,
-  getUser,
   getUserByEmail,
   initializeTimeZone,
   initializeUnits,
   updateUser,
-  deleteUser,
 };
 
 export default UserService;

--- a/src/services/test/CachedUserService.test.ts
+++ b/src/services/test/CachedUserService.test.ts
@@ -1,5 +1,4 @@
 import { setHttpServiceMocks, clearHttpServiceMocks } from './HttpServiceMocks';
-import UserService from '../UserService';
 import CachedUserService from '../CachedUserService';
 import PreferencesService from '../PreferencesService';
 import { User } from '../../types/User';
@@ -8,16 +7,6 @@ const USER = {
   id: 1,
   firstName: 'Constanza',
   email: 'constanza@terraformation.com',
-};
-
-const UPDATED_USER: User = {
-  email: 'constanza@terraformation.com',
-  emailNotificationsEnabled: false,
-  firstName: 'Constanza',
-  globalRoles: [],
-  id: 1,
-  lastName: 'Uanini',
-  userType: 'Individual',
 };
 
 const PREFERENCES = {
@@ -41,21 +30,12 @@ describe('Cached user service test', () => {
     clearHttpServiceMocks();
   });
 
-  test('get cached user should return correct user', async () => {
-    setHttpServiceMocks({
-      get: () =>
-        Promise.resolve({
-          user: USER,
-          requestSucceeded: true,
-          statusCode: 200,
-        }),
-    });
+  test('get cached user should return correct user', () => {
+    CachedUserService.setUser(USER as User);
 
-    const { user } = await UserService.getUser();
+    const cachedUser = CachedUserService.getUser();
 
-    const cachedUser = await CachedUserService.getUser();
-
-    expect(cachedUser).toEqual({ ...user, isTerraformation: true });
+    expect(cachedUser).toEqual({ ...USER, isTerraformation: true });
   });
 
   test('get cached user preferences should return correct preferences', async () => {
@@ -90,28 +70,6 @@ describe('Cached user service test', () => {
     const cachedOrgPreferences = CachedUserService.getUserOrgPreferences(1);
 
     expect(cachedOrgPreferences).toEqual(preferences);
-  });
-
-  test('cached user should be updated', async () => {
-    setHttpServiceMocks({
-      put: () =>
-        Promise.resolve({
-          requestSucceeded: true,
-          statusCode: 200,
-        }),
-      get: () =>
-        Promise.resolve({
-          user: UPDATED_USER,
-          requestSucceeded: true,
-          statusCode: 200,
-        }),
-    });
-
-    await UserService.updateUser(UPDATED_USER);
-
-    const cachedUser = CachedUserService.getUser();
-
-    expect(cachedUser).toEqual({ ...UPDATED_USER, isTerraformation: true });
   });
 
   test('user preferences should be updated', async () => {


### PR DESCRIPTION
Add users RTK Query module, Users tag + extension, useUpdateCurrentUser
wrapper. Rewire UserProvider (getMyself), MyAccountForm + LocaleSelector
(update), DeleteAccountModal (delete). Remove getUser/deleteUser from
UserService.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>