### PR TITLE
SW-8678 Fix styling for photos in annotations

### DIFF
--- a/src/components/GaussianSplat/AnnotationPanel.tsx
+++ b/src/components/GaussianSplat/AnnotationPanel.tsx
@@ -50,8 +50,10 @@ const PANEL_STYLE: React.CSSProperties = {
 };
 
 const IMAGE_STYLE: React.CSSProperties = {
-  width: '100%',
+  width: 'auto',
   height: 'auto',
+  maxWidth: '100%',
+  maxHeight: '60vh',
   display: 'block',
   borderRadius: '12px 12px 0 0',
   flexShrink: 0,
@@ -125,7 +127,9 @@ const AnnotationPanel = ({ annotation, hotspotPosition, onClose }: AnnotationPan
 
   const panelStyle: React.CSSProperties = {
     ...PANEL_STYLE,
-    ...(annotation.imageUrl ? { width: '60vw' } : { width: 'fit-content', maxWidth: '50vw' }),
+    ...(annotation.imageUrl
+      ? { width: 'fit-content', maxWidth: '60vw' }
+      : { width: 'fit-content', maxWidth: '50vw' }),
     ...(panelLeft !== null ? { left: `${panelLeft}px` } : {}),
   };
 

--- a/src/components/GaussianSplat/AnnotationPanel.tsx
+++ b/src/components/GaussianSplat/AnnotationPanel.tsx
@@ -127,9 +127,7 @@ const AnnotationPanel = ({ annotation, hotspotPosition, onClose }: AnnotationPan
 
   const panelStyle: React.CSSProperties = {
     ...PANEL_STYLE,
-    ...(annotation.imageUrl
-      ? { width: 'fit-content', maxWidth: '60vw' }
-      : { width: 'fit-content', maxWidth: '50vw' }),
+    ...(annotation.imageUrl ? { width: 'fit-content', maxWidth: '60vw' } : { width: 'fit-content', maxWidth: '50vw' }),
     ...(panelLeft !== null ? { left: `${panelLeft}px` } : {}),
   };
 

--- a/src/scenes/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/scenes/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -32,6 +32,14 @@ import {
 const DEFAULT_FOCUS_POINT: [number, number, number] = [0, 0.1, 0];
 const DEFAULT_POSITION: [number, number, number] = [1, 0.1, 0];
 
+// TODO: replace with actual image urls once retrieval is available
+const PLACEHOLDER_IMAGE_URLS = [
+  'https://placehold.co/1080x1920',
+  'https://placehold.co/1920x1080',
+  'https://placehold.co/800x450',
+  'https://placehold.co/450x800',
+];
+
 export type VirtualWalkthroughViewerProps = {
   fileId: number;
   observationId?: number;
@@ -147,7 +155,7 @@ const VirtualWalkthroughViewer = ({
 
   const apiAnnotations = useMemo<AnnotationProps[]>(
     () =>
-      data?.annotations?.map((annotation) => {
+      data?.annotations?.map((annotation, index) => {
         const [firstMedia] = annotation.media;
         const icon: AnnotationIconType = !firstMedia
           ? 'text'
@@ -169,7 +177,8 @@ const VirtualWalkthroughViewer = ({
             : undefined,
           icon,
           // TODO: replace with actual image url once retrieval is available
-          imageUrl: annotation.media.length > 0 ? 'https://placehold.co/800x450' : undefined,
+          imageUrl:
+            annotation.media.length > 0 ? PLACEHOLDER_IMAGE_URLS[index % PLACEHOLDER_IMAGE_URLS.length] : undefined,
         } as AnnotationProps;
       }) ?? [],
     [data?.annotations]

--- a/src/scenes/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/scenes/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -32,8 +32,8 @@ import {
 const DEFAULT_FOCUS_POINT: [number, number, number] = [0, 0.1, 0];
 const DEFAULT_POSITION: [number, number, number] = [1, 0.1, 0];
 
-// TODO: replace with actual image urls once retrieval is available
 const PLACEHOLDER_IMAGE_URLS = [
+  'https://images.unsplash.com/photo-1722444366501-6e5de9e768d1?fm=jpg&q=60&w=3000&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NHx8cG9ydHJhaXQlMjBsYW5kc2NhcGV8ZW58MHx8MHx8fDA%3D',
   'https://placehold.co/1080x1920',
   'https://placehold.co/1920x1080',
   'https://placehold.co/800x450',


### PR DESCRIPTION
Make photos fit correctly in annotations regardless of orientation or size.

Because it's currently not possible to save a photo to an annotation, the test urls are safe to merge and will only be visible for testing when manually inserting photos.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>