### PR TITLE
SW-7734 Migrate SeedFund report reads to RTK Query

### DIFF
--- a/src/components/SeedFundReports/ReportEdit.tsx
+++ b/src/components/SeedFundReports/ReportEdit.tsx
@@ -17,11 +17,12 @@ import SubmitConfirmationDialog from 'src/components/SeedFundReports/SubmitConfi
 import PageForm from 'src/components/common/PageForm';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import useSeedFundReport from 'src/hooks/useSeedFundReport';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization, useUser } from 'src/providers';
 import SeedFundReportService from 'src/services/SeedFundReportService';
 import strings from 'src/strings';
-import { Report, ReportFile } from 'src/types/Report';
+import { SeedFundReport, SeedFundReportFile } from 'src/types/SeedFundReport';
 import { overWordLimit } from 'src/utils/text';
 import useSnackbar from 'src/utils/useSnackbar';
 
@@ -40,12 +41,12 @@ export default function ReportEdit(): JSX.Element {
   const [showInvalidUserModal, setShowInvalidUserModal] = useState(false);
   const [photos, setPhotos] = useState<File[]>([]);
   const [photoIdsToRemove, setPhotoIdsToRemove] = useState<number[]>([]);
-  const [report, setReport] = useState<Report>();
+  const [report, setReport] = useState<SeedFundReport>();
   const [validateFields, setValidateFields] = useState(false);
   const [busyState, setBusyState] = useState(false);
   const [idInView, setIdInView] = useState('');
   const [newReportFiles, setNewReportFiles] = useState<File[]>([]);
-  const [updatedReportFiles, setUpdatedReportFiles] = useState<ReportFile[]>([]);
+  const [updatedReportFiles, setUpdatedReportFiles] = useState<SeedFundReportFile[]>([]);
   const [showAnnual, setShowAnnual] = useState(false);
   const [confirmSubmitDialogOpen, setConfirmSubmitDialogOpen] = useState(false);
   const [currentUserEditing, setCurrentUserEditing] = useState(true);
@@ -54,6 +55,8 @@ export default function ReportEdit(): JSX.Element {
 
   const reportIdInt = reportId ? parseInt(reportId, 10) : -1;
   const reportName = `Report (${report?.year}-Q${report?.quarter}) ` + (report?.projectName ?? '');
+
+  const { report: loadedReport, isError, reload } = useSeedFundReport(reportIdInt);
 
   useEffect(() => {
     const el = document.getElementById(idInView);
@@ -66,23 +69,16 @@ export default function ReportEdit(): JSX.Element {
   const reportIdValid = useCallback(() => reportIdInt && reportIdInt !== -1, [reportIdInt]);
 
   useEffect(() => {
-    const getReport = async () => {
-      if (reportIdValid()) {
-        const result = await SeedFundReportService.getReport(reportIdInt);
-        if (result.requestSucceeded && result.report) {
-          setReport(result.report);
-        } else {
-          snackbar.toastError(strings.GENERIC_ERROR, strings.REPORT_COULD_NOT_OPEN);
-        }
-      }
-    };
+    if (loadedReport && !report) {
+      setReport(loadedReport);
+    }
+  }, [loadedReport, report]);
 
-    if (reportIdInt) {
-      void getReport();
-    } else {
+  useEffect(() => {
+    if (isError) {
       snackbar.toastError(strings.GENERIC_ERROR, strings.REPORT_COULD_NOT_OPEN);
     }
-  }, [reportIdInt, snackbar, reportIdValid]);
+  }, [isError, snackbar]);
 
   const updateFiles = async () => {
     if (reportIdValid()) {
@@ -99,22 +95,20 @@ export default function ReportEdit(): JSX.Element {
   };
 
   useEffect(() => {
-    const getReport = async () => {
-      if (reportIdInt && reportIdInt !== -1) {
-        const result = await SeedFundReportService.getReport(reportIdInt);
-        if (result.requestSucceeded && result.report) {
-          setCurrentUserEditing(result.report.lockedByUserId === user?.id);
-        }
+    const checkLockOwner = async () => {
+      const latest = await reload();
+      if (latest) {
+        setCurrentUserEditing(latest.lockedByUserId === user?.id);
       }
     };
 
-    const interval = setInterval(() => void getReport(), 60000);
+    const interval = setInterval(() => void checkLockOwner(), 60000);
 
     // Clean up existing interval.
     return () => {
       clearInterval(interval);
     };
-  }, [reportIdInt, user?.id]);
+  }, [reload, user?.id]);
 
   useEffect(() => {
     if (report && user && !currentUserEditing && !showInvalidUserModal) {
@@ -219,7 +213,7 @@ export default function ReportEdit(): JSX.Element {
     };
   }, [snackbar]);
 
-  const hasEmptyRequiredFields = (iReport: Report) => {
+  const hasEmptyRequiredFields = (iReport: SeedFundReport) => {
     if (!iReport.summaryOfProgress) {
       return 'summary-of-progress';
     }
@@ -290,7 +284,7 @@ export default function ReportEdit(): JSX.Element {
     return '';
   };
 
-  const hasEmptyRequiredAnnualFields = (iReport: Report) => {
+  const hasEmptyRequiredAnnualFields = (iReport: SeedFundReport) => {
     if (!iReport.isAnnual) {
       return '';
     }
@@ -376,7 +370,7 @@ export default function ReportEdit(): JSX.Element {
     setNewReportFiles(filesList);
   };
 
-  const onExistingFilesChanged = (filesList: ReportFile[]) => {
+  const onExistingFilesChanged = (filesList: SeedFundReportFile[]) => {
     setUpdatedReportFiles(filesList);
   };
 

--- a/src/components/SeedFundReports/ReportList.tsx
+++ b/src/components/SeedFundReports/ReportList.tsx
@@ -1,4 +1,4 @@
-import React, { type JSX, useEffect, useRef, useState } from 'react';
+import React, { type JSX, useRef } from 'react';
 
 import { Grid, Typography } from '@mui/material';
 import { TableColumnType } from '@terraware/web-components';
@@ -6,10 +6,9 @@ import { TableColumnType } from '@terraware/web-components';
 import Card from 'src/components/common/Card';
 import TfMain from 'src/components/common/TfMain';
 import Table from 'src/components/common/table';
+import useSeedFundReports from 'src/hooks/useSeedFundReports';
 import { useOrganization } from 'src/providers';
-import SeedFundReportService from 'src/services/SeedFundReportService';
 import strings from 'src/strings';
-import { ListReport } from 'src/types/Report';
 
 import PageHeaderWrapper from '../common/PageHeaderWrapper';
 import ReportsCellRenderer from './TableCellRenderer';
@@ -24,19 +23,9 @@ const columns = (): TableColumnType[] => [
 
 export default function ReportList(): JSX.Element {
   const contentRef = useRef(null);
-  const [results, setResults] = useState<ListReport[]>([]);
   const { selectedOrganization } = useOrganization();
 
-  useEffect(() => {
-    if (selectedOrganization) {
-      const refreshSearch = async () => {
-        const reportsResults = await SeedFundReportService.getReports(selectedOrganization.id);
-        setResults(reportsResults.reports || []);
-      };
-
-      void refreshSearch();
-    }
-  }, [selectedOrganization]);
+  const { reports: results } = useSeedFundReports(selectedOrganization?.id);
 
   return (
     <TfMain>

--- a/src/components/SeedFundReports/ReportSettingsEdit.tsx
+++ b/src/components/SeedFundReports/ReportSettingsEdit.tsx
@@ -1,26 +1,17 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import PageHeader from 'src/components/PageHeader';
 import TfMain from 'src/components/common/TfMain';
+import useSeedFundReportSettings from 'src/hooks/useSeedFundReportSettings';
 import { useOrganization } from 'src/providers';
-import { selectReportsSettings } from 'src/redux/features/reportsSettings/reportsSettingsSelectors';
-import { requestReportsSettings } from 'src/redux/features/reportsSettings/reportsSettingsThunks';
-import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 
 import ReportSettingsEditForm from './ReportSettingsEditForm';
 
 const ReportSettingsEdit = () => {
-  const dispatch = useAppDispatch();
   const { selectedOrganization } = useOrganization();
 
-  const reportsSettings = useAppSelector(selectReportsSettings);
-
-  useEffect(() => {
-    if (!reportsSettings && selectedOrganization) {
-      void dispatch(requestReportsSettings(selectedOrganization.id));
-    }
-  }, [dispatch, reportsSettings, selectedOrganization]);
+  const { settings: reportsSettings } = useSeedFundReportSettings(selectedOrganization?.id);
 
   return (
     <TfMain>

--- a/src/components/SeedFundReports/ReportView.tsx
+++ b/src/components/SeedFundReports/ReportView.tsx
@@ -10,10 +10,10 @@ import useReportFiles from 'src/components/SeedFundReports/useReportFiles';
 import BackToLink from 'src/components/common/BackToLink';
 import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
+import useSeedFundReport from 'src/hooks/useSeedFundReport';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import SeedFundReportService from 'src/services/SeedFundReportService';
 import strings from 'src/strings';
-import { Report } from 'src/types/Report';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import useSnackbar from 'src/utils/useSnackbar';
 
@@ -28,31 +28,24 @@ export default function ReportView(): JSX.Element {
 
   const snackbar = useSnackbar();
 
-  const [report, setReport] = useState<Report>();
   const [showAnnual, setShowAnnual] = useState(false);
   const [confirmEditDialogOpen, setConfirmEditDialogOpen] = useState(false);
 
+  const reportIdInt = reportId ? parseInt(reportId, 10) : -1;
+
+  const { report, isError } = useSeedFundReport(reportIdInt);
+
   const initialReportFiles = useReportFiles(report);
 
-  const reportIdInt = reportId ? parseInt(reportId, 10) : -1;
   const reportName = `Report (${report?.year}-Q${report?.quarter}) ` + (report?.projectName ?? '');
 
   const reportIdValid = useCallback(() => reportIdInt && reportIdInt !== -1, [reportIdInt]);
 
   useEffect(() => {
-    const getReport = async () => {
-      const result = await SeedFundReportService.getReport(reportIdInt);
-      if (result.requestSucceeded) {
-        setReport(result.report);
-      } else {
-        snackbar.toastError(strings.GENERIC_ERROR, strings.REPORT_COULD_NOT_OPEN);
-      }
-    };
-
-    if (reportIdValid()) {
-      void getReport();
+    if (isError) {
+      snackbar.toastError(strings.GENERIC_ERROR, strings.REPORT_COULD_NOT_OPEN);
     }
-  }, [reportIdInt, snackbar, reportIdValid]);
+  }, [isError, snackbar]);
 
   const confirmEdit = async () => {
     // lock the report

--- a/src/components/SeedFundReports/ReportsView.tsx
+++ b/src/components/SeedFundReports/ReportsView.tsx
@@ -1,4 +1,4 @@
-import React, { type JSX, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { type JSX, useCallback, useMemo, useRef, useState } from 'react';
 
 import { Box, Container, Grid, List, ListItem, Typography, useTheme } from '@mui/material';
 import { Message, TableColumnType, Tabs } from '@terraware/web-components';
@@ -11,14 +11,12 @@ import ReportsCellRenderer from 'src/components/SeedFundReports/TableCellRendere
 import TfMain from 'src/components/common/TfMain';
 import Table from 'src/components/common/table';
 import { APP_PATHS } from 'src/constants';
+import useSeedFundReportSettings from 'src/hooks/useSeedFundReportSettings';
+import useSeedFundReports from 'src/hooks/useSeedFundReports';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers';
-import { selectReportsSettings } from 'src/redux/features/reportsSettings/reportsSettingsSelectors';
-import { requestReportsSettings } from 'src/redux/features/reportsSettings/reportsSettingsThunks';
-import { useAppDispatch, useAppSelector } from 'src/redux/store';
-import SeedFundReportService from 'src/services/SeedFundReportService';
 import strings from 'src/strings';
-import { ListReport } from 'src/types/Report';
+import { SeedFundReportListElement } from 'src/types/SeedFundReport';
 
 import ReportSettingsEditFormFields from './ReportSettingsEditFormFields';
 
@@ -40,17 +38,28 @@ interface ReportsViewProps {
 export default function ReportsView(props: ReportsViewProps): JSX.Element {
   const tab = props.tab || DEFAULT_TAB;
 
-  const dispatch = useAppDispatch();
   const contentRef = useRef(null);
   const { selectedOrganization } = useOrganization();
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
   const navigate = useSyncNavigate();
 
-  const reportsSettings = useAppSelector(selectReportsSettings);
+  const { settings: reportsSettings } = useSeedFundReportSettings(selectedOrganization?.id);
+  const { reports } = useSeedFundReports(selectedOrganization?.id);
 
   const [activeTab, setActiveTab] = useState<string>(tab);
-  const [results, setResults] = useState<(ListReport & { organizationName?: string })[]>([]);
+
+  const results: (SeedFundReportListElement & { organizationName?: string })[] = useMemo(
+    () =>
+      reports.map((report) => {
+        if (report.projectName) {
+          return report;
+        }
+        // Reports without a project name are for the organization
+        return { ...report, organizationName: selectedOrganization?.name };
+      }),
+    [reports, selectedOrganization?.name]
+  );
 
   const onChangeTab = useCallback(
     (newTab: string) => {
@@ -68,31 +77,6 @@ export default function ReportsView(props: ReportsViewProps): JSX.Element {
     },
     [navigate]
   );
-
-  useEffect(() => {
-    if (selectedOrganization) {
-      void dispatch(requestReportsSettings(selectedOrganization.id));
-    }
-  }, [dispatch, selectedOrganization]);
-
-  useEffect(() => {
-    if (selectedOrganization) {
-      const refreshSearch = async () => {
-        const reportsResults = await SeedFundReportService.getReports(selectedOrganization.id);
-        setResults(
-          (reportsResults.reports || []).map((report) => {
-            if (report.projectName) {
-              return report;
-            }
-            // Reports without a project name are for the organization
-            return { ...report, organizationName: selectedOrganization.name };
-          })
-        );
-      };
-
-      void refreshSearch();
-    }
-  }, [selectedOrganization]);
 
   const reportsToComplete = useMemo(() => results.filter((report) => report.status !== 'Submitted'), [results]);
 

--- a/src/hooks/useSeedFundReport.ts
+++ b/src/hooks/useSeedFundReport.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect } from 'react';
+
+import { useLazyGetReportQuery } from 'src/queries/generated/seedFundReports';
+
+/**
+ * Loads a single SeedFund report. Auto-fires when a valid reportId is provided and exposes a
+ * `reload` trigger for imperative refreshes (e.g. polling the lock owner).
+ */
+const useSeedFundReport = (reportId?: number) => {
+  const [trigger, response] = useLazyGetReportQuery();
+
+  const isValid = reportId !== undefined && reportId > 0;
+
+  useEffect(() => {
+    if (reportId !== undefined && reportId > 0) {
+      void trigger(reportId, true);
+    }
+  }, [trigger, reportId]);
+
+  const report = isValid ? response.currentData?.report : undefined;
+
+  const reload = useCallback(async () => {
+    if (reportId === undefined || reportId <= 0) {
+      return undefined;
+    }
+    const result = await trigger(reportId, false).unwrap();
+    return result.report;
+  }, [trigger, reportId]);
+
+  return { report, isLoading: response.isFetching, isError: response.isError, reload };
+};
+
+export default useSeedFundReport;

--- a/src/hooks/useSeedFundReport.ts
+++ b/src/hooks/useSeedFundReport.ts
@@ -9,15 +9,18 @@ import { useLazyGetReportQuery } from 'src/queries/generated/seedFundReports';
 const useSeedFundReport = (reportId?: number) => {
   const [getReport, response] = useLazyGetReportQuery();
 
-  const isValid = useMemo(() => reportId !== undefined && reportId > 0, []);
+  const isValid = useMemo(() => reportId !== undefined && reportId > 0, [reportId]);
 
   useEffect(() => {
     if (isValid) {
       void getReport(reportId!, true);
     }
-  }, [getReport, reportId]);
+  }, [getReport, isValid, reportId]);
 
-  const report = isValid ? response.currentData?.report : undefined;
+  const report = useMemo(
+    () => (isValid ? response.currentData?.report : undefined),
+    [isValid, response.currentData?.report]
+  );
 
   const reload = useCallback(async () => {
     if (isValid) {
@@ -25,7 +28,7 @@ const useSeedFundReport = (reportId?: number) => {
     }
     const result = await getReport(reportId!, false).unwrap();
     return result.report;
-  }, [getReport, reportId]);
+  }, [isValid, getReport, reportId]);
 
   return { report, isLoading: response.isFetching, isError: response.isError, reload };
 };

--- a/src/hooks/useSeedFundReport.ts
+++ b/src/hooks/useSeedFundReport.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
 import { useLazyGetReportQuery } from 'src/queries/generated/seedFundReports';
 
@@ -7,25 +7,25 @@ import { useLazyGetReportQuery } from 'src/queries/generated/seedFundReports';
  * `reload` trigger for imperative refreshes (e.g. polling the lock owner).
  */
 const useSeedFundReport = (reportId?: number) => {
-  const [trigger, response] = useLazyGetReportQuery();
+  const [getReport, response] = useLazyGetReportQuery();
 
-  const isValid = reportId !== undefined && reportId > 0;
+  const isValid = useMemo(() => reportId !== undefined && reportId > 0, []);
 
   useEffect(() => {
-    if (reportId !== undefined && reportId > 0) {
-      void trigger(reportId, true);
+    if (isValid) {
+      void getReport(reportId!, true);
     }
-  }, [trigger, reportId]);
+  }, [getReport, reportId]);
 
   const report = isValid ? response.currentData?.report : undefined;
 
   const reload = useCallback(async () => {
-    if (reportId === undefined || reportId <= 0) {
+    if (isValid) {
       return undefined;
     }
-    const result = await trigger(reportId, false).unwrap();
+    const result = await getReport(reportId!, false).unwrap();
     return result.report;
-  }, [trigger, reportId]);
+  }, [getReport, reportId]);
 
   return { report, isLoading: response.isFetching, isError: response.isError, reload };
 };

--- a/src/hooks/useSeedFundReport.ts
+++ b/src/hooks/useSeedFundReport.ts
@@ -23,7 +23,7 @@ const useSeedFundReport = (reportId?: number) => {
   );
 
   const reload = useCallback(async () => {
-    if (isValid) {
+    if (!isValid) {
       return undefined;
     }
     const result = await getReport(reportId!, false).unwrap();

--- a/src/hooks/useSeedFundReportSettings.ts
+++ b/src/hooks/useSeedFundReportSettings.ts
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+
+import { useGetReportSettingsQuery } from 'src/queries/generated/seedFundReports';
+import { SeedFundReportsSettings } from 'src/types/SeedFundReport';
+
+/**
+ * Loads the SeedFund report settings for an organization.
+ */
+const useSeedFundReportSettings = (organizationId?: number) => {
+  const response = useGetReportSettingsQuery(organizationId as number, { skip: organizationId === undefined });
+
+  const settings: SeedFundReportsSettings | undefined = useMemo(() => {
+    if (!response.currentData) {
+      return undefined;
+    }
+    const { isConfigured, organizationEnabled, projects } = response.currentData;
+    return { isConfigured, organizationEnabled, projects };
+  }, [response.currentData]);
+
+  return { settings, isLoading: response.isFetching, isError: response.isError };
+};
+
+export default useSeedFundReportSettings;

--- a/src/hooks/useSeedFundReports.ts
+++ b/src/hooks/useSeedFundReports.ts
@@ -1,0 +1,20 @@
+import { useMemo } from 'react';
+
+import { useListReportsQuery } from 'src/queries/generated/seedFundReports';
+import { SeedFundReportListElement } from 'src/types/SeedFundReport';
+
+/**
+ * Lists the SeedFund reports for an organization.
+ */
+const useSeedFundReports = (organizationId?: number) => {
+  const response = useListReportsQuery(organizationId as number, { skip: organizationId === undefined });
+
+  const reports: SeedFundReportListElement[] = useMemo(
+    () => response.currentData?.reports ?? [],
+    [response.currentData]
+  );
+
+  return { reports, isLoading: response.isFetching, isError: response.isError };
+};
+
+export default useSeedFundReports;


### PR DESCRIPTION
Add the read hooks (useSeedFundReport, useSeedFundReports,
useSeedFundReportSettings) and switch the report list, reports view,
and settings views off SeedFundReportService/redux onto the new
queries. ReportView and ReportEdit migrate their report load (and the
lock-owner poll) to useSeedFundReport; their write paths still use the
old service and are migrated in later branches.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>