### PR TITLE
Send raw enum values in planting date requests search filter

### DIFF
--- a/src/queries/search/plantingDateRequests.ts
+++ b/src/queries/search/plantingDateRequests.ts
@@ -63,13 +63,13 @@ const injectedRtkApi = api.injectEndpoints({
           },
           {
             operation: 'field',
-            field: 'scheduledPlantingDate_plantingSeason_status',
+            field: 'scheduledPlantingDate_plantingSeason_status(raw)',
             type: 'Exact',
             values: includedPlantingSeasonStatuses,
           },
           {
             operation: 'field',
-            field: 'status',
+            field: 'status(raw)',
             type: 'Exact',
             values: ['Pending', 'Partial'],
           },


### PR DESCRIPTION
The status filters in listPlantingDateRequests were sent as localized display names, which failed for users on non-English locales. Switched to the (raw) field variants so values match against locale-independent jsonValue.