### PR TITLE
SW-8654 Fix the 404s when deleting a planting season

### DIFF
--- a/src/queries/extensions/plantingSeasons.ts
+++ b/src/queries/extensions/plantingSeasons.ts
@@ -27,11 +27,10 @@ api.enhanceEndpoints({
       ],
     },
     deletePlantingSeason: {
-      invalidatesTags: (_result, _error, plantingSeasonId) => [
-        { type: QueryTagTypes.PlantingSeasons, id: plantingSeasonId },
-        { type: QueryTagTypes.PlantingSeasons, id: 'LIST' },
-        { type: QueryTagTypes.PlantingSeasonDates, id: plantingSeasonId },
-      ],
+      // Invalidating the per-season tags would refetch the detail page's still-mounted
+      // season/species-targets/scheduled-dates queries against the just-deleted season (404s) before navigation
+      // unmounts them. The season is gone, so there is nothing to refresh — only the list needs to drop it.
+      invalidatesTags: () => [{ type: QueryTagTypes.PlantingSeasons, id: 'LIST' }],
     },
     closePlantingSeason: {
       invalidatesTags: (_result, _error, plantingSeasonId) => [


### PR DESCRIPTION
When invalidating individual IDs inside the component doing the delete, it causes redux to refetch the data before the delete mutation completes, potetially causing 404s because of a race condition. Instead of directly invalidating them, just invalidate the list and let the rtk cache timeout (60s) do the actual removal.