### PR TITLE
SW-8697 Migrate species CRUD/lookup to RTK Query

### DIFF
--- a/rtk-codegen.config.ts
+++ b/rtk-codegen.config.ts
@@ -130,6 +130,9 @@ const config: ConfigFile = {
     './src/queries/generated/plantingSeasons.ts': {
       filterEndpoints: (_, operation) => operation.path.startsWith('/api/v1/planting-seasons'),
     },
+    './src/queries/generated/species.ts': {
+      filterEndpoints: (_, operation) => operation.path.startsWith('/api/v1/species'),
+    },
     './src/queries/generated/stats.ts': {
       filterEndpoints: (_, operation) => operation.path.startsWith('/api/v1/tracking/stats'),
     },

--- a/src/queries/extensions/species.ts
+++ b/src/queries/extensions/species.ts
@@ -1,0 +1,38 @@
+import { api } from '../generated/species';
+import { QueryTagTypes } from '../tags';
+
+api.enhanceEndpoints({
+  endpoints: {
+    listSpecies: {
+      providesTags: (result) => [
+        ...(result ? result.species.map((species) => ({ type: QueryTagTypes.Species, id: species.id })) : []),
+        { type: QueryTagTypes.Species, id: 'LIST' },
+      ],
+    },
+    getSpecies: {
+      providesTags: (_result, _error, arg) => [{ type: QueryTagTypes.Species, id: arg.speciesId }],
+    },
+    createSpecies: {
+      invalidatesTags: [{ type: QueryTagTypes.Species, id: 'LIST' }],
+    },
+    updateSpecies: {
+      invalidatesTags: (_result, _error, arg) => [
+        { type: QueryTagTypes.Species, id: arg.speciesId },
+        { type: QueryTagTypes.Species, id: 'LIST' },
+      ],
+    },
+    deleteSpecies: {
+      invalidatesTags: (_result, _error, speciesId) => [
+        { type: QueryTagTypes.Species, id: speciesId },
+        { type: QueryTagTypes.Species, id: 'LIST' },
+      ],
+    },
+    resolveSpeciesListUpload: {
+      invalidatesTags: [{ type: QueryTagTypes.Species, id: 'LIST' }],
+    },
+    acceptProblemSuggestion: {
+      // Accepting a suggestion rewrites the species' scientific name.
+      invalidatesTags: [{ type: QueryTagTypes.Species, id: 'LIST' }],
+    },
+  },
+});

--- a/src/queries/generated/species.ts
+++ b/src/queries/generated/species.ts
@@ -1,0 +1,573 @@
+import { baseApi as api } from '../baseApi';
+
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    listSpecies: build.query<ListSpeciesApiResponse, ListSpeciesApiArg>({
+      query: (queryArg) => ({
+        url: `/api/v1/species`,
+        params: {
+          organizationId: queryArg.organizationId,
+          inUse: queryArg.inUse,
+        },
+      }),
+    }),
+    createSpecies: build.mutation<CreateSpeciesApiResponse, CreateSpeciesApiArg>({
+      query: (queryArg) => ({ url: `/api/v1/species`, method: 'POST', body: queryArg }),
+    }),
+    getSpeciesDetails: build.query<GetSpeciesDetailsApiResponse, GetSpeciesDetailsApiArg>({
+      query: (queryArg) => ({
+        url: `/api/v1/species/lookup/details`,
+        params: {
+          scientificName: queryArg.scientificName,
+          language: queryArg.language,
+        },
+      }),
+    }),
+    listSpeciesNames: build.query<ListSpeciesNamesApiResponse, ListSpeciesNamesApiArg>({
+      query: (queryArg) => ({
+        url: `/api/v1/species/lookup/names`,
+        params: {
+          search: queryArg.search,
+          maxResults: queryArg.maxResults,
+        },
+      }),
+    }),
+    deleteProblem: build.mutation<DeleteProblemApiResponse, DeleteProblemApiArg>({
+      query: (queryArg) => ({ url: `/api/v1/species/problems/${queryArg}`, method: 'DELETE' }),
+    }),
+    getSpeciesProblem: build.query<GetSpeciesProblemApiResponse, GetSpeciesProblemApiArg>({
+      query: (queryArg) => ({ url: `/api/v1/species/problems/${queryArg}` }),
+    }),
+    acceptProblemSuggestion: build.mutation<AcceptProblemSuggestionApiResponse, AcceptProblemSuggestionApiArg>({
+      query: (queryArg) => ({ url: `/api/v1/species/problems/${queryArg}`, method: 'POST' }),
+    }),
+    assignSpeciesToProjects: build.mutation<AssignSpeciesToProjectsApiResponse, AssignSpeciesToProjectsApiArg>({
+      query: (queryArg) => ({ url: `/api/v1/species/projects/assign`, method: 'POST', body: queryArg }),
+    }),
+    overrideProjectSpeciesData: build.mutation<OverrideProjectSpeciesDataApiResponse, OverrideProjectSpeciesDataApiArg>(
+      {
+        query: (queryArg) => ({ url: `/api/v1/species/projects/override`, method: 'POST', body: queryArg }),
+      }
+    ),
+    unassignSpeciesFromProjects: build.mutation<
+      UnassignSpeciesFromProjectsApiResponse,
+      UnassignSpeciesFromProjectsApiArg
+    >({
+      query: (queryArg) => ({ url: `/api/v1/species/projects/unassign`, method: 'POST', body: queryArg }),
+    }),
+    uploadSpeciesList: build.mutation<UploadSpeciesListApiResponse, UploadSpeciesListApiArg>({
+      query: (queryArg) => ({
+        url: `/api/v1/species/uploads`,
+        method: 'POST',
+        body: queryArg.body,
+        params: {
+          organizationId: queryArg.organizationId,
+        },
+      }),
+    }),
+    getSpeciesListUploadTemplate: build.query<
+      GetSpeciesListUploadTemplateApiResponse,
+      GetSpeciesListUploadTemplateApiArg
+    >({
+      query: () => ({ url: `/api/v1/species/uploads/template` }),
+    }),
+    deleteSpeciesListUpload: build.mutation<DeleteSpeciesListUploadApiResponse, DeleteSpeciesListUploadApiArg>({
+      query: (queryArg) => ({ url: `/api/v1/species/uploads/${queryArg}`, method: 'DELETE' }),
+    }),
+    getSpeciesListUploadStatus: build.query<GetSpeciesListUploadStatusApiResponse, GetSpeciesListUploadStatusApiArg>({
+      query: (queryArg) => ({ url: `/api/v1/species/uploads/${queryArg}` }),
+    }),
+    resolveSpeciesListUpload: build.mutation<ResolveSpeciesListUploadApiResponse, ResolveSpeciesListUploadApiArg>({
+      query: (queryArg) => ({
+        url: `/api/v1/species/uploads/${queryArg.uploadId}/resolve`,
+        method: 'POST',
+        body: queryArg.resolveUploadRequestPayload,
+      }),
+    }),
+    deleteSpecies: build.mutation<DeleteSpeciesApiResponse, DeleteSpeciesApiArg>({
+      query: (queryArg) => ({ url: `/api/v1/species/${queryArg}`, method: 'DELETE' }),
+    }),
+    getSpecies: build.query<GetSpeciesApiResponse, GetSpeciesApiArg>({
+      query: (queryArg) => ({
+        url: `/api/v1/species/${queryArg.speciesId}`,
+        params: {
+          organizationId: queryArg.organizationId,
+        },
+      }),
+    }),
+    updateSpecies: build.mutation<UpdateSpeciesApiResponse, UpdateSpeciesApiArg>({
+      query: (queryArg) => ({
+        url: `/api/v1/species/${queryArg.speciesId}`,
+        method: 'PUT',
+        body: queryArg.updateSpeciesRequestPayload,
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as api };
+export type ListSpeciesApiResponse = /** status 200 OK */ ListSpeciesResponsePayload;
+export type ListSpeciesApiArg = {
+  /** Organization whose species should be listed. */
+  organizationId: number;
+  /** Only list species that are currently used in the organization's inventory, accessions or planting sites. */
+  inUse?: boolean;
+};
+export type CreateSpeciesApiResponse = /** status 200 Species created. */ CreateSpeciesResponsePayload;
+export type CreateSpeciesApiArg = CreateSpeciesRequestPayload;
+export type GetSpeciesDetailsApiResponse = /** status 200 OK */ SpeciesLookupDetailsResponsePayload;
+export type GetSpeciesDetailsApiArg = {
+  /** Exact scientific name to look up. This name is case-sensitive. */
+  scientificName: string;
+  /** If specified, only return common names in this language or whose language is unknown. Names with unknown languages are always included. This is a two-letter ISO 639-1 language code. */
+  language?: string;
+};
+export type ListSpeciesNamesApiResponse = /** status 200 OK */ SpeciesLookupNamesResponsePayload;
+export type ListSpeciesNamesApiArg = {
+  /** Space-delimited list of word prefixes to search for. Non-alphabetic characters are ignored, and matches are case-insensitive. The order of prefixes is significant; "ag sc" will match "Aglaonema schottianum" but won't match "Scabiosa agrestis". */
+  search: string;
+  /** Maximum number of results to return. */
+  maxResults?: number;
+};
+export type DeleteProblemApiResponse =
+  /** status 200 The requested operation succeeded. */ SimpleSuccessResponsePayload;
+export type DeleteProblemApiArg = number;
+export type GetSpeciesProblemApiResponse = /** status 200 Problem retrieved. */ GetSpeciesProblemResponsePayload;
+export type GetSpeciesProblemApiArg = number;
+export type AcceptProblemSuggestionApiResponse =
+  /** status 200 Suggestion applied. Response contains the updated species information. */ GetSpeciesResponsePayload;
+export type AcceptProblemSuggestionApiArg = number;
+export type AssignSpeciesToProjectsApiResponse =
+  /** status 200 The requested operation succeeded. */ SimpleSuccessResponsePayload;
+export type AssignSpeciesToProjectsApiArg = AssignSpeciesToProjectsPayload;
+export type OverrideProjectSpeciesDataApiResponse = /** status 200 OK */ SimpleSuccessResponsePayload;
+export type OverrideProjectSpeciesDataApiArg = OverrideSpeciesProjectDataRequestPayload;
+export type UnassignSpeciesFromProjectsApiResponse =
+  /** status 200 The requested operation succeeded. */ SimpleSuccessResponsePayload;
+export type UnassignSpeciesFromProjectsApiArg = AssignSpeciesToProjectsPayload;
+export type UploadSpeciesListApiResponse =
+  /** status 200 The file has been successfully received. It will be processed asynchronously; use the ID returned in the response payload to poll for its status using the `/api/v1/species/uploads/{uploadId}` GET endpoint. */ UploadFileResponsePayload;
+export type UploadSpeciesListApiArg = {
+  organizationId: number;
+  body: {
+    file: Blob;
+  };
+};
+export type GetSpeciesListUploadTemplateApiResponse = /** status 200 OK */ string;
+export type GetSpeciesListUploadTemplateApiArg = void;
+export type DeleteSpeciesListUploadApiResponse =
+  /** status 200 The requested operation succeeded. */ SimpleSuccessResponsePayload;
+export type DeleteSpeciesListUploadApiArg = number;
+export type GetSpeciesListUploadStatusApiResponse = /** status 200 OK */ GetUploadStatusResponsePayload;
+export type GetSpeciesListUploadStatusApiArg = number;
+export type ResolveSpeciesListUploadApiResponse =
+  /** status 200 The requested operation succeeded. */ SimpleSuccessResponsePayload;
+export type ResolveSpeciesListUploadApiArg = {
+  uploadId: number;
+  resolveUploadRequestPayload: ResolveUploadRequestPayload;
+};
+export type DeleteSpeciesApiResponse = /** status 200 Species deleted. */ SimpleSuccessResponsePayload;
+export type DeleteSpeciesApiArg = number;
+export type GetSpeciesApiResponse = /** status 200 Species retrieved. */ GetSpeciesResponsePayload;
+export type GetSpeciesApiArg = {
+  speciesId: number;
+  /** Organization whose information about the species should be returned. */
+  organizationId: number;
+};
+export type UpdateSpeciesApiResponse =
+  /** status 200 Species updated or merged with an existing species. */ SimpleSuccessResponsePayload;
+export type UpdateSpeciesApiArg = {
+  speciesId: number;
+  updateSpeciesRequestPayload: UpdateSpeciesRequestPayload;
+};
+export type SpeciesDataSourcePayload = {
+  datasetDate: string;
+  datasetType: 'GBIF' | 'WCVP' | 'GRIIS' | 'RESOLVE' | 'NaturalEarth';
+};
+export type SpeciesProblemElement = {
+  field: 'Scientific Name';
+  id: number;
+  /** Value for the field in question that would correct the problem. Absent if the system is unable to calculate a corrected value. */
+  suggestedValue?: string;
+  type: 'Name Misspelled' | 'Name Not Found' | 'Name Is Synonym';
+};
+export type SpeciesProjectElement = {
+  calculatedNativity?: 'Invasive' | 'Introduced' | 'Native' | 'Unknown';
+  calculatedNativitySource?: SpeciesDataSourcePayload;
+  overriddenJustification?: string;
+  overriddenNativity?: 'Invasive' | 'Introduced' | 'Native' | 'Unknown';
+  projectId?: number;
+};
+export type SpeciesResponseElement = {
+  averageWoodDensity?: number;
+  commonName?: string;
+  commonNameSource?: SpeciesDataSourcePayload;
+  /** IUCN Red List conservation category code. */
+  conservationCategory?: 'CR' | 'DD' | 'EN' | 'EW' | 'EX' | 'LC' | 'NE' | 'NT' | 'VU';
+  createdTime: string;
+  dbhSource?: string;
+  dbhValue?: number;
+  ecologicalRoleKnown?: string;
+  ecosystemTypes?: (
+    | 'Boreal forests/Taiga'
+    | 'Deserts and xeric shrublands'
+    | 'Flooded grasslands and savannas'
+    | 'Mangroves'
+    | 'Mediterranean forests, woodlands and scrubs'
+    | 'Montane grasslands and shrublands'
+    | 'Temperate broad leaf and mixed forests'
+    | 'Temperate coniferous forest'
+    | 'Temperate grasslands, savannas and shrublands'
+    | 'Tropical and subtropical coniferous forests'
+    | 'Tropical and subtropical dry broad leaf forests'
+    | 'Tropical and subtropical grasslands, savannas and shrublands'
+    | 'Tropical and subtropical moist broad leaf forests'
+    | 'Tundra'
+  )[];
+  familyName?: string;
+  familyNameSource?: SpeciesDataSourcePayload;
+  growthForms?: (
+    | 'Tree'
+    | 'Shrub'
+    | 'Forb'
+    | 'Graminoid'
+    | 'Fern'
+    | 'Fungus'
+    | 'Lichen'
+    | 'Moss'
+    | 'Vine'
+    | 'Liana'
+    | 'Subshrub'
+    | 'Multiple Forms'
+    | 'Mangrove'
+    | 'Herb'
+  )[];
+  heightAtMaturitySource?: string;
+  heightAtMaturityValue?: number;
+  id: number;
+  localUsesKnown?: string;
+  modifiedTime: string;
+  nativeEcosystem?: string;
+  otherFacts?: string;
+  plantMaterialSourcingMethods?: (
+    | 'Seed collection & germination'
+    | 'Seed purchase & germination'
+    | 'Mangrove propagules'
+    | 'Vegetative propagation'
+    | 'Wildling harvest'
+    | 'Seedling purchase'
+    | 'Other'
+  )[];
+  problems?: SpeciesProblemElement[];
+  projects: SpeciesProjectElement[];
+  rare?: boolean;
+  scientificName: string;
+  seedStorageBehavior?:
+    | 'Orthodox'
+    | 'Recalcitrant'
+    | 'Intermediate'
+    | 'Unknown'
+    | 'Likely Orthodox'
+    | 'Likely Recalcitrant'
+    | 'Likely Intermediate'
+    | 'Intermediate - Cool Temperature Sensitive'
+    | 'Intermediate - Partial Desiccation Tolerant'
+    | 'Intermediate - Short Lived'
+    | 'Likely Intermediate - Cool Temperature Sensitive'
+    | 'Likely Intermediate - Partial Desiccation Tolerant'
+    | 'Likely Intermediate - Short Lived';
+  successionalGroups?: ('Pioneer' | 'Early secondary' | 'Late secondary' | 'Mature')[];
+  woodDensityLevel?: 'Species' | 'Genus' | 'Family';
+};
+export type SuccessOrError = 'ok' | 'error';
+export type ListSpeciesResponsePayload = {
+  species: SpeciesResponseElement[];
+  status: SuccessOrError;
+};
+export type CreateSpeciesResponsePayload = {
+  id: number;
+  status: SuccessOrError;
+};
+export type CreateSpeciesRequestPayload = {
+  averageWoodDensity?: number;
+  commonName?: string;
+  /** IUCN Red List conservation category code. */
+  conservationCategory?: 'CR' | 'DD' | 'EN' | 'EW' | 'EX' | 'LC' | 'NE' | 'NT' | 'VU';
+  dbhSource?: string;
+  dbhValue?: number;
+  ecologicalRoleKnown?: string;
+  ecosystemTypes?: (
+    | 'Boreal forests/Taiga'
+    | 'Deserts and xeric shrublands'
+    | 'Flooded grasslands and savannas'
+    | 'Mangroves'
+    | 'Mediterranean forests, woodlands and scrubs'
+    | 'Montane grasslands and shrublands'
+    | 'Temperate broad leaf and mixed forests'
+    | 'Temperate coniferous forest'
+    | 'Temperate grasslands, savannas and shrublands'
+    | 'Tropical and subtropical coniferous forests'
+    | 'Tropical and subtropical dry broad leaf forests'
+    | 'Tropical and subtropical grasslands, savannas and shrublands'
+    | 'Tropical and subtropical moist broad leaf forests'
+    | 'Tundra'
+  )[];
+  familyName?: string;
+  growthForms?: (
+    | 'Tree'
+    | 'Shrub'
+    | 'Forb'
+    | 'Graminoid'
+    | 'Fern'
+    | 'Fungus'
+    | 'Lichen'
+    | 'Moss'
+    | 'Vine'
+    | 'Liana'
+    | 'Subshrub'
+    | 'Multiple Forms'
+    | 'Mangrove'
+    | 'Herb'
+  )[];
+  heightAtMaturitySource?: string;
+  heightAtMaturityValue?: number;
+  localUsesKnown?: string;
+  nativeEcosystem?: string;
+  /** Which organization's species list to update. */
+  organizationId: number;
+  otherFacts?: string;
+  plantMaterialSourcingMethods?: (
+    | 'Seed collection & germination'
+    | 'Seed purchase & germination'
+    | 'Mangrove propagules'
+    | 'Vegetative propagation'
+    | 'Wildling harvest'
+    | 'Seedling purchase'
+    | 'Other'
+  )[];
+  projectIds?: number[];
+  rare?: boolean;
+  scientificName: string;
+  seedStorageBehavior?:
+    | 'Orthodox'
+    | 'Recalcitrant'
+    | 'Intermediate'
+    | 'Unknown'
+    | 'Likely Orthodox'
+    | 'Likely Recalcitrant'
+    | 'Likely Intermediate'
+    | 'Intermediate - Cool Temperature Sensitive'
+    | 'Intermediate - Partial Desiccation Tolerant'
+    | 'Intermediate - Short Lived'
+    | 'Likely Intermediate - Cool Temperature Sensitive'
+    | 'Likely Intermediate - Partial Desiccation Tolerant'
+    | 'Likely Intermediate - Short Lived';
+  successionalGroups?: ('Pioneer' | 'Early secondary' | 'Late secondary' | 'Mature')[];
+  woodDensityLevel?: 'Species' | 'Genus' | 'Family';
+};
+export type SpeciesLookupCommonNamePayload = {
+  /** ISO 639-1 two-letter language code indicating the name's language. Some common names in the server's taxonomic database are not tagged with languages; this value will not be present for those names. */
+  language?: string;
+  name: string;
+};
+export type SpeciesLookupDetailsResponsePayload = {
+  /** IUCN Red List conservation category code. */
+  commonNameSource: SpeciesDataSourcePayload;
+  /** List of known common names for the species, if any. */
+  commonNames?: SpeciesLookupCommonNamePayload[];
+  conservationCategory?: 'CR' | 'DD' | 'EN' | 'EW' | 'EX' | 'LC' | 'NE' | 'NT' | 'VU';
+  familyName: string;
+  familyNameSource: SpeciesDataSourcePayload;
+  /** If this is not the accepted name for the species, the type of problem the name has. Currently, this will always be "Name Is Synonym". */
+  problemType?: 'Name Misspelled' | 'Name Not Found' | 'Name Is Synonym';
+  scientificName: string;
+  status: SuccessOrError;
+  /** If this is not the accepted name for the species, the name to suggest as an alternative. */
+  suggestedScientificName?: string;
+};
+export type ErrorDetails = {
+  message: string;
+};
+export type SimpleErrorResponsePayload = {
+  error: ErrorDetails;
+  status: SuccessOrError;
+};
+export type SpeciesLookupNamesResponsePayload = {
+  names: string[];
+  /** True if there were more matching names than could be included in the response. */
+  partial: boolean;
+  status: SuccessOrError;
+};
+export type SimpleSuccessResponsePayload = {
+  status: SuccessOrError;
+};
+export type GetSpeciesProblemResponsePayload = {
+  problem: SpeciesProblemElement;
+  status: SuccessOrError;
+};
+export type GetSpeciesResponsePayload = {
+  species: SpeciesResponseElement;
+  status: SuccessOrError;
+};
+export type SpeciesProjectsPayload = {
+  projectIds: number[];
+  speciesId: number;
+};
+export type AssignSpeciesToProjectsPayload = {
+  /** The species to assign, each with the projects to associate it with. */
+  species: SpeciesProjectsPayload[];
+};
+export type OverrideSpeciesProjectDataElement = {
+  overriddenJustification: string;
+  overriddenNativity: 'Invasive' | 'Introduced' | 'Native' | 'Unknown';
+  projectId?: number;
+  speciesId: number;
+};
+export type OverrideSpeciesProjectDataRequestPayload = {
+  overrides: OverrideSpeciesProjectDataElement[];
+};
+export type UploadFileResponsePayload = {
+  /** ID of uploaded file. This may be used to poll for the file's status. */
+  id: number;
+  status: SuccessOrError;
+};
+export type UploadProblemPayload = {
+  /** Name of the field with the problem. Absent if the problem isn't specific to a single field. */
+  fieldName?: string;
+  /** Human-readable description of the problem. */
+  message?: string;
+  /** Position (row number) of the record with the problem. */
+  position?: number;
+  type: 'Unrecognized Value' | 'Missing Required Value' | 'Duplicate Value' | 'Malformed Value';
+  /** The value that caused the problem. Absent if the problem wasn't caused by a specific field value. */
+  value?: string;
+};
+export type GetUploadStatusDetailsPayload = {
+  errors?: UploadProblemPayload[];
+  /** True if the server is finished processing the file, either successfully or not. */
+  finished: boolean;
+  id: number;
+  status:
+    | 'Receiving'
+    | 'Validating'
+    | 'Processing'
+    | 'Completed'
+    | 'Processing Failed'
+    | 'Invalid'
+    | 'Receiving Failed'
+    | 'Awaiting Validation'
+    | 'Awaiting User Action'
+    | 'Awaiting Processing';
+  warnings?: UploadProblemPayload[];
+};
+export type GetUploadStatusResponsePayload = {
+  details: GetUploadStatusDetailsPayload;
+  status: SuccessOrError;
+};
+export type ResolveUploadRequestPayload = {
+  /** If true, the data for entries that already exist will be overwritten with the values in the uploaded file. If false, only entries that don't already exist will be imported. */
+  overwriteExisting: boolean;
+};
+export type UpdateSpeciesRequestPayload = {
+  averageWoodDensity?: number;
+  commonName?: string;
+  /** IUCN Red List conservation category code. */
+  conservationCategory?: 'CR' | 'DD' | 'EN' | 'EW' | 'EX' | 'LC' | 'NE' | 'NT' | 'VU';
+  dbhSource?: string;
+  dbhValue?: number;
+  ecologicalRoleKnown?: string;
+  ecosystemTypes?: (
+    | 'Boreal forests/Taiga'
+    | 'Deserts and xeric shrublands'
+    | 'Flooded grasslands and savannas'
+    | 'Mangroves'
+    | 'Mediterranean forests, woodlands and scrubs'
+    | 'Montane grasslands and shrublands'
+    | 'Temperate broad leaf and mixed forests'
+    | 'Temperate coniferous forest'
+    | 'Temperate grasslands, savannas and shrublands'
+    | 'Tropical and subtropical coniferous forests'
+    | 'Tropical and subtropical dry broad leaf forests'
+    | 'Tropical and subtropical grasslands, savannas and shrublands'
+    | 'Tropical and subtropical moist broad leaf forests'
+    | 'Tundra'
+  )[];
+  familyName?: string;
+  growthForms?: (
+    | 'Tree'
+    | 'Shrub'
+    | 'Forb'
+    | 'Graminoid'
+    | 'Fern'
+    | 'Fungus'
+    | 'Lichen'
+    | 'Moss'
+    | 'Vine'
+    | 'Liana'
+    | 'Subshrub'
+    | 'Multiple Forms'
+    | 'Mangrove'
+    | 'Herb'
+  )[];
+  heightAtMaturitySource?: string;
+  heightAtMaturityValue?: number;
+  localUsesKnown?: string;
+  nativeEcosystem?: string;
+  /** Which organization's species list to update. */
+  organizationId: number;
+  otherFacts?: string;
+  plantMaterialSourcingMethods?: (
+    | 'Seed collection & germination'
+    | 'Seed purchase & germination'
+    | 'Mangrove propagules'
+    | 'Vegetative propagation'
+    | 'Wildling harvest'
+    | 'Seedling purchase'
+    | 'Other'
+  )[];
+  rare?: boolean;
+  scientificName: string;
+  seedStorageBehavior?:
+    | 'Orthodox'
+    | 'Recalcitrant'
+    | 'Intermediate'
+    | 'Unknown'
+    | 'Likely Orthodox'
+    | 'Likely Recalcitrant'
+    | 'Likely Intermediate'
+    | 'Intermediate - Cool Temperature Sensitive'
+    | 'Intermediate - Partial Desiccation Tolerant'
+    | 'Intermediate - Short Lived'
+    | 'Likely Intermediate - Cool Temperature Sensitive'
+    | 'Likely Intermediate - Partial Desiccation Tolerant'
+    | 'Likely Intermediate - Short Lived';
+  successionalGroups?: ('Pioneer' | 'Early secondary' | 'Late secondary' | 'Mature')[];
+  woodDensityLevel?: 'Species' | 'Genus' | 'Family';
+};
+export const {
+  useListSpeciesQuery,
+  useLazyListSpeciesQuery,
+  useCreateSpeciesMutation,
+  useGetSpeciesDetailsQuery,
+  useLazyGetSpeciesDetailsQuery,
+  useListSpeciesNamesQuery,
+  useLazyListSpeciesNamesQuery,
+  useDeleteProblemMutation,
+  useGetSpeciesProblemQuery,
+  useLazyGetSpeciesProblemQuery,
+  useAcceptProblemSuggestionMutation,
+  useAssignSpeciesToProjectsMutation,
+  useOverrideProjectSpeciesDataMutation,
+  useUnassignSpeciesFromProjectsMutation,
+  useUploadSpeciesListMutation,
+  useGetSpeciesListUploadTemplateQuery,
+  useLazyGetSpeciesListUploadTemplateQuery,
+  useDeleteSpeciesListUploadMutation,
+  useGetSpeciesListUploadStatusQuery,
+  useLazyGetSpeciesListUploadStatusQuery,
+  useResolveSpeciesListUploadMutation,
+  useDeleteSpeciesMutation,
+  useGetSpeciesQuery,
+  useLazyGetSpeciesQuery,
+  useUpdateSpeciesMutation,
+} = injectedRtkApi;

--- a/src/queries/tags.ts
+++ b/src/queries/tags.ts
@@ -42,6 +42,7 @@ export enum QueryTagTypes {
   SeedbankSummary = 'SeedbankSummary',
   SeedFundReportMedia = 'SeedFundReportMedia',
   SeedFundReports = 'SeedFundReports',
+  Species = 'Species',
   T0 = 'T0',
   TrackingStats = 'TrackingStats',
   Users = 'Users',

--- a/src/scenes/Species/ProblemTooltip.tsx
+++ b/src/scenes/Species/ProblemTooltip.tsx
@@ -2,7 +2,7 @@ import React, { type JSX } from 'react';
 
 import { Box, useTheme } from '@mui/material';
 
-import { SpeciesService } from 'src/services';
+import { useAcceptProblemSuggestionMutation, useDeleteProblemMutation } from 'src/queries/generated/species';
 import strings from 'src/strings';
 import { SpeciesProblemElement } from 'src/types/Species';
 import useSnackbar from 'src/utils/useSnackbar';
@@ -26,6 +26,9 @@ export default function ProblemTooltip({
   const theme = useTheme();
   const snackbar = useSnackbar();
 
+  const [ignoreProblem] = useDeleteProblemMutation();
+  const [acceptProblem] = useAcceptProblemSuggestionMutation();
+
   const spacingStyles = {
     marginRight: theme.spacing(1),
   };
@@ -42,7 +45,7 @@ export default function ProblemTooltip({
   };
 
   const ignoreFix = async (problemId: number) => {
-    await SpeciesService.ignoreProblemSuggestion(problemId);
+    await ignoreProblem(problemId);
     onClose();
     if (reloadData) {
       reloadData();
@@ -50,8 +53,9 @@ export default function ProblemTooltip({
   };
 
   const acceptFix = async (problemId: number) => {
-    const response = await SpeciesService.acceptProblemSuggestion(problemId);
-    if (!response.requestSucceeded) {
+    try {
+      await acceptProblem(problemId).unwrap();
+    } catch {
       snackbar.toastError(strings.UNEXPECTED_ERROR, strings.GENERIC_ERROR);
     }
     onClose();

--- a/src/scenes/Species/SpeciesAddView.tsx
+++ b/src/scenes/Species/SpeciesAddView.tsx
@@ -9,8 +9,8 @@ import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
+import { useCreateSpeciesMutation } from 'src/queries/generated/species';
 import SpeciesDetailsForm from 'src/scenes/Species/SpeciesDetailsForm';
-import { SpeciesService } from 'src/services';
 import strings from 'src/strings';
 import { Species, SpeciesRequestError } from 'src/types/Species';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
@@ -37,7 +37,7 @@ export default function SpeciesAddView({ reloadData }: SpeciesAddViewProps): JSX
   const organizationId = selectedOrganization?.id || -1; // TODO: Add null check for selectedOrganization
   const [record, setRecord, , onChangeCallback] = useForm<Species>(initSpecies());
   const [nameFormatError, setNameFormatError] = useState<string | string[]>('');
-  const [isBusy, setIsBusy] = useState<boolean>(false);
+  const [createSpecies, { isLoading: isBusy }] = useCreateSpeciesMutation();
   const navigate = useSyncNavigate();
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
@@ -50,19 +50,33 @@ export default function SpeciesAddView({ reloadData }: SpeciesAddViewProps): JSX
     }
     if (!record.scientificName) {
       setNameFormatError(strings.REQUIRED_FIELD);
-    } else {
-      setIsBusy(true);
-      const response = await SpeciesService.createSpecies(record, organizationId);
-      setIsBusy(false);
-      if (response.requestSucceeded) {
-        if (response.speciesId) {
-          reloadData();
-          navigate(APP_PATHS.SPECIES_DETAILS.replace(':speciesId', response.speciesId.toString()));
-        }
-      } else {
-        if (response.error === SpeciesRequestError.PreexistingSpecies) {
-          setNameFormatError(strings.formatString(strings.EXISTING_SPECIES_MSG, record.scientificName));
-        }
+      return;
+    }
+
+    try {
+      const { id } = await createSpecies({
+        organizationId,
+        scientificName: record.scientificName,
+        commonName: record.commonName,
+        conservationCategory: record.conservationCategory,
+        ecologicalRoleKnown: record.ecologicalRoleKnown,
+        ecosystemTypes: record.ecosystemTypes,
+        familyName: record.familyName,
+        growthForms: record.growthForms,
+        localUsesKnown: record.localUsesKnown,
+        nativeEcosystem: record.nativeEcosystem,
+        otherFacts: record.otherFacts,
+        plantMaterialSourcingMethods: record.plantMaterialSourcingMethods,
+        rare: record.rare,
+        seedStorageBehavior: record.seedStorageBehavior,
+        successionalGroups: record.successionalGroups,
+      }).unwrap();
+      reloadData();
+      navigate(APP_PATHS.SPECIES_DETAILS.replace(':speciesId', id.toString()));
+    } catch (e) {
+      const errorMessage = (e as { data?: { error?: { message?: string } } })?.data?.error?.message;
+      if (errorMessage === SpeciesRequestError.PreexistingSpecies) {
+        setNameFormatError(strings.formatString(strings.EXISTING_SPECIES_MSG, record.scientificName));
       }
     }
   };

--- a/src/scenes/Species/SpeciesDetailView.tsx
+++ b/src/scenes/Species/SpeciesDetailView.tsx
@@ -13,10 +13,9 @@ import { APP_PATHS } from 'src/constants';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 import { useOrganization } from 'src/providers/hooks';
-import { SpeciesService } from 'src/services';
+import { useDeleteSpeciesMutation, useLazyGetSpeciesQuery } from 'src/queries/generated/species';
 import strings from 'src/strings';
 import {
-  Species,
   getConservationCategoryString,
   getEcosystemTypesString,
   getGrowthFormsString,
@@ -39,16 +38,25 @@ type SpeciesDetailViewProps = {
 
 export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps): JSX.Element {
   const theme = useTheme();
-  const [species, setSpecies] = useState<Species>();
   const navigate = useSyncNavigate();
   const { isMobile } = useDeviceInfo();
   const { selectedOrganization } = useOrganization();
   const { speciesId } = useParams<{ speciesId: string }>();
   const userCanEdit = !isContributor(selectedOrganization);
   const [deleteSpeciesModalOpen, setDeleteSpeciesModalOpen] = useState(false);
-  const [isBusy, setIsBusy] = useState<boolean>(false);
   const snackbar = useSnackbar();
   const { orgHasParticipants } = useParticipantData();
+
+  const [getSpecies, { currentData: speciesData, isError: getSpeciesError }] = useLazyGetSpeciesQuery();
+  const species = speciesData?.species;
+
+  const [deleteSpecies, { isLoading: isDeleting }] = useDeleteSpeciesMutation();
+
+  useEffect(() => {
+    if (selectedOrganization && speciesId) {
+      void getSpecies({ speciesId: Number(speciesId), organizationId: selectedOrganization.id }, true);
+    }
+  }, [getSpecies, selectedOrganization, speciesId]);
 
   const gridSize = useMemo(() => {
     if (isMobile) {
@@ -58,18 +66,10 @@ export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps
   }, [isMobile]);
 
   useEffect(() => {
-    if (selectedOrganization) {
-      const getSpecies = async () => {
-        const speciesResponse = await SpeciesService.getSpecies(Number(speciesId), selectedOrganization.id);
-        if (speciesResponse.requestSucceeded) {
-          setSpecies(speciesResponse.species);
-        } else {
-          navigate(APP_PATHS.SPECIES);
-        }
-      };
-      void getSpecies();
+    if (getSpeciesError) {
+      navigate(APP_PATHS.SPECIES);
     }
-  }, [speciesId, selectedOrganization, navigate]);
+  }, [getSpeciesError, navigate]);
 
   const goToEditSpecies = () => {
     if (speciesId) {
@@ -87,18 +87,14 @@ export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps
   };
 
   const deleteSelectedSpecies = async (id: number) => {
-    if (selectedOrganization) {
-      setIsBusy(true);
-      const success = await SpeciesService.deleteSpecies(id, selectedOrganization.id);
-      setIsBusy(false);
-      if (!success) {
-        snackbar.toastError(strings.GENERIC_ERROR);
-      } else {
-        reloadData();
-      }
-      setDeleteSpeciesModalOpen(false);
-      navigate(APP_PATHS.SPECIES);
+    try {
+      await deleteSpecies(id).unwrap();
+      reloadData();
+    } catch {
+      snackbar.toastError(strings.GENERIC_ERROR);
     }
+    setDeleteSpeciesModalOpen(false);
+    navigate(APP_PATHS.SPECIES);
   };
 
   const GridItemWrapper = useCallback(
@@ -112,7 +108,7 @@ export default function SpeciesDetailView({ reloadData }: SpeciesDetailViewProps
 
   return (
     <TfMain>
-      {isBusy && <BusySpinner withSkrim={true} />}
+      {isDeleting && <BusySpinner withSkrim={true} />}
       <Grid container padding={theme.spacing(0, 0, 4, 0)}>
         <Grid item xs={12} marginBottom={theme.spacing(3)}>
           <BackToLink id='back' to={APP_PATHS.SPECIES} name={strings.SPECIES} />

--- a/src/scenes/Species/SpeciesDetailsForm.tsx
+++ b/src/scenes/Species/SpeciesDetailsForm.tsx
@@ -10,7 +10,7 @@ import TextField from 'src/components/common/Textfield/Textfield';
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 import { useLocalization } from 'src/providers/hooks';
-import { SpeciesService } from 'src/services';
+import { useLazyGetSpeciesDetailsQuery, useLazyListSpeciesNamesQuery } from 'src/queries/generated/species';
 import strings from 'src/strings';
 import { AcceleratorProjectSpecies } from 'src/types/AcceleratorProjectSpecies';
 import {
@@ -26,7 +26,6 @@ import {
   storageBehaviors,
   successionalGroups,
 } from 'src/types/Species';
-import { getRequestId, setRequestId } from 'src/utils/requestsId';
 import useDebounce from 'src/utils/useDebounce';
 
 import { ProjectSpecies } from './AddToProjectModal';
@@ -73,59 +72,68 @@ export default function SpeciesDetailsForm({
   const { isAcceleratorRoute } = useAcceleratorConsole();
   const { orgHasParticipants } = useParticipantData();
 
+  const searchTermTooShort = debouncedSearchTerm.length <= 1;
+
+  const [listSpeciesNames, { currentData: namesData }] = useLazyListSpeciesNamesQuery();
+  const [getSpeciesDetails, { currentData: speciesDetails, isError: detailsError }] = useLazyGetSpeciesDetailsQuery();
+
   useEffect(() => {
-    const getOptionsForTyped = async () => {
-      const requestId = Math.random().toString();
-      setRequestId('names', requestId);
-      const response = await SpeciesService.getSpeciesNames(debouncedSearchTerm);
-      if (response.requestSucceeded) {
-        if (getRequestId('names') === requestId) {
-          setOptionsForName(response.names);
-        }
-      }
-    };
-
-    const getDetails = async () => {
-      if (!debouncedSearchTerm) {
-        setNewScientificName(false);
-      }
-      if (debouncedSearchTerm.length > 1 && setRecord) {
-        const requestId = Math.random().toString();
-        setRequestId('details', requestId);
-        const response = await SpeciesService.getSpeciesDetails(debouncedSearchTerm);
-        if (response.requestSucceeded) {
-          if (getRequestId('details') === requestId) {
-            setNewScientificName(false);
-            const speciesDetails = response.speciesDetails;
-            setRecord((previousRecord: Species) => {
-              if (speciesDetails?.commonNames?.length === 1) {
-                return {
-                  ...previousRecord,
-                  familyName: speciesDetails.familyName,
-                  commonName: speciesDetails.commonNames[0].name,
-                  conservationCategory: speciesDetails.conservationCategory ?? previousRecord.conservationCategory,
-                };
-              } else {
-                setOptionsForCommonName(speciesDetails?.commonNames?.map((cN) => cN.name));
-                return {
-                  ...previousRecord,
-                  conservationCategory: speciesDetails?.conservationCategory ?? previousRecord.conservationCategory,
-                  familyName: speciesDetails?.familyName ?? previousRecord.familyName,
-                };
-              }
-            });
-          }
-        } else {
-          setNewScientificName(true);
-        }
-      }
-    };
-
-    if (userSearched) {
-      void getOptionsForTyped();
-      void getDetails();
+    if (userSearched && !searchTermTooShort) {
+      void listSpeciesNames({ search: debouncedSearchTerm }, true);
     }
-  }, [debouncedSearchTerm, setRecord, userSearched]);
+  }, [listSpeciesNames, debouncedSearchTerm, searchTermTooShort, userSearched]);
+
+  useEffect(() => {
+    if (userSearched && !searchTermTooShort && setRecord) {
+      void getSpeciesDetails({ scientificName: debouncedSearchTerm }, true);
+    }
+  }, [getSpeciesDetails, debouncedSearchTerm, searchTermTooShort, setRecord, userSearched]);
+
+  useEffect(() => {
+    if (!userSearched) {
+      return;
+    }
+    if (searchTermTooShort) {
+      setOptionsForName([]);
+    } else if (namesData) {
+      setOptionsForName(namesData.names);
+    }
+  }, [namesData, searchTermTooShort, userSearched]);
+
+  useEffect(() => {
+    if (!debouncedSearchTerm) {
+      setNewScientificName(false);
+    }
+  }, [debouncedSearchTerm]);
+
+  useEffect(() => {
+    if (!userSearched || searchTermTooShort || !setRecord) {
+      return;
+    }
+
+    if (speciesDetails) {
+      setNewScientificName(false);
+      if (speciesDetails.commonNames?.length !== 1) {
+        setOptionsForCommonName(speciesDetails.commonNames?.map((cN) => cN.name));
+      }
+      setRecord((previousRecord: Species) =>
+        speciesDetails.commonNames?.length === 1
+          ? {
+              ...previousRecord,
+              familyName: speciesDetails.familyName,
+              commonName: speciesDetails.commonNames[0].name,
+              conservationCategory: speciesDetails.conservationCategory ?? previousRecord.conservationCategory,
+            }
+          : {
+              ...previousRecord,
+              conservationCategory: speciesDetails.conservationCategory ?? previousRecord.conservationCategory,
+              familyName: speciesDetails.familyName ?? previousRecord.familyName,
+            }
+      );
+    } else if (detailsError) {
+      setNewScientificName(true);
+    }
+  }, [speciesDetails, detailsError, searchTermTooShort, setRecord, userSearched]);
 
   const onChangeScientificName = (value: string) => {
     setNameFormatError('');

--- a/src/scenes/Species/SpeciesEditView.tsx
+++ b/src/scenes/Species/SpeciesEditView.tsx
@@ -11,6 +11,7 @@ import TfMain from 'src/components/common/TfMain';
 import { APP_PATHS } from 'src/constants';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useOrganization } from 'src/providers/hooks';
+import { useLazyGetSpeciesQuery, useUpdateSpeciesMutation } from 'src/queries/generated/species';
 import {
   requestAddManyAcceleratorProjectSpecies,
   requestDeleteManyAcceleratorProjectSpecies,
@@ -21,7 +22,6 @@ import {
 } from 'src/redux/features/acceleratorProjectSpecies/acceleratorProjectSpeciesSelectors';
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import SpeciesDetailsForm from 'src/scenes/Species/SpeciesDetailsForm';
-import { SpeciesService } from 'src/services';
 import { CreateAcceleratorProjectSpeciesRequestPayload } from 'src/services/AcceleratorProjectSpeciesService';
 import strings from 'src/strings';
 import { Species } from 'src/types/Species';
@@ -45,15 +45,24 @@ function initSpecies(species?: Species): Species {
 
 export default function SpeciesEditView(): JSX.Element {
   const theme = useTheme();
-  const [species, setSpecies] = useState<Species>();
   const navigate = useSyncNavigate();
   const { isMobile } = useDeviceInfo();
   const { selectedOrganization } = useOrganization();
   const { speciesId } = useParams<{ speciesId: string }>();
-  const [isBusy, setIsBusy] = useState<boolean>(false);
   const [record, setRecord, , onChangeCallback] = useForm<Species>(initSpecies());
   const snackbar = useSnackbar();
   const [nameFormatError, setNameFormatError] = useState<string | string[]>('');
+
+  const [getSpecies, { currentData: speciesData, isError: getSpeciesError }] = useLazyGetSpeciesQuery();
+  const species = speciesData?.species;
+
+  const [updateSpecies, { isLoading: isBusy }] = useUpdateSpeciesMutation();
+
+  useEffect(() => {
+    if (selectedOrganization && speciesId) {
+      void getSpecies({ speciesId: Number(speciesId), organizationId: selectedOrganization.id }, true);
+    }
+  }, [getSpecies, selectedOrganization, speciesId]);
   const [addedProjectsSpecies, setAddedProjectsSpecies] = useState<ProjectSpecies[]>();
   const [removedProjectsIds, setRemovedProjectsIds] = useState<number[]>();
 
@@ -110,18 +119,10 @@ export default function SpeciesEditView(): JSX.Element {
   }, [addedResult, goToSpecies, record.id, removedResult]);
 
   useEffect(() => {
-    const getSpecies = async () => {
-      const speciesResponse = await SpeciesService.getSpecies(Number(speciesId), selectedOrganization?.id || -1);
-      if (speciesResponse.requestSucceeded) {
-        setSpecies(speciesResponse.species);
-      } else {
-        navigate(APP_PATHS.SPECIES);
-      }
-    };
-    if (selectedOrganization && speciesId) {
-      void getSpecies();
+    if (getSpeciesError) {
+      navigate(APP_PATHS.SPECIES);
     }
-  }, [speciesId, selectedOrganization, navigate]);
+  }, [getSpeciesError, navigate]);
 
   useEffect(() => {
     const now = DateTime.now().toISO();
@@ -146,33 +147,60 @@ export default function SpeciesEditView(): JSX.Element {
     }
     if (!record.scientificName) {
       setNameFormatError(strings.REQUIRED_FIELD);
-    } else {
-      setIsBusy(true);
-      const response = await SpeciesService.updateSpecies(record, selectedOrganization.id);
-      setIsBusy(false);
-      if (response.requestSucceeded) {
-        if (removedProjectsIds) {
-          const request = dispatch(requestDeleteManyAcceleratorProjectSpecies(removedProjectsIds));
-          setRemoveRequestId(request.requestId);
-        }
-        if (addedProjectsSpecies && speciesId) {
-          const createRequests = addedProjectsSpecies.map((aPS) => {
-            return {
-              projectId: aPS.project.id,
-              speciesId: Number(speciesId),
-              speciesNativeCategory: aPS.nativeCategory,
-            } as CreateAcceleratorProjectSpeciesRequestPayload;
-          });
-          const request = dispatch(requestAddManyAcceleratorProjectSpecies(createRequests));
-          setAddRequestId(request.requestId);
-        }
-        if (
-          (!removedProjectsIds || !removedProjectsIds.length) &&
-          (!addedProjectsSpecies || !addedProjectsSpecies.length)
-        ) {
-          goToSpecies(record.id);
-        }
-      } else if (response.statusCode === 409) {
+      return;
+    }
+
+    try {
+      await updateSpecies({
+        speciesId: record.id,
+        updateSpeciesRequestPayload: {
+          organizationId: selectedOrganization.id,
+          scientificName: record.scientificName,
+          averageWoodDensity: record.averageWoodDensity,
+          commonName: record.commonName,
+          conservationCategory: record.conservationCategory,
+          dbhSource: record.dbhSource,
+          dbhValue: record.dbhValue,
+          ecologicalRoleKnown: record.ecologicalRoleKnown,
+          ecosystemTypes: record.ecosystemTypes,
+          familyName: record.familyName,
+          growthForms: record.growthForms,
+          heightAtMaturitySource: record.heightAtMaturitySource,
+          heightAtMaturityValue: record.heightAtMaturityValue,
+          localUsesKnown: record.localUsesKnown,
+          nativeEcosystem: record.nativeEcosystem,
+          otherFacts: record.otherFacts,
+          plantMaterialSourcingMethods: record.plantMaterialSourcingMethods,
+          rare: record.rare,
+          seedStorageBehavior: record.seedStorageBehavior,
+          successionalGroups: record.successionalGroups,
+          woodDensityLevel: record.woodDensityLevel,
+        },
+      }).unwrap();
+
+      if (removedProjectsIds) {
+        const request = dispatch(requestDeleteManyAcceleratorProjectSpecies(removedProjectsIds));
+        setRemoveRequestId(request.requestId);
+      }
+      if (addedProjectsSpecies && speciesId) {
+        const createRequests = addedProjectsSpecies.map((aPS) => {
+          return {
+            projectId: aPS.project.id,
+            speciesId: Number(speciesId),
+            speciesNativeCategory: aPS.nativeCategory,
+          } as CreateAcceleratorProjectSpeciesRequestPayload;
+        });
+        const request = dispatch(requestAddManyAcceleratorProjectSpecies(createRequests));
+        setAddRequestId(request.requestId);
+      }
+      if (
+        (!removedProjectsIds || !removedProjectsIds.length) &&
+        (!addedProjectsSpecies || !addedProjectsSpecies.length)
+      ) {
+        goToSpecies(record.id);
+      }
+    } catch (e) {
+      if ((e as { status?: number })?.status === 409) {
         snackbar.toastError(strings.formatString(strings.EXISTING_SPECIES_MSG, record.scientificName));
       } else {
         snackbar.toastError();

--- a/src/scenes/Species/SpeciesListView.tsx
+++ b/src/scenes/Species/SpeciesListView.tsx
@@ -31,12 +31,7 @@ import { useLocalization, useOrganization } from 'src/providers/hooks';
 import SearchService from 'src/services/SearchService';
 import strings from 'src/strings';
 import { SearchRequestPayload } from 'src/types/Search';
-import {
-  Species,
-  SpeciesProblemElement,
-  conservationCategories,
-  getConservationCategoryString,
-} from 'src/types/Species';
+import { Species, conservationCategories, getConservationCategoryString } from 'src/types/Species';
 import { makeCsv } from 'src/utils/csv';
 import { isContributor } from 'src/utils/organization';
 import { getRequestId, setRequestId } from 'src/utils/requestsId';
@@ -88,7 +83,7 @@ const ProblemsCellComponent = ({ row, reloadData, onRowClick }: ProblemsCellProp
           transformOrigin={{ vertical: 'top', horizontal: 'center' }}
         >
           <ProblemTooltip
-            problems={value as SpeciesProblemElement[]}
+            problems={value}
             openedTooltip={Boolean(anchorEl)}
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
             reloadData={reloadData}

--- a/src/services/SpeciesService.ts
+++ b/src/services/SpeciesService.ts
@@ -1,10 +1,10 @@
 import { paths } from 'src/api/types/generated-schema';
 import { GetUploadStatusResponsePayload, UploadFileResponse } from 'src/types/File';
 import { FieldNodePayload, SearchRequestPayload, SearchResponseElement } from 'src/types/Search';
-import { MergeOtherSpeciesPayload, Species, SpeciesDetails, SuggestedSpecies } from 'src/types/Species';
+import { MergeOtherSpeciesPayload, Species, SuggestedSpecies } from 'src/types/Species';
 import { parseSearchTerm } from 'src/utils/search';
 
-import HttpService, { Response, Response2, ServerData } from './HttpService';
+import HttpService, { Response, Response2 } from './HttpService';
 import SearchService from './SearchService';
 
 /**
@@ -15,10 +15,6 @@ import SearchService from './SearchService';
  * Types exported from service
  */
 
-export type CreateSpeciesResponse = Response & {
-  speciesId: number | null;
-};
-
 export type SpeciesUploadTemplate = {
   template?: string;
 };
@@ -28,19 +24,11 @@ export type SpeciesUploadStatusDetails = {
 
 export type SpeciesIdResponse = Response & SpeciesIdData;
 
-export type SpeciesDetailsResponse = Response & SpeciesDetailsData;
-
-export type SpeciesNamesResponse = Response & SpeciesNamesData;
-
 export type AllSpeciesResponse = Response & AllSpeciesData;
 
 export type AllSpeciesData = { species?: Species[] };
 
 export type SpeciesIdData = { species?: Species };
-
-export type SpeciesDetailsData = { speciesDetails?: SpeciesDetails };
-
-export type SpeciesNamesData = { names?: string[] };
 
 export type SpeciesProjectsSearchResponse = SearchResponseElement & {
   projects: {
@@ -54,59 +42,17 @@ const SPECIES_TEMPLATE_ENDPOINT = '/api/v1/species/uploads/template';
 const SPECIES_UPLOADS_ENDPOINT = '/api/v1/species/uploads';
 const SPECIES_UPLOAD_STATUS_ENDPOINT = '/api/v1/species/uploads/{uploadId}';
 const SPECIES_UPLOAD_RESOLVE_ENDPOINT = '/api/v1/species/uploads/{uploadId}/resolve';
-const SPECIES_UPLOAD_PROBLEM = '/api/v1/species/problems/{problemId}';
-const SPECIES_DETAILS_ENDPOINT = '/api/v1/species/lookup/details';
-const SPECIES_NAMES_ENDPOINT = '/api/v1/species/lookup/names';
 const MERGE_OTHER_SPECIES_ENDPOINT = '/api/v1/tracking/observations/{observationId}/mergeOtherSpecies';
 
-type CreateSpeciesRequestPayload = paths[typeof SPECIES_ENDPOINT]['post']['requestBody']['content']['application/json'];
 type UpdateSpeciesRequestPayload =
   paths[typeof SPECIES_ID_ENDPOINT]['put']['requestBody']['content']['application/json'];
 type SpeciesResponsePayload = paths[typeof SPECIES_ENDPOINT]['get']['responses'][200]['content']['application/json'];
 type SpeciesIdResponsePayload =
   paths[typeof SPECIES_ID_ENDPOINT]['get']['responses'][200]['content']['application/json'];
-type SpeciesDetailsResponsePayload =
-  paths[typeof SPECIES_DETAILS_ENDPOINT]['get']['responses'][200]['content']['application/json'] & ServerData;
-type SpeciesNamesResponsePayload =
-  paths[typeof SPECIES_NAMES_ENDPOINT]['get']['responses'][200]['content']['application/json'];
 
 const httpSpecies = HttpService.root(SPECIES_ENDPOINT);
 const httpSpeciesId = HttpService.root(SPECIES_ID_ENDPOINT);
-const httpSpeciesDetails = HttpService.root(SPECIES_DETAILS_ENDPOINT);
-const httpSpeciesNames = HttpService.root(SPECIES_NAMES_ENDPOINT);
 const httpMergeOtherSpecies = HttpService.root(MERGE_OTHER_SPECIES_ENDPOINT);
-
-/**
- * create a species
- */
-const createSpecies = async (species: Omit<Species, 'id'>, organizationId: number): Promise<CreateSpeciesResponse> => {
-  const entity: CreateSpeciesRequestPayload = {
-    ecosystemTypes: species.ecosystemTypes,
-    commonName: species.commonName,
-    conservationCategory: species.conservationCategory,
-    ecologicalRoleKnown: species.ecologicalRoleKnown,
-    familyName: species.familyName,
-    growthForms: species.growthForms,
-    localUsesKnown: species.localUsesKnown,
-    nativeEcosystem: species.nativeEcosystem,
-    organizationId,
-    otherFacts: species.otherFacts,
-    plantMaterialSourcingMethods: species.plantMaterialSourcingMethods,
-    rare: species.rare,
-    scientificName: species.scientificName,
-    seedStorageBehavior: species.seedStorageBehavior,
-    successionalGroups: species.successionalGroups,
-  };
-
-  const serverResponse: Response = await httpSpecies.post({ entity });
-
-  const response: CreateSpeciesResponse = {
-    ...serverResponse,
-    speciesId: serverResponse.data?.id ?? null,
-  };
-
-  return response;
-};
 
 /**
  * get a species by id
@@ -168,21 +114,6 @@ const updateSpecies = async (species: Species, organizationId: number): Promise<
       '{speciesId}': species.id.toString(),
     },
   });
-};
-
-/**
- * delete a species
- */
-const deleteSpecies = async (speciesId: number, organizationId: number): Promise<Response> => {
-  const params = { organizationId: organizationId.toString() };
-  const response: Response = await httpSpeciesId.delete({
-    params,
-    urlReplacements: {
-      '{speciesId}': speciesId.toString(),
-    },
-  });
-
-  return response;
 };
 
 /**
@@ -258,65 +189,6 @@ const resolveSpeciesUpload = async (uploadId: number, overwriteExisting: boolean
     },
     entity: { overwriteExisting: overwriteExisting.toString() },
   });
-};
-
-/**
- * Accept species upload problem suggestion
- */
-const acceptProblemSuggestion = async (problemId: number): Promise<Response> => {
-  return await HttpService.root(SPECIES_UPLOAD_PROBLEM).post({
-    urlReplacements: {
-      '{problemId}': problemId.toString(),
-    },
-  });
-};
-
-/**
- * Ignore species upload problem suggestion
- */
-const ignoreProblemSuggestion = async (problemId: number): Promise<Response> => {
-  return await HttpService.root(SPECIES_UPLOAD_PROBLEM).delete({
-    urlReplacements: {
-      '{problemId}': problemId.toString(),
-    },
-  });
-};
-
-/**
- * get details of a species
- */
-const getSpeciesDetails = async (scientificName: string): Promise<SpeciesDetailsResponse> => {
-  const params = { scientificName };
-  const response: SpeciesDetailsResponse = await httpSpeciesDetails.get<
-    SpeciesDetailsResponsePayload,
-    SpeciesDetailsData
-  >(
-    {
-      params,
-    },
-    (data) => ({ speciesDetails: data })
-  );
-
-  return response;
-};
-
-/**
- * get all species names
- */
-const getSpeciesNames = async (search: string): Promise<SpeciesNamesResponse> => {
-  const params = { search };
-
-  const response: SpeciesNamesResponse =
-    search.length > 1
-      ? await httpSpeciesNames.get<SpeciesNamesResponsePayload, SpeciesNamesData>(
-          {
-            params,
-          },
-          (data) => ({ names: data?.names })
-        )
-      : { names: [], requestSucceeded: true };
-
-  return response;
 };
 
 /**
@@ -418,17 +290,11 @@ const mergeOtherSpecies = (
  * Exported functions
  */
 const SpeciesService = {
-  acceptProblemSuggestion,
-  createSpecies,
-  deleteSpecies,
   downloadSpeciesTemplate,
   getAllSpecies,
   getSpecies,
-  getSpeciesDetails,
-  getSpeciesNames,
   getSpeciesProjects,
   getSpeciesUploadStatus,
-  ignoreProblemSuggestion,
   mergeOtherSpecies,
   resolveSpeciesUpload,
   suggestSpecies,

--- a/src/services/test/SpeciesService.test.ts
+++ b/src/services/test/SpeciesService.test.ts
@@ -8,13 +8,6 @@ const SPECIES_LIST = [
   },
 ];
 
-const SPECIES = {
-  organizationId: 1,
-  scientificName: 'New species',
-  createdTime: '2024-10-01T15:00:00Z',
-  modifiedTime: '2024-10-01T15:00:00Z',
-};
-
 const UPDATED_SPECIES = {
   id: 1,
   organizationId: 1,
@@ -24,29 +17,9 @@ const UPDATED_SPECIES = {
   modifiedTime: '2024-10-01T15:00:00Z',
 };
 
-const SPECIES_DETAILS = {
-  scientificName: 'Test',
-  familyName: 'Constanza',
-};
-
 describe('Species service test', () => {
   beforeEach(() => {
     clearHttpServiceMocks();
-  });
-
-  test('post species should return the new id', async () => {
-    setHttpServiceMocks({
-      post: () =>
-        Promise.resolve({
-          data: { id: 1 },
-          requestSucceeded: true,
-          statusCode: 200,
-        }),
-    });
-
-    const { speciesId } = await SpeciesService.createSpecies(SPECIES, 1);
-
-    expect(speciesId).toEqual(1);
   });
 
   test('get species should return the correct species', async () => {
@@ -82,20 +55,6 @@ describe('Species service test', () => {
     expect(requestSucceeded).toEqual(true);
   });
 
-  test('delete species should succeed when no errors', async () => {
-    setHttpServiceMocks({
-      delete: () =>
-        Promise.resolve({
-          requestSucceeded: true,
-          statusCode: 200,
-        }),
-    });
-
-    const { requestSucceeded } = await SpeciesService.deleteSpecies(1, 1);
-
-    expect(requestSucceeded).toEqual(true);
-  });
-
   test('get all species should return a list of species', async () => {
     setHttpServiceMocks({
       get2: () =>
@@ -113,48 +72,4 @@ describe('Species service test', () => {
     expect(response.data?.species).toHaveLength(1);
   });
 
-  test('get species details should contain details', async () => {
-    setHttpServiceMocks({
-      get: () =>
-        Promise.resolve({
-          speciesDetails: SPECIES_DETAILS,
-          requestSucceeded: true,
-          statusCode: 200,
-        }),
-    });
-
-    const { speciesDetails } = await SpeciesService.getSpeciesDetails('Test');
-
-    expect(speciesDetails?.familyName).toBe('Constanza');
-  });
-
-  test('get species names should return empty list if search query has less than 2 characters', async () => {
-    setHttpServiceMocks({
-      get: () =>
-        Promise.resolve({
-          names: ['Species 1', 'Species 2'],
-          requestSucceeded: true,
-          statusCode: 200,
-        }),
-    });
-
-    const { names } = await SpeciesService.getSpeciesNames('a');
-
-    expect(names).toHaveLength(0);
-  });
-
-  test('get species names should return the list if search query has more than 1 characters', async () => {
-    setHttpServiceMocks({
-      get: () =>
-        Promise.resolve({
-          names: ['Species 1', 'Species 2'],
-          requestSucceeded: true,
-          statusCode: 200,
-        }),
-    });
-
-    const { names } = await SpeciesService.getSpeciesNames('aa');
-
-    expect(names).toHaveLength(2);
-  });
 });

--- a/src/types/Species.ts
+++ b/src/types/Species.ts
@@ -1,11 +1,18 @@
 import { DropdownItem } from '@terraware/web-components';
 
 import { components } from 'src/api/types/generated-schema';
+import { SpeciesLookupDetailsResponsePayload, SpeciesResponseElement } from 'src/queries/generated/species';
 import strings from 'src/strings';
 
 import { ArrayDeref, NonUndefined } from './utils';
 
-export type Species = components['schemas']['GetSpeciesResponsePayload']['species'];
+// `projects` is required on the API response, but the app also uses `Species` as a form/partial model
+// (new-species forms, search-result rows) where projects is not present, so it stays optional here.
+export type Species = Omit<SpeciesResponseElement, 'projects'> & {
+  projects?: SpeciesResponseElement['projects'];
+};
+
+export type { SpeciesProblemElement } from 'src/queries/generated/species';
 
 export type WoodDensityLevel = NonUndefined<Species['woodDensityLevel']>;
 
@@ -20,14 +27,6 @@ export type EcosystemType = ArrayDeref<NonUndefined<Species['ecosystemTypes']>>;
 export type GrowthForm = ArrayDeref<NonUndefined<Species['growthForms']>>;
 
 export type SeedStorageBehavior = NonUndefined<Species['seedStorageBehavior']>;
-
-export type SpeciesProblemElement = {
-  id: number;
-  field: 'Scientific Name';
-  type: 'Name Misspelled' | 'Name Not Found' | 'Name Is Synonym';
-  /** Value for the field in question that would correct the problem. Absent if the system is unable to calculate a corrected value. */
-  suggestedValue?: string;
-};
 
 export function conservationCategories() {
   return [
@@ -382,7 +381,7 @@ export enum SpeciesRequestError {
   RequestFailed = 'AN_UNRECOVERABLE_ERROR_OCCURRED',
 }
 
-export type SpeciesDetails = components['schemas']['SpeciesLookupDetailsResponsePayload'];
+export type SpeciesDetails = SpeciesLookupDetailsResponsePayload;
 
 export type SuggestedSpecies = Partial<Species> & { scientificName: string };
 


### PR DESCRIPTION
Generate species RTK Query endpoints + extension with cache tags, reroute
src/types/Species to the generated schema, and migrate the direct
SpeciesService consumers.

Co-Authored-By: Claude Opus 4.8 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)