### PR TITLE
SW-8682 Add splat boundary ring

### DIFF
--- a/src/components/GaussianSplat/BoundaryRing.tsx
+++ b/src/components/GaussianSplat/BoundaryRing.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect } from 'react';
+
+import { Entity } from '@playcanvas/react';
+import { Script } from '@playcanvas/react/components';
+import { useApp } from '@playcanvas/react/hooks';
+import { Vec3 } from 'playcanvas';
+
+import { BoundaryRingScript } from 'src/components/GaussianSplat/boundary-ring';
+
+export type BoundaryRingProps = {
+  center: Vec3;
+  radius: number;
+  groundPlane: Vec3[];
+};
+
+const BoundaryRing = ({ center, radius, groundPlane }: BoundaryRingProps) => {
+  const app = useApp();
+
+  useEffect(() => {
+    // Set imperatively rather than via reactive Script props. @playcanvas/react wraps Script
+    // in memo() whose shallowEquals returns early on the first prop with a .equals() method
+    // (Vec3), so any prop after a Vec3 is never compared and would not propagate. This mirrors
+    // the WalkthroughCamera.groundPlane workaround.
+    // @ts-expect-error - scripts are added dynamically to the entity
+    const script = app.root.findByName('boundary-ring')?.script?.boundaryRing;
+    if (script) {
+      script.center = center;
+      script.radius = radius;
+      script.groundPlane = groundPlane;
+    }
+  }, [app, center, radius, groundPlane]);
+
+  return (
+    <Entity name='boundary-ring'>
+      <Script script={BoundaryRingScript} />
+    </Entity>
+  );
+};
+
+export default BoundaryRing;

--- a/src/components/GaussianSplat/BoundaryRing.tsx
+++ b/src/components/GaussianSplat/BoundaryRing.tsx
@@ -19,14 +19,14 @@ const BoundaryRing = ({ center, radius, groundPlane }: BoundaryRingProps) => {
   useEffect(() => {
     // Set imperatively rather than via reactive Script props. @playcanvas/react wraps Script
     // in memo() whose shallowEquals returns early on the first prop with a .equals() method
-    // (Vec3), so any prop after a Vec3 is never compared and would not propagate. This mirrors
-    // the WalkthroughCamera.groundPlane workaround.
+    // (Vec3), so any prop after a Vec3 is never compared and would not propagate.
     // @ts-expect-error - scripts are added dynamically to the entity
     const script = app.root.findByName('boundary-ring')?.script?.boundaryRing;
     if (script) {
       script.center = center;
       script.radius = radius;
       script.groundPlane = groundPlane;
+      script.rebuild();
     }
   }, [app, center, radius, groundPlane]);
 

--- a/src/components/GaussianSplat/boundary-ring.test.ts
+++ b/src/components/GaussianSplat/boundary-ring.test.ts
@@ -1,0 +1,43 @@
+import { Vec3 } from 'playcanvas';
+
+import { boundaryRingSegments } from './boundary-ring';
+
+const FLAT = [new Vec3(0, 0, 0), new Vec3(1, 0, 0), new Vec3(0, 0, 1)];
+
+describe('boundaryRingSegments', () => {
+  it('produces one segment per dash', () => {
+    const segments = boundaryRingSegments({ center: new Vec3(0, 0, 0), radius: 5, groundPlane: FLAT, dashCount: 16 });
+    expect(segments).toHaveLength(16);
+  });
+
+  it('places every endpoint at the given radius from center in XZ', () => {
+    const center = new Vec3(2, 0, -3);
+    const radius = 4;
+    const segments = boundaryRingSegments({ center, radius, groundPlane: FLAT, dashCount: 32 });
+    for (const [p0, p1] of segments) {
+      for (const p of [p0, p1]) {
+        const dx = p.x - center.x;
+        const dz = p.z - center.z;
+        expect(Math.sqrt(dx * dx + dz * dz)).toBeCloseTo(radius);
+      }
+    }
+  });
+
+  it('lifts endpoints onto a tilted ground plane (y = z)', () => {
+    const tilted = [new Vec3(0, 0, 0), new Vec3(1, 0, 0), new Vec3(0, 1, 1)];
+    const segments = boundaryRingSegments({ center: new Vec3(0, 0, 0), radius: 3, groundPlane: tilted, dashCount: 8 });
+    for (const [p0, p1] of segments) {
+      expect(p0.y).toBeCloseTo(p0.z);
+      expect(p1.y).toBeCloseTo(p1.z);
+    }
+  });
+
+  it('returns no segments for a non-positive radius', () => {
+    expect(boundaryRingSegments({ center: new Vec3(0, 0, 0), radius: 0, groundPlane: FLAT })).toHaveLength(0);
+  });
+
+  it('returns no segments for an invalid ground plane', () => {
+    const collinear = [new Vec3(0, 0, 0), new Vec3(1, 0, 0), new Vec3(2, 0, 0)];
+    expect(boundaryRingSegments({ center: new Vec3(0, 0, 0), radius: 5, groundPlane: collinear })).toHaveLength(0);
+  });
+});

--- a/src/components/GaussianSplat/boundary-ring.test.ts
+++ b/src/components/GaussianSplat/boundary-ring.test.ts
@@ -1,43 +1,75 @@
 import { Vec3 } from 'playcanvas';
 
-import { boundaryRingSegments } from './boundary-ring';
+import { boundaryRingMesh } from './boundary-ring';
 
 const FLAT = [new Vec3(0, 0, 0), new Vec3(1, 0, 0), new Vec3(0, 0, 1)];
 
-describe('boundaryRingSegments', () => {
-  it('produces one segment per dash', () => {
-    const segments = boundaryRingSegments({ center: new Vec3(0, 0, 0), radius: 5, groundPlane: FLAT, dashCount: 16 });
-    expect(segments).toHaveLength(16);
+const toVertices = (positions: number[]): [number, number, number][] => {
+  const out: [number, number, number][] = [];
+  for (let i = 0; i < positions.length; i += 3) {
+    out.push([positions[i], positions[i + 1], positions[i + 2]]);
+  }
+  return out;
+};
+
+describe('boundaryRingMesh', () => {
+  it('produces four vertices and six indices per dash', () => {
+    const geom = boundaryRingMesh({ center: new Vec3(0, 0, 0), radius: 5, width: 0.1, groundPlane: FLAT, dashCount: 16 });
+    expect(geom.positions).toHaveLength(16 * 4 * 3);
+    expect(geom.indices).toHaveLength(16 * 6);
   });
 
-  it('places every endpoint at the given radius from center in XZ', () => {
+  it('places every vertex at the inner or outer radius from center in XZ', () => {
     const center = new Vec3(2, 0, -3);
     const radius = 4;
-    const segments = boundaryRingSegments({ center, radius, groundPlane: FLAT, dashCount: 32 });
-    for (const [p0, p1] of segments) {
-      for (const p of [p0, p1]) {
-        const dx = p.x - center.x;
-        const dz = p.z - center.z;
-        expect(Math.sqrt(dx * dx + dz * dz)).toBeCloseTo(radius);
-      }
+    const width = 0.2;
+    const inner = radius - width / 2;
+    const outer = radius + width / 2;
+    const geom = boundaryRingMesh({ center, radius, width, groundPlane: FLAT, dashCount: 32 });
+    for (const [x, , z] of toVertices(geom.positions)) {
+      const d = Math.sqrt((x - center.x) ** 2 + (z - center.z) ** 2);
+      const atInner = Math.abs(d - inner) < 1e-6;
+      const atOuter = Math.abs(d - outer) < 1e-6;
+      expect(atInner || atOuter).toBe(true);
     }
   });
 
-  it('lifts endpoints onto a tilted ground plane (y = z)', () => {
+  it('lifts every vertex onto a tilted ground plane (y = z)', () => {
     const tilted = [new Vec3(0, 0, 0), new Vec3(1, 0, 0), new Vec3(0, 1, 1)];
-    const segments = boundaryRingSegments({ center: new Vec3(0, 0, 0), radius: 3, groundPlane: tilted, dashCount: 8 });
-    for (const [p0, p1] of segments) {
-      expect(p0.y).toBeCloseTo(p0.z);
-      expect(p1.y).toBeCloseTo(p1.z);
+    const geom = boundaryRingMesh({ center: new Vec3(0, 0, 0), radius: 3, width: 0.1, groundPlane: tilted, dashCount: 8 });
+    for (const [, y, z] of toVertices(geom.positions)) {
+      expect(y).toBeCloseTo(z);
     }
   });
 
-  it('returns no segments for a non-positive radius', () => {
-    expect(boundaryRingSegments({ center: new Vec3(0, 0, 0), radius: 0, groundPlane: FLAT })).toHaveLength(0);
+  it('references only in-range vertices from the index buffer', () => {
+    const geom = boundaryRingMesh({ center: new Vec3(0, 0, 0), radius: 5, width: 0.1, groundPlane: FLAT, dashCount: 8 });
+    const vertexCount = geom.positions.length / 3;
+    for (const idx of geom.indices) {
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(idx).toBeLessThan(vertexCount);
+    }
   });
 
-  it('returns no segments for an invalid ground plane', () => {
+  it('returns empty geometry for a non-positive radius', () => {
+    const geom = boundaryRingMesh({ center: new Vec3(0, 0, 0), radius: 0, width: 0.1, groundPlane: FLAT });
+    expect(geom.positions).toHaveLength(0);
+    expect(geom.indices).toHaveLength(0);
+  });
+
+  it('returns empty geometry for a non-positive width', () => {
+    const geom = boundaryRingMesh({ center: new Vec3(0, 0, 0), radius: 5, width: 0, groundPlane: FLAT });
+    expect(geom.positions).toHaveLength(0);
+  });
+
+  it('returns empty geometry for a non-positive dashCount', () => {
+    const geom = boundaryRingMesh({ center: new Vec3(0, 0, 0), radius: 5, width: 0.1, groundPlane: FLAT, dashCount: 0 });
+    expect(geom.positions).toHaveLength(0);
+  });
+
+  it('returns empty geometry for an invalid ground plane', () => {
     const collinear = [new Vec3(0, 0, 0), new Vec3(1, 0, 0), new Vec3(2, 0, 0)];
-    expect(boundaryRingSegments({ center: new Vec3(0, 0, 0), radius: 5, groundPlane: collinear })).toHaveLength(0);
+    const geom = boundaryRingMesh({ center: new Vec3(0, 0, 0), radius: 5, width: 0.1, groundPlane: collinear });
+    expect(geom.positions).toHaveLength(0);
   });
 });

--- a/src/components/GaussianSplat/boundary-ring.ts
+++ b/src/components/GaussianSplat/boundary-ring.ts
@@ -1,0 +1,78 @@
+import { Color, Script, Vec3 } from 'playcanvas';
+
+import { computeGroundPlane, yOnPlane } from 'src/components/GaussianSplat/groundPlane';
+
+export type BoundaryRingParams = {
+  center: Vec3;
+  radius: number;
+  groundPlane: Vec3[];
+  dashCount?: number;
+  dashRatio?: number;
+};
+
+/**
+ * Endpoint pairs of the "on" dashes of a boundary ring laid on the ground plane.
+ * Each dash is one straight segment spanning `dashRatio` of the angular step between dashes;
+ * both endpoints are sampled on the circle (center XZ + radius) and lifted onto the plane.
+ * Returns an empty array when the radius is non-positive, dashCount is non-positive,
+ * or the ground plane is invalid.
+ */
+export const boundaryRingSegments = ({
+  center,
+  radius,
+  groundPlane,
+  dashCount = 64,
+  dashRatio = 0.5,
+}: BoundaryRingParams): [Vec3, Vec3][] => {
+  const plane = computeGroundPlane(groundPlane);
+  if (radius <= 0 || dashCount <= 0 || !plane) {
+    return [];
+  }
+  const segments: [Vec3, Vec3][] = [];
+  const step = (Math.PI * 2) / dashCount;
+  const on = step * dashRatio;
+  for (let i = 0; i < dashCount; i++) {
+    const a0 = i * step;
+    const a1 = a0 + on;
+    const x0 = center.x + radius * Math.cos(a0);
+    const z0 = center.z + radius * Math.sin(a0);
+    const x1 = center.x + radius * Math.cos(a1);
+    const z1 = center.z + radius * Math.sin(a1);
+    const p0 = new Vec3(x0, yOnPlane(x0, z0, plane.normal, plane.point, center.y), z0);
+    const p1 = new Vec3(x1, yOnPlane(x1, z1, plane.normal, plane.point, center.y), z1);
+    segments.push([p0, p1]);
+  }
+  return segments;
+};
+
+/**
+ * Immediate-mode Script that draws a dashed boundary ring on the ground plane every frame.
+ * center / radius / groundPlane are set imperatively by the BoundaryRing component
+ * (see BoundaryRing.tsx for why they are not reactive Script props).
+ */
+export class BoundaryRingScript extends Script {
+  static scriptName = 'boundaryRing';
+
+  center = new Vec3();
+  radius = 0;
+  groundPlane: Vec3[] = [];
+  color = new Color(1, 1, 1);
+  dashCount = 64;
+  dashRatio = 0.5;
+
+  update() {
+    if (this.radius <= 0 || this.groundPlane.length < 3) {
+      return;
+    }
+    const segments = boundaryRingSegments({
+      center: this.center,
+      radius: this.radius,
+      groundPlane: this.groundPlane,
+      dashCount: this.dashCount,
+      dashRatio: this.dashRatio,
+    });
+    for (const [p0, p1] of segments) {
+      this.app.drawLine(p0, p1, this.color);
+    }
+  }
+}

--- a/src/components/GaussianSplat/boundary-ring.ts
+++ b/src/components/GaussianSplat/boundary-ring.ts
@@ -1,54 +1,82 @@
-import { Color, Script, Vec3 } from 'playcanvas';
+import {
+  CULLFACE_NONE,
+  Color,
+  LAYERID_IMMEDIATE,
+  Mesh,
+  MeshInstance,
+  Script,
+  StandardMaterial,
+  Vec3,
+} from 'playcanvas';
 
 import { computeGroundPlane, yOnPlane } from 'src/components/GaussianSplat/groundPlane';
 
-export type BoundaryRingParams = {
+export type BoundaryRingGeometryParams = {
   center: Vec3;
   radius: number;
   groundPlane: Vec3[];
+  /** Band width in world units (the ring spans radius ± width / 2). */
+  width: number;
   dashCount?: number;
   dashRatio?: number;
 };
 
+/** Flat-array triangle geometry ready for `Mesh.setPositions` / `Mesh.setIndices`. */
+export type BoundaryRingGeometry = { positions: number[]; indices: number[] };
+
 /**
- * Endpoint pairs of the "on" dashes of a boundary ring laid on the ground plane.
- * Each dash is one straight segment spanning `dashRatio` of the angular step between dashes;
- * both endpoints are sampled on the circle (center XZ + radius) and lifted onto the plane.
- * Returns an empty array when the radius is non-positive, dashCount is non-positive,
- * or the ground plane is invalid.
+ * Triangle geometry for a dashed boundary ring laid flat on the ground plane. Each dash is a
+ * short band (a quad = two triangles) sweeping from `radius - width / 2` to `radius + width / 2`;
+ * every vertex is sampled on the circle in XZ and lifted onto the plane via `yOnPlane`.
+ * Returns empty arrays when radius, width, or dashCount is non-positive, or the plane is invalid.
  */
-export const boundaryRingSegments = ({
+export const boundaryRingMesh = ({
   center,
   radius,
   groundPlane,
+  width,
   dashCount = 64,
   dashRatio = 0.5,
-}: BoundaryRingParams): [Vec3, Vec3][] => {
+}: BoundaryRingGeometryParams): BoundaryRingGeometry => {
   const plane = computeGroundPlane(groundPlane);
-  if (radius <= 0 || dashCount <= 0 || !plane) {
-    return [];
+  if (radius <= 0 || width <= 0 || dashCount <= 0 || !plane) {
+    return { positions: [], indices: [] };
   }
-  const segments: [Vec3, Vec3][] = [];
+
+  const innerR = radius - width / 2;
+  const outerR = radius + width / 2;
   const step = (Math.PI * 2) / dashCount;
   const on = step * dashRatio;
+  const positions: number[] = [];
+  const indices: number[] = [];
+
+  const pushVertex = (r: number, angle: number) => {
+    const x = center.x + r * Math.cos(angle);
+    const z = center.z + r * Math.sin(angle);
+    positions.push(x, yOnPlane(x, z, plane.normal, plane.point, center.y), z);
+  };
+
   for (let i = 0; i < dashCount; i++) {
     const a0 = i * step;
     const a1 = a0 + on;
-    const x0 = center.x + radius * Math.cos(a0);
-    const z0 = center.z + radius * Math.sin(a0);
-    const x1 = center.x + radius * Math.cos(a1);
-    const z1 = center.z + radius * Math.sin(a1);
-    const p0 = new Vec3(x0, yOnPlane(x0, z0, plane.normal, plane.point, center.y), z0);
-    const p1 = new Vec3(x1, yOnPlane(x1, z1, plane.normal, plane.point, center.y), z1);
-    segments.push([p0, p1]);
+    const base = i * 4;
+    // Per dash: v0 inner@a0, v1 outer@a0, v2 inner@a1, v3 outer@a1.
+    pushVertex(innerR, a0);
+    pushVertex(outerR, a0);
+    pushVertex(innerR, a1);
+    pushVertex(outerR, a1);
+    indices.push(base, base + 1, base + 3, base, base + 3, base + 2);
   }
-  return segments;
+
+  return { positions, indices };
 };
 
 /**
- * Immediate-mode Script that draws a dashed boundary ring on the ground plane every frame.
- * center / radius / groundPlane are set imperatively by the BoundaryRing component
- * (see BoundaryRing.tsx for why they are not reactive Script props).
+ * Draws a dashed boundary ring as a flat band mesh on the ground plane.
+ *
+ * Rendered as a thin triangle band whose width is a fraction of the radius (`widthRatio`).
+ * center / radius / groundPlane are set imperatively by the BoundaryRing component (see BoundaryRing.tsx for why
+ * they are not reactive Script props), which calls `rebuild()` after updating them.
  */
 export class BoundaryRingScript extends Script {
   static scriptName = 'boundaryRing';
@@ -59,20 +87,66 @@ export class BoundaryRingScript extends Script {
   color = new Color(1, 1, 1);
   dashCount = 64;
   dashRatio = 0.5;
+  /** Band width as a fraction of the radius. */
+  widthRatio = 0.05;
 
-  update() {
-    if (this.radius <= 0 || this.groundPlane.length < 3) {
-      return;
-    }
-    const segments = boundaryRingSegments({
+  private _material?: StandardMaterial;
+  private _mesh?: Mesh;
+
+  initialize() {
+    const material = new StandardMaterial();
+    material.useLighting = false;
+    material.emissive = this.color;
+    material.cull = CULLFACE_NONE;
+    material.update();
+    this._material = material;
+    this.rebuild();
+  }
+
+  rebuild() {
+    this._clearMesh();
+
+    const geometry = boundaryRingMesh({
       center: this.center,
       radius: this.radius,
       groundPlane: this.groundPlane,
+      width: this.radius * this.widthRatio,
       dashCount: this.dashCount,
       dashRatio: this.dashRatio,
     });
-    for (const [p0, p1] of segments) {
-      this.app.drawLine(p0, p1, this.color);
+    if (geometry.positions.length === 0 || !this._material) {
+      return;
     }
+
+    const mesh = new Mesh(this.app.graphicsDevice);
+    mesh.setPositions(geometry.positions);
+    mesh.setIndices(geometry.indices);
+    mesh.update();
+    this._mesh = mesh;
+
+    const meshInstance = new MeshInstance(mesh, this._material);
+    if (this.entity.render) {
+      this.entity.render.meshInstances = [meshInstance];
+    } else {
+      // Render on the Immediate layer (drawn after the World layer where the splats render) so
+      // the ring is not composited behind them.
+      this.entity.addComponent('render', { meshInstances: [meshInstance], layers: [LAYERID_IMMEDIATE] });
+    }
+  }
+
+  private _clearMesh() {
+    if (this.entity.render) {
+      this.entity.render.meshInstances = [];
+    }
+    if (this._mesh) {
+      this._mesh.destroy();
+      this._mesh = undefined;
+    }
+  }
+
+  destroy() {
+    this._clearMesh();
+    this._material?.destroy();
+    this._material = undefined;
   }
 }

--- a/src/scenes/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/scenes/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -8,6 +8,7 @@ import { XrControllers } from 'playcanvas/scripts/esm/xr-controllers.mjs';
 
 import Annotation, { AnnotationProps } from 'src/components/GaussianSplat/Annotation';
 import { AutoRotator } from 'src/components/GaussianSplat/AutoRotator';
+import BoundaryRing from 'src/components/GaussianSplat/BoundaryRing';
 import GradientSky from 'src/components/GaussianSplat/GradientSky';
 import SplatControls from 'src/components/GaussianSplat/SplatControls';
 import SplatModel from 'src/components/GaussianSplat/SplatModel';
@@ -317,6 +318,10 @@ const VirtualWalkthroughViewer = ({
       </Entity>
 
       {splatModel}
+
+      {data?.sceneBounds?.m !== undefined && groundPlane.length === 3 && (
+        <BoundaryRing center={sceneBoundsCenter} radius={sceneBoundsRadius} groundPlane={groundPlane} />
+      )}
 
       {localAnnotations.length > 0 && (
         <Entity name='annotations-root'>


### PR DESCRIPTION
Add a boundary ring to splat viewing to indicate to the user the edge of the movable area.

Co-Authored-By: Claude Opus 4.8 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>