### PR TITLE
Prevent dev env data from polluting RUM

### DIFF
--- a/src/setupRum.ts
+++ b/src/setupRum.ts
@@ -9,7 +9,7 @@ const applicationId = import.meta.env.PUBLIC_DATADOG_APP_ID;
 const clientToken = import.meta.env.PUBLIC_DATADOG_CLIENT_TOKEN;
 
 export const canEnableRum = (): boolean => {
-  return !(tier === 'test' || !appVersion || !applicationId || !clientToken);
+  return !(tier === 'test' || tier === 'dev' || !appVersion || !applicationId || !clientToken);
 };
 
 const setupRum = () => {


### PR DESCRIPTION
We don't have datadog keys set in our dev env, but at least once recently someone did for some testing and it ended up polluting our data.