### PR TITLE
Change validate-types to run sequentially

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -118,6 +118,7 @@ steps:
     depends_on:
       - step: 'build-and-test'
       - step: 'e2e-tests'
+      - step: 'validate-types'
         allow_failure: true
     plugins:
       - *shallow-clone

--- a/.buildkite/scripts/validate-types.sh
+++ b/.buildkite/scripts/validate-types.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 .buildkite/scripts/install-deps.sh --node --tools
 
-# generate-types and generate-queries needs the backend's OpenAPI spec at
+# generate-types and generate-queries need the backend's OpenAPI spec at
 # localhost:8080. If a server is already running, reuse it; otherwise start
 # one (no server:reset needed since we only read the spec, not the seeded data).
 if curl -sf http://localhost:8080/swagger-ui/index.html > /dev/null 2>&1; then

--- a/.buildkite/scripts/validate-types.sh
+++ b/.buildkite/scripts/validate-types.sh
@@ -3,6 +3,20 @@ set -euo pipefail
 
 .buildkite/scripts/install-deps.sh --node --tools
 
+# generate-types and generate-queries needs the backend's OpenAPI spec at
+# localhost:8080. If a server is already running, reuse it; otherwise start
+# one (no server:reset needed since we only read the spec, not the seeded data).
+if curl -sf http://localhost:8080/swagger-ui/index.html > /dev/null 2>&1; then
+  echo "--- :docker: Backend already running at localhost:8080"
+else
+  echo "--- :docker: Start backend"
+  yarn docker:start:prod
+  if ! yarn wait-be; then
+    docker compose logs terraware-server
+    exit 1
+  fi
+fi
+
 echo "--- :yarn: Generate types"
 yarn generate-types
 


### PR DESCRIPTION
The CI step `validate-types` was running in parallel to `Build and push Docker image`. Change this to sequential so it doesn't spin up another host.

Also make sure the BE is running prior to generation, and start it if not. This way if it does happen to run on a different host, it won't immediately fail.