### PR TITLE
Fix pipeline for different agents

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -113,6 +113,10 @@ steps:
             - file
             - branch
     command: .buildkite/scripts/validate-types.sh
+    env:
+      SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUERURI: https://auth.staging.terraware.io/realms/terraware
+      SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTSECRET: dummy
+      SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI: https://auth.staging.terraware.io/realms/terraware
 
   - label: ':docker: Build and push Docker image'
     key: 'docker'


### PR DESCRIPTION
The `Validate type generation` step needs spring security env to work properly on different agents. This ensures that if that step is run on a different agent than the previous step (`Run end-to-end tests`) then it correctly starts the BE server with the spring security env variables necessary.