### PR TITLE
SW-8640 Update withdrawal value validation message

### DIFF
--- a/src/scenes/InventoryRouter/BatchWithdrawModal/SeedlingBatchBox.tsx
+++ b/src/scenes/InventoryRouter/BatchWithdrawModal/SeedlingBatchBox.tsx
@@ -182,7 +182,7 @@ const SeedlingBatchBox = ({
                     max={batch.readyQuantity}
                     errorText={
                       exceeds
-                        ? strings.formatString(strings.EXCEEDS_READY_TO_PLANT, batch.readyQuantity).toString()
+                        ? strings.formatString(strings.EXCEEDS_READY_TO_PLANT, value, batch.readyQuantity).toString()
                         : ''
                     }
                   />

--- a/src/scenes/NurseryRouter/RequestSpeciesBox.tsx
+++ b/src/scenes/NurseryRouter/RequestSpeciesBox.tsx
@@ -114,7 +114,9 @@ const RequestSpeciesBox = ({
                   min={0}
                   max={batch.readyQuantity}
                   errorText={
-                    exceeds ? strings.formatString(strings.EXCEEDS_READY_TO_PLANT, batch.readyQuantity).toString() : ''
+                    exceeds
+                      ? strings.formatString(strings.EXCEEDS_READY_TO_PLANT, batchTotal, batch.readyQuantity).toString()
+                      : ''
                   }
                 />
               </Box>

--- a/src/strings/csv/en.csv
+++ b/src/strings/csv/en.csv
@@ -714,6 +714,7 @@ EVENT_RECORDED_SESSION_REQUIREMENTS_SPEAKERS,"Speakers or headset - built-in, US
 EVENTS,Events,
 EXCEEDS_AVAILABLE_X,Exceeds available ({0}),
 EXCEEDS_READY_TO_PLANT,Exceeds Ready to Plant ({0}),
+EXCEEDS_READY_TO_PLANT,Total withdrawn ({0}) across all substrata exceeds Ready to Plant ({1}) in this batch,
 EXCEEDS_TARGET,Exceeds target,
 EXCLUSION_AREAS,Exclusion Areas,
 EXISTING,Existing,

--- a/src/strings/csv/es.csv
+++ b/src/strings/csv/es.csv
@@ -713,7 +713,7 @@ EVENT_RECORDED_SESSION_DESCRIPTION_1,Puedes ver esta sesión grabada cuando quie
 EVENT_RECORDED_SESSION_REQUIREMENTS_SPEAKERS,"Altavoces o auriculares: integrados, con conexión USB o inalámbricos con tecnología Bluetooth.",b87be889
 EVENTS,Eventos,a18b73bc
 EXCEEDS_AVAILABLE_X,Supera lo disponible ({0}),4391f9df
-EXCEEDS_READY_TO_PLANT,Supera Listo para Transplantar ({0}),42faa655
+EXCEEDS_READY_TO_PLANT,El total retirado ({0}) en todos los sustratos supera la cantidad Lista para Transplantar ({1}) en este lote,3e3cd4a4
 EXCEEDS_TARGET,Supera el objetivo,edcff874
 EXCLUSION_AREAS,Zonas de exclusión,08c7d391
 EXISTING,Existente,fa67ac1d

--- a/src/strings/csv/fr.csv
+++ b/src/strings/csv/fr.csv
@@ -712,7 +712,7 @@ EVENT_RECORDED_SESSION_DESCRIPTION_1,"Regardez cette session enregistrée à tou
 EVENT_RECORDED_SESSION_REQUIREMENTS_SPEAKERS,"Haut-parleurs ou casque – intégré, branché sur le port USB ou sans fil Bluetooth",b87be889
 EVENTS,Evénements,a18b73bc
 EXCEEDS_AVAILABLE_X,Dépasse le disponible ({0}),4391f9df
-EXCEEDS_READY_TO_PLANT,Dépasse le prêt à planter ({0}),42faa655
+EXCEEDS_READY_TO_PLANT,Le total retiré ({0}) pour tous les substrats dépasse le nombre Prêt à planter ({1}) dans ce lot,3e3cd4a4
 EXCEEDS_TARGET,Dépasse l'objectif,edcff874
 EXCLUSION_AREAS,Zones d'exclusion,08c7d391
 EXISTING,Existant,fa67ac1d


### PR DESCRIPTION
If a species is requested in multiple substrata, the copy can be confusing when withdrawing from the same batch across the multiple substrata if the value exceeds the batch total, because it can seem like what's being withdrawn is less than the batch total. In actuality, the value being withdrawn is summed across all substrata. Update the copy to clarify this.