### PR TITLE
SW-8697 Migrate Plants Dashboard species to useOrganizationSpecies

### DIFF
--- a/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
+++ b/src/scenes/PlantsDashboardRouter/PlantsDashboardView.tsx
@@ -13,7 +13,6 @@ import useStickyPlantingSiteId, { ALL_PLANTING_SITES } from 'src/hooks/useSticky
 import useSurvivalRateCalculationInProgress from 'src/hooks/useSurvivalRateCalculationInProgress';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization, useOrganization } from 'src/providers';
-import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import SimplePlantingSiteMap from 'src/scenes/PlantsDashboardRouter/components/SimplePlantingSiteMap';
 
 import EmptyPlantingSiteMap from './components/EmptyPlantingSiteMap';
@@ -54,11 +53,16 @@ export default function PlantsDashboardView({
 
   const { selectPlantingSite, selectedPlantingSiteId } = useStickyPlantingSiteId(PREFERENCE_NAME);
 
-  const { setAcceleratorOrganizationId } = useSpeciesData();
+  // Effective organization for the dashboard: the accelerator project's org when on an accelerator
+  // route, otherwise the selected org. Threaded down so species/planting-site queries target it.
+  const dashboardOrganizationId = useMemo(
+    () => (isAcceleratorRoute ? organizationId : undefined) ?? selectedOrganization?.id,
+    [isAcceleratorRoute, organizationId, selectedOrganization?.id]
+  );
 
   // The header owns selection normalization; the view only needs `showAllSitesOption` to label the
   // totals section. The scoped query is shared (RTK cache) with the header.
-  const { showAllSitesOption } = useDashboardPlantingSites(projectId);
+  const { showAllSitesOption } = useDashboardPlantingSites(projectId, dashboardOrganizationId);
 
   // Keep the URL :plantingSiteId param in sync with the selection in org mode (no project selected),
   // so a specific site stays bookmarkable/deep-linkable.
@@ -93,14 +97,6 @@ export default function PlantsDashboardView({
   // Poll for survival rate recalculation and refresh observation results when it completes.
   const { inProgress: survivalRateRecalculationInProgress } = useSurvivalRateCalculationInProgress(plantingSite?.id);
   const hasObservationResults = useMemo(() => !!plantingSite?.latestObservationId, [plantingSite]);
-
-  useEffect(() => {
-    if (organizationId) {
-      setAcceleratorOrganizationId(organizationId);
-    } else if (!isAcceleratorRoute && selectedOrganization?.id) {
-      setAcceleratorOrganizationId(selectedOrganization?.id);
-    }
-  }, [isAcceleratorRoute, organizationId, selectedOrganization?.id, setAcceleratorOrganizationId]);
 
   const sectionHeader = (title: string) => (
     <Grid item xs={12}>
@@ -138,7 +134,11 @@ export default function PlantsDashboardView({
             </Box>
           </Grid>
           <Grid item xs={12}>
-            <SurvivalRateCard plantingSiteId={plantingSite?.id} projectId={projectId} />
+            <SurvivalRateCard
+              plantingSiteId={plantingSite?.id}
+              projectId={projectId}
+              organizationId={dashboardOrganizationId}
+            />
           </Grid>
         </>
       ) : undefined,
@@ -150,6 +150,7 @@ export default function PlantsDashboardView({
       projectId,
       isProjectSelected,
       survivalRateRecalculationInProgress,
+      dashboardOrganizationId,
     ]
   );
 
@@ -175,6 +176,7 @@ export default function PlantsDashboardView({
         <PlantsAndSpeciesCard
           plantingSiteId={selectedPlantingSiteId !== ALL_PLANTING_SITES ? plantingSite?.id : undefined}
           projectId={projectId}
+          organizationId={dashboardOrganizationId}
         />
       </Grid>
     </>
@@ -318,6 +320,7 @@ export default function PlantsDashboardView({
       onSelectPlantingSite={selectPlantingSite}
       projectId={projectId}
       onSelectProject={setProjectId}
+      organizationId={dashboardOrganizationId}
     >
       <Grid container spacing={3} alignItems='flex-start' height='fit-content'>
         {renderTotalPlantsAndSpecies()}

--- a/src/scenes/PlantsDashboardRouter/components/HighestAndLowestSurvivalRateSpeciesCard.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/HighestAndLowestSurvivalRateSpeciesCard.tsx
@@ -4,19 +4,21 @@ import { Box, Typography, useTheme } from '@mui/material';
 
 import FormattedNumber from 'src/components/common/FormattedNumber';
 import { useLatestSiteObservationResult } from 'src/hooks/observations';
-import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
+import { useOrganizationSpecies } from 'src/hooks/useOrganizationSpecies';
 import strings from 'src/strings';
 import { ObservationSpeciesResultsPayload } from 'src/types/Observations';
 
 type HighestAndLowestSurvivalRateSpeciesCardProps = {
   plantingSiteId: number;
+  organizationId?: number;
 };
 
 export default function HighestAndLowestSurvivalRateSpeciesCard({
   plantingSiteId,
+  organizationId,
 }: HighestAndLowestSurvivalRateSpeciesCardProps): JSX.Element {
   const theme = useTheme();
-  const { species } = useSpeciesData();
+  const { species } = useOrganizationSpecies({ organizationId });
 
   const { observation: latestObservationResult } = useLatestSiteObservationResult(plantingSiteId, 'Substratum');
 

--- a/src/scenes/PlantsDashboardRouter/components/LiveDeadPlantsPerSpeciesCard.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/LiveDeadPlantsPerSpeciesCard.tsx
@@ -6,19 +6,21 @@ import { ChartTypeRegistry, TooltipItem } from 'chart.js';
 
 import PieChart from 'src/components/common/Chart/PieChart';
 import { useLatestSiteObservationResult } from 'src/hooks/observations';
+import { useOrganizationSpecies } from 'src/hooks/useOrganizationSpecies';
 import { useLocalization } from 'src/providers';
-import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import { useNumberFormatter } from 'src/utils/useNumberFormatter';
 
 type LiveDeadPlantsPerSpeciesCardProps = {
   plantingSiteId: number;
+  organizationId?: number;
 };
 
 export default function LiveDeadPlantsPerSpeciesCard({
   plantingSiteId,
+  organizationId,
 }: LiveDeadPlantsPerSpeciesCardProps): JSX.Element {
   const [selectedSpecies, setSelectedSpecies] = useState<string>();
-  const { species: availableSpecies } = useSpeciesData();
+  const { species: availableSpecies } = useOrganizationSpecies({ organizationId });
   const [allSpecies, setAllSpecies] = useState<
     {
       label: string;

--- a/src/scenes/PlantsDashboardRouter/components/NumberOfSpeciesPlantedCard.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/NumberOfSpeciesPlantedCard.tsx
@@ -5,8 +5,8 @@ import { Icon, Tooltip } from '@terraware/web-components';
 import { ChartTypeRegistry, TooltipItem } from 'chart.js';
 
 import PieChart from 'src/components/common/Chart/PieChart';
+import { useOrganizationSpecies } from 'src/hooks/useOrganizationSpecies';
 import { useLocalization } from 'src/providers';
-import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
 import {
   useGetPlantingSiteReportedPlantsQuery,
   useLazyGetPlantingSiteQuery,
@@ -60,11 +60,13 @@ const processConservationCategories = (
 type NumberOfSpeciesPlantedCardProps = {
   plantingSiteId?: number;
   projectId?: number | 'all';
+  organizationId?: number;
 };
 
 export default function NumberOfSpeciesPlantedCard({
   plantingSiteId,
   projectId,
+  organizationId,
 }: NumberOfSpeciesPlantedCardProps): JSX.Element | undefined {
   const [getPlantingSite, getPlantingSiteResponse] = useLazyGetPlantingSiteQuery();
   const plantingSite = useMemo(() => getPlantingSiteResponse.data?.site, [getPlantingSiteResponse]);
@@ -76,19 +78,19 @@ export default function NumberOfSpeciesPlantedCard({
   }, [getPlantingSite, plantingSiteId]);
 
   if (typeof projectId === 'number' && plantingSiteId === undefined) {
-    return <RolledUpCard projectId={projectId} />;
+    return <RolledUpCard projectId={projectId} organizationId={organizationId} />;
   } else if (plantingSite && !plantingSite?.strata?.length) {
-    return <SiteWithoutStrataCard plantingSiteId={plantingSite.id} />;
+    return <SiteWithoutStrataCard plantingSiteId={plantingSite.id} organizationId={organizationId} />;
   } else if (plantingSite && plantingSite?.strata?.length) {
-    return <SiteWithStrataCard plantingSiteId={plantingSite.id} />;
+    return <SiteWithStrataCard plantingSiteId={plantingSite.id} organizationId={organizationId} />;
   } else {
     return <ChartData labels={[]} values={[]} />;
   }
 }
 
-const RolledUpCard = ({ projectId }: { projectId?: number }): JSX.Element => {
+const RolledUpCard = ({ projectId, organizationId }: { projectId?: number; organizationId?: number }): JSX.Element => {
   const { strings } = useLocalization();
-  const { species: orgSpecies } = useSpeciesData();
+  const { species: orgSpecies } = useOrganizationSpecies({ organizationId });
 
   const listReportedPlantsResponse = useListPlantingSiteReportedPlantsQuery({ projectId });
   const reportedPlants = useMemo(() => listReportedPlantsResponse.data?.sites ?? [], [listReportedPlantsResponse]);
@@ -154,11 +156,17 @@ const RolledUpCard = ({ projectId }: { projectId?: number }): JSX.Element => {
   return <ChartData labels={labels} values={values} rareSpecies={rareSpecies} />;
 };
 
-const SiteWithoutStrataCard = ({ plantingSiteId }: { plantingSiteId: number }): JSX.Element | undefined => {
+const SiteWithoutStrataCard = ({
+  plantingSiteId,
+  organizationId,
+}: {
+  plantingSiteId: number;
+  organizationId?: number;
+}): JSX.Element | undefined => {
   const { strings } = useLocalization();
   const plantingsResponse = useGetPlantingSiteReportedPlantsQuery(plantingSiteId);
   const speciesPlantings = useMemo(() => plantingsResponse.data?.site?.species ?? [], [plantingsResponse.data?.site]);
-  const { species: orgSpecies } = useSpeciesData();
+  const { species: orgSpecies } = useOrganizationSpecies({ organizationId });
 
   const { labels, values, rareSpecies } = useMemo(() => {
     const speciesNames: Set<string> = new Set();
@@ -201,11 +209,17 @@ const SiteWithoutStrataCard = ({ plantingSiteId }: { plantingSiteId: number }): 
   return <ChartData labels={labels} values={values} rareSpecies={rareSpecies} />;
 };
 
-const SiteWithStrataCard = ({ plantingSiteId }: { plantingSiteId: number }): JSX.Element => {
+const SiteWithStrataCard = ({
+  plantingSiteId,
+  organizationId,
+}: {
+  plantingSiteId: number;
+  organizationId?: number;
+}): JSX.Element => {
   const { strings } = useLocalization();
   const plantingsResponse = useGetPlantingSiteReportedPlantsQuery(plantingSiteId);
   const plantingSiteReportedPlants = useMemo(() => plantingsResponse.data?.site, [plantingsResponse.data?.site]);
-  const { species: orgSpecies } = useSpeciesData();
+  const { species: orgSpecies } = useOrganizationSpecies({ organizationId });
 
   const totalSpecies = useMemo(() => plantingSiteReportedPlants?.species.length ?? 0, [plantingSiteReportedPlants]);
 

--- a/src/scenes/PlantsDashboardRouter/components/PlantsAndSpeciesCard.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/PlantsAndSpeciesCard.tsx
@@ -22,9 +22,11 @@ import PlantsReportedPerSpeciesCard from './PlantsReportedPerSpeciesCard';
 export default function PlantsAndSpeciesCard({
   plantingSiteId,
   projectId,
+  organizationId,
 }: {
   plantingSiteId?: number;
   projectId?: number | 'all';
+  organizationId?: number;
 }): JSX.Element {
   const theme = useTheme();
   const { strings } = useLocalization();
@@ -223,7 +225,12 @@ export default function PlantsAndSpeciesCard({
       <Grid item xs={12}>
         <Card radius='8px' style={{ display: 'flex', flexDirection: isDesktop ? 'row' : 'column' }}>
           <Box flexBasis='100%'>
-            <PlantsReportedPerSpeciesCard newVersion plantingSiteId={plantingSiteId} projectId={projectId} />
+            <PlantsReportedPerSpeciesCard
+              newVersion
+              plantingSiteId={plantingSiteId}
+              projectId={projectId}
+              organizationId={organizationId}
+            />
           </Box>
           <div
             style={{
@@ -235,7 +242,11 @@ export default function PlantsAndSpeciesCard({
             }}
           />
           <Box flexBasis='100%'>
-            <NumberOfSpeciesPlantedCard plantingSiteId={plantingSiteId} projectId={projectId} />
+            <NumberOfSpeciesPlantedCard
+              plantingSiteId={plantingSiteId}
+              projectId={projectId}
+              organizationId={organizationId}
+            />
           </Box>
         </Card>
       </Grid>

--- a/src/scenes/PlantsDashboardRouter/components/PlantsDashboardHeader.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/PlantsDashboardHeader.tsx
@@ -31,6 +31,7 @@ export type PlantsDashboardHeaderProps = {
   onSelectPlantingSite: (plantingSiteId: PlantingSiteId) => void;
   projectId: number | typeof ALL_PLANTING_SITES;
   onSelectProject: (projectId: number | typeof ALL_PLANTING_SITES) => void;
+  organizationId?: number;
 };
 
 export default function PlantsDashboardHeader({
@@ -39,6 +40,7 @@ export default function PlantsDashboardHeader({
   onSelectPlantingSite,
   projectId,
   onSelectProject,
+  organizationId: dashboardOrganizationId,
 }: PlantsDashboardHeaderProps): JSX.Element {
   const { strings, activeLocale } = useLocalization();
   const theme = useTheme();
@@ -46,8 +48,10 @@ export default function PlantsDashboardHeader({
   const { isAcceleratorRoute } = useAcceleratorConsole();
   const { selectedOrganization } = useOrganization();
 
-  const { organizationId, plantingSites, showAllSitesOption, isLoading, isSuccess } =
-    useDashboardPlantingSites(projectId);
+  const { organizationId, plantingSites, showAllSitesOption, isLoading, isSuccess } = useDashboardPlantingSites(
+    projectId,
+    dashboardOrganizationId
+  );
 
   // Project ids that have at least one planting site, used to populate the project dropdown.
   const [searchPlantingSiteProjects, { currentData: projectIdsWithSites }] = useLazySearchPlantingSiteProjectsQuery();

--- a/src/scenes/PlantsDashboardRouter/components/PlantsReportedPerSpeciesCard.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/PlantsReportedPerSpeciesCard.tsx
@@ -7,7 +7,7 @@ import { ChartTypeRegistry, TooltipItem } from 'chart.js';
 import BarChart from 'src/components/common/Chart/BarChart';
 import PieChart from 'src/components/common/Chart/PieChart';
 import OverviewItemCard from 'src/components/common/OverviewItemCard';
-import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
+import { useOrganizationSpecies } from 'src/hooks/useOrganizationSpecies';
 import {
   useGetPlantingSiteReportedPlantsQuery,
   useLazyGetPlantingSiteQuery,
@@ -23,12 +23,14 @@ type PlantsReportedPerSpeciesCardProps = {
   newVersion?: boolean;
   plantingSiteId?: number;
   projectId?: number | 'all';
+  organizationId?: number;
 };
 
 export default function PlantsReportedPerSpeciesCard({
   newVersion,
   plantingSiteId,
   projectId,
+  organizationId,
 }: PlantsReportedPerSpeciesCardProps): JSX.Element | undefined {
   const [getPlantingSite, getPlantingSiteResponse] = useLazyGetPlantingSiteQuery();
   const plantingSite = useMemo(() => getPlantingSiteResponse.data?.site, [getPlantingSiteResponse]);
@@ -40,11 +42,15 @@ export default function PlantsReportedPerSpeciesCard({
   }, [getPlantingSite, plantingSiteId]);
 
   if (typeof projectId === 'number' && plantingSiteId === undefined) {
-    return <RolledUpCard projectId={projectId} />;
+    return <RolledUpCard projectId={projectId} organizationId={organizationId} />;
   } else if (plantingSite && !plantingSite?.strata?.length) {
-    return <SiteWithoutStrataCard plantingSiteId={plantingSite.id} newVersion={newVersion} />;
+    return (
+      <SiteWithoutStrataCard plantingSiteId={plantingSite.id} newVersion={newVersion} organizationId={organizationId} />
+    );
   } else if (plantingSite && plantingSite?.strata?.length) {
-    return <SiteWithStrataCard plantingSiteId={plantingSite.id} newVersion={newVersion} />;
+    return (
+      <SiteWithStrataCard plantingSiteId={plantingSite.id} newVersion={newVersion} organizationId={organizationId} />
+    );
   } else {
     return (
       <ChartData plantingSiteId={plantingSiteId} tooltipTitles={[]} labels={[]} values={[]} newVersion={newVersion} />
@@ -95,8 +101,8 @@ const calculateSpeciesQuantities = (plantings: { plants: number; scientificName:
   return speciesQuantities;
 };
 
-const RolledUpCard = ({ projectId }: { projectId: number }): JSX.Element => {
-  const { species: orgSpecies } = useSpeciesData();
+const RolledUpCard = ({ projectId, organizationId }: { projectId: number; organizationId?: number }): JSX.Element => {
+  const { species: orgSpecies } = useOrganizationSpecies({ organizationId });
 
   const listReportedPlantsResponse = useListPlantingSiteReportedPlantsQuery({ projectId });
   const reportedPlants = useMemo(() => listReportedPlantsResponse.data?.sites ?? [], [listReportedPlantsResponse]);
@@ -124,13 +130,15 @@ const RolledUpCard = ({ projectId }: { projectId: number }): JSX.Element => {
 const SiteWithoutStrataCard = ({
   plantingSiteId,
   newVersion,
+  organizationId,
 }: {
   plantingSiteId: number;
   newVersion?: boolean;
+  organizationId?: number;
 }): JSX.Element => {
   const plantingsResponse = useGetPlantingSiteReportedPlantsQuery(plantingSiteId);
   const speciesPlantings = useMemo(() => plantingsResponse.data?.site?.species ?? [], [plantingsResponse.data?.site]);
-  const { species: orgSpecies } = useSpeciesData();
+  const { species: orgSpecies } = useOrganizationSpecies({ organizationId });
 
   const speciesQuantities = useMemo(() => {
     const transformedPlantings = speciesPlantings?.map((planting) => ({
@@ -161,6 +169,7 @@ const SiteWithoutStrataCard = ({
 const SiteWithStrataCard = ({
   plantingSiteId,
   newVersion,
+  organizationId,
 }: {
   plantingSiteId: number;
   newVersion?: boolean;
@@ -171,7 +180,7 @@ const SiteWithStrataCard = ({
     () => plantingSiteReportedPlantsResponse.data?.site,
     [plantingSiteReportedPlantsResponse]
   );
-  const { species: orgSpecies } = useSpeciesData();
+  const { species: orgSpecies } = useOrganizationSpecies({ organizationId });
 
   const speciesQuantities = useMemo(() => {
     if (plantingSiteReportedPlants && orgSpecies) {

--- a/src/scenes/PlantsDashboardRouter/components/SurvivalRateCard.tsx
+++ b/src/scenes/PlantsDashboardRouter/components/SurvivalRateCard.tsx
@@ -20,9 +20,14 @@ import LiveDeadPlantsPerSpeciesCard from './LiveDeadPlantsPerSpeciesCard';
 type SurvivalRateCardProps = {
   plantingSiteId?: number;
   projectId?: number | 'all';
+  organizationId?: number;
 };
 
-export default function SurvivalRateCard({ plantingSiteId, projectId }: SurvivalRateCardProps): JSX.Element {
+export default function SurvivalRateCard({
+  plantingSiteId,
+  projectId,
+  organizationId,
+}: SurvivalRateCardProps): JSX.Element {
   const theme = useTheme();
   const { isDesktop } = useDeviceInfo();
   const isProjectView = !plantingSiteId && typeof projectId === 'number';
@@ -152,7 +157,10 @@ export default function SurvivalRateCard({ plantingSiteId, projectId }: Survival
               </Tooltip>
             </Box>
             <Box paddingTop={2}>
-              <HighestAndLowestSurvivalRateSpeciesCard plantingSiteId={plantingSiteId} />
+              <HighestAndLowestSurvivalRateSpeciesCard
+                plantingSiteId={plantingSiteId}
+                organizationId={organizationId}
+              />
             </Box>
           </Box>
           <div style={separatorStyles} />
@@ -168,7 +176,7 @@ export default function SurvivalRateCard({ plantingSiteId, projectId }: Survival
               </Tooltip>
             </Box>
             <Box paddingTop={2}>
-              <LiveDeadPlantsPerSpeciesCard plantingSiteId={plantingSiteId} />
+              <LiveDeadPlantsPerSpeciesCard plantingSiteId={plantingSiteId} organizationId={organizationId} />
             </Box>
           </Box>
         </>

--- a/src/scenes/PlantsDashboardRouter/useDashboardPlantingSites.ts
+++ b/src/scenes/PlantsDashboardRouter/useDashboardPlantingSites.ts
@@ -2,20 +2,17 @@ import { useMemo } from 'react';
 
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
 import { ALL_PLANTING_SITES } from 'src/hooks/useStickyPlantingSiteId';
-import { useLocalization, useOrganization } from 'src/providers';
-import { useSpeciesData } from 'src/providers/Species/SpeciesContext';
+import { useLocalization } from 'src/providers';
 import { useListPlantingSitesQuery } from 'src/queries/generated/plantingSites';
 
 // Loads the planting sites the dashboard should display, scoped to the selected project via the
 // backend `projectId` filter (no client-side filtering). Shared by the dashboard view and header so
-// they stay consistent.
-const useDashboardPlantingSites = (projectId: number | typeof ALL_PLANTING_SITES) => {
+// they stay consistent. `organizationId` is resolved by the caller (PlantsDashboardView) so accelerator
+// routes can target the project's organization.
+const useDashboardPlantingSites = (projectId: number | typeof ALL_PLANTING_SITES, organizationId?: number) => {
   const { activeLocale } = useLocalization();
-  const { selectedOrganization } = useOrganization();
-  const { acceleratorOrganizationId } = useSpeciesData();
   const { isAcceleratorRoute } = useAcceleratorConsole();
 
-  const organizationId = (isAcceleratorRoute ? acceleratorOrganizationId : undefined) ?? selectedOrganization?.id;
   const isProjectSelected = typeof projectId === 'number';
 
   const { currentData, isFetching, isSuccess } = useListPlantingSitesQuery(

--- a/src/scenes/PlantsDashboardRouter/useDashboardPlantingSites.ts
+++ b/src/scenes/PlantsDashboardRouter/useDashboardPlantingSites.ts
@@ -1,15 +1,14 @@
 import { useMemo } from 'react';
 
 import useAcceleratorConsole from 'src/hooks/useAcceleratorConsole';
-import { ALL_PLANTING_SITES } from 'src/hooks/useStickyPlantingSiteId';
 import { useLocalization } from 'src/providers';
 import { useListPlantingSitesQuery } from 'src/queries/generated/plantingSites';
 
 // Loads the planting sites the dashboard should display, scoped to the selected project via the
 // backend `projectId` filter (no client-side filtering). Shared by the dashboard view and header so
-// they stay consistent. `organizationId` is resolved by the caller (PlantsDashboardView) so accelerator
-// routes can target the project's organization.
-const useDashboardPlantingSites = (projectId: number | typeof ALL_PLANTING_SITES, organizationId?: number) => {
+// they stay consistent. `organizationId` is resolved by the caller so accelerator routes can target
+// the project's organization.
+const useDashboardPlantingSites = (projectId: number | 'all', organizationId?: number) => {
   const { activeLocale } = useLocalization();
   const { isAcceleratorRoute } = useAcceleratorConsole();
 


### PR DESCRIPTION
Resolve the effective organization id in PlantsDashboardView (accelerator
project org vs selected org) and load species via
useOrganizationSpecies({ organizationId }).

Co-Authored-By: Claude Opus 4.8 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)