### PR TITLE
SW-8410 Invite user with global roles if user does not exist

### DIFF
--- a/rtk-codegen.config.ts
+++ b/rtk-codegen.config.ts
@@ -43,7 +43,7 @@ const config: ConfigFile = {
     },
     './src/queries/generated/globalRoles.ts': {
       filterEndpoints: (_, operation) =>
-        operation.path === '/api/v1/globalRoles/users' || operation.path === '/api/v1/users/{userId}/globalRoles',
+        operation.path.startsWith('/api/v1/globalRoles') || operation.path === '/api/v1/users/{userId}/globalRoles',
     },
     './src/queries/generated/mapbox.ts': {
       filterEndpoints: (_, operation) => operation.path.startsWith('/api/v1/tracking/mapbox'),

--- a/src/queries/extensions/globalRoles.ts
+++ b/src/queries/extensions/globalRoles.ts
@@ -9,6 +9,9 @@ api.enhanceEndpoints({
     deleteGlobalRoles: {
       invalidatesTags: [{ type: QueryTagTypes.GlobalRolesUsers, id: 'LIST' }],
     },
+    inviteGlobalRolesUser: {
+      invalidatesTags: [{ type: QueryTagTypes.GlobalRolesUsers, id: 'LIST' }],
+    },
     updateGlobalRoles: {
       invalidatesTags: (_result, _error, args) => [
         { type: QueryTagTypes.GlobalRolesUsers, id: 'LIST' },

--- a/src/queries/generated/globalRoles.ts
+++ b/src/queries/generated/globalRoles.ts
@@ -2,6 +2,9 @@ import { baseApi as api } from '../baseApi';
 
 const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({
+    inviteGlobalRolesUser: build.mutation<InviteGlobalRolesUserApiResponse, InviteGlobalRolesUserApiArg>({
+      query: (queryArg) => ({ url: `/api/v1/globalRoles/invite`, method: 'POST', body: queryArg }),
+    }),
     deleteGlobalRoles: build.mutation<DeleteGlobalRolesApiResponse, DeleteGlobalRolesApiArg>({
       query: (queryArg) => ({ url: `/api/v1/globalRoles/users`, method: 'DELETE', body: queryArg }),
     }),
@@ -19,6 +22,9 @@ const injectedRtkApi = api.injectEndpoints({
   overrideExisting: false,
 });
 export { injectedRtkApi as api };
+export type InviteGlobalRolesUserApiResponse =
+  /** status 200 The requested operation succeeded. */ GetGlobalRolesUserResponsePayload;
+export type InviteGlobalRolesUserApiArg = InviteGlobalRolesUserRequestPayload;
 export type DeleteGlobalRolesApiResponse = /** status 200 The requested operation succeeded. */ SuccessResponsePayload;
 export type DeleteGlobalRolesApiArg = DeleteGlobalRolesRequestPayload;
 export type ListGlobalRolesApiResponse =
@@ -30,19 +36,6 @@ export type UpdateGlobalRolesApiArg = {
   updateGlobalRolesRequestPayload: UpdateGlobalRolesRequestPayload;
 };
 export type SuccessOrError = 'ok' | 'error';
-export type SuccessResponsePayload = {
-  status: SuccessOrError;
-};
-export type ErrorDetails = {
-  message: string;
-};
-export type SimpleErrorResponsePayload = {
-  error: ErrorDetails;
-  status: SuccessOrError;
-};
-export type DeleteGlobalRolesRequestPayload = {
-  userIds: number[];
-};
 export type UserWithGlobalRolesPayload = {
   createdTime: string;
   email: string;
@@ -62,6 +55,27 @@ export type UserWithGlobalRolesPayload = {
   )[];
   lastName?: string;
 };
+export type GetGlobalRolesUserResponsePayload = {
+  status: SuccessOrError;
+  user: UserWithGlobalRolesPayload;
+};
+export type ErrorDetails = {
+  message: string;
+};
+export type SimpleErrorResponsePayload = {
+  error: ErrorDetails;
+  status: SuccessOrError;
+};
+export type InviteGlobalRolesUserRequestPayload = {
+  email: string;
+  globalRoles: ('Super-Admin' | 'Accelerator Admin' | 'TF Expert' | 'Read Only')[];
+};
+export type SuccessResponsePayload = {
+  status: SuccessOrError;
+};
+export type DeleteGlobalRolesRequestPayload = {
+  userIds: number[];
+};
 export type GlobalRoleUsersListResponsePayload = {
   status: SuccessOrError;
   users: UserWithGlobalRolesPayload[];
@@ -70,6 +84,7 @@ export type UpdateGlobalRolesRequestPayload = {
   globalRoles: ('Super-Admin' | 'Accelerator Admin' | 'TF Expert' | 'Read Only')[];
 };
 export const {
+  useInviteGlobalRolesUserMutation,
   useDeleteGlobalRolesMutation,
   useListGlobalRolesQuery,
   useLazyListGlobalRolesQuery,

--- a/src/scenes/AcceleratorRouter/People/NewView.tsx
+++ b/src/scenes/AcceleratorRouter/People/NewView.tsx
@@ -19,8 +19,7 @@ const NewView = () => {
   const location = useStateLocation();
   const updatePerson = useUpdatePerson();
 
-  const personData = usePersonData();
-  const { setUserId, user } = personData;
+  const { setUserId, user } = usePersonData();
   const [email, setEmail] = useState('');
   const [emailError, setEmailError] = useState('');
   const [roleError, setRoleError] = useState('');
@@ -45,10 +44,14 @@ const NewView = () => {
         noErrors = false;
       }
       if (noErrors) {
-        updatePerson.update(record);
+        if (currentData?.user) {
+          updatePerson.update(record);
+        } else {
+          void updatePerson.invite(record);
+        }
       }
     },
-    [updatePerson]
+    [currentData?.user, updatePerson]
   );
 
   const handleOnChange = useCallback(
@@ -72,12 +75,10 @@ const NewView = () => {
       return;
     }
 
+    setEmailError('');
     if (currentData?.user) {
-      setEmailError('');
       setUserId(currentData.user.id);
-    } else if (isError) {
-      setEmailError(strings.USER_WITH_EMAIL_DOES_NOT_EXIST);
-    }
+    } // else if isError - new user, no op
   }, [currentData, isError, isFetching, isValidEmail, setUserId]);
 
   useEffect(() => {

--- a/src/scenes/AcceleratorRouter/People/useUpdatePerson.tsx
+++ b/src/scenes/AcceleratorRouter/People/useUpdatePerson.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo } from 'react';
 
-import { useUpdateGlobalRolesMutation } from 'src/queries/generated/globalRoles';
+import { useInviteGlobalRolesUserMutation, useUpdateGlobalRolesMutation } from 'src/queries/generated/globalRoles';
 import { useUpdateUserInternalInterestsMutation } from 'src/queries/generated/userInternalInterests';
 import { UserWithInternalnterests } from 'src/scenes/AcceleratorRouter/People/UserWithInternalInterests';
 import strings from 'src/strings';
@@ -9,6 +9,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 export type Response = {
   busy?: boolean;
   succeeded?: boolean;
+  invite: (user: UserWithInternalnterests) => Promise<void>;
   update: (user: UserWithInternalnterests) => void;
 };
 
@@ -17,6 +18,7 @@ export default function useUpdatePerson(): Response {
 
   const [updateInternalInterests, updateInternalInterestsResponse] = useUpdateUserInternalInterestsMutation();
   const [updateGlobalRoles, updateGlobalRolesResponse] = useUpdateGlobalRolesMutation();
+  const [inviteGlobalRolesUser, inviteGlobalRolesResponse] = useInviteGlobalRolesUserMutation();
 
   const update = useCallback(
     (user: UserWithInternalnterests) => {
@@ -33,6 +35,32 @@ export default function useUpdatePerson(): Response {
     [updateInternalInterests, updateGlobalRoles]
   );
 
+  const invite = useCallback(
+    async (user: UserWithInternalnterests) => {
+      try {
+        const response = await inviteGlobalRolesUser({
+          email: user.email,
+          globalRoles: user.globalRoles,
+        }).unwrap();
+
+        if (response.status !== 'ok') {
+          snackbar.toastError(strings.GENERIC_ERROR);
+          return;
+        }
+
+        if (user.internalInterests?.length > 0) {
+          void updateInternalInterests({
+            userId: response.user.id,
+            updateUserInternalInterestsRequestPayload: { internalInterests: user.internalInterests },
+          });
+        }
+      } catch (e) {
+        snackbar.toastError(strings.GENERIC_ERROR);
+      }
+    },
+    [inviteGlobalRolesUser, updateInternalInterests, snackbar]
+  );
+
   useEffect(() => {
     if (updateInternalInterestsResponse.isError || updateGlobalRolesResponse.isError) {
       snackbar.toastError(strings.GENERIC_ERROR);
@@ -41,10 +69,16 @@ export default function useUpdatePerson(): Response {
 
   return useMemo<Response>(
     () => ({
-      busy: updateInternalInterestsResponse.isLoading || updateGlobalRolesResponse.isLoading,
-      succeeded: updateInternalInterestsResponse.isSuccess && updateGlobalRolesResponse.isSuccess,
+      busy:
+        updateInternalInterestsResponse.isLoading ||
+        updateGlobalRolesResponse.isLoading ||
+        inviteGlobalRolesResponse.isLoading,
+      succeeded:
+        (updateGlobalRolesResponse.isSuccess || inviteGlobalRolesResponse.isSuccess) &&
+        updateInternalInterestsResponse.isSuccess,
       update,
+      invite,
     }),
-    [update, updateInternalInterestsResponse, updateGlobalRolesResponse]
+    [update, invite, updateInternalInterestsResponse, updateGlobalRolesResponse, inviteGlobalRolesResponse]
   );
 }

--- a/src/scenes/AcceleratorRouter/People/useUpdatePerson.tsx
+++ b/src/scenes/AcceleratorRouter/People/useUpdatePerson.tsx
@@ -75,7 +75,7 @@ export default function useUpdatePerson(): Response {
         inviteGlobalRolesResponse.isLoading,
       succeeded:
         (updateGlobalRolesResponse.isSuccess || inviteGlobalRolesResponse.isSuccess) &&
-        updateInternalInterestsResponse.isSuccess,
+        (updateInternalInterestsResponse.isSuccess || updateInternalInterestsResponse.isUninitialized),
       update,
       invite,
     }),


### PR DESCRIPTION
When adding a global roles user, if a user doesn't exist then send an invite for the user, and then add the global roles (performed by the BE during the invite) and internal interests after.

Co-authored-by: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)