### PR TITLE
SW-8644 Fix 404 when deleting an accession

### DIFF
--- a/src/queries/extensions/accessionsV1.ts
+++ b/src/queries/extensions/accessionsV1.ts
@@ -25,10 +25,7 @@ api.enhanceEndpoints({
       providesTags: (_results, _error, id) => [{ type: QueryTagTypes.Accessions, id }],
     },
     deleteApiV1SeedbankAccessionsById: {
-      invalidatesTags: (_results, _error, id) => [
-        { type: QueryTagTypes.Accessions, id },
-        { type: QueryTagTypes.Accessions, id: 'LIST' },
-      ],
+      invalidatesTags: () => [{ type: QueryTagTypes.Accessions, id: 'LIST' }],
     },
   },
 });


### PR DESCRIPTION
Invalidating the per-accession tag would refetch the just-deleted accession getting a 404. The accession is gone, so there is nothing to refresh. Only invalidate the list