### PR TITLE
Update web-components to fix breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@rsbuild/plugin-type-check": "^1.3.3",
     "@rstest/core": "^0.11.0",
     "@rstest/coverage-istanbul": "^0.11.0",
-    "@terraware/web-components": "^v4.2.14",
+    "@terraware/web-components": "^v4.2.17",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/src/scenes/VirtualWalkthrough/VirtualWalkthroughWrapper.tsx
+++ b/src/scenes/VirtualWalkthrough/VirtualWalkthroughWrapper.tsx
@@ -118,9 +118,9 @@ const VirtualWalkthroughWrapper = ({
               ])
             : undefined,
           icon,
-          // TODO: replace with actual image url once retrieval is available
-          imageUrl:
-            annotation.media.length > 0 ? PLACEHOLDER_IMAGE_URLS[index % PLACEHOLDER_IMAGE_URLS.length] : undefined,
+          // TODO: replace with actual image urls once retrieval is available
+          imageUrls:
+            annotation.media.length > 0 ? [PLACEHOLDER_IMAGE_URLS[index % PLACEHOLDER_IMAGE_URLS.length]] : undefined,
         } as AnnotationProps;
       }) ?? [],
     [data?.annotations]

--- a/yarn.lock
+++ b/yarn.lock
@@ -6359,10 +6359,10 @@
   resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.11.2.tgz#00409e743ac4eea9afe5b7708594d5fcebb00212"
   integrity sha512-vTtpNt7mKCiZ1pwU9hfKPhpdVO2sVzFQsxoVBGtOSHxlrRRzYr8iQ2TlwbAcRYCcEiZ9ECAM8kBzH0v2+VzfKw==
 
-"@terraware/web-components@^v4.2.14":
-  version "4.2.14"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-4.2.14.tgz#3ab7f300b70241139b71835c6357c0fcaf0ae8f0"
-  integrity sha512-Knf/NQ4gSp2DVfuk11IJfEICPma8Ev7OC5wKaI5KBAqqvbzCPrLVq8C5d5Qne1TwB5ODpzK/OVL8dVh6NZzxHw==
+"@terraware/web-components@^v4.2.17":
+  version "4.2.17"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-4.2.17.tgz#8588b96e07d16ca34fe4f8e147d82b7fdcf70fac"
+  integrity sha512-yPX0ycOaW5dGIh0oveUabarj7QCqANmpEsWEvbNGPC7DrjTJTWRpE+RxYibCK9drVmsqDNKBFZuPPF3jMiwHzQ==
   dependencies:
     "@dnd-kit/core" "^6.0.7"
     "@dnd-kit/sortable" "^10.0.0"


### PR DESCRIPTION
The latest version of web-components introduced a minor breaking change for annotations with images. Get ahead of this by updating terraware-web to pass imageUrls instead of imageUrl.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>