### PR TITLE
Use custom S3 bucket for Buildkite artifacts

### DIFF
--- a/.buildkite/pipeline.screenshot-check.yml
+++ b/.buildkite/pipeline.screenshot-check.yml
@@ -46,8 +46,7 @@ steps:
       - *load-secrets
     command: .buildkite/scripts/run-screenshot-check.sh
     artifact_paths:
-      - 'playwright/test-results/**/*'
-      - 'playwright-report/**/*'
+      - 'playwright/public/**/*'
     env:
       SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUERURI: https://auth.staging.terraware.io/realms/terraware
       SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTSECRET: dummy

--- a/.buildkite/pipeline.screenshot-check.yml
+++ b/.buildkite/pipeline.screenshot-check.yml
@@ -45,8 +45,6 @@ steps:
       - *restore-dist
       - *load-secrets
     command: .buildkite/scripts/run-screenshot-check.sh
-    artifact_paths:
-      - 'playwright/public/**/*'
     env:
       SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUERURI: https://auth.staging.terraware.io/realms/terraware
       SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTSECRET: dummy

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -93,8 +93,6 @@ steps:
       - *restore-dist
       - *load-secrets
     command: .buildkite/scripts/run-e2e-tests.sh
-    artifact_paths:
-      - 'playwright/public/**/*'
     env:
       SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUERURI: https://auth.staging.terraware.io/realms/terraware
       SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTSECRET: dummy

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,6 +34,9 @@ agents:
   # Run all steps on the same kind of runner.
   queue: 'x86-8core'
 
+env:
+  BUILDKITE_ARTIFACT_UPLOAD_DESTINATION: 's3://$BUILDKITE_PLUGIN_S3_CACHE_BUCKET/artifacts/$BUILDKITE_PIPELINE_SLUG/$BUILDKITE_BUILD_ID'
+
 steps:
   - label: ':graphite: CI optimizer'
     key: 'graphite-ci-optimizer'
@@ -59,6 +62,7 @@ steps:
       - artifacts#v1.9.4:
           upload: 'dist'
           compressed: 'dist.tgz'
+          s3-upload-acl: 'private'
     command: .buildkite/scripts/build-and-test.sh
 
   - label: ':vercel: Deploy Vercel preview'
@@ -90,8 +94,7 @@ steps:
       - *load-secrets
     command: .buildkite/scripts/run-e2e-tests.sh
     artifact_paths:
-      - 'playwright/test-results/**/*'
-      - 'playwright-report/**/*'
+      - 'playwright/public/**/*'
     env:
       SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUERURI: https://auth.staging.terraware.io/realms/terraware
       SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTSECRET: dummy

--- a/.buildkite/scripts/build-and-test.sh
+++ b/.buildkite/scripts/build-and-test.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-.buildkite/scripts/install-deps.sh --node --tools
-
 echo "--- :buildkite: S3 public artifact files test"
-
 mkdir -p playwright/test-results playwright-report
 date > playwright/test-results/date.txt
 .buildkite/scripts/upload-playwright-results.sh
+
+.buildkite/scripts/install-deps.sh --node --tools
 
 echo "--- :yarn: Install dependencies"
 yarn install --frozen-lockfile --prefer-offline

--- a/.buildkite/scripts/build-and-test.sh
+++ b/.buildkite/scripts/build-and-test.sh
@@ -3,6 +3,12 @@ set -euo pipefail
 
 .buildkite/scripts/install-deps.sh --node --tools
 
+echo "--- :buildkite: S3 public artifact files test"
+
+mkdir -p playwright/test-results playwright-report
+date > playwright/test-results/date.txt
+.buildkite/scripts/upload-playwright-results.sh
+
 echo "--- :yarn: Install dependencies"
 yarn install --frozen-lockfile --prefer-offline
 

--- a/.buildkite/scripts/build-and-test.sh
+++ b/.buildkite/scripts/build-and-test.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "--- :buildkite: S3 public artifact files test"
-mkdir -p playwright/test-results playwright-report
-date > playwright/test-results/date.txt
-.buildkite/scripts/upload-playwright-results.sh
-
 .buildkite/scripts/install-deps.sh --node --tools
 
 echo "--- :yarn: Install dependencies"

--- a/.buildkite/scripts/run-e2e-tests.sh
+++ b/.buildkite/scripts/run-e2e-tests.sh
@@ -56,8 +56,4 @@ run_tests() {
 # suites directory, excluding the screenshots subdirectory.
 run_tests "Run remaining end-to-end tests" "playwright/e2e/suites/*.spec.ts"
 
-# Move the test output to a "public" subdirectory so it's readable in the
-# S3 bucket without AWS authentication.
-mkdir -p playwright/public
-mv playwright/test-results playwright/public
-mv playwright-report playwright/public/report
+.buildkite/scripts/upload-playwright-results.sh

--- a/.buildkite/scripts/run-e2e-tests.sh
+++ b/.buildkite/scripts/run-e2e-tests.sh
@@ -55,3 +55,9 @@ run_tests() {
 # The shell inside Docker expands the glob to all spec files directly in the
 # suites directory, excluding the screenshots subdirectory.
 run_tests "Run remaining end-to-end tests" "playwright/e2e/suites/*.spec.ts"
+
+# Move the test output to a "public" subdirectory so it's readable in the
+# S3 bucket without AWS authentication.
+mkdir -p playwright/public
+mv playwright/test-results playwright/public
+mv playwright-report playwright/public/report

--- a/.buildkite/scripts/run-screenshot-check.sh
+++ b/.buildkite/scripts/run-screenshot-check.sh
@@ -35,3 +35,9 @@ echo "--- :camera_with_flash: Run screenshot regression tests"
 "${DOCKER_BASE[@]}" \
   sh -c "node_modules/.bin/wait-on -t 60000 http://localhost:3001 \
          && node_modules/.bin/playwright test playwright/e2e/suites/screenshots --project=prod"
+
+# Move the test output to a "public" subdirectory so it's readable in the
+# S3 bucket without AWS authentication.
+mkdir -p playwright/public
+mv playwright/test-results playwright/public
+mv playwright-report playwright/public/report

--- a/.buildkite/scripts/run-screenshot-check.sh
+++ b/.buildkite/scripts/run-screenshot-check.sh
@@ -36,8 +36,4 @@ echo "--- :camera_with_flash: Run screenshot regression tests"
   sh -c "node_modules/.bin/wait-on -t 60000 http://localhost:3001 \
          && node_modules/.bin/playwright test playwright/e2e/suites/screenshots --project=prod"
 
-# Move the test output to a "public" subdirectory so it's readable in the
-# S3 bucket without AWS authentication.
-mkdir -p playwright/public
-mv playwright/test-results playwright/public
-mv playwright-report playwright/public/report
+.buildkite/scripts/upload-playwright-results.sh

--- a/.buildkite/scripts/upload-playwright-results.sh
+++ b/.buildkite/scripts/upload-playwright-results.sh
@@ -10,5 +10,4 @@ sudo mv playwright-report playwright/public/report
 # We need to disable KMS encryption on public artifacts so they will be
 # downloadable without AWS authentication. There's no good way to do this
 # selectively using the built-in artifacts support, so do it explicitly.
-export BUILDKITE_S3_SSE_ENABLED=false
-buildkite-agent artifact upload 'playwright/public/**/*'
+BUILDKITE_S3_SSE_ENABLED=false buildkite-agent artifact upload 'playwright/public/**/*'

--- a/.buildkite/scripts/upload-playwright-results.sh
+++ b/.buildkite/scripts/upload-playwright-results.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Move the test output to a "public" subdirectory so it's readable in the
+# S3 bucket without AWS authentication.
+mkdir playwright/public
+sudo mv playwright/test-results playwright/public
+sudo mv playwright-report playwright/public/report
+
+# We need to disable KMS encryption on public artifacts so they will be
+# downloadable without AWS authentication. There's no good way to do this
+# selectively using the built-in artifacts support, so do it explicitly.
+export BUILDKITE_S3_SSE_ENABLED=false
+buildkite-agent artifact upload 'playwright/public/**/*'

--- a/.buildkite/scripts/upload-playwright-results.sh
+++ b/.buildkite/scripts/upload-playwright-results.sh
@@ -9,5 +9,7 @@ sudo mv playwright-report playwright/public/report
 
 # We need to disable KMS encryption on public artifacts so they will be
 # downloadable without AWS authentication. There's no good way to do this
-# selectively using the built-in artifacts support, so do it explicitly.
+# selectively using the built-in artifacts support, so do it explicitly
+# by telling the agent to use the default server-side encryption mode,
+# which uses an AWS-managed key that works for public files.
 BUILDKITE_S3_SSE_ENABLED=true buildkite-agent artifact upload 'playwright/public/**/*'

--- a/.buildkite/scripts/upload-playwright-results.sh
+++ b/.buildkite/scripts/upload-playwright-results.sh
@@ -10,4 +10,4 @@ sudo mv playwright-report playwright/public/report
 # We need to disable KMS encryption on public artifacts so they will be
 # downloadable without AWS authentication. There's no good way to do this
 # selectively using the built-in artifacts support, so do it explicitly.
-BUILDKITE_S3_SSE_ENABLED=false buildkite-agent artifact upload 'playwright/public/**/*'
+BUILDKITE_S3_SSE_ENABLED=true buildkite-agent artifact upload 'playwright/public/**/*'

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ src/strings/strings-*.js
 
 # playwright
 /playwright-report/
+/playwright/public/
 /playwright/test-results/
 
 # test gaussian splat models


### PR DESCRIPTION
Configure Buildkite to use our own S3 bucket for artifact storage.

Playwright output is moved to a new `public` subdirectory so it matches the
S3 bucket's path-based public-read-access rule; this will allow browsing test
results from the Buildkite web UI.