### PR TITLE
SW-8487 Show plot coordinates edits in plot history

### DIFF
--- a/src/api/types/generated-schema.ts
+++ b/src/api/types/generated-schema.ts
@@ -7275,7 +7275,7 @@ export interface components {
         };
         EventLogEntryPayload: {
             action: components["schemas"]["CreatedActionPayload"] | components["schemas"]["DeletedActionPayload"] | components["schemas"]["FieldUpdatedActionPayload"];
-            subject: components["schemas"]["BiomassDetailsSubjectPayload"] | components["schemas"]["BiomassQuadratSpeciesSubjectPayload"] | components["schemas"]["BiomassQuadratSubjectPayload"] | components["schemas"]["BiomassSpeciesSubjectPayload"] | components["schemas"]["MonitoringSpeciesSubjectPayload"] | components["schemas"]["ObservationPlotMediaSubjectPayload"] | components["schemas"]["ObservationPlotSubjectPayload"] | components["schemas"]["OrganizationSubjectPayload"] | components["schemas"]["PlantingDateRequestSpeciesSubjectPayload"] | components["schemas"]["PlantingDateRequestSubjectPayload"] | components["schemas"]["PlantingSeasonAllocatedSpeciesSubjectPayload"] | components["schemas"]["PlantingSeasonScheduledDateSpeciesSubjectPayload"] | components["schemas"]["PlantingSeasonScheduledDateSubjectPayload"] | components["schemas"]["PlantingSeasonSpeciesTargetSubjectPayload"] | components["schemas"]["PlantingSeasonSubjectPayload"] | components["schemas"]["PlantingSeasonWithdrawalSubjectPayload"] | components["schemas"]["ProjectSubjectPayload"] | components["schemas"]["RecordedTreeSubjectPayload"];
+            subject: components["schemas"]["BiomassDetailsSubjectPayload"] | components["schemas"]["BiomassQuadratSpeciesSubjectPayload"] | components["schemas"]["BiomassQuadratSubjectPayload"] | components["schemas"]["BiomassSpeciesSubjectPayload"] | components["schemas"]["MonitoringSpeciesSubjectPayload"] | components["schemas"]["ObservationPlotCoordinatesSubjectPayload"] | components["schemas"]["ObservationPlotMediaSubjectPayload"] | components["schemas"]["ObservationPlotSubjectPayload"] | components["schemas"]["OrganizationSubjectPayload"] | components["schemas"]["PlantingDateRequestSpeciesSubjectPayload"] | components["schemas"]["PlantingDateRequestSubjectPayload"] | components["schemas"]["PlantingSeasonAllocatedSpeciesSubjectPayload"] | components["schemas"]["PlantingSeasonScheduledDateSpeciesSubjectPayload"] | components["schemas"]["PlantingSeasonScheduledDateSubjectPayload"] | components["schemas"]["PlantingSeasonSpeciesTargetSubjectPayload"] | components["schemas"]["PlantingSeasonSubjectPayload"] | components["schemas"]["PlantingSeasonWithdrawalSubjectPayload"] | components["schemas"]["ProjectSubjectPayload"] | components["schemas"]["RecordedTreeSubjectPayload"];
             /** Format: date-time */
             timestamp: string;
             /** Format: int64 */
@@ -8567,7 +8567,7 @@ export interface components {
             /** Format: int64 */
             projectId?: number;
             /** @description If specified, only return event log entries for specific subject types. This can be used to narrow the scope of the results in cases where there might be events related to child entities and you don't care about those. */
-            subjects?: ("BiomassDetails" | "BiomassQuadrat" | "BiomassQuadratSpecies" | "BiomassSpecies" | "MonitoringSpecies" | "ObservationPlot" | "ObservationPlotMedia" | "Organization" | "PlantingDateRequest" | "PlantingDateRequestSpecies" | "PlantingSeason" | "PlantingSeasonAllocatedSpecies" | "PlantingSeasonScheduledDate" | "PlantingSeasonScheduledDateSpecies" | "PlantingSeasonSpeciesTarget" | "PlantingSeasonWithdrawal" | "Project" | "RecordedTree")[];
+            subjects?: ("BiomassDetails" | "BiomassQuadrat" | "BiomassQuadratSpecies" | "BiomassSpecies" | "MonitoringSpecies" | "ObservationPlot" | "ObservationPlotCoordinates" | "ObservationPlotMedia" | "Organization" | "PlantingDateRequest" | "PlantingDateRequestSpecies" | "PlantingSeason" | "PlantingSeasonAllocatedSpecies" | "PlantingSeasonScheduledDate" | "PlantingSeasonScheduledDateSpecies" | "PlantingSeasonSpeciesTarget" | "PlantingSeasonWithdrawal" | "Project" | "RecordedTree")[];
         };
         ListEventLogEntriesResponsePayload: {
             events: components["schemas"]["EventLogEntryPayload"][];
@@ -9498,6 +9498,22 @@ export interface components {
             state: "Upcoming" | "InProgress" | "Completed" | "Overdue" | "Abandoned";
             /** @enum {string} */
             type: "Monitoring" | "Biomass Measurements";
+        };
+        ObservationPlotCoordinatesSubjectPayload: Omit<WithRequired<components["schemas"]["EventSubjectPayload"], "fullText" | "shortText">, "type"> & {
+            /** Format: int64 */
+            monitoringPlotId: number;
+            /** Format: int64 */
+            observationId: number;
+            /** Format: int64 */
+            plantingSiteId: number;
+            /** @enum {string} */
+            position: "SouthwestCorner" | "SoutheastCorner" | "NortheastCorner" | "NorthwestCorner";
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "ObservationPlotCoordinates";
         };
         ObservationPlotMediaSubjectPayload: Omit<WithRequired<components["schemas"]["EventSubjectPayload"], "fullText" | "shortText">, "type"> & {
             /** Format: int64 */

--- a/src/queries/generated/events.ts
+++ b/src/queries/generated/events.ts
@@ -85,6 +85,14 @@ export type MonitoringSpeciesSubjectPayload = {
     scientificName?: string;
     speciesId?: number;
   };
+export type ObservationPlotCoordinatesSubjectPayload = {
+  type: 'ObservationPlotCoordinates';
+} & EventSubjectPayloadBase & {
+    monitoringPlotId: number;
+    observationId: number;
+    plantingSiteId: number;
+    position: 'SouthwestCorner' | 'SoutheastCorner' | 'NortheastCorner' | 'NorthwestCorner';
+  };
 export type ObservationPlotMediaSubjectPayload = {
   type: 'ObservationPlotMedia';
 } & EventSubjectPayloadBase & {
@@ -207,6 +215,7 @@ export type EventLogEntryPayload = {
     | BiomassQuadratSubjectPayload
     | BiomassSpeciesSubjectPayload
     | MonitoringSpeciesSubjectPayload
+    | ObservationPlotCoordinatesSubjectPayload
     | ObservationPlotMediaSubjectPayload
     | ObservationPlotSubjectPayload
     | OrganizationSubjectPayload
@@ -245,6 +254,7 @@ export type ListEventLogEntriesRequestPayload = {
     | 'BiomassSpecies'
     | 'MonitoringSpecies'
     | 'ObservationPlot'
+    | 'ObservationPlotCoordinates'
     | 'ObservationPlotMedia'
     | 'Organization'
     | 'PlantingDateRequest'

--- a/src/queries/observations/observations.ts
+++ b/src/queries/observations/observations.ts
@@ -21,6 +21,7 @@ const injectedRtkApi = api.injectEndpoints({
           subjects: queryArgs.isBiomass
             ? [
                 'ObservationPlot',
+                'ObservationPlotCoordinates',
                 'ObservationPlotMedia',
                 'BiomassDetails',
                 'BiomassQuadrat',
@@ -28,7 +29,7 @@ const injectedRtkApi = api.injectEndpoints({
                 'BiomassSpecies',
                 'RecordedTree',
               ]
-            : ['ObservationPlot', 'ObservationPlotMedia', 'MonitoringSpecies'],
+            : ['ObservationPlot', 'ObservationPlotCoordinates', 'ObservationPlotMedia', 'MonitoringSpecies'],
           organizationId: queryArgs.organizationId,
         },
       }),


### PR DESCRIPTION
The server is now recording persistent events when a user edits the
optional observed GPS coordinates on a monitoring plot. Show these
events in the plot's version history.