### PR TITLE
SW-8626 Show spinner instead of flashing empty state while species load

### DIFF
--- a/src/scenes/InventoryRouter/InventoryV2View.tsx
+++ b/src/scenes/InventoryRouter/InventoryV2View.tsx
@@ -1,6 +1,6 @@
 import React, { type JSX, useCallback, useMemo, useRef, useState } from 'react';
 
-import { Box, Container, Grid, Typography, useTheme } from '@mui/material';
+import { Box, CircularProgress, Container, Grid, Typography, useTheme } from '@mui/material';
 import { Button, DropdownItem, Tabs } from '@terraware/web-components';
 
 import PageSnackbar from 'src/components/PageSnackbar';
@@ -156,6 +156,7 @@ export type BatchInventoryResult = {
 type InventoryProps = {
   hasNurseries: boolean;
   hasSpecies: boolean;
+  speciesLoading?: boolean;
 };
 
 export default function InventoryV2View(props: InventoryProps): JSX.Element {
@@ -164,7 +165,7 @@ export default function InventoryV2View(props: InventoryProps): JSX.Element {
   const { isMobile } = useDeviceInfo();
   const theme = useTheme();
   const navigate = useSyncNavigate();
-  const { hasNurseries, hasSpecies } = props;
+  const { hasNurseries, hasSpecies, speciesLoading } = props;
   const [importInventoryModalOpen, setImportInventoryModalOpen] = useState(false);
   const contentRef = useRef(null);
 
@@ -263,6 +264,17 @@ export default function InventoryV2View(props: InventoryProps): JSX.Element {
   const onCloseImportInventoryModal = useCallback(() => setImportInventoryModalOpen(false), []);
 
   const navigateToInventoryCreateView = useCallback(() => goTo(APP_PATHS.INVENTORY_NEW), [goTo]);
+
+  // Show a spinner while species are still loading so the onboarding empty state doesn't flash first.
+  if (speciesLoading) {
+    return (
+      <TfMain>
+        <Box sx={{ display: 'flex', justifyContent: 'center', paddingTop: '64px' }}>
+          <CircularProgress />
+        </Box>
+      </TfMain>
+    );
+  }
 
   return (
     <TfMain>

--- a/src/scenes/InventoryRouter/InventoryV2View.tsx
+++ b/src/scenes/InventoryRouter/InventoryV2View.tsx
@@ -265,7 +265,6 @@ export default function InventoryV2View(props: InventoryProps): JSX.Element {
 
   const navigateToInventoryCreateView = useCallback(() => goTo(APP_PATHS.INVENTORY_NEW), [goTo]);
 
-  // Show a spinner while species are still loading so the onboarding empty state doesn't flash first.
   if (speciesLoading) {
     return (
       <TfMain>

--- a/src/scenes/InventoryRouter/index.tsx
+++ b/src/scenes/InventoryRouter/index.tsx
@@ -13,7 +13,7 @@ import { selectedOrgHasFacilityType } from 'src/utils/organization';
 
 const InventoryRouter = () => {
   const { selectedOrganization } = useOrganization();
-  const { species } = useOrganizationSpecies();
+  const { species, isLoading: speciesLoading } = useOrganizationSpecies();
 
   return (
     <Routes>
@@ -23,6 +23,7 @@ const InventoryRouter = () => {
           <InventoryV2View
             hasNurseries={selectedOrganization ? selectedOrgHasFacilityType(selectedOrganization, 'Nursery') : false}
             hasSpecies={species.length > 0}
+            speciesLoading={speciesLoading}
           />
         }
       />

--- a/src/scenes/Species/index.tsx
+++ b/src/scenes/Species/index.tsx
@@ -1,6 +1,8 @@
 import React, { type JSX, useCallback } from 'react';
 import { Route, Routes } from 'react-router';
 
+import { Box, CircularProgress } from '@mui/material';
+
 import EmptyStatePage from 'src/components/emptyStatePages/EmptyStatePage';
 import { useOrganizationSpecies } from 'src/hooks/useOrganizationSpecies';
 import SpeciesAddView from 'src/scenes/Species/SpeciesAddView';
@@ -9,15 +11,24 @@ import SpeciesEditView from 'src/scenes/Species/SpeciesEditView';
 import SpeciesListView from 'src/scenes/Species/SpeciesListView';
 
 const SpeciesRouter = () => {
-  const { species, refetch } = useOrganizationSpecies();
+  const { species, isLoading, refetch } = useOrganizationSpecies();
 
   const getSpeciesView = useCallback((): JSX.Element => {
+    // Show a spinner while species are still loading so the onboarding empty state doesn't flash first.
+    if (isLoading) {
+      return (
+        <Box sx={{ display: 'flex', justifyContent: 'center', paddingTop: '64px' }}>
+          <CircularProgress />
+        </Box>
+      );
+    }
+
     if (species.length > 0) {
       return <SpeciesListView reloadData={refetch} species={species} />;
     }
 
     return <EmptyStatePage pageName={'Species'} reloadData={refetch} />;
-  }, [species, refetch]);
+  }, [isLoading, species, refetch]);
 
   return (
     <Routes>

--- a/src/scenes/Species/index.tsx
+++ b/src/scenes/Species/index.tsx
@@ -14,7 +14,6 @@ const SpeciesRouter = () => {
   const { species, isLoading, refetch } = useOrganizationSpecies();
 
   const getSpeciesView = useCallback((): JSX.Element => {
-    // Show a spinner while species are still loading so the onboarding empty state doesn't flash first.
     if (isLoading) {
       return (
         <Box sx={{ display: 'flex', justifyContent: 'center', paddingTop: '64px' }}>


### PR DESCRIPTION
On the Species and Inventory screens, render a loading spinner while the species
list is still loading (via useOrganizationSpecies' isLoading) instead of briefly
flashing the onboarding empty state before data arrives.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>