### PR TITLE
Remove the modified counter from the inventory seedlings table

### DIFF
--- a/src/scenes/InventoryRouter/InventoryForNurseryView.tsx
+++ b/src/scenes/InventoryRouter/InventoryForNurseryView.tsx
@@ -1,4 +1,4 @@
-import React, { type JSX, useRef, useState } from 'react';
+import React, { type JSX, useRef } from 'react';
 import { useParams } from 'react-router';
 
 import { Grid, Typography, useTheme } from '@mui/material';
@@ -27,8 +27,6 @@ export default function InventoryForNurseryView(): JSX.Element {
   const { selectedOrganization } = useOrganization();
   const contentRef = useRef(null);
   const theme = useTheme();
-
-  const [modified, setModified] = useState<number>(-1);
 
   const nurseryId = Number(pathParams.nurseryId);
   const openBatchNumber = (query.get('batch') || '').toLowerCase();
@@ -78,8 +76,6 @@ export default function InventoryForNurseryView(): JSX.Element {
           <Card flushMobile style={{ marginTop: theme.spacing(3) }}>
             <InventorySeedlingsTableForNursery
               nurseryId={nurseryId}
-              modified={modified}
-              setModified={setModified}
               onUpdateOpenBatch={setBatchNumber}
               openBatchNumber={openBatchNumber}
               origin={'Nursery'}

--- a/src/scenes/InventoryRouter/InventoryForSpeciesView.tsx
+++ b/src/scenes/InventoryRouter/InventoryForSpeciesView.tsx
@@ -29,7 +29,6 @@ export default function InventoryForSpeciesView(props: InventoryForSpeciesViewPr
   const { species } = props;
   const { speciesId } = useParams<{ speciesId: string }>();
   const [inventorySpecies, setInventorySpecies] = useState<Species>();
-  const [modified, setModified] = useState<number>(-1);
   const contentRef = useRef(null);
   const theme = useTheme();
 
@@ -88,8 +87,6 @@ export default function InventoryForSpeciesView(props: InventoryForSpeciesViewPr
             <Card flushMobile style={{ marginTop: theme.spacing(3) }}>
               <InventorySeedlingsTableForSpecies
                 speciesId={Number(speciesId)}
-                modified={modified}
-                setModified={setModified}
                 openBatchNumber={openBatchNumber}
                 onUpdateOpenBatch={setBatchNumber}
                 origin={'Species'}

--- a/src/scenes/InventoryRouter/view/BatchDetailsModal.tsx
+++ b/src/scenes/InventoryRouter/view/BatchDetailsModal.tsx
@@ -11,13 +11,12 @@ import useSnackbar from 'src/utils/useSnackbar';
 
 export interface BatchDetailsModalProps {
   onClose: () => void;
-  reload: () => void;
   originId?: number;
   origin: OriginPage;
 }
 
 export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.Element {
-  const { onClose, reload, originId, origin } = props;
+  const { onClose, originId, origin } = props;
 
   const snackbar = useSnackbar();
   const saveBatch = useSaveBatch();
@@ -40,7 +39,6 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
 
         if (savedBatch) {
           markSubmitted();
-          reload();
           onClose();
         } else {
           snackbar.toastError(strings.GENERIC_ERROR);
@@ -50,7 +48,7 @@ export default function BatchDetailsModal(props: BatchDetailsModalProps): JSX.El
 
       void save();
     },
-    [markSubmitted, onClose, reload, saveBatch, snackbar]
+    [markSubmitted, onClose, saveBatch, snackbar]
   );
 
   const onSaveBatch = useCallback(() => {

--- a/src/scenes/InventoryRouter/view/InventorySeedlingsTable.tsx
+++ b/src/scenes/InventoryRouter/view/InventorySeedlingsTable.tsx
@@ -22,11 +22,11 @@ import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import useTableState from 'src/hooks/useTableState';
 import { useLocalization, useOrganization } from 'src/providers';
 import { useDeleteBatchMutation } from 'src/queries/generated/nurseryBatches';
+import { useListBatchesForNurseryQuery, useListBatchesForSpeciesQuery } from 'src/queries/search/batches';
 import { isBatchEmpty } from 'src/scenes/InventoryRouter/FilterUtils';
 import { InventoryFiltersUnion } from 'src/scenes/InventoryRouter/InventoryFilter';
-import { FieldNodePayload, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
+import { FieldNodePayload, SearchResponseElement } from 'src/types/Search';
 import { downloadCsv } from 'src/utils/csv';
-import { getRequestId, setRequestId } from 'src/utils/requestsId';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import useForm from 'src/utils/useForm';
 import { useNumberFormatter } from 'src/utils/useNumberFormatter';
@@ -42,34 +42,16 @@ import QuantitiesMenu from './QuantitiesMenu';
 export interface InventorySeedlingsTableProps {
   speciesId?: number;
   facilityId?: number;
-  modified: number;
-  setModified: (val: number) => void;
   openBatchNumber: string | null;
   onUpdateOpenBatch: (batchNum: string | null) => void;
   origin: OriginPage;
   columns: TableColumnType[] | (() => TableColumnType[]);
   isSelectionBulkWithdrawable: (selectedRows: SearchResponseElement[]) => boolean;
-  getFuzzySearchFields: (debouncedSearchTerm: string) => FieldNodePayload[];
-  // Origin ID is either the facility ID or the species ID
-  getBatchesSearch: (
-    orgId: number,
-    originId: number,
-    searchFields: FieldNodePayload[],
-    searchSortOrder: SearchSortOrder | undefined
-  ) => Promise<SearchResponseElement[] | null>;
 }
 
 export default function InventorySeedlingsTable(props: InventorySeedlingsTableProps): JSX.Element {
-  const {
-    modified,
-    setModified,
-    openBatchNumber,
-    onUpdateOpenBatch,
-    origin,
-    columns,
-    isSelectionBulkWithdrawable,
-    getBatchesSearch,
-  } = props;
+  const { openBatchNumber, onUpdateOpenBatch, origin, columns, isSelectionBulkWithdrawable } = props;
+  // Origin ID is either the facility ID or the species ID
   const originId: number | undefined = props.facilityId || props.speciesId;
 
   const { activeLocale, strings } = useLocalization();
@@ -84,7 +66,6 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
   const [deleteBatch] = useDeleteBatchMutation();
   const tableStorageKey = `inventorySeedlingsTable_${origin.toLowerCase()}`;
 
-  const [batches, setBatches] = useState<SearchResponseElement[]>([]);
   const [filteredBatches, setFilteredBatches] = useState<SearchResponseElement[]>([]);
   const [filters, setFilters] = useForm<InventoryFiltersUnion>({});
   const [rowSelection, setRowSelection] = useState<MRT_RowSelectionState>({});
@@ -102,16 +83,6 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
         .filter((row): row is SearchResponseElement => row !== undefined),
     [rowSelection, filteredBatches]
   );
-
-  useEffect(() => {
-    if (
-      (origin === 'Species' || origin === 'Nursery') &&
-      batches.length > 0 &&
-      batches.filter((batch: SearchResponseElement) => !isBatchEmpty(batch)).length === 0
-    ) {
-      setFilters({ showEmptyBatches: ['true'] });
-    }
-  }, [batches, origin, setFilters]);
 
   const filterEmptyBatches = useCallback(
     (unfiltered: SearchResponseElement[]) => {
@@ -160,48 +131,58 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
     return fields;
   }, [getNonSpeciesSearchFields, filters.speciesIds]);
 
+  const searchFields = useMemo(() => getSearchFields(), [getSearchFields]);
+  const isNurseryOrigin = origin === 'Nursery';
+  const skipSearch = !originId || isNaN(originId) || !selectedOrganization || !activeLocale;
+
+  const { currentData: nurseryBatchResults } = useListBatchesForNurseryQuery(
+    { organizationId: selectedOrganization?.id ?? -1, nurseryId: originId ?? -1, searchFields },
+    { skip: skipSearch || !isNurseryOrigin }
+  );
+
+  const { currentData: speciesBatchResults } = useListBatchesForSpeciesQuery(
+    { organizationId: selectedOrganization?.id ?? -1, speciesId: originId ?? -1, searchFields },
+    { skip: skipSearch || isNurseryOrigin }
+  );
+
+  // Resolve species names from the org species list so they stay fresh even if the search
+  // response carries a stale (or, eventually, absent) embedded name.
+  const withOrgSpecies = useCallback(
+    (batch: SearchResponseElement): SearchResponseElement => {
+      const orgSpecies = findSpeciesById(Number(batch.species_id));
+      return orgSpecies
+        ? {
+            ...batch,
+            species_scientificName: orgSpecies.scientificName,
+            species_commonName: orgSpecies.commonName ?? batch.species_commonName,
+          }
+        : batch;
+    },
+    [findSpeciesById]
+  );
+
+  // The origin is not a column of the search results, so it is folded back into each row
+  const batches = useMemo(
+    (): SearchResponseElement[] =>
+      isNurseryOrigin
+        ? (nurseryBatchResults ?? []).map((batch) => ({ ...withOrgSpecies(batch), facilityId: originId }))
+        : (speciesBatchResults ?? []).map((batch) => ({
+            ...withOrgSpecies(batch),
+            facilityId: batch.facility_id,
+            species_id: originId,
+          })),
+    [isNurseryOrigin, nurseryBatchResults, originId, speciesBatchResults, withOrgSpecies]
+  );
+
   useEffect(() => {
-    const requestId = setRequestId('inventory-seedlings');
-
-    const populateResults = async () => {
-      if (!originId || !selectedOrganization || !activeLocale) {
-        return;
-      }
-
-      const searchFields = getSearchFields();
-      const batchesResults = await getBatchesSearch(selectedOrganization.id, originId, searchFields, undefined);
-
-      // Resolve species names from the org species list so they stay fresh even if the search
-      // response carries a stale (or, eventually, absent) embedded name.
-      const withOrgSpecies = (batchesResults || []).map((batch) => {
-        const orgSpecies = findSpeciesById(Number(batch.species_id));
-        return orgSpecies
-          ? {
-              ...batch,
-              species_scientificName: orgSpecies.scientificName,
-              species_commonName: orgSpecies.commonName ?? batch.species_commonName,
-            }
-          : batch;
-      });
-
-      if (requestId === getRequestId('inventory-seedlings')) {
-        setBatches(withOrgSpecies);
-      }
-    };
-
-    if (!originId || !isNaN(originId)) {
-      void populateResults();
+    if (
+      (origin === 'Species' || origin === 'Nursery') &&
+      batches.length > 0 &&
+      batches.filter((batch: SearchResponseElement) => !isBatchEmpty(batch)).length === 0
+    ) {
+      setFilters({ showEmptyBatches: ['true'] });
     }
-  }, [
-    activeLocale,
-    filters.facilityIds,
-    findSpeciesById,
-    getBatchesSearch,
-    getSearchFields,
-    modified,
-    originId,
-    selectedOrganization,
-  ]);
+  }, [batches, origin, setFilters]);
 
   useEffect(() => {
     const batch = batches.find((b) => b.batchNumber === openBatchNumber);
@@ -229,13 +210,8 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
     setFilteredBatches(filterEmptyBatches(batches));
   }, [batches, filterEmptyBatches]);
 
-  const reloadData = useCallback(() => {
-    setModified(Date.now());
-  }, [setModified]);
-
   const addBatch = () => {
     setOpenNewBatchModal(true);
-    reloadData();
   };
 
   const deleteSelectedBatches = useCallback(() => {
@@ -244,10 +220,9 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
       if (results.some((result) => result.status === 'rejected')) {
         snackbar.toastError();
       }
-      reloadData();
       setOpenDeleteModal(false);
     });
-  }, [deleteBatch, reloadData, selectedRows, snackbar]);
+  }, [deleteBatch, selectedRows, snackbar]);
 
   const selectAllRows = useCallback(() => {
     const newSelection: MRT_RowSelectionState = {};
@@ -452,7 +427,6 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
       >
         {openNewBatchModal && (
           <BatchDetailsModal
-            reload={reloadData}
             onClose={() => {
               onUpdateOpenBatch(null);
               setOpenNewBatchModal(false);
@@ -478,7 +452,6 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
             onClose={() => setModalValues({ openChangeQuantityModal: false, type: 'germinating' })}
             modalValues={modalValues}
             row={modalValues.batch}
-            reload={reloadData}
           />
         )}
         <Grid item xs={12} sx={{ marginTop: theme.spacing(1) }}>
@@ -552,7 +525,6 @@ export default function InventorySeedlingsTable(props: InventorySeedlingsTablePr
                     <ProjectAssignTopBarButton
                       totalResultsCount={filteredBatches?.length}
                       selectAllRows={selectAllRows}
-                      reloadData={reloadData}
                       projectAssignPayloadCreator={() => ({ batchIds: selectedRows.map((row) => Number(row.id)) })}
                     />
                     <Tooltip title={withdrawTooltip || ''}>

--- a/src/scenes/InventoryRouter/view/InventorySeedlingsTableForNursery.tsx
+++ b/src/scenes/InventoryRouter/view/InventorySeedlingsTableForNursery.tsx
@@ -3,23 +3,16 @@ import React, { type JSX, useCallback, useMemo } from 'react';
 import { TableColumnType } from '@terraware/web-components';
 
 import { useLocalization } from 'src/providers';
-import { useLazyListBatchesForNurseryQuery } from 'src/queries/search/batches';
 import InventorySeedlingsTable, {
   InventorySeedlingsTableProps,
 } from 'src/scenes/InventoryRouter/view/InventorySeedlingsTable';
-import { FieldNodePayload, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
-import { parseSearchTerm } from 'src/utils/search';
 
 interface InventorySeedlingsTableForNurseryProps
-  extends Omit<
-    InventorySeedlingsTableProps,
-    'columns' | 'isSelectionBulkWithdrawable' | 'getFuzzySearchFields' | 'getBatchesSearch'
-  > {
+  extends Omit<InventorySeedlingsTableProps, 'columns' | 'isSelectionBulkWithdrawable'> {
   nurseryId: number;
 }
 
 export default function InventorySeedlingsTableForNursery(props: InventorySeedlingsTableForNurseryProps): JSX.Element {
-  const [listBatchesForNursery] = useLazyListBatchesForNurseryQuery();
   const facilityId = props.nurseryId;
   const { strings } = useLocalization();
 
@@ -68,36 +61,6 @@ export default function InventorySeedlingsTableForNursery(props: InventorySeedli
     [strings]
   );
 
-  const getFuzzySearchFields = useCallback((debouncedSearchTerm: string): FieldNodePayload[] => {
-    const { type, values } = parseSearchTerm(debouncedSearchTerm);
-    return [
-      {
-        operation: 'field',
-        field: 'species_scientificName',
-        type,
-        values,
-      },
-    ];
-  }, []);
-
-  const getBatchesSearch = useCallback(
-    async (
-      orgId: number,
-      originId: number,
-      searchFields: FieldNodePayload[],
-      searchSortOrder: SearchSortOrder | undefined
-    ): Promise<SearchResponseElement[] | null> => {
-      const searchResponse = await listBatchesForNursery({
-        organizationId: orgId,
-        nurseryId: originId,
-        searchFields,
-        sortOrder: searchSortOrder,
-      }).unwrap();
-      return searchResponse.map((sr): SearchResponseElement => ({ ...sr, facilityId }));
-    },
-    [facilityId, listBatchesForNursery]
-  );
-
   const isSelectionBulkWithdrawable = useCallback(() => true, []);
 
   return (
@@ -106,8 +69,6 @@ export default function InventorySeedlingsTableForNursery(props: InventorySeedli
       facilityId={facilityId}
       columns={columns}
       isSelectionBulkWithdrawable={isSelectionBulkWithdrawable}
-      getFuzzySearchFields={getFuzzySearchFields}
-      getBatchesSearch={getBatchesSearch}
     />
   );
 }

--- a/src/scenes/InventoryRouter/view/InventorySeedlingsTableForSpecies.tsx
+++ b/src/scenes/InventoryRouter/view/InventorySeedlingsTableForSpecies.tsx
@@ -3,24 +3,17 @@ import React, { type JSX, useCallback, useMemo } from 'react';
 import { TableColumnType } from '@terraware/web-components';
 
 import { useLocalization } from 'src/providers';
-import { useLazyListBatchesForSpeciesQuery } from 'src/queries/search/batches';
 import InventorySeedlingsTable, {
   InventorySeedlingsTableProps,
 } from 'src/scenes/InventoryRouter/view/InventorySeedlingsTable';
-import { FieldNodePayload, SearchResponseElement, SearchSortOrder } from 'src/types/Search';
-import { parseSearchTerm } from 'src/utils/search';
+import { SearchResponseElement } from 'src/types/Search';
 
 interface InventorySeedlingsTableForSpeciesProps
-  extends Omit<
-    InventorySeedlingsTableProps,
-    'columns' | 'isSelectionBulkWithdrawable' | 'getFuzzySearchFields' | 'getBatchesSearch'
-  > {
+  extends Omit<InventorySeedlingsTableProps, 'columns' | 'isSelectionBulkWithdrawable'> {
   speciesId: number;
 }
 
 export default function InventorySeedlingsTableForSpecies(props: InventorySeedlingsTableForSpeciesProps): JSX.Element {
-  const [listBatchesForSpecies] = useLazyListBatchesForSpeciesQuery();
-  const speciesId = props.speciesId;
   const { strings } = useLocalization();
 
   const columns = useMemo(
@@ -69,42 +62,6 @@ export default function InventorySeedlingsTableForSpecies(props: InventorySeedli
     [strings]
   );
 
-  const getFuzzySearchFields = useCallback((debouncedSearchTerm: string): FieldNodePayload[] => {
-    const { type, values } = parseSearchTerm(debouncedSearchTerm);
-    return [
-      {
-        operation: 'field',
-        field: 'facility_name',
-        type,
-        values,
-      },
-    ];
-  }, []);
-
-  const getBatchesSearch = useCallback(
-    async (
-      orgId: number,
-      originId: number,
-      searchFields: FieldNodePayload[],
-      searchSortOrder: SearchSortOrder | undefined
-    ): Promise<SearchResponseElement[] | null> => {
-      const searchResponse = await listBatchesForSpecies({
-        organizationId: orgId,
-        speciesId: originId,
-        searchFields,
-        sortOrder: searchSortOrder,
-      }).unwrap();
-      return searchResponse.map(
-        (sr): SearchResponseElement => ({
-          ...sr,
-          facilityId: sr.facility_id,
-          species_id: speciesId,
-        })
-      );
-    },
-    [listBatchesForSpecies, speciesId]
-  );
-
   const areAllFromSameNursery = (selectedRows: SearchResponseElement[]) => {
     if (!selectedRows.length) {
       return false;
@@ -121,12 +78,6 @@ export default function InventorySeedlingsTableForSpecies(props: InventorySeedli
   );
 
   return (
-    <InventorySeedlingsTable
-      {...props}
-      columns={columns}
-      isSelectionBulkWithdrawable={isSelectionBulkWithdrawable}
-      getFuzzySearchFields={getFuzzySearchFields}
-      getBatchesSearch={getBatchesSearch}
-    />
+    <InventorySeedlingsTable {...props} columns={columns} isSelectionBulkWithdrawable={isSelectionBulkWithdrawable} />
   );
 }


### PR DESCRIPTION
Simplified reload logic by getting rid of hte modified counter, since RTK Query already handles refetching automatically.

Co-Authored-By: Claude Opus 5 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)