### PR TITLE
SW-7734 Migrate SeedFund report photo CRUD to RTK Query

### DIFF
--- a/src/components/SeedFundReports/ReportEdit.tsx
+++ b/src/components/SeedFundReports/ReportEdit.tsx
@@ -22,7 +22,7 @@ import useSeedFundReportActions from 'src/hooks/useSeedFundReportActions';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization, useUser } from 'src/providers';
 import { useBatchSeedFundReportFilesMutation } from 'src/queries/seedFundReports/files';
-import SeedFundReportService from 'src/services/SeedFundReportService';
+import { useBatchSeedFundReportPhotosMutation } from 'src/queries/seedFundReports/photos';
 import strings from 'src/strings';
 import { SeedFundReport, SeedFundReportFile } from 'src/types/SeedFundReport';
 import { overWordLimit } from 'src/utils/text';
@@ -55,14 +55,15 @@ export default function ReportEdit(): JSX.Element {
   const initialReportFiles = useReportFiles(report, setUpdatedReportFiles);
 
   const reportIdInt = reportId ? parseInt(reportId, 10) : -1;
-  const reportName = `Report (${report?.year}-Q${report?.quarter}) ` + (report?.projectName ?? '');
+  const reportName = `SeedFundReport (${report?.year}-Q${report?.quarter}) ` + (report?.projectName ?? '');
 
   const { report: loadedReport, isError, reload } = useSeedFundReport(reportIdInt);
 
   const { onUpdate, unlockReport, onSubmit, isLoading: reportActionInProgress } = useSeedFundReportActions();
   const [batchFiles, batchFilesResult] = useBatchSeedFundReportFilesMutation();
+  const [batchPhotos, batchPhotosResult] = useBatchSeedFundReportPhotosMutation();
 
-  const busyState = reportActionInProgress || batchFilesResult.isLoading;
+  const busyState = reportActionInProgress || batchFilesResult.isLoading || batchPhotosResult.isLoading;
 
   useEffect(() => {
     const el = document.getElementById(idInView);
@@ -122,12 +123,13 @@ export default function ReportEdit(): JSX.Element {
   }, [report, user, showInvalidUserModal, currentUserEditing]);
 
   const updatePhotos = async (iReportId: number) => {
-    await SeedFundReportService.uploadReportPhotos(iReportId, photos);
-    setPhotos([]);
-    if (photoIdsToRemove) {
-      await SeedFundReportService.deleteReportPhotos(iReportId, photoIdsToRemove);
-      setPhotoIdsToRemove([]);
+    try {
+      await batchPhotos({ reportId: iReportId, photosToUpload: photos, photoIdsToDelete: photoIdsToRemove }).unwrap();
+    } catch {
+      snackbar.toastError();
     }
+    setPhotos([]);
+    setPhotoIdsToRemove([]);
   };
 
   const gotoReportView = async (saveChanges: boolean) => {
@@ -409,7 +411,7 @@ export default function ReportEdit(): JSX.Element {
   };
 
   /**
-   * Report update functions
+   * SeedFundReport update functions
    */
   const updateReport = (field: string, value: any) => {
     if (report) {

--- a/src/components/SeedFundReports/ReportEdit.tsx
+++ b/src/components/SeedFundReports/ReportEdit.tsx
@@ -127,6 +127,7 @@ export default function ReportEdit(): JSX.Element {
       await batchPhotos({ reportId: iReportId, photosToUpload: photos, photoIdsToDelete: photoIdsToRemove }).unwrap();
     } catch {
       snackbar.toastError();
+      return;
     }
     setPhotos([]);
     setPhotoIdsToRemove([]);

--- a/src/components/SeedFundReports/ReportForm.tsx
+++ b/src/components/SeedFundReports/ReportForm.tsx
@@ -7,18 +7,18 @@ import LocationSection from 'src/components/SeedFundReports/LocationSelection';
 import ViewPhotos from 'src/components/SeedFundReports/ViewPhotos';
 import OverviewItemCard from 'src/components/common/OverviewItemCard';
 import SelectPhotos from 'src/components/common/Photos/SelectPhotos';
-import SeedFundReportService from 'src/services/SeedFundReportService';
+import useSeedFundReportPhotos from 'src/hooks/useSeedFundReportPhotos';
 import strings from 'src/strings';
-import { Report, ReportNursery, ReportPlantingSite } from 'src/types/Report';
-import { ReportSeedBank } from 'src/types/Report';
+import { SeedFundReport, SeedFundReportNursery, SeedFundReportPlantingSite } from 'src/types/SeedFundReport';
+import { SeedFundReportSeedBank } from 'src/types/SeedFundReport';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 
 const MAX_PHOTOS = 30;
 
 export type ReportFormProps = {
   editable: boolean;
-  draftReport: Report;
-  onChange?: (report: Report) => void;
+  draftReport: SeedFundReport;
+  onChange?: (report: SeedFundReport) => void;
   onUpdateReport?: (field: string, value: any) => void;
   onUpdateLocation?: (
     index: number,
@@ -34,9 +34,9 @@ export type ReportFormProps = {
   ) => void;
   onPhotosChanged?: (photos: File[]) => void;
   onPhotoRemove?: (id: number) => void;
-  reportNurseries?: ReportNursery[];
-  reportPlantingSites?: ReportPlantingSite[];
-  reportSeedBanks?: ReportSeedBank[];
+  reportNurseries?: SeedFundReportNursery[];
+  reportPlantingSites?: SeedFundReportPlantingSite[];
+  reportSeedBanks?: SeedFundReportSeedBank[];
   validate?: boolean;
 };
 
@@ -62,6 +62,8 @@ export default function ReportForm(props: ReportFormProps): JSX.Element {
   const [projectNotes, setProjectNotes] = useState(draftReport.notes ?? '');
   const [photoCount, setPhotoCount] = useState(0);
 
+  const { photos } = useSeedFundReportPhotos(draftReport.id);
+
   const infoCardStyle = {
     padding: 0,
   };
@@ -76,17 +78,8 @@ export default function ReportForm(props: ReportFormProps): JSX.Element {
   const isProjectReport = !!draftReport.projectName;
 
   useEffect(() => {
-    const getPhotoCount = async () => {
-      const photoListResponse = await SeedFundReportService.getReportPhotos(draftReport.id);
-      if (!photoListResponse.requestSucceeded || photoListResponse.error) {
-        setPhotoCount(0);
-      } else {
-        setPhotoCount(photoListResponse.photos?.length ?? 0);
-      }
-    };
-
-    void getPhotoCount();
-  }, [draftReport.id]);
+    setPhotoCount(photos.length);
+  }, [photos]);
 
   const handleAddRemoveLocation = useCallback(
     (selected: boolean, index: number, location: 'seedBanks' | 'nurseries' | 'plantingSites') => {

--- a/src/components/SeedFundReports/ViewPhotos.tsx
+++ b/src/components/SeedFundReports/ViewPhotos.tsx
@@ -3,9 +3,10 @@ import React, { type JSX, useEffect, useState } from 'react';
 import { Box, useTheme } from '@mui/material';
 import { Button, ViewPhotosDialog } from '@terraware/web-components';
 
-import SeedFundReportService, { REPORT_PHOTO_ENDPOINT } from 'src/services/SeedFundReportService';
+import { API_PATHS } from 'src/constants';
+import useSeedFundReportPhotos from 'src/hooks/useSeedFundReportPhotos';
 import strings from 'src/strings';
-import { ReportPhoto } from 'src/types/Report';
+import { SeedFundReportPhoto } from 'src/types/SeedFundReport';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import useSnackbar from 'src/utils/useSnackbar';
 
@@ -15,7 +16,7 @@ type PhotosSectionProps = {
   editable: boolean;
 };
 
-type ReportPhotoWithUrl = ReportPhoto & { url: string };
+type ReportPhotoWithUrl = SeedFundReportPhoto & { url: string };
 
 export default function ViewPhotos({ reportId, onPhotoRemove, editable }: PhotosSectionProps): JSX.Element {
   const theme = useTheme();
@@ -25,30 +26,25 @@ export default function ViewPhotos({ reportId, onPhotoRemove, editable }: Photos
   const [selectedSlide, setSelectedSlide] = useState(0);
   const { isMobile } = useDeviceInfo();
 
+  const { photos: fetchedPhotos, isError } = useSeedFundReportPhotos(reportId);
+
   useEffect(() => {
-    const getPhotos = async () => {
-      const photoListResponse = await SeedFundReportService.getReportPhotos(reportId);
-      if (!photoListResponse.requestSucceeded || photoListResponse.error) {
-        setPhotos([]);
-        snackbar.toastError();
-      } else {
-        const photosWithUrl: ReportPhotoWithUrl[] =
-          photoListResponse.photos?.map((photo) => {
-            return {
-              ...photo,
-              url: REPORT_PHOTO_ENDPOINT.replace('{reportId}', reportId.toString()).replace(
-                '{photoId}',
-                photo.id.toString()
-              ),
-            };
-          }) || [];
+    setPhotos(
+      fetchedPhotos.map((photo) => ({
+        ...photo,
+        url: API_PATHS.SEED_FUND_REPORT_PHOTO.replace('{reportId}', reportId.toString()).replace(
+          '{photoId}',
+          photo.id.toString()
+        ),
+      }))
+    );
+  }, [fetchedPhotos, reportId]);
 
-        setPhotos(photosWithUrl);
-      }
-    };
-
-    void getPhotos();
-  }, [reportId, snackbar]);
+  useEffect(() => {
+    if (isError) {
+      snackbar.toastError();
+    }
+  }, [isError, snackbar]);
 
   const closeHandler = () => {
     setPhotosModalOpened(false);

--- a/src/hooks/useSeedFundReportPhotos.ts
+++ b/src/hooks/useSeedFundReportPhotos.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+
+import { useListReportPhotosQuery } from 'src/queries/generated/seedFundReports';
+import { SeedFundReportPhoto } from 'src/types/SeedFundReport';
+
+/**
+ * Lists the photos for a SeedFund report.
+ */
+const useSeedFundReportPhotos = (reportId?: number) => {
+  const response = useListReportPhotosQuery(reportId as number, { skip: reportId === undefined });
+
+  const photos: SeedFundReportPhoto[] = useMemo(() => response.currentData?.photos ?? [], [response.currentData]);
+
+  return { photos, isLoading: response.isFetching, isError: response.isError };
+};
+
+export default useSeedFundReportPhotos;

--- a/src/queries/seedFundReports/photos.ts
+++ b/src/queries/seedFundReports/photos.ts
@@ -1,0 +1,86 @@
+import { baseApi as api } from '../baseApi';
+import { QueryTagTypes } from '../tags';
+
+export type BatchSeedFundReportPhotosRequest = {
+  reportId: number;
+  photosToUpload?: File[];
+  photoIdsToDelete?: number[];
+};
+
+export type BatchSeedFundReportPhotosResponse = {
+  uploadedFileIds?: number[];
+};
+
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    batchSeedFundReportPhotos: build.mutation<BatchSeedFundReportPhotosResponse, BatchSeedFundReportPhotosRequest>({
+      queryFn: async (args, _api, _extraOptions, baseQuery) => {
+        const { reportId, photosToUpload = [], photoIdsToDelete = [] } = args;
+
+        try {
+          const deleteResults =
+            photoIdsToDelete.length > 0
+              ? await Promise.all(
+                  photoIdsToDelete.map(async (photoId) => {
+                    const result = await baseQuery({
+                      url: `/api/v1/reports/${reportId}/photos/${photoId}`,
+                      method: 'DELETE',
+                    });
+                    return { success: !result.error, error: result.error };
+                  })
+                )
+              : [];
+
+          const uploadResults =
+            photosToUpload.length > 0
+              ? await Promise.all(
+                  photosToUpload.map(async (photo) => {
+                    const formData = new FormData();
+                    formData.append('file', photo);
+                    const result = await baseQuery({
+                      url: `/api/v1/reports/${reportId}/photos`,
+                      method: 'POST',
+                      body: formData,
+                    });
+                    return {
+                      success: !result.error,
+                      fileId: result.data ? (result.data as any).id : undefined,
+                      error: result.error,
+                    };
+                  })
+                )
+              : [];
+
+          const allSucceeded = deleteResults.every((r) => r.success) && uploadResults.every((r) => r.success);
+
+          if (!allSucceeded) {
+            return {
+              error: {
+                status: 'CUSTOM_ERROR',
+                error: 'One or more photo operations failed',
+                data: [...deleteResults, ...uploadResults].filter((r) => !r.success).map((r) => r.error),
+              },
+            };
+          }
+
+          const uploadedFileIds = uploadResults.filter((r) => r.success && r.fileId).map((r) => r.fileId as number);
+
+          return { data: { uploadedFileIds: uploadedFileIds.length > 0 ? uploadedFileIds : undefined } };
+        } catch (error) {
+          return {
+            error: {
+              status: 'CUSTOM_ERROR',
+              error: 'Failed to process batch photo operations',
+              data: error,
+            },
+          };
+        }
+      },
+      invalidatesTags: (_result, _error, args) => [{ type: QueryTagTypes.SeedFundReportMedia, id: args.reportId }],
+    }),
+  }),
+});
+
+export { injectedRtkApi as api };
+
+export const { useBatchSeedFundReportPhotosMutation } = injectedRtkApi;


### PR DESCRIPTION
Add the batch photo mutation (src/queries/seedFundReports/photos.ts)
and the useSeedFundReportPhotos list hook, switch ViewPhotos and
ReportForm off SeedFundReportService, and complete ReportEdit by
routing photo uploads/deletes through the batch mutation. ReportEdit
no longer references SeedFundReportService.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>