### PR TITLE
SW-8772 Login issue after visiting microsite

### DIFF
--- a/src/scenes/LearnMore/LearnMoreView.tsx
+++ b/src/scenes/LearnMore/LearnMoreView.tsx
@@ -44,7 +44,7 @@ const LearnMoreView = (): JSX.Element => {
 
   useEffect(() => {
     let active = true;
-    fetch('/api/v1/users/me', { credentials: 'include' })
+    fetch('/api/v1/users/me', { credentials: 'include', headers: { Accept: 'application/json' } })
       .then((response) => {
         if (active) {
           setIsLoggedIn(response.ok);


### PR DESCRIPTION
terraware-server relies on Spring Security's single-slot HttpSessionRequestCache to remember where to send you after login (it doesn't persist the redirect param itself). Any "browser-style" request to a protected endpoint overwrites that slot. The Learn More page's mount-time fetch('/api/v1/users/me') was a "browser-style" request (native fetch sends Accept: */*, not application/json), so it clobbered the original /api/v1/login?redirect=<home> with /api/v1/users/me. Finishing login later replayed the wrong URL → /api/v1/users/me?continue.

Added Accept: application/json to the login-status check. Now the server returns a clean 401 without saving/overwriting the request, so the original login redirect survives and post-login lands on home. 