### PR TITLE
Refactor splat ground plane

### DIFF
--- a/src/components/GaussianSplat/groundPlane.test.ts
+++ b/src/components/GaussianSplat/groundPlane.test.ts
@@ -1,0 +1,54 @@
+import { Vec3 } from 'playcanvas';
+
+import { computeGroundPlane, yOnPlane } from './groundPlane';
+
+describe('computeGroundPlane', () => {
+  it('returns an up normal for a flat horizontal plane', () => {
+    const plane = computeGroundPlane([new Vec3(0, 5, 0), new Vec3(1, 5, 0), new Vec3(0, 5, 1)]);
+    expect(plane).not.toBeNull();
+    expect(plane!.normal.x).toBeCloseTo(0);
+    expect(plane!.normal.y).toBeCloseTo(1);
+    expect(plane!.normal.z).toBeCloseTo(0);
+    expect(plane!.point.y).toBeCloseTo(5);
+  });
+
+  it('flips a downward-facing normal so normal.y >= 0', () => {
+    const plane = computeGroundPlane([new Vec3(0, 0, 0), new Vec3(0, 0, 1), new Vec3(1, 0, 0)]);
+    expect(plane).not.toBeNull();
+    expect(plane!.normal.y).toBeCloseTo(1);
+  });
+
+  it('computes a unit normal for a plane tilted 45deg about X (y = z)', () => {
+    const plane = computeGroundPlane([new Vec3(0, 0, 0), new Vec3(1, 0, 0), new Vec3(0, 1, 1)]);
+    expect(plane).not.toBeNull();
+    const n = plane!.normal;
+    expect(Math.sqrt(n.x * n.x + n.y * n.y + n.z * n.z)).toBeCloseTo(1);
+    expect(n.x).toBeCloseTo(0);
+    expect(n.y).toBeCloseTo(Math.SQRT1_2);
+    expect(n.z).toBeCloseTo(-Math.SQRT1_2);
+  });
+
+  it('returns null for fewer than 3 points', () => {
+    expect(computeGroundPlane([new Vec3(0, 0, 0), new Vec3(1, 0, 0)])).toBeNull();
+  });
+
+  it('returns null for collinear points', () => {
+    expect(computeGroundPlane([new Vec3(0, 0, 0), new Vec3(1, 0, 0), new Vec3(2, 0, 0)])).toBeNull();
+  });
+});
+
+describe('yOnPlane', () => {
+  it('returns the constant height on a flat plane', () => {
+    expect(yOnPlane(3, 7, new Vec3(0, 1, 0), new Vec3(0, 5, 0), -1)).toBeCloseTo(5);
+  });
+
+  it('interpolates height on a plane where y = z', () => {
+    const n = new Vec3(0, Math.SQRT1_2, -Math.SQRT1_2);
+    expect(yOnPlane(0, 2, n, new Vec3(0, 0, 0), 0)).toBeCloseTo(2);
+    expect(yOnPlane(10, -3, n, new Vec3(0, 0, 0), 0)).toBeCloseTo(-3);
+  });
+
+  it('returns the fallback when the normal is (near) horizontal', () => {
+    expect(yOnPlane(1, 1, new Vec3(1, 0, 0), new Vec3(0, 9, 0), 42)).toBe(42);
+  });
+});

--- a/src/components/GaussianSplat/groundPlane.ts
+++ b/src/components/GaussianSplat/groundPlane.ts
@@ -1,0 +1,47 @@
+import { Vec3 } from 'playcanvas';
+
+export type GroundPlane = { normal: Vec3; point: Vec3 };
+
+/** Compute Y on the plane defined by `normal` passing through `point` at world XZ coords (x, z). */
+export const yOnPlane = (x: number, z: number, normal: Vec3, point: Vec3, fallback: number): number => {
+  if (Math.abs(normal.y) < 1e-6) {
+    return fallback;
+  }
+  return point.y - (normal.x * (x - point.x) + normal.z * (z - point.z)) / normal.y;
+};
+
+/**
+ * Derive a ground plane from 3 world-space points.
+ * Returns a normalized normal (flipped so normal.y >= 0) and a point on the plane,
+ * or null when fewer than 3 points are supplied or they are degenerate/collinear.
+ */
+export const computeGroundPlane = (points: Vec3[]): GroundPlane | null => {
+  if (points.length < 3) {
+    return null;
+  }
+  const p0 = points[0];
+  const p1 = points[1];
+  const p2 = points[2];
+  const v1x = p1.x - p0.x;
+  const v1y = p1.y - p0.y;
+  const v1z = p1.z - p0.z;
+  const v2x = p2.x - p0.x;
+  const v2y = p2.y - p0.y;
+  const v2z = p2.z - p0.z;
+  let nx = v1y * v2z - v1z * v2y;
+  let ny = v1z * v2x - v1x * v2z;
+  let nz = v1x * v2y - v1y * v2x;
+  const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+  if (len < 1e-10) {
+    return null;
+  }
+  nx /= len;
+  ny /= len;
+  nz /= len;
+  if (ny < 0) {
+    nx = -nx;
+    ny = -ny;
+    nz = -nz;
+  }
+  return { normal: new Vec3(nx, ny, nz), point: new Vec3(p0.x, p0.y, p0.z) };
+};

--- a/src/components/GaussianSplat/walkthrough-camera.ts
+++ b/src/components/GaussianSplat/walkthrough-camera.ts
@@ -1,5 +1,7 @@
 import { Quat, Script, Vec3, math } from 'playcanvas';
 
+import { computeGroundPlane, yOnPlane } from 'src/components/GaussianSplat/groundPlane';
+
 /**
  * First-person walkthrough camera for Gaussian Splat scenes.
  *
@@ -16,14 +18,6 @@ import { Quat, Script, Vec3, math } from 'playcanvas';
 const _quat = new Quat();
 const _flatForward = new Vec3();
 const _flatRight = new Vec3();
-
-/** Compute Y on the plane defined by `normal` passing through `point` at world XZ coords (x, z). */
-const yOnPlane = (x: number, z: number, normal: Vec3, point: Vec3, fallback: number): number => {
-  if (Math.abs(normal.y) < 1e-6) {
-    return fallback;
-  }
-  return point.y - (normal.x * (x - point.x) + normal.z * (z - point.z)) / normal.y;
-};
 
 /** Frame-rate-independent damping lerp rate — matches PlayCanvas CameraControls. */
 const dampRate = (damping: number, dt: number) => 1 - Math.pow(damping, dt * 1000);
@@ -113,32 +107,12 @@ export class WalkthroughCamera extends Script {
     if (this._hasGroundPlane || this.groundPlane.length < 3) {
       return;
     }
-    const p0 = this.groundPlane[0];
-    const p1 = this.groundPlane[1];
-    const p2 = this.groundPlane[2];
-    const v1x = p1.x - p0.x;
-    const v1y = p1.y - p0.y;
-    const v1z = p1.z - p0.z;
-    const v2x = p2.x - p0.x;
-    const v2y = p2.y - p0.y;
-    const v2z = p2.z - p0.z;
-    let nx = v1y * v2z - v1z * v2y;
-    let ny = v1z * v2x - v1x * v2z;
-    let nz = v1x * v2y - v1y * v2x;
-    const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
-    if (len < 1e-10) {
+    const plane = computeGroundPlane(this.groundPlane);
+    if (!plane) {
       return;
     }
-    nx /= len;
-    ny /= len;
-    nz /= len;
-    if (ny < 0) {
-      nx = -nx;
-      ny = -ny;
-      nz = -nz;
-    }
-    this._planeNormal.set(nx, ny, nz);
-    this._planePoint.set(p0.x, p0.y, p0.z);
+    this._planeNormal.copy(plane.normal);
+    this._planePoint.copy(plane.point);
     this._hasGroundPlane = true;
   }
 


### PR DESCRIPTION
In preparation for the splat boundary ring which needs the ground plane methods, refactor the ground plane logic to be reusable and testable, and add tests for them. 

Co-Authored-By: Claude Opus 4.8 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>