### PR TITLE
SW-8679 Update annotations to be centered and displayed when clicked

### DIFF
--- a/src/components/GaussianSplat/Annotation.tsx
+++ b/src/components/GaussianSplat/Annotation.tsx
@@ -13,6 +13,13 @@ import './annotation-styles.css';
 
 export type AnnotationIconType = 'text' | 'image' | 'video';
 
+/**
+ * Target normalized-device x coordinate for a clicked annotation. +0.5 places
+ * the hotspot three quarters across the screen (25% from the right), leaving room
+ * for the annotation panel on the left without covering the hotspot.
+ */
+const VIEW_HORIZONTAL_NDC_BIAS = 0.5;
+
 export interface AnnotationProps {
   position: [number, number, number];
   title: string;
@@ -24,10 +31,11 @@ export interface AnnotationProps {
   visible?: boolean;
   isEdit?: boolean;
   isSelected?: boolean;
+  isViewed?: boolean;
   onSelect?: () => void;
   onPositionChange?: (position: [number, number, number]) => void;
   onView?: (annotation: AnnotationProps, screenX: number, screenY: number) => void;
-  onScreenPositionUpdate?: (index: number, screenX: number, screenY: number) => void;
+  onScreenPositionUpdate?: (index: number, screenX: number, screenY: number, size?: number) => void;
 }
 
 /**
@@ -59,9 +67,11 @@ const Annotation = (props: AnnotationProps & { index: number }) => {
     visible = true,
     isEdit = false,
     isSelected = false,
+    isViewed = false,
     onSelect,
     onPositionChange,
     onView,
+    onScreenPositionUpdate,
     index,
   } = props;
   const app = useApp();
@@ -73,6 +83,7 @@ const Annotation = (props: AnnotationProps & { index: number }) => {
   const isEditRef = useRef(isEdit);
   const onSelectRef = useRef(onSelect);
   const onViewRef = useRef(onView);
+  const onScreenPositionUpdateRef = useRef(onScreenPositionUpdate);
   const positionRef = useRef(position);
   const cameraPositionRef = useRef(cameraPosition);
   const annotationForViewRef = useRef<AnnotationProps>({
@@ -88,10 +99,11 @@ const Annotation = (props: AnnotationProps & { index: number }) => {
     isEditRef.current = isEdit;
     onSelectRef.current = onSelect;
     onViewRef.current = onView;
+    onScreenPositionUpdateRef.current = onScreenPositionUpdate;
     positionRef.current = position;
     cameraPositionRef.current = cameraPosition;
     annotationForViewRef.current = { position, title, label, bodyText, imageUrl, cameraPosition };
-  }, [isEdit, onSelect, onView, position, cameraPosition, title, label, bodyText, imageUrl]);
+  }, [isEdit, onSelect, onView, onScreenPositionUpdate, position, cameraPosition, title, label, bodyText, imageUrl]);
 
   // Create a stable callback that reads from refs, because this is read from TfAnnotationManager when the annotation is added to the scene
   const handleClick = useCallback(
@@ -99,13 +111,21 @@ const Annotation = (props: AnnotationProps & { index: number }) => {
       if (isEditRef.current) {
         onSelectRef.current?.();
       } else {
-        setCamera(positionRef.current, cameraPositionRef.current);
+        setCamera(positionRef.current, cameraPositionRef.current, VIEW_HORIZONTAL_NDC_BIAS);
         if (onViewRef.current && screenX !== undefined && screenY !== undefined) {
           onViewRef.current(annotationForViewRef.current, screenX, screenY);
         }
       }
     },
     [setCamera]
+  );
+
+  // Stable callback so its identity doesn't churn the underlying script prop each frame.
+  const handleScreenPositionUpdate = useCallback(
+    (screenX: number, screenY: number, size?: number) => {
+      onScreenPositionUpdateRef.current?.(index, screenX, screenY, size);
+    },
+    [index]
   );
 
   const entityName = useMemo(() => `annotation-${index}`, [index]);
@@ -208,6 +228,7 @@ const Annotation = (props: AnnotationProps & { index: number }) => {
         text={bodyText}
         enabled={visible}
         onClickCallback={handleClick}
+        onScreenPositionUpdateCallback={isViewed ? handleScreenPositionUpdate : undefined}
       />
     </Entity>
   );

--- a/src/components/GaussianSplat/AnnotationPanel.tsx
+++ b/src/components/GaussianSplat/AnnotationPanel.tsx
@@ -24,13 +24,6 @@ const PANEL_HOTSPOT_GAP = 48;
 // width, so the panel never drifts further left than this.
 const MIN_LEFT_FRACTION = 0.02;
 
-const BACKDROP_STYLE: React.CSSProperties = {
-  position: 'absolute',
-  inset: 0,
-  zIndex: 5001,
-  cursor: 'default',
-};
-
 const CONNECTOR_STYLE: React.CSSProperties = {
   position: 'absolute',
   inset: 0,
@@ -89,8 +82,18 @@ const AnnotationPanel = ({ annotation, hotspotPosition, onClose }: AnnotationPan
       }
     };
 
+    const handlePointerDown = (e: PointerEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+
     document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('pointerdown', handlePointerDown);
+    };
   }, [annotation, onClose]);
 
   // Position the panel just to the left of the hotspot (clamped so it never
@@ -139,7 +142,6 @@ const AnnotationPanel = ({ annotation, hotspotPosition, onClose }: AnnotationPan
 
   return (
     <>
-      <div data-testid='annotation-panel-backdrop' style={BACKDROP_STYLE} onClick={onClose} />
       <svg ref={connectorRef} data-testid='annotation-panel-connector' style={CONNECTOR_STYLE}>
         {lineStart && lineEnd && (
           <line x1={lineStart.x} y1={lineStart.y} x2={lineEnd.x} y2={lineEnd.y} stroke='#ffffff' strokeWidth={2} />

--- a/src/components/GaussianSplat/AnnotationPanel.tsx
+++ b/src/components/GaussianSplat/AnnotationPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { useTheme } from '@mui/material';
 
@@ -6,23 +6,40 @@ import { AnnotationProps } from './Annotation';
 
 interface AnnotationPanelProps {
   annotation: AnnotationProps | null;
+  // Screen position (and rendered diameter) of the associated hotspot, relative
+  // to the viewer, used to draw the connector line. Null until the hotspot's
+  // position is known.
+  hotspotPosition?: { x: number; y: number; size?: number } | null;
   onClose: () => void;
 }
 
+// Fallback hotspot diameter (px) when the rendered size isn't reported yet.
+const DEFAULT_HOTSPOT_DIAMETER = 35;
+
 const BACKDROP_STYLE: React.CSSProperties = {
-  position: 'fixed',
+  position: 'absolute',
   inset: 0,
   zIndex: 5001,
   cursor: 'pointer',
 };
 
-const PANEL_STYLE: React.CSSProperties = {
-  position: 'fixed',
-  left: '2%',
-  top: '10%',
-  width: '60vw',
-  height: '80vh',
+const CONNECTOR_STYLE: React.CSSProperties = {
+  position: 'absolute',
+  inset: 0,
+  width: '100%',
+  height: '100%',
+  pointerEvents: 'none',
+  overflow: 'visible',
   zIndex: 5002,
+};
+
+const PANEL_STYLE: React.CSSProperties = {
+  position: 'absolute',
+  left: '2%',
+  top: '50%',
+  transform: 'translateY(-50%)',
+  maxHeight: '80vh',
+  zIndex: 5003,
   backgroundColor: '#ffffff',
   borderRadius: 12,
   boxShadow: '0 8px 32px rgba(0,0,0,0.32)',
@@ -46,8 +63,11 @@ const TEXT_BLOCK_STYLE: React.CSSProperties = {
   gap: 8,
 };
 
-const AnnotationPanel = ({ annotation, onClose }: AnnotationPanelProps) => {
+const AnnotationPanel = ({ annotation, hotspotPosition, onClose }: AnnotationPanelProps) => {
   const theme = useTheme();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const connectorRef = useRef<SVGSVGElement>(null);
+  const [lineStart, setLineStart] = useState<{ x: number; y: number } | null>(null);
 
   useEffect(() => {
     if (!annotation) {
@@ -64,20 +84,58 @@ const AnnotationPanel = ({ annotation, onClose }: AnnotationPanelProps) => {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [annotation, onClose]);
 
+  // Anchor the line at the vertical center of the panel's right edge, in the
+  // connector SVG's coordinate space.
+  useLayoutEffect(() => {
+    if (!annotation || !hotspotPosition || !panelRef.current || !connectorRef.current) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setLineStart(null);
+      return;
+    }
+    const panelRect = panelRef.current.getBoundingClientRect();
+    const connectorRect = connectorRef.current.getBoundingClientRect();
+    setLineStart({
+      x: panelRect.right - connectorRect.left,
+      y: panelRect.top + panelRect.height / 2 - connectorRect.top,
+    });
+  }, [annotation, hotspotPosition]);
+
   if (!annotation) {
     return null;
+  }
+
+  const panelStyle: React.CSSProperties = {
+    ...PANEL_STYLE,
+    ...(annotation.imageUrl ? { width: '60vw' } : { width: 'fit-content', maxWidth: '50vw' }),
+  };
+
+  // Stop the line at the edge of the hotspot circle
+  let lineEnd: { x: number; y: number } | null = null;
+  if (lineStart && hotspotPosition) {
+    const dx = hotspotPosition.x - lineStart.x;
+    const dy = hotspotPosition.y - lineStart.y;
+    const dist = Math.hypot(dx, dy);
+    const radius = (hotspotPosition.size ?? DEFAULT_HOTSPOT_DIAMETER) / 2;
+    const t = dist > radius ? (dist - radius) / dist : 0;
+    lineEnd = { x: lineStart.x + dx * t, y: lineStart.y + dy * t };
   }
 
   return (
     <>
       <div data-testid='annotation-panel-backdrop' style={BACKDROP_STYLE} onClick={onClose} />
-      <div data-testid='annotation-panel' style={PANEL_STYLE}>
+      <svg ref={connectorRef} data-testid='annotation-panel-connector' style={CONNECTOR_STYLE}>
+        {lineStart && lineEnd && (
+          <line x1={lineStart.x} y1={lineStart.y} x2={lineEnd.x} y2={lineEnd.y} stroke='#ffffff' strokeWidth={2} />
+        )}
+      </svg>
+      <div ref={panelRef} data-testid='annotation-panel' style={panelStyle}>
         {annotation.imageUrl && <img src={annotation.imageUrl} alt={annotation.title} style={IMAGE_STYLE} />}
         <div style={TEXT_BLOCK_STYLE}>
           {annotation.label && (
             <span
               data-testid='annotation-panel-label'
               style={{
+                alignSelf: 'flex-start',
                 fontSize: 14,
                 fontWeight: 500,
                 color: theme.palette.TwClrTxtSuccess,

--- a/src/components/GaussianSplat/AnnotationPanel.tsx
+++ b/src/components/GaussianSplat/AnnotationPanel.tsx
@@ -16,11 +16,19 @@ interface AnnotationPanelProps {
 // Fallback hotspot diameter (px) when the rendered size isn't reported yet.
 const DEFAULT_HOTSPOT_DIAMETER = 35;
 
+// Horizontal gap (px) kept between the panel's right edge and the hotspot so
+// the connector line stays visible.
+const PANEL_HOTSPOT_GAP = 48;
+
+// Minimum distance from the left edge of the viewer, as a fraction of its
+// width, so the panel never drifts further left than this.
+const MIN_LEFT_FRACTION = 0.02;
+
 const BACKDROP_STYLE: React.CSSProperties = {
   position: 'absolute',
   inset: 0,
   zIndex: 5001,
-  cursor: 'pointer',
+  cursor: 'default',
 };
 
 const CONNECTOR_STYLE: React.CSSProperties = {
@@ -68,6 +76,7 @@ const AnnotationPanel = ({ annotation, hotspotPosition, onClose }: AnnotationPan
   const panelRef = useRef<HTMLDivElement>(null);
   const connectorRef = useRef<SVGSVGElement>(null);
   const [lineStart, setLineStart] = useState<{ x: number; y: number } | null>(null);
+  const [panelLeft, setPanelLeft] = useState<number | null>(null);
 
   useEffect(() => {
     if (!annotation) {
@@ -84,19 +93,26 @@ const AnnotationPanel = ({ annotation, hotspotPosition, onClose }: AnnotationPan
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [annotation, onClose]);
 
-  // Anchor the line at the vertical center of the panel's right edge, in the
+  // Position the panel just to the left of the hotspot (clamped so it never
+  // goes further left than MIN_LEFT_FRACTION of the viewer) and anchor the
+  // connector line at the vertical center of the panel's right edge, in the
   // connector SVG's coordinate space.
   useLayoutEffect(() => {
     if (!annotation || !hotspotPosition || !panelRef.current || !connectorRef.current) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
+      setPanelLeft(null);
       setLineStart(null);
       return;
     }
-    const panelRect = panelRef.current.getBoundingClientRect();
+    const panelWidth = panelRef.current.getBoundingClientRect().width;
     const connectorRect = connectorRef.current.getBoundingClientRect();
+    const minLeft = connectorRect.width * MIN_LEFT_FRACTION;
+    const desiredLeft = hotspotPosition.x - PANEL_HOTSPOT_GAP - panelWidth;
+    const left = Math.max(desiredLeft, minLeft);
+    setPanelLeft(left);
     setLineStart({
-      x: panelRect.right - connectorRect.left,
-      y: panelRect.top + panelRect.height / 2 - connectorRect.top,
+      x: left + panelWidth,
+      y: connectorRect.height / 2,
     });
   }, [annotation, hotspotPosition]);
 
@@ -107,6 +123,7 @@ const AnnotationPanel = ({ annotation, hotspotPosition, onClose }: AnnotationPan
   const panelStyle: React.CSSProperties = {
     ...PANEL_STYLE,
     ...(annotation.imageUrl ? { width: '60vw' } : { width: 'fit-content', maxWidth: '50vw' }),
+    ...(panelLeft !== null ? { left: `${panelLeft}px` } : {}),
   };
 
   // Stop the line at the edge of the hotspot circle

--- a/src/components/GaussianSplat/TfAnnotationManager.ts
+++ b/src/components/GaussianSplat/TfAnnotationManager.ts
@@ -281,7 +281,10 @@ export class TfAnnotationManager extends PcAnnotationManager {
     }
 
     if (annotation.onScreenPositionUpdateCallback) {
-      annotation.onScreenPositionUpdateCallback(screenPos.x + offsetX, screenPos.y + offsetY);
+      // Rendered hotspot diameter (px), set by _updateAnnotationRotationAndScale.
+      // Parsed from the style rather than measured to avoid forcing a reflow.
+      const hotspotSize = parseFloat(resources.hotspotDom.style.width) || undefined;
+      annotation.onScreenPositionUpdateCallback(screenPos.x + offsetX, screenPos.y + offsetY, hotspotSize);
     }
   }
 

--- a/src/components/GaussianSplat/walkthrough-camera.ts
+++ b/src/components/GaussianSplat/walkthrough-camera.ts
@@ -201,8 +201,15 @@ export class WalkthroughCamera extends Script {
   /**
    * Position the camera at `position` looking toward `focus`.
    * Compatible with the useCameraPosition hook's reset() call.
+   *
+   * `horizontalNdcBias` offsets the aim horizontally so `focus` lands off-center
+   * on screen. It is the target normalized-device x coordinate for `focus`
+   * (0 = centered, +0.5 = three quarters across / 25% from the right). It is
+   * applied as a pure yaw offset, so the pitch toward `focus` — looking up/down
+   * at the hotspot, and its vertical centering — is preserved, and the on-screen
+   * position is independent of the distance to `focus`.
    */
-  reset(focus: Vec3, position: Vec3) {
+  reset(focus: Vec3, position: Vec3, horizontalNdcBias = 0) {
     this.entity.setPosition(position);
 
     const dx = focus.x - position.x;
@@ -211,10 +218,23 @@ export class WalkthroughCamera extends Script {
     const len = Math.sqrt(dx * dx + dy * dy + dz * dz);
     if (len > 0) {
       // PlayCanvas uses right-handed CCW Y rotation: forward = (-sinθ, 0, -cosθ),
-      // so to look toward (dx, 0, dz): θ = atan2(-dx, -dz).
+      // so to look toward (dx, 0, dz): yaw = atan2(-dx, -dz). Positive pitch tilts
+      // the view up (matching the pointer-look controls), so a focus above the
+      // camera (dy > 0) uses a positive pitch.
       this._yaw = Math.atan2(-dx, -dz) * (180 / Math.PI);
-      this._pitch = Math.atan2(-dy, Math.sqrt(dx * dx + dz * dz)) * (180 / Math.PI);
+      this._pitch = Math.atan2(dy, Math.sqrt(dx * dx + dz * dz)) * (180 / Math.PI);
       this._pitch = math.clamp(this._pitch, this.pitchMin, this.pitchMax);
+
+      if (horizontalNdcBias !== 0) {
+        // projectionMatrix.data[0] = 1 / tan(halfFovX), so atan(ndc / data[0]) =
+        // atan(ndc * tan(halfFovX)) is the yaw offset that slides `focus` to the
+        // requested normalized-device x, independent of distance. Only yaw
+        // changes, so the pitch toward `focus` is retained.
+        const projScaleX = this.entity.camera?.projectionMatrix?.data?.[0];
+        if (projScaleX) {
+          this._yaw += Math.atan(horizontalNdcBias / projScaleX) * (180 / Math.PI);
+        }
+      }
     }
 
     // Snap targets so there's no damped drift from the previous pose.

--- a/src/hooks/useCameraPosition.ts
+++ b/src/hooks/useCameraPosition.ts
@@ -7,12 +7,13 @@ export const useCameraPosition = () => {
   const app = useApp();
 
   const setCamera = useCallback(
-    (focus: [number, number, number], position?: [number, number, number]) => {
+    (focus: [number, number, number], position?: [number, number, number], horizontalNdcBias = 0) => {
       const camera = app.root.findByName('camera');
       // @ts-expect-error - scripts are added dynamically to the camera entity
       const controls = camera?.script?.cameraControls ?? camera?.script?.walkthroughCamera;
       if (controls && camera) {
-        controls.reset(new Vec3(focus), position ? new Vec3(position) : camera.getPosition());
+        // The extra bias arg is only honored by WalkthroughCamera; CameraControls ignores it.
+        controls.reset(new Vec3(focus), position ? new Vec3(position) : camera.getPosition(), horizontalNdcBias);
       }
     },
     [app]

--- a/src/scenes/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/scenes/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -62,6 +62,8 @@ const VirtualWalkthroughViewer = ({
   const [localAnnotations, setLocalAnnotations] = useState<AnnotationProps[]>([]);
   const [isTextFieldFocused, setIsTextFieldFocused] = useState(false);
   const [viewingAnnotation, setViewingAnnotation] = useState<AnnotationProps | null>(null);
+  const [viewingAnnotationIndex, setViewingAnnotationIndex] = useState(-1);
+  const [viewedScreenPos, setViewedScreenPos] = useState<{ x: number; y: number; size?: number } | null>(null);
   const [getOrgSplatInfo, { data: orgData }] = useLazyGetOrganizationSplatInfoQuery();
   const [getObsSplatInfo, { data: obsData }] = useLazyListSplatDetailsQuery();
   const [saveObservationAnnotations] = useSetObservationSplatAnnotationsMutation();
@@ -282,9 +284,30 @@ const VirtualWalkthroughViewer = ({
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     (annotation: AnnotationProps, annotationIndex: number, screenX: number, screenY: number) => {
       setViewingAnnotation(annotation);
+      setViewingAnnotationIndex(annotationIndex);
+      // Cleared so the connector line waits for the hotspot's post-aim position
+      // rather than briefly pointing at its old spot.
+      setViewedScreenPos(null);
     },
     []
   );
+
+  const handleAnnotationScreenPositionUpdate = useCallback(
+    (_index: number, screenX: number, screenY: number, size?: number) => {
+      // The scene is frozen while the panel is open, so guard against redundant
+      // updates from the per-frame callback to avoid needless re-renders.
+      setViewedScreenPos((prev) =>
+        prev && prev.x === screenX && prev.y === screenY && prev.size === size ? prev : { x: screenX, y: screenY, size }
+      );
+    },
+    []
+  );
+
+  const handleCloseAnnotation = useCallback(() => {
+    setViewingAnnotation(null);
+    setViewingAnnotationIndex(-1);
+    setViewedScreenPos(null);
+  }, []);
 
   const handleAnnotationUpdate = useCallback(
     (updates: Partial<AnnotationProps>) => {
@@ -333,7 +356,7 @@ const VirtualWalkthroughViewer = ({
         <Script script={TfXrNavigation} enabled={!isEdit} enableTeleport={false} />
         <Script
           script={AutoRotator}
-          enabled={!isEdit && autoRotate}
+          enabled={!isEdit && autoRotate && !viewingAnnotation}
           startDelay={0.5}
           restartDelay={3}
           startFadeInTime={0.5}
@@ -366,9 +389,11 @@ const VirtualWalkthroughViewer = ({
               visible={showAnnotations}
               isEdit={isEdit}
               isSelected={selectedAnnotationIndex === index}
+              isViewed={viewingAnnotationIndex === index}
               onSelect={() => setSelectedAnnotationIndex(index)}
               onPositionChange={handleAnnotationPositionChange}
               onView={(anno, screenX, screenY) => handleAnnotationView(anno, index, screenX, screenY)}
+              onScreenPositionUpdate={handleAnnotationScreenPositionUpdate}
             />
           ))}
         </Entity>
@@ -402,9 +427,8 @@ const VirtualWalkthroughViewer = ({
 
       <AnnotationPanel
         annotation={viewingAnnotation}
-        onClose={() => {
-          setViewingAnnotation(null);
-        }}
+        hotspotPosition={viewedScreenPos}
+        onClose={handleCloseAnnotation}
       />
     </>
   );


### PR DESCRIPTION
When an annotation is clicked, move it to (roughly) the vertical center of the screen and 25% from the right side of the screen so both the panel and the annotation are visible together. 

Add a connecting line between the center of the panel and the annotation.

Move the panel closer to the annotation when it is smaller than 60vw.

Allow the virtual walkthrough to still be interactible when the panel is open (it will close once a click event happens).

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>