### PR TITLE
SW-7907 Update Planting tooltips in withdrawal form

### DIFF
--- a/src/components/BatchWithdrawFlow/flow/SelectPurposeForm.tsx
+++ b/src/components/BatchWithdrawFlow/flow/SelectPurposeForm.tsx
@@ -517,19 +517,15 @@ export default function SelectPurposeForm(props: SelectPurposeFormProps): JSX.El
     return batchesFromNursery.reduce((acc, batch) => acc + (Number(batch['readyQuantity(raw)']) || 0), 0);
   }, [batchesFromNursery]);
 
-  const outplantDisabled = useMemo(() => {
-    if ((!isLoading && !plantingSites.length) || noReadySeedlings) {
-      return true;
-    }
+  const noPlantingSites = useMemo(() => !isLoading && !plantingSites.length, [isLoading, plantingSites]);
 
-    return false;
-  }, [plantingSites, isLoading, noReadySeedlings]);
+  const outplantDisabled = useMemo(() => noPlantingSites || noReadySeedlings, [noPlantingSites, noReadySeedlings]);
 
   const getOutplantLabel = () => {
     return (
       <>
         {strings.PLANTING}
-        {outplantDisabled ? (
+        {noPlantingSites ? (
           <IconTooltip placement='top' title={strings.PLANTINGS_REQUIRE_PLANTING_SITES} />
         ) : (
           <IconTooltip placement='top' title={strings.PLANTINGS_REQUIRE_READY_TO_PLANT_SEEDLINGS} />

--- a/src/scenes/InventoryRouter/BatchWithdrawModal/PurposeAndDestinationStep.tsx
+++ b/src/scenes/InventoryRouter/BatchWithdrawModal/PurposeAndDestinationStep.tsx
@@ -236,7 +236,7 @@ const PurposeAndDestinationStep = ({
   const outplantLabel = (
     <>
       {strings.PLANTING}
-      {outplantDisabled ? (
+      {plantingSitesDisabled ? (
         <IconTooltip placement='top' title={strings.PLANTINGS_REQUIRE_PLANTING_SITES} />
       ) : (
         <IconTooltip placement='top' title={strings.PLANTINGS_REQUIRE_READY_TO_PLANT_SEEDLINGS} />


### PR DESCRIPTION
The Planting tooltip in the withdrawal form was displaying "Plantings require a planting site for allocation" if there were none ready to plant, even when there were planting sites. Fix this to only show that if there are no planting sites.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>