### PR TITLE
Cleanup playwright tests

### DIFF
--- a/.buildkite/scripts/run-e2e-tests.sh
+++ b/.buildkite/scripts/run-e2e-tests.sh
@@ -54,6 +54,6 @@ run_tests() {
 
 # The shell inside Docker expands the glob to all spec files directly in the
 # suites directory, excluding the screenshots subdirectory.
-run_tests "Run remaining end-to-end tests" "playwright/e2e/suites/*.spec.ts"
+run_tests "Run remaining end-to-end tests" "playwright/e2e/suites/interaction"
 
 .buildkite/scripts/upload-playwright-results.sh

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "playwright:run": "yarn run playwright test --ui playwright/e2e --project=dev",
     "playwright:debug": "yarn run playwright test playwright/e2e --debug --project=dev",
     "playwright:demo": "SLOW_MO=750 TIMEOUT=600000 yarn run playwright test playwright/e2e --headed --project=dev",
-    "playwright:run:prod": "yarn run playwright test playwright/e2e/suites/screenshots --project=prod && yarn run playwright test 'playwright/e2e/suites/*.spec.ts' --project=prod",
+    "playwright:run:prod": "yarn run playwright test 'playwright/e2e/suites/interaction' --project=prod",
     "test:e2e": "yarn run wait-on -t 60000 http://localhost:3001 && NODE_OPTIONS=--max-old-space-size=16384 yarn run playwright:run:prod",
     "screenshots:update": "./scripts/update-screenshots.sh",
     "screenshots:update:all-pages": "./scripts/update-screenshots-all-pages.sh",

--- a/playwright/e2e/suites/interaction/accession.spec.ts
+++ b/playwright/e2e/suites/interaction/accession.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
-import { changeToSuperAdmin } from '../utils/userUtils';
-import { exactOptions, selectOrg, waitFor } from '../utils/utils';
+import { changeToSuperAdmin } from '../../utils/userUtils';
+import { exactOptions, selectOrg, waitFor } from '../../utils/utils';
 
 const yearId = new Date().getFullYear().toString().slice(-2);
 

--- a/playwright/e2e/suites/interaction/deliverables.spec.ts
+++ b/playwright/e2e/suites/interaction/deliverables.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { openTodoFromHome } from '../participantHome';
+import { openTodoFromHome } from '../../participantHome';
 import {
   addQuestionnaireComments,
   approveDeliverableSpecies,
@@ -13,8 +13,8 @@ import {
   validateConsoleQuestionnaireStatusCard,
   validateQuestionnaireQuestionUpdateComments,
   validateQuestionnaireUpdateComments,
-} from '../utils/consoleDeliverable';
-import { navigateConsoleToParticipant, navigateHome } from '../utils/navigation';
+} from '../../utils/consoleDeliverable';
+import { navigateConsoleToParticipant, navigateHome } from '../../utils/navigation';
 import {
   deleteDeliverableSpecies,
   fillQuestionnaireInputField,
@@ -33,9 +33,9 @@ import {
   validateQuestionnaireTableFields,
   validateSpeciesStatus,
   verifyHomepageDeliverableStatus,
-} from '../utils/participantDeliverable';
-import { changeToSuperAdmin } from '../utils/userUtils';
-import { exactOptions, selectOrg, waitFor } from '../utils/utils';
+} from '../../utils/participantDeliverable';
+import { changeToSuperAdmin } from '../../utils/userUtils';
+import { exactOptions, selectOrg, waitFor } from '../../utils/utils';
 
 test.describe('DeliverableTests', () => {
   test.beforeEach(async ({ page, context, baseURL }) => {

--- a/playwright/e2e/suites/interaction/funderProjectProfile.spec.ts
+++ b/playwright/e2e/suites/interaction/funderProjectProfile.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@playwright/test';
 
-import { ProjectDetails, publishProjectProfile, validateProjectProfilePage } from '../utils/projectProfile';
-import { changeToFunderUser, changeToSuperAdmin } from '../utils/userUtils';
+import { ProjectDetails, publishProjectProfile, validateProjectProfilePage } from '../../utils/projectProfile';
+import { changeToFunderUser, changeToSuperAdmin } from '../../utils/userUtils';
 
 test.describe('FunderProjectProfileTests', () => {
   test('Publish Project and then View Published Project', async ({ page, context, baseURL }, testInfo) => {

--- a/playwright/e2e/suites/interaction/fundingEntities.spec.ts
+++ b/playwright/e2e/suites/interaction/fundingEntities.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
 import { Page } from 'playwright-core';
 
-import { navigateToFundingEntities } from '../utils/navigation';
-import { publishProjectProfile } from '../utils/projectProfile';
-import { changeToSuperAdmin } from '../utils/userUtils';
-import { exactOptions } from '../utils/utils';
+import { navigateToFundingEntities } from '../../utils/navigation';
+import { publishProjectProfile } from '../../utils/projectProfile';
+import { changeToSuperAdmin } from '../../utils/userUtils';
+import { exactOptions } from '../../utils/utils';
 
 type Funder = {
   name: string;

--- a/playwright/e2e/suites/interaction/inventory.spec.ts
+++ b/playwright/e2e/suites/interaction/inventory.spec.ts
@@ -1,8 +1,8 @@
 import { Locator, expect, test } from '@playwright/test';
 import { Page } from 'playwright-core';
 
-import { changeToSuperAdmin } from '../utils/userUtils';
-import { exactOptions, selectOrg, waitFor } from '../utils/utils';
+import { changeToSuperAdmin } from '../../utils/userUtils';
+import { exactOptions, selectOrg, waitFor } from '../../utils/utils';
 
 test.describe('InventoryTests', () => {
   test.beforeEach(async ({ page, context, baseURL }, testInfo) => {

--- a/playwright/e2e/suites/interaction/locations.spec.ts
+++ b/playwright/e2e/suites/interaction/locations.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
-import { changeToSuperAdmin } from '../utils/userUtils';
-import { selectOrg, waitFor } from '../utils/utils';
+import { changeToSuperAdmin } from '../../utils/userUtils';
+import { selectOrg, waitFor } from '../../utils/utils';
 
 test.describe('LocationTests', () => {
   test.beforeEach(async ({ page, context, baseURL }, testInfo) => {

--- a/playwright/e2e/suites/interaction/matrixView.spec.ts
+++ b/playwright/e2e/suites/interaction/matrixView.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
-import { changeToSuperAdmin } from '../utils/userUtils';
-import { exactOptions, selectOrg, waitFor } from '../utils/utils';
+import { changeToSuperAdmin } from '../../utils/userUtils';
+import { waitFor } from '../../utils/utils';
 
 test.describe('MatrixViewTests', () => {
   test.beforeEach(async ({ page, context, baseURL }, testInfo) => {

--- a/playwright/e2e/suites/interaction/observationDetails.spec.ts
+++ b/playwright/e2e/suites/interaction/observationDetails.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
-import { changeToSuperAdmin } from '../utils/userUtils';
-import { selectOrg, waitFor } from '../utils/utils';
+import { changeToSuperAdmin } from '../../utils/userUtils';
+import { selectOrg, waitFor } from '../../utils/utils';
 
 test.describe('ObservationDetailsTests', () => {
   test.beforeEach(async ({ page, context, baseURL }, testInfo) => {

--- a/playwright/e2e/suites/interaction/observations.spec.ts
+++ b/playwright/e2e/suites/interaction/observations.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
-import { changeToSuperAdmin } from '../utils/userUtils';
-import { selectOrg, waitFor } from '../utils/utils';
+import { changeToSuperAdmin } from '../../utils/userUtils';
+import { selectOrg, waitFor } from '../../utils/utils';
 
 test.describe('ObservationsTests', () => {
   test.beforeEach(async ({ page, context, baseURL }, testInfo) => {

--- a/playwright/e2e/suites/interaction/participantPlantsDashboard.spec.ts
+++ b/playwright/e2e/suites/interaction/participantPlantsDashboard.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
-import { changeToSuperAdmin } from '../utils/userUtils';
-import { exactOptions, selectOrg, waitFor } from '../utils/utils';
+import { changeToSuperAdmin } from '../../utils/userUtils';
+import { exactOptions, selectOrg, waitFor } from '../../utils/utils';
 
 test.describe('ParticipantPlantsDashboardTests', () => {
   test.beforeEach(async ({ page, context, baseURL }, testInfo) => {

--- a/playwright/e2e/suites/interaction/plantsDashboard.spec.ts
+++ b/playwright/e2e/suites/interaction/plantsDashboard.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
-import { changeToSuperAdmin } from '../utils/userUtils';
-import { selectOrg, waitFor } from '../utils/utils';
+import { changeToSuperAdmin } from '../../utils/userUtils';
+import { waitFor } from '../../utils/utils';
 
 test.describe('PlantsDashboardTests', () => {
   test.beforeEach(async ({ page, context, baseURL }, testInfo) => {

--- a/playwright/e2e/suites/interaction/projectDeliverables.spec.ts
+++ b/playwright/e2e/suites/interaction/projectDeliverables.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
-import { navigateToProjectProfile } from '../utils/navigation';
-import { changeToSuperAdmin } from '../utils/userUtils';
+import { navigateToProjectProfile } from '../../utils/navigation';
+import { changeToSuperAdmin } from '../../utils/userUtils';
 
 test.describe('ProjectDeliverablesTests', () => {
   test.beforeEach(async ({ context, baseURL }, testInfo) => {

--- a/playwright/e2e/suites/interaction/projectDocuments.spec.ts
+++ b/playwright/e2e/suites/interaction/projectDocuments.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
 
-import { APP_PATHS } from '../../../src/constants';
-import { navigateToProjectProfile } from '../utils/navigation';
-import { changeToSuperAdmin } from '../utils/userUtils';
+import { APP_PATHS } from '../../../../src/constants';
+import { navigateToProjectProfile } from '../../utils/navigation';
+import { changeToSuperAdmin } from '../../utils/userUtils';
 
 test.describe('ProjectDocumentsTests', () => {
   test.beforeEach(async ({ page, context, baseURL }, testInfo) => {

--- a/playwright/e2e/suites/interaction/projectProfile.spec.ts
+++ b/playwright/e2e/suites/interaction/projectProfile.spec.ts
@@ -1,9 +1,9 @@
 import { test } from '@playwright/test';
 
-import { navigateToProjectProfile } from '../utils/navigation';
-import { ProjectDetails, validateProjectProfilePage } from '../utils/projectProfile';
-import { changeToSuperAdmin } from '../utils/userUtils';
-import { exactOptions, waitFor } from '../utils/utils';
+import { navigateToProjectProfile } from '../../utils/navigation';
+import { ProjectDetails, validateProjectProfilePage } from '../../utils/projectProfile';
+import { changeToSuperAdmin } from '../../utils/userUtils';
+import { exactOptions, waitFor } from '../../utils/utils';
 
 test.describe('ProjectProfileTests', () => {
   test.beforeEach(async ({ context, baseURL }, testInfo) => {

--- a/playwright/e2e/suites/interaction/projectVariables.spec.ts
+++ b/playwright/e2e/suites/interaction/projectVariables.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
 
-import { navigateToProjectProfile } from '../utils/navigation';
-import { changeToSuperAdmin } from '../utils/userUtils';
-import { waitFor } from '../utils/utils';
+import { navigateToProjectProfile } from '../../utils/navigation';
+import { changeToSuperAdmin } from '../../utils/userUtils';
+import { waitFor } from '../../utils/utils';
 
 test.describe('ProjectVariablesTests', () => {
   test.beforeEach(async ({ context, baseURL }, testInfo) => {

--- a/playwright/e2e/suites/interaction/reportSubmit.spec.ts
+++ b/playwright/e2e/suites/interaction/reportSubmit.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
-import { changeToSuperAdmin } from '../utils/userUtils';
-import { exactOptions, selectOrg, waitFor } from '../utils/utils';
+import { changeToSuperAdmin } from '../../utils/userUtils';
+import { exactOptions, selectOrg, waitFor } from '../../utils/utils';
 
 // Phase 1 Project (projectId=3) belongs to Terraformation (staging) org (id=1)
 // and has a cohort/phase set, making it a valid accelerator project for reports.

--- a/playwright/e2e/suites/interaction/species.spec.ts
+++ b/playwright/e2e/suites/interaction/species.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
-import { changeToSuperAdmin } from '../utils/userUtils';
-import { exactOptions, selectOrg, waitFor } from '../utils/utils';
+import { changeToSuperAdmin } from '../../utils/userUtils';
+import { exactOptions, selectOrg, waitFor } from '../../utils/utils';
 
 test.describe('SpeciesTests', () => {
   test.beforeEach(async ({ page, context, baseURL }, testInfo) => {

--- a/playwright/e2e/suites/interaction/survivalRateSettings.spec.ts
+++ b/playwright/e2e/suites/interaction/survivalRateSettings.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
-import { changeToSuperAdmin } from '../utils/userUtils';
-import { exactOptions, selectOrg, waitFor } from '../utils/utils';
+import { changeToSuperAdmin } from '../../utils/userUtils';
+import { exactOptions, selectOrg, waitFor } from '../../utils/utils';
 
 test.describe('SurvivalRateSettingsTests', () => {
   test.describe.configure({ timeout: 120000 });

--- a/scripts/preparedb.sh
+++ b/scripts/preparedb.sh
@@ -4,23 +4,6 @@ echo "---- E2E: start ----"
 
 NOW=$(TZ=UTC date "+%Y-%m-%dT%H:%M:%SZ")
 
-case "$(uname -s)" in
-
-   Darwin)
-     echo 'Mac OS X'
-     LAST_WEEK=$(TZ=UTC date -v -7d "+%Y-%m-%dT%H:%M:%SZ")
-     ;;
-
-   Linux)
-     echo 'Linux'
-     LAST_WEEK=$(TZ=UTC date -d "last week" "+%Y-%m-%dT%H:%M:%SZ")
-     ;;
-
-   *)
-     echo 'Other OS' 
-     ;;
-esac
-
 COOKIE="SESSION=Mjc2NzE0YWQtYWIwYS00OGFhLThlZjgtZGI2NWVjMmU5NTBh"
 
 echo "---- E2E: adding species records ----"
@@ -38,10 +21,11 @@ if [ -z "$speciesId1" ]; then
     exit 1
 fi
 
-speciesId2=$(curl 'http://localhost:8080/api/v1/species' \
+# species 2
+curl 'http://localhost:8080/api/v1/species' \
   --cookie "${COOKIE}"  \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
-  --data '{"scientificName":"Coconut","organizationId":1}' | jq -r '.id')
+  --data '{"scientificName":"Coconut","organizationId":1}' | jq -r '.id'
 
 echo "---- E2E: finished ----"


### PR DESCRIPTION
Remove screenshot tests when running `playwright:run:prod` since CI runs them directly now.

Move the non-screenshot tests to their own folder because `playwright:run:prod` was broken once `playwright/e2e/suites/` no longer contained only `spec.ts` files. 

Cleanup some unused items from `preparedb.sh`