### PR TITLE
SW-8679 Display icons for annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@rsbuild/plugin-type-check": "^1.3.3",
     "@rstest/core": "^0.11.0",
     "@rstest/coverage-istanbul": "^0.11.0",
-    "@terraware/web-components": "^v4.2.12",
+    "@terraware/web-components": "^v4.2.13",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/src/components/GaussianSplat/Annotation.tsx
+++ b/src/components/GaussianSplat/Annotation.tsx
@@ -11,12 +11,15 @@ import { useCameraPosition } from 'src/hooks/useCameraPosition';
 
 import './annotation-styles.css';
 
+export type AnnotationIconType = 'menu' | 'image' | 'video';
+
 export interface AnnotationProps {
   position: [number, number, number];
   title: string;
   bodyText?: string;
   label?: string;
   imageUrl?: string;
+  icon?: AnnotationIconType;
   cameraPosition?: [number, number, number];
   visible?: boolean;
   isEdit?: boolean;
@@ -50,6 +53,7 @@ const Annotation = (props: AnnotationProps & { index: number }) => {
     cameraPosition,
     bodyText,
     imageUrl,
+    icon,
     title,
     label,
     visible = true,
@@ -200,6 +204,7 @@ const Annotation = (props: AnnotationProps & { index: number }) => {
         script={PcAnnotation}
         title={title}
         label={label}
+        icon={icon}
         text={bodyText}
         enabled={visible}
         onClickCallback={handleClick}

--- a/src/components/GaussianSplat/Annotation.tsx
+++ b/src/components/GaussianSplat/Annotation.tsx
@@ -11,7 +11,7 @@ import { useCameraPosition } from 'src/hooks/useCameraPosition';
 
 import './annotation-styles.css';
 
-export type AnnotationIconType = 'menu' | 'image' | 'video';
+export type AnnotationIconType = 'text' | 'image' | 'video';
 
 export interface AnnotationProps {
   position: [number, number, number];

--- a/src/components/GaussianSplat/TfAnnotationManager.ts
+++ b/src/components/GaussianSplat/TfAnnotationManager.ts
@@ -9,7 +9,7 @@ import { AnnotationIconType } from './Annotation';
 
 // Maps each annotation icon type to a @terraware/web-components icon.
 const ANNOTATION_ICONS: Record<AnnotationIconType, IconName> = {
-  menu: 'iconMenu',
+  text: 'iconDocument',
   image: 'iconPhoto',
   video: 'iconVideo',
 };

--- a/src/components/GaussianSplat/TfAnnotationManager.ts
+++ b/src/components/GaussianSplat/TfAnnotationManager.ts
@@ -1,5 +1,18 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { Icon, IconName } from '@terraware/web-components';
 import { FILTER_LINEAR, PIXELFORMAT_RGBA8, Texture } from 'playcanvas';
 import { AnnotationManager as PcAnnotationManager } from 'playcanvas/scripts/esm/annotations.mjs';
+
+import { AnnotationIconType } from './Annotation';
+
+// Maps each annotation icon type to a @terraware/web-components icon.
+const ANNOTATION_ICONS: Record<AnnotationIconType, IconName> = {
+  menu: 'iconMenu',
+  image: 'iconPhoto',
+  video: 'iconVideo',
+};
 
 /**
  * Extended AnnotationManager that adds max size clamping for annotations
@@ -12,6 +25,7 @@ export class TfAnnotationManager extends PcAnnotationManager {
   private _customParentDom: HTMLElement | null = null;
   private _clickHandlersAttached = new Set<any>();
   private _hotspotBackgroundColor = '#2C8658';
+  private _iconImages = new Map<AnnotationIconType, HTMLImageElement>();
 
   /**
    * Maximum world-space size for annotations.
@@ -64,6 +78,48 @@ export class TfAnnotationManager extends PcAnnotationManager {
 
     // Call parent initialize
     super.initialize();
+
+    this._loadIconImages();
+  }
+
+  /**
+   * Renders each web-components icon to an SVG image once. When an image finishes
+   * loading, any annotations already using that icon are redrawn.
+   * @private
+   */
+  _loadIconImages() {
+    const fillColor = (this as any)._hotspotColor?.toString() ?? '#ffffff';
+
+    (Object.keys(ANNOTATION_ICONS) as AnnotationIconType[]).forEach((iconType) => {
+      const name = ANNOTATION_ICONS[iconType];
+      const markup = renderToStaticMarkup(createElement(Icon, { name, fillColor })).replace(
+        /^<svg/,
+        '<svg width="128" height="128"'
+      );
+
+      const image = new Image();
+      image.onload = () => this._refreshIcon(iconType);
+      image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(markup)}`;
+      this._iconImages.set(iconType, image);
+    });
+  }
+
+  /**
+   * Redraws the texture for all annotations using the given icon, once its image
+   * has loaded.
+   * @private
+   */
+  _refreshIcon(iconType: AnnotationIconType) {
+    const annotationResources = (this as any)._annotationResources;
+    if (!annotationResources) {
+      return;
+    }
+
+    annotationResources.forEach((_resources: any, annotation: any) => {
+      if ((annotation.icon ?? 'menu') === iconType) {
+        this._applyAnnotationIcon(annotation);
+      }
+    });
   }
 
   /**
@@ -102,6 +158,85 @@ export class TfAnnotationManager extends PcAnnotationManager {
         }
       }
     });
+  }
+
+  /**
+   * Override annotation registration to draw the media icon onto the hotspot
+   * texture once the annotation (and its icon) is available.
+   * @private
+   */
+  _registerAnnotation(annotation: any) {
+    super._registerAnnotation(annotation);
+    this._applyAnnotationIcon(annotation);
+  }
+
+  /**
+   * Recreates the hotspot texture with the appropriate media icon drawn on it.
+   * @private
+   */
+  _applyAnnotationIcon(annotation: any) {
+    const resources = (this as any)._annotationResources.get(annotation);
+    if (!resources) {
+      return;
+    }
+
+    const icon: AnnotationIconType = annotation.icon ?? 'menu';
+
+    resources.texture.destroy();
+    resources.texture = this._createHotspotTexture(annotation.label, 64, 6, icon);
+    resources.materials.forEach((material: any) => {
+      material.emissiveMap = resources.texture;
+      material.opacityMap = resources.texture;
+      material.update();
+    });
+  }
+
+  /**
+   * Draws the icon image onto the hotspot texture canvas, scaled to fit the
+   * circle. Does nothing if the image has not finished loading yet; the
+   * annotation is redrawn once it has (see `_refreshIcon`).
+   * @private
+   */
+  _drawIcon(ctx: CanvasRenderingContext2D, icon: AnnotationIconType, size: number) {
+    const image = this._iconImages.get(icon);
+    if (!image || !image.complete || image.naturalWidth === 0) {
+      return;
+    }
+
+    const iconSize = size * 0.5;
+    const offset = (size - iconSize) / 2;
+    ctx.drawImage(image, offset, offset, iconSize, iconSize);
+  }
+
+  /**
+   * Keep the media icon drawn on the hotspot texture. The label text itself
+   * is not rendered on the hotspot, so we simply redraw with the icon.
+   * @private
+   */
+  _onLabelChange(annotation: any) {
+    this._applyAnnotationIcon(annotation);
+  }
+
+  /**
+   * The hotspot colors are baked into the texture in `_createHotspotTexture`,
+   * so the material emissive is kept white to let those colors render as drawn.
+   * @private
+   */
+  _createHotspotMaterial(texture: any, options?: any) {
+    const material = super._createHotspotMaterial(texture, options);
+    material.emissive.set(1, 1, 1);
+    material.update();
+    return material;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _setAnnotationHover(_annotation: any, _hover: boolean) {
+    // No-op: hotspot colors are baked into the texture, so there is no emissive
+    // re-tint on hover.
+  }
+
+  _updateAllAnnotationColors() {
+    // No-op: hotspot colors are baked into the texture (see _createHotspotMaterial).
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -183,7 +318,7 @@ export class TfAnnotationManager extends PcAnnotationManager {
    * Override to create hotspot texture with custom background color.
    * @private
    */
-  _createHotspotTexture(label: string, size = 64, borderWidth = 6) {
+  _createHotspotTexture(label: string, size = 64, borderWidth = 6, icon?: AnnotationIconType) {
     const canvas = document.createElement('canvas');
     canvas.width = size;
     canvas.height = size;
@@ -204,33 +339,30 @@ export class TfAnnotationManager extends PcAnnotationManager {
     const centerY = size / 2;
     const radius = size / 2 - 4;
 
+    // The icon fill and border share the hotspot color
+    const foregroundColor = (this as any)._hotspotColor?.toString() ?? '#ffffff';
+
     // Draw main circle
     ctx.beginPath();
     ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
-    ctx.fillStyle = this._hotspotBackgroundColor; // this is the only line different from playcanvas in this method
+    ctx.fillStyle = this._hotspotBackgroundColor;
     ctx.fill();
 
     // Draw border
     ctx.beginPath();
     ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
     ctx.lineWidth = borderWidth;
-    ctx.strokeStyle = 'white';
+    ctx.strokeStyle = foregroundColor;
     ctx.stroke();
+
+    // Draw the media icon inside the circle
+    if (icon) {
+      this._drawIcon(ctx, icon, size);
+    }
 
     // Get pixel data
     const imageData = ctx.getImageData(0, 0, size, size);
     const data = imageData.data;
-
-    // Set the color channel of semitransparent pixels to white so the blending at
-    // the edges is correct
-    for (let i = 0; i < data.length; i += 4) {
-      const a = data[i + 3];
-      if (a < 255) {
-        data[i] = 255;
-        data[i + 1] = 255;
-        data[i + 2] = 255;
-      }
-    }
 
     // Create and return the texture
     return new Texture(this.app.graphicsDevice, {

--- a/src/components/GaussianSplat/TfAnnotationManager.ts
+++ b/src/components/GaussianSplat/TfAnnotationManager.ts
@@ -9,7 +9,7 @@ import { AnnotationIconType } from './Annotation';
 
 // Maps each annotation icon type to a @terraware/web-components icon.
 const ANNOTATION_ICONS: Record<AnnotationIconType, IconName> = {
-  text: 'iconDocument',
+  text: 'iconComment',
   image: 'iconPhoto',
   video: 'iconVideo',
 };

--- a/src/components/GaussianSplat/TfAnnotationManager.ts
+++ b/src/components/GaussianSplat/TfAnnotationManager.ts
@@ -116,7 +116,7 @@ export class TfAnnotationManager extends PcAnnotationManager {
     }
 
     annotationResources.forEach((_resources: any, annotation: any) => {
-      if ((annotation.icon ?? 'menu') === iconType) {
+      if ((annotation.icon ?? 'text') === iconType) {
         this._applyAnnotationIcon(annotation);
       }
     });
@@ -180,7 +180,7 @@ export class TfAnnotationManager extends PcAnnotationManager {
       return;
     }
 
-    const icon: AnnotationIconType = annotation.icon ?? 'menu';
+    const icon: AnnotationIconType = annotation.icon ?? 'text';
 
     resources.texture.destroy();
     resources.texture = this._createHotspotTexture(annotation.label, 64, 6, icon);

--- a/src/scenes/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/scenes/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { useTheme } from '@mui/material';
 import { Entity } from '@playcanvas/react';
 import { Camera, Script } from '@playcanvas/react/components';
 import { useApp } from '@playcanvas/react/hooks';
 import { Color, Vec3 } from 'playcanvas';
 import { XrControllers } from 'playcanvas/scripts/esm/xr-controllers.mjs';
 
-import Annotation, { AnnotationProps } from 'src/components/GaussianSplat/Annotation';
+import Annotation, { AnnotationIconType, AnnotationProps } from 'src/components/GaussianSplat/Annotation';
 import AnnotationPanel from 'src/components/GaussianSplat/AnnotationPanel';
 import { AutoRotator } from 'src/components/GaussianSplat/AutoRotator';
 import BoundaryRing from 'src/components/GaussianSplat/BoundaryRing';
@@ -48,6 +49,7 @@ const VirtualWalkthroughViewer = ({
   isFullScreen = false,
   onToggleFullScreen,
 }: VirtualWalkthroughViewerProps) => {
+  const theme = useTheme();
   const { setCamera } = useCameraPosition();
   const { isHighPerformance } = useDevicePerformance();
   const app = useApp();
@@ -143,22 +145,31 @@ const VirtualWalkthroughViewer = ({
 
   const apiAnnotations = useMemo<AnnotationProps[]>(
     () =>
-      data?.annotations?.map(
-        (annotation) =>
-          ({
-            ...annotation,
-            position: [annotation.position.x, annotation.position.y, annotation.position.z] as [number, number, number],
-            cameraPosition: annotation.cameraPosition
-              ? ([annotation.cameraPosition.x, annotation.cameraPosition.y, annotation.cameraPosition.z] as [
-                  number,
-                  number,
-                  number,
-                ])
-              : undefined,
-            // TODO: replace with actual image url once retrieval is available
-            imageUrl: annotation.media.length > 0 ? 'https://placehold.co/800x450' : undefined,
-          }) as AnnotationProps
-      ) ?? [],
+      data?.annotations?.map((annotation) => {
+        const [firstMedia] = annotation.media;
+        const icon: AnnotationIconType = !firstMedia
+          ? 'menu'
+          : firstMedia.contentType.startsWith('image')
+            ? 'image'
+            : firstMedia.contentType.startsWith('video')
+              ? 'video'
+              : 'menu';
+
+        return {
+          ...annotation,
+          position: [annotation.position.x, annotation.position.y, annotation.position.z] as [number, number, number],
+          cameraPosition: annotation.cameraPosition
+            ? ([annotation.cameraPosition.x, annotation.cameraPosition.y, annotation.cameraPosition.z] as [
+                number,
+                number,
+                number,
+              ])
+            : undefined,
+          icon,
+          // TODO: replace with actual image url once retrieval is available
+          imageUrl: annotation.media.length > 0 ? 'https://placehold.co/800x450' : undefined,
+        } as AnnotationProps;
+      }) ?? [],
     [data?.annotations]
   );
 
@@ -343,9 +354,9 @@ const VirtualWalkthroughViewer = ({
             hotspotSize={30}
             maxWorldSize={0.05}
             opacity={1}
-            hotspotColor={new Color().fromString('#ffffff')}
+            hotspotColor={new Color().fromString(theme.palette.TwClrIcnBrand as string)}
             hoverColor={new Color().fromString('#ffffff')}
-            hotspotBackgroundColor='#2C8658'
+            hotspotBackgroundColor={theme.palette.TwClrBaseWhite as string}
           />
           {localAnnotations.map((annotation, index) => (
             <Annotation

--- a/src/scenes/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/scenes/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -148,12 +148,12 @@ const VirtualWalkthroughViewer = ({
       data?.annotations?.map((annotation) => {
         const [firstMedia] = annotation.media;
         const icon: AnnotationIconType = !firstMedia
-          ? 'menu'
+          ? 'text'
           : firstMedia.contentType.startsWith('image')
             ? 'image'
             : firstMedia.contentType.startsWith('video')
               ? 'video'
-              : 'menu';
+              : 'text';
 
         return {
           ...annotation,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6359,10 +6359,10 @@
   resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.11.2.tgz#00409e743ac4eea9afe5b7708594d5fcebb00212"
   integrity sha512-vTtpNt7mKCiZ1pwU9hfKPhpdVO2sVzFQsxoVBGtOSHxlrRRzYr8iQ2TlwbAcRYCcEiZ9ECAM8kBzH0v2+VzfKw==
 
-"@terraware/web-components@^v4.2.12":
-  version "4.2.12"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-4.2.12.tgz#36f37a095bdc036fc4a967125105c5aa07a05e5b"
-  integrity sha512-0TotNMwDBiN2ch17WHrq8fbzhTKAvcivUbs6RQKAGtWP12dgCdrQKJ+iD+vkD0JQNBmDs5H5MZpZQMfBvWEsoQ==
+"@terraware/web-components@^v4.2.13":
+  version "4.2.13"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-4.2.13.tgz#febe83dcf528ce6616b610de5416f7dc18fb83a4"
+  integrity sha512-VbczvktkXzMDHmD5gWvn3yUpyIvHBFCOsfustm+KS5Waa7nvSG+5Zaga1FBRqMTOJl1lLblgJU7R0XvHwPlTtw==
   dependencies:
     "@dnd-kit/core" "^6.0.7"
     "@dnd-kit/sortable" "^10.0.0"


### PR DESCRIPTION
Display either a menu, camera, or video icon depending on if the annotation has media or not.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>

(waiting on https://github.com/terraware/web-components/pull/772 to change the menu icon to a text icon)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>