### PR TITLE
SW-8635: Biomass Monitoring Observations: Shrub Crown Diameter not editable for Shrubs in Trees and Shrubs table

### DIFF
--- a/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/TreesAndShrubsEditableTable.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/BiomassMeasurements/TreesAndShrubsEditableTable.tsx
@@ -202,7 +202,7 @@ export default function TreesAndShrubsEditableTable(): JSX.Element {
         id: 'shrubDiameter',
         accessorKey: 'shrubDiameter',
         header: strings.SHRUB_CROWN_DIAMETER_CM,
-        enableEditing: (row) => row.original.treeGrowthForm === 'Shrub' && forestType === 'Terrestrial',
+        enableEditing: (row) => row.original.treeGrowthForm === 'Shrub',
         editConfig: {
           onSave: (row, value) => saveRecordedTree('shrubDiameter', row, value),
         },


### PR DESCRIPTION
This PR removes an unnecessary restriction to edit the Shrub Crown Diameter field for shrubs in biomass observations.