### PR TITLE
SW-7734 Migrate SeedFund report file CRUD to RTK Query

### DIFF
--- a/src/components/SeedFundReports/ReportEdit.tsx
+++ b/src/components/SeedFundReports/ReportEdit.tsx
@@ -21,6 +21,7 @@ import useSeedFundReport from 'src/hooks/useSeedFundReport';
 import useSeedFundReportActions from 'src/hooks/useSeedFundReportActions';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization, useUser } from 'src/providers';
+import { useBatchSeedFundReportFilesMutation } from 'src/queries/seedFundReports/files';
 import SeedFundReportService from 'src/services/SeedFundReportService';
 import strings from 'src/strings';
 import { SeedFundReport, SeedFundReportFile } from 'src/types/SeedFundReport';
@@ -57,7 +58,11 @@ export default function ReportEdit(): JSX.Element {
   const reportName = `Report (${report?.year}-Q${report?.quarter}) ` + (report?.projectName ?? '');
 
   const { report: loadedReport, isError, reload } = useSeedFundReport(reportIdInt);
-  const { onUpdate, unlockReport, onSubmit, isLoading: busyState } = useSeedFundReportActions();
+
+  const { onUpdate, unlockReport, onSubmit, isLoading: reportActionInProgress } = useSeedFundReportActions();
+  const [batchFiles, batchFilesResult] = useBatchSeedFundReportFilesMutation();
+
+  const busyState = reportActionInProgress || batchFilesResult.isLoading;
 
   useEffect(() => {
     const el = document.getElementById(idInView);
@@ -83,15 +88,14 @@ export default function ReportEdit(): JSX.Element {
 
   const updateFiles = async () => {
     if (reportIdValid()) {
-      await Promise.all(
-        initialReportFiles?.map((f: { id: number; filename: string }) => {
-          if (!updatedReportFiles?.includes(f)) {
-            return SeedFundReportService.deleteReportFile(reportIdInt, f.id);
-          }
-          return undefined;
-        }) ?? []
-      );
-      await Promise.all(newReportFiles?.map((f) => SeedFundReportService.uploadReportFile(reportIdInt, f)) ?? []);
+      const fileIdsToDelete = (initialReportFiles ?? [])
+        .filter((f) => !updatedReportFiles?.includes(f))
+        .map((f) => f.id);
+      try {
+        await batchFiles({ reportId: reportIdInt, filesToUpload: newReportFiles, fileIdsToDelete }).unwrap();
+      } catch {
+        snackbar.toastError();
+      }
     }
   };
 

--- a/src/components/SeedFundReports/useReportFiles.ts
+++ b/src/components/SeedFundReports/useReportFiles.ts
@@ -1,38 +1,32 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
-import SeedFundReportService from 'src/services/SeedFundReportService';
-import { Report, ReportFile } from 'src/types/Report';
+import { useListReportFilesQuery } from 'src/queries/generated/seedFundReports';
+import { SeedFundReport, SeedFundReportFile } from 'src/types/SeedFundReport';
 import useSnackbar from 'src/utils/useSnackbar';
 
 export default function useReportFiles(
-  report?: Report,
-  setUpdatedReportFiles?: React.Dispatch<React.SetStateAction<ReportFile[]>>
-): ReportFile[] {
+  report?: SeedFundReport,
+  setUpdatedReportFiles?: React.Dispatch<React.SetStateAction<SeedFundReportFile[]>>
+): SeedFundReportFile[] {
   const snackbar = useSnackbar();
-  const [initialReportFiles, setInitialReportFiles] = useState<ReportFile[]>([]);
+  const response = useListReportFilesQuery(report?.id as number, { skip: !report });
+
+  const initialReportFiles: SeedFundReportFile[] = useMemo(
+    () => response.currentData?.files ?? [],
+    [response.currentData]
+  );
+
   useEffect(() => {
-    const getFiles = async () => {
-      if (report) {
-        const fileListResponse = await SeedFundReportService.getReportFiles(report.id);
-        if (!fileListResponse.requestSucceeded) {
-          setInitialReportFiles([]);
-          snackbar.toastError();
-        } else {
-          const fileArray: ReportFile[] = [];
-          fileListResponse.files?.forEach((f) => {
-            fileArray.push(f);
-          });
+    if (response.isError) {
+      snackbar.toastError();
+    }
+  }, [response.isError, snackbar]);
 
-          setInitialReportFiles(fileArray);
-          if (setUpdatedReportFiles) {
-            setUpdatedReportFiles(fileArray);
-          }
-        }
-      }
-    };
-
-    void getFiles();
-  }, [report, snackbar, setUpdatedReportFiles]);
+  useEffect(() => {
+    if (response.currentData && setUpdatedReportFiles) {
+      setUpdatedReportFiles(initialReportFiles);
+    }
+  }, [initialReportFiles, response.currentData, setUpdatedReportFiles]);
 
   return initialReportFiles;
 }

--- a/src/queries/seedFundReports/files.ts
+++ b/src/queries/seedFundReports/files.ts
@@ -1,0 +1,86 @@
+import { baseApi as api } from '../baseApi';
+import { QueryTagTypes } from '../tags';
+
+export type BatchSeedFundReportFilesRequest = {
+  reportId: number;
+  filesToUpload?: File[];
+  fileIdsToDelete?: number[];
+};
+
+export type BatchSeedFundReportFilesResponse = {
+  uploadedFileIds?: number[];
+};
+
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    batchSeedFundReportFiles: build.mutation<BatchSeedFundReportFilesResponse, BatchSeedFundReportFilesRequest>({
+      queryFn: async (args, _api, _extraOptions, baseQuery) => {
+        const { reportId, filesToUpload = [], fileIdsToDelete = [] } = args;
+
+        try {
+          const deleteResults =
+            fileIdsToDelete.length > 0
+              ? await Promise.all(
+                  fileIdsToDelete.map(async (fileId) => {
+                    const result = await baseQuery({
+                      url: `/api/v1/reports/${reportId}/files/${fileId}`,
+                      method: 'DELETE',
+                    });
+                    return { success: !result.error, error: result.error };
+                  })
+                )
+              : [];
+
+          const uploadResults =
+            filesToUpload.length > 0
+              ? await Promise.all(
+                  filesToUpload.map(async (file) => {
+                    const formData = new FormData();
+                    formData.append('file', file);
+                    const result = await baseQuery({
+                      url: `/api/v1/reports/${reportId}/files`,
+                      method: 'POST',
+                      body: formData,
+                    });
+                    return {
+                      success: !result.error,
+                      fileId: result.data ? (result.data as any).id : undefined,
+                      error: result.error,
+                    };
+                  })
+                )
+              : [];
+
+          const allSucceeded = deleteResults.every((r) => r.success) && uploadResults.every((r) => r.success);
+
+          if (!allSucceeded) {
+            return {
+              error: {
+                status: 'CUSTOM_ERROR',
+                error: 'One or more file operations failed',
+                data: [...deleteResults, ...uploadResults].filter((r) => !r.success).map((r) => r.error),
+              },
+            };
+          }
+
+          const uploadedFileIds = uploadResults.filter((r) => r.success && r.fileId).map((r) => r.fileId as number);
+
+          return { data: { uploadedFileIds: uploadedFileIds.length > 0 ? uploadedFileIds : undefined } };
+        } catch (error) {
+          return {
+            error: {
+              status: 'CUSTOM_ERROR',
+              error: 'Failed to process batch file operations',
+              data: error,
+            },
+          };
+        }
+      },
+      invalidatesTags: (_result, _error, args) => [{ type: QueryTagTypes.SeedFundReportMedia, id: args.reportId }],
+    }),
+  }),
+});
+
+export { injectedRtkApi as api };
+
+export const { useBatchSeedFundReportFilesMutation } = injectedRtkApi;


### PR DESCRIPTION
Add the batch file mutation (src/queries/seedFundReports/files.ts) that
uploads and deletes report files in one action, switch useReportFiles
to the generated listReportFiles query, and update ReportEdit's
updateFiles flow to call the batch mutation instead of
SeedFundReportService. Photo uploads still use the old service.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>