### PR TITLE
Remove unused type declarations

### DIFF
--- a/src/components/ProjectField/index.tsx
+++ b/src/components/ProjectField/index.tsx
@@ -18,10 +18,6 @@ export interface ProjectFieldProps {
   backgroundColor?: string;
 }
 
-export type ProjectIdFieldProps = ProjectFieldProps & {
-  id: string;
-};
-
 export type EditFieldValue = string | number | undefined;
 
 export interface ProjectFieldEditProps {

--- a/src/components/common/Chart/Chart.tsx
+++ b/src/components/common/Chart/Chart.tsx
@@ -44,11 +44,6 @@ export type ChartData = {
   datasets: ChartDataset[];
 };
 
-export interface StyleProps {
-  minHeight?: string;
-  maxWidth?: string;
-}
-
 export type BaseChartProps = {
   chartId: string;
   chartData?: ChartData;

--- a/src/components/common/Photos/SelectPhotos.tsx
+++ b/src/components/common/Photos/SelectPhotos.tsx
@@ -1,10 +1,8 @@
 import React, { type JSX } from 'react';
 
-import { PhotoChooser, PhotoChooserErrorType, PhotoChooserProps } from '@terraware/web-components';
+import { PhotoChooser, PhotoChooserProps } from '@terraware/web-components';
 
 import strings from 'src/strings';
-
-export type ErrorType = PhotoChooserErrorType;
 
 /**
  * Wrapper for photo chooser with strings set

--- a/src/components/common/table/types.ts
+++ b/src/components/common/table/types.ts
@@ -1,3 +1,3 @@
-import { EnhancedTableDetailsRow, RendererProps, TableColumnType } from '@terraware/web-components';
+import { RendererProps, TableColumnType } from '@terraware/web-components';
 
-export type { TableColumnType, EnhancedTableDetailsRow, RendererProps };
+export type { TableColumnType, RendererProps };

--- a/src/redux/features/observations/utils.ts
+++ b/src/redux/features/observations/utils.ts
@@ -9,7 +9,6 @@ import {
   ObservationSubstratumResults,
   PlotCondition,
 } from 'src/types/Observations';
-import { MultiPolygon } from 'src/types/Tracking';
 import { getShortDate } from 'src/utils/dateFormatter';
 import { regexMatch } from 'src/utils/search';
 
@@ -80,12 +79,6 @@ export const searchPlots = (search: string, observations?: AdHocObservationResul
   return observations?.filter((observation: AdHocObservationResults) =>
     observation.adHocPlot ? regexMatch(observation.adHocPlot.monitoringPlotNumber.toString(), search) : true
   );
-};
-
-export type Value = {
-  name: string;
-  boundary: MultiPolygon;
-  timeZone?: string;
 };
 
 export const getConditionString = (

--- a/src/scenes/AcceleratorRouter/Modules/ModuleView.tsx
+++ b/src/scenes/AcceleratorRouter/Modules/ModuleView.tsx
@@ -22,25 +22,6 @@ export const InventoryListTypes: Record<string, string> = {
   BATCHES_BY_BATCH: 'batches_by_batch',
 } as const;
 
-type InventoryListTypeKeys = keyof typeof InventoryListTypes;
-export type InventoryListType = (typeof InventoryListTypes)[InventoryListTypeKeys];
-
-export type FacilityName = {
-  facility_name: string;
-};
-export type InventoryResult = {
-  facility_id: string;
-  species_id: string;
-  species_scientificName: string;
-  species_commonName?: string;
-  germinatingQuantity: string;
-  hardeningOffQuantity: string;
-  activeGrowthQuantity: string;
-  readyQuantity: string;
-  totalQuantity: string;
-  facilityInventories: FacilityName[];
-};
-
 export default function ModuleView(): JSX.Element {
   const contentRef = useRef(null);
   const { moduleId } = useParams<{ moduleId: string }>();

--- a/src/scenes/InventoryRouter/InventoryV2View.tsx
+++ b/src/scenes/InventoryRouter/InventoryV2View.tsx
@@ -36,10 +36,6 @@ export type FacilityName = {
   facility_name: string;
 };
 
-export type SpeciesName = {
-  species_scientificName: string;
-};
-
 export type InventoryResult = {
   facility_id: string;
   species_id: string;
@@ -108,28 +104,11 @@ export type FacilitySpeciesInventoryResult = {
   }[];
 };
 
-export type InventoryResultWithFacilityNames = Omit<InventoryResult, 'facilityInventories'> & {
-  facilityInventories: string;
-};
-
 export type InventoryResultWithBatchNumber = Omit<InventoryResult, 'facilityInventories'> & {
   batchId: string;
   batchNumber: string;
   facility_name_noLink: string;
   species_scientificName_noLink: string;
-};
-
-export type FacilityInventoryResult = {
-  facility_id: string;
-  facility_name: string;
-  species_id: string;
-  species_scientificName: string;
-  species_commonName?: string;
-  'germinatingQuantity(raw)': string;
-  'hardeningOffQuantity(raw)': string;
-  'readyQuantity(raw)': string;
-  'activeGrowthQuantity(raw)': string;
-  'totalQuantity(raw)': string;
 };
 
 export type BatchInventoryResult = {

--- a/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
+++ b/src/scenes/NurseryRouter/NurseryWithdrawalsDetailsView.tsx
@@ -25,20 +25,6 @@ import NonOutplantWithdrawalContent from './WithdrawalDetails/NonOutplantWithdra
 import ReassignmentTabPanelContent from './WithdrawalDetails/ReassignmentTabPanelContent';
 import WithdrawalTabPanelContent from './WithdrawalDetails/WithdrawalTabPanelContent';
 
-export interface WithdrawalSummary {
-  id: string;
-  delivery_id: string;
-  withdrawnDate: string;
-  purpose: string;
-  facilityName: string;
-  destinationName: string;
-  stratumNames: string;
-  substratumShortNames: string;
-  scientificNames: string[];
-  totalWithdrawn: string;
-  hasReassignments: boolean;
-}
-
 type NurseryWithdrawalsDetailsViewProps = {
   species: Species[];
 };

--- a/src/services/DeliverablesService.ts
+++ b/src/services/DeliverablesService.ts
@@ -40,8 +40,6 @@ export type UpdateSubmissionRequestPayload =
   paths[typeof ENDPOINT_DELIVERABLE_SUBMISSION]['put']['requestBody']['content']['application/json'];
 export type UpdateSubmissionResponsePayload =
   paths[typeof ENDPOINT_DELIVERABLE_SUBMISSION]['put']['responses'][200]['content']['application/json'];
-export type SubmitSubmissionResponsePayload =
-  paths[typeof ENDPOINT_DELIVERABLE_SUBMISSION_SUBMIT]['post']['responses'][200]['content']['application/json'];
 export type ImportDeliverablesResponsePayload =
   paths[typeof DELIVERABLES_IMPORT_ENDPOINT]['post']['responses'][200]['content']['application/json'];
 

--- a/src/services/HttpService.ts
+++ b/src/services/HttpService.ts
@@ -32,8 +32,6 @@ export type PostRequest = Request & {
 
 export type PutRequest = PostRequest;
 
-export type PatchRequest = PostRequest;
-
 export type DeleteRequest = PostRequest;
 
 /**

--- a/src/services/TrackingService.ts
+++ b/src/services/TrackingService.ts
@@ -1,7 +1,7 @@
 import { paths } from 'src/api/types/generated-schema';
 import { CreatePlantingSiteRequestPayload, ValidatePlantingSiteResponsePayload } from 'src/types/PlantingSite';
 import { SearchNodePayload, SearchRequestPayload, SearchSortOrder } from 'src/types/Search';
-import { Delivery, MonitoringPlotSearchResult, PlantingSite, PlantingSiteSearchResult } from 'src/types/Tracking';
+import { MonitoringPlotSearchResult, PlantingSite, PlantingSiteSearchResult } from 'src/types/Tracking';
 
 import { isArray } from '../types/utils';
 import HttpService, { Response, Response2 } from './HttpService';
@@ -41,10 +41,6 @@ export type PlantingSitesData = {
 
 export type PlantingSiteData = {
   site?: PlantingSite;
-};
-
-export type DeliveryData = {
-  delivery?: Delivery;
 };
 
 const httpPlantingSites = HttpService.root(PLANTING_SITES_ENDPOINT);

--- a/src/types/Accelerator.ts
+++ b/src/types/Accelerator.ts
@@ -1,5 +1,3 @@
 import { components } from 'src/api/types/generated-schema';
 
 export type AcceleratorOrg = components['schemas']['AcceleratorOrganizationPayload'];
-
-export type AcceleratorOrgProject = AcceleratorOrg['projects'][0];

--- a/src/types/AcceleratorReport.ts
+++ b/src/types/AcceleratorReport.ts
@@ -1,46 +1,12 @@
 import {
   AcceleratorReportPayload,
-  CreateAcceleratorReportConfigRequestPayload,
-  ExistingAcceleratorReportConfigPayload,
   NewAcceleratorReportConfigPayload,
   ReportChallengePayload,
   ReportPhotoPayload,
-  ReportReviewPayload,
-  UpdateAcceleratorReportConfigPayload,
-  UpdateAcceleratorReportConfigRequestPayload,
-  UpdateAcceleratorReportValuesRequestPayload,
 } from 'src/queries/generated/acceleratorReports';
 import { PublishedReportPayload } from 'src/queries/generated/publishedReports';
 
-export type {
-  CreateAcceleratorReportConfigRequestPayload,
-  ReportReviewPayload,
-  UpdateAcceleratorReportConfigPayload,
-  UpdateAcceleratorReportConfigRequestPayload,
-};
-
-export type UpdateAcceleratorReportRequest = UpdateAcceleratorReportValuesRequestPayload;
-
-export type ExistingAcceleratorReportConfig = ExistingAcceleratorReportConfigPayload;
-
 export type NewAcceleratorReportConfig = NewAcceleratorReportConfigPayload;
-
-export type CreateAcceleratorReportConfigRequest = CreateAcceleratorReportConfigRequestPayload & { projectId: string };
-
-export type UpdateAcceleratorReportConfigRequest = UpdateAcceleratorReportConfigRequestPayload & {
-  projectId: string;
-};
-
-export type ReviewAcceleratorReportRequest = {
-  review: ReportReviewPayload;
-  projectId: number;
-  reportId: number;
-};
-
-export type PublishAcceleratorReportRequest = {
-  projectId: number;
-  reportId: number;
-};
 
 export type AcceleratorReport = AcceleratorReportPayload;
 

--- a/src/types/Activity.ts
+++ b/src/types/Activity.ts
@@ -7,7 +7,6 @@ import {
   AdminActivityPayload as RtkAdminActivityPayload,
   AdminCreateActivityRequestPayload as RtkAdminCreateActivityRequestPayload,
   CreateActivityRequestPayload as RtkCreateActivityRequestPayload,
-  UpdateActivityMediaRequestPayload as RtkUpdateActivityMediaRequestPayload,
   UpdateActivityRequestPayload as RtkUpdateActivityRequestPayload,
 } from 'src/queries/generated/activities';
 import defaultStrings from 'src/strings';
@@ -34,7 +33,6 @@ export type AdminActivityMediaFile = AdminActivityMediaFilePayload;
 export type AdminCreateActivityRequestPayload = RtkAdminCreateActivityRequestPayload;
 export type CreateActivityRequestPayload = RtkCreateActivityRequestPayload;
 export type UpdateActivityRequestPayload = RtkUpdateActivityRequestPayload;
-export type UpdateActivityMediaRequestPayload = RtkUpdateActivityMediaRequestPayload;
 
 export type ActivityType = Activity['type'];
 export const ACTIVITY_TYPES: ActivityType[] = [

--- a/src/types/Deliverables.ts
+++ b/src/types/Deliverables.ts
@@ -3,7 +3,6 @@ import strings from 'src/strings';
 
 export type Deliverable = components['schemas']['DeliverablePayload'];
 export type DeliverableTypeType = components['schemas']['DeliverablePayload']['type'];
-export type ImportDeliverableProblemElement = components['schemas']['ImportDeliverableProblemElement'];
 export const DeliverableTypes: DeliverableTypeType[] = ['Document', 'Species', 'Questions'];
 
 export type DeliverableCategoryType = components['schemas']['DeliverablePayload']['category'];
@@ -49,8 +48,6 @@ export const DeliverableStatusesWithOverdue: DeliverableStatusTypeWithOverdue[] 
   'Not Needed',
   'Overdue',
 ];
-
-export type DeliverableDocument = components['schemas']['SubmissionDocumentPayload'];
 
 export type UploadDeliverableDocumentRequest = {
   description: string;

--- a/src/types/Module.ts
+++ b/src/types/Module.ts
@@ -16,7 +16,6 @@ export type ModuleEventWithStartTime = Omit<ModuleEvent, 'startTime'> & { startT
 
 export type ModuleEventStatus = components['schemas']['ModuleEvent']['status'];
 export type ModuleEventType = ModuleEvent['type'];
-export type ImportModuleProblemElement = components['schemas']['ImportModuleProblemElement'];
 
 export const getEventType = (input: ModuleEventType): string => {
   switch (input) {

--- a/src/types/Notifications.ts
+++ b/src/types/Notifications.ts
@@ -8,5 +8,3 @@ export type ClientNotification = Omit<Notification, 'body'> & {
   body: string | JSX.Element;
   markAsRead: (read: boolean) => void;
 };
-
-export type NotificationCriticality = Notification['notificationCriticality'];

--- a/src/types/Observations.ts
+++ b/src/types/Observations.ts
@@ -14,16 +14,11 @@ import { MultiPolygon } from './Tracking';
 // basic information on a single observation (excluding observation results)
 export type Observation = components['schemas']['ObservationPayload'];
 
-export type ScheduleObservationRequestPayload = components['schemas']['ScheduleObservationRequestPayload'];
-export type RescheduleObservationRequestPayload = components['schemas']['RescheduleObservationRequestPayload'];
-
 // "Upcoming" | "InProgress" | "Completed" | "Overdue"
 export type ObservationState = Observation['state'];
 
 // plot replacement
 export type ReplaceObservationPlotRequestPayload = components['schemas']['ReplaceObservationPlotRequestPayload'];
-export type ReplaceObservationPlotResponseFullPayload = components['schemas']['ReplaceObservationPlotResponsePayload'];
-export type ReplaceObservationPlotResponsePayload = Omit<ReplaceObservationPlotResponseFullPayload, 'status'>;
 // "Temporary" | "LongTerm"
 export type ReplaceObservationPlotDuration = ReplaceObservationPlotRequestPayload['duration'];
 
@@ -101,10 +96,6 @@ export type ObservationSubstratumResultsWithLastObv = ObservationSubstratumResul
 };
 // monitoring plot level results
 export type ObservationMonitoringPlotResultsPayload = RtkObservationMonitoringPlotResultsPayload;
-export type ObservationMonitoringPlotForMap = ObservationMonitoringPlotResultsPayload & {
-  isBiomassMeasurement?: boolean;
-  totalShrubs?: number;
-};
 export type MonitoringPlotStatus = ObservationMonitoringPlotResultsPayload['status'];
 export type ObservationMonitoringPlotResults = ObservationMonitoringPlotResultsPayload & {
   completedDate?: string;
@@ -172,8 +163,6 @@ export type RecordedPlant = components['schemas']['RecordedPlantPayload'];
 export type RecordedPlantStatus = RecordedPlant['status'];
 
 export type ExistingTreePayload = components['schemas']['ExistingTreePayload'];
-
-export type BiomassSpeciesPayload = components['schemas']['BiomassSpeciesPayload'];
 
 export type PlotCondition = components['schemas']['CompleteAdHocObservationRequestPayload']['conditions'][0];
 

--- a/src/types/PlantingSite.ts
+++ b/src/types/PlantingSite.ts
@@ -2,8 +2,6 @@ import { components } from 'src/api/types/generated-schema';
 
 import { MinimalPlantingSite, MultiPolygon } from './Tracking';
 
-export type PlantingSiteReportedPlants = components['schemas']['PlantingSiteReportedPlantsPayload'];
-
 export type UpdateSubstratumPayload = components['schemas']['UpdateSubstratumRequestPayload'];
 
 export type SiteType = 'simple' | 'detailed';
@@ -30,19 +28,14 @@ export type PlantingSitesFilters = {
 export type DraftPlantingSitePayloadRaw = components['schemas']['DraftPlantingSitePayload'];
 export type DraftPlantingSitePayload = Omit<DraftPlantingSitePayloadRaw, 'createdTime' | 'modifiedTime'>;
 export type CreateDraftPlantingSiteRequestPayload = components['schemas']['CreateDraftPlantingSiteRequestPayload'];
-export type CreateDraftPlantingSiteResponsePayload = components['schemas']['CreateDraftPlantingSiteResponsePayload'];
 export type UpdateDraftPlantingSiteRequestPayload = components['schemas']['UpdateDraftPlantingSiteRequestPayload'];
 export type GetDraftPlantingSiteResponsePayload = components['schemas']['GetDraftPlantingSiteResponsePayload'];
 
 /**
  * Planting Sites Payloads
  */
-export type PlantingSitePayload = components['schemas']['PlantingSitePayload'];
 export type CreatePlantingSiteRequestPayload = components['schemas']['CreatePlantingSiteRequestPayload'];
-export type CreatePlantingSiteResponsePayload = components['schemas']['CreatePlantingSiteResponsePayload'];
 export type ValidatePlantingSiteResponsePayload = components['schemas']['ValidatePlantingSiteResponsePayload'];
-export type UpdatePlantingSiteRequestPayload = components['schemas']['UpdatePlantingSiteRequestPayload'];
-export type GetPlantingSiteResponsePayload = components['schemas']['GetPlantingSiteResponsePayload'];
 
 export type PlantingSiteProblem = components['schemas']['PlantingSiteValidationProblemPayload'];
 

--- a/src/types/ProjectScore.ts
+++ b/src/types/ProjectScore.ts
@@ -1,4 +1,3 @@
-import { ProjectOverallScorePayload, UpdateProjectOverallScorePayload } from 'src/queries/generated/projectScores';
+import { ProjectOverallScorePayload } from 'src/queries/generated/projectScores';
 
 export type Score = ProjectOverallScorePayload;
-export type UpdateScore = UpdateProjectOverallScorePayload;

--- a/src/types/Search.ts
+++ b/src/types/Search.ts
@@ -13,7 +13,6 @@ export type SearchType = components['schemas']['FieldNodePayload']['type'];
 export type SearchResponseElement = components['schemas']['SearchResponsePayload']['results'][0];
 export type SearchResponseElementWithId = SearchResponseElement & { id: string };
 export type SearchValuesResponseElement = components['schemas']['SearchValuesResponsePayload']['results'];
-export type SearchValuesResponseElementWithId = SearchValuesResponseElement & { id: string };
 
 export type FieldOptionsMap = { [key: string]: { partial: boolean; values: (string | null)[] } };
 
@@ -23,7 +22,6 @@ export type SearchRequestPayload = components['schemas']['SearchRequestPayload']
   count: number;
   search: SearchNodePayload;
 };
-export type OptionalSearchRequestPayload = components['schemas']['SearchRequestPayload'];
 
 export const isFieldNodePayload = (node: SearchNodePayload): node is FieldNodePayload => node.operation === 'field';
 export const isNotNodePayload = (node: SearchNodePayload): node is NotNodePayload => node.operation === 'not';

--- a/src/types/Species.ts
+++ b/src/types/Species.ts
@@ -1,7 +1,7 @@
 import { DropdownItem } from '@terraware/web-components';
 
 import { components } from 'src/api/types/generated-schema';
-import { SpeciesLookupDetailsResponsePayload, SpeciesResponseElement } from 'src/queries/generated/species';
+import { SpeciesResponseElement } from 'src/queries/generated/species';
 import strings from 'src/strings';
 
 import { ArrayDeref, NonUndefined } from './utils';
@@ -20,13 +20,9 @@ export type PlantMaterialSourcingMethod = ArrayDeref<NonUndefined<Species['plant
 
 export type SuccessionalGroup = ArrayDeref<NonUndefined<Species['successionalGroups']>>;
 
-export type NativeStatus = 'Native' | 'Non-Native';
-
 export type EcosystemType = ArrayDeref<NonUndefined<Species['ecosystemTypes']>>;
 
 export type GrowthForm = ArrayDeref<NonUndefined<Species['growthForms']>>;
-
-export type SeedStorageBehavior = NonUndefined<Species['seedStorageBehavior']>;
 
 export function conservationCategories() {
   return [
@@ -368,20 +364,12 @@ export const getWoodDensityLevelOptions = (
       ]
     : [];
 
-export type SpeciesWithScientificName = Species & {
-  scientificName?: string;
-};
-
-export type SpeciesById = Map<number, SpeciesWithScientificName>;
-
 export enum SpeciesRequestError {
   PreexistingSpecies = 'A species with that name already exists.',
   // Server returned any other error (3xx, 4xx, 5xxx), or server did not respond, or there was an error
   // setting up the request. In other words, there was a developer error or server outage.
   RequestFailed = 'AN_UNRECOVERABLE_ERROR_OCCURRED',
 }
-
-export type SpeciesDetails = SpeciesLookupDetailsResponsePayload;
 
 export type SuggestedSpecies = Partial<Species> & { scientificName: string };
 

--- a/src/types/Tracking.ts
+++ b/src/types/Tracking.ts
@@ -28,7 +28,6 @@ export type PlantingSiteSearchResult = {
 
 // delivery and plantings
 export type Delivery = components['schemas']['DeliveryPayload'];
-export type Planting = components['schemas']['PlantingPayload'];
 
 // reported plants
 export type PlantingSiteReportedPlants = components['schemas']['PlantingSiteReportedPlantsPayload'];

--- a/src/types/documentProducer/Variable.ts
+++ b/src/types/documentProducer/Variable.ts
@@ -10,8 +10,6 @@ export type Variable = VariableListResponse['variables'][0];
 
 export type VariableType = components['schemas']['ExistingValuePayload']['type'];
 
-export type Column = components['schemas']['TableColumnPayload'];
-
 export type LinkVariable = components['schemas']['LinkVariablePayload'];
 
 export type SectionVariable = components['schemas']['SectionVariablePayload'];
@@ -89,20 +87,11 @@ export const isSectionVariableWithValues = (input: unknown): input is SectionVar
     isArray((input as SectionVariableWithValues).children)
   );
 
-export type ImageFile = {
-  url: string;
-  id: string;
-  caption?: string;
-  citation?: string;
-};
-
 export type GetVariableHistoryResponse = components['schemas']['GetVariableWorkflowHistoryResponsePayload'];
 
 export type UpdateVariableWorkflowDetailsPayload = components['schemas']['UpdateVariableWorkflowDetailsRequestPayload'];
 
 export type UpdateVariableOwnerPayload = components['schemas']['UpdateVariableOwnerRequestPayload'];
-
-export type VariableHistoryElement = components['schemas']['VariableWorkflowHistoryElement'];
 
 export type VariableStatusType = components['schemas']['UpdateVariableWorkflowDetailsRequestPayload']['status'];
 

--- a/src/types/documentProducer/VariableValue.ts
+++ b/src/types/documentProducer/VariableValue.ts
@@ -105,10 +105,6 @@ export type VariableValueEmailValue = components['schemas']['ExistingEmailValueP
 
 export type VariableValueLinkValue = components['schemas']['ExistingLinkValuePayload'];
 
-export type UpdateVariableValueRequestWithDocId = components['schemas']['UpdateValueOperationPayload'] & {
-  docId: number;
-};
-
 export type NewTextValuePayload = components['schemas']['NewTextValuePayload'];
 
 export type NewNumberValuePayload = components['schemas']['NewNumberValuePayload'];
@@ -121,53 +117,13 @@ export type NewEmailValuePayload = components['schemas']['NewEmailValuePayload']
 
 export type NewLinkValuePayload = components['schemas']['NewLinkValuePayload'];
 
-export type NewImageValuePayload = components['schemas']['NewImageValuePayload'];
-
-export type UpdateVariableValuesRequestWithDocId = UpdateVariableValuesRequestPayload & {
-  docId: number;
-};
-
 export type UpdateVariableValuesRequestWithProjectId = UpdateVariableValuesRequestPayload & {
   projectId: number;
 };
 
-export type UpdateTextVariableValueRequestWithDocId = Omit<
-  components['schemas']['UpdateValueOperationPayload'],
-  'value'
-> & {
-  docId: number;
-  value: NewTextValuePayload | NewNumberValuePayload | NewImageValuePayload | NewSelectValuePayload;
-};
-
-export type UpdateTextVariableValueRequestWithProjectId = Omit<
-  components['schemas']['UpdateValueOperationPayload'],
-  'value'
-> & {
-  projectId: number;
-  value: NewTextValuePayload | NewNumberValuePayload | NewImageValuePayload | NewSelectValuePayload;
-};
-
 export type DeleteVariableValueOperation = components['schemas']['DeleteValueOperationPayload'];
 
-export type DeleteVariableValueRequestWithDocId = components['schemas']['DeleteValueOperationPayload'] & {
-  docId: number;
-};
-
-export type DeleteVariableValueRequestWithProjectId = components['schemas']['DeleteValueOperationPayload'] & {
-  projectId: number;
-};
-
-export type NewValuePayload = components['schemas']['NewValuePayload'];
-
 export type UpdateVariableValuesRequestPayload = components['schemas']['UpdateVariableValuesRequestPayload'];
-
-export type AppendVariableRequestWithDocId = components['schemas']['UpdateValueOperationPayload'] & {
-  docId: number;
-};
-
-export type AppendVariableRequestWithProjectId = components['schemas']['UpdateValueOperationPayload'] & {
-  projectId: number;
-};
 
 export type Operation =
   | components['schemas']['AppendValueOperationPayload']
@@ -182,10 +138,6 @@ export type OriginalUploadImageValue = Required<
 // Change type for file attribute from string to File, because that is how we process it in the frontend
 export type UploadImageValueRequestPayload = Omit<OriginalUploadImageValue, 'file'> & { file: File };
 
-export type UploadImageValueRequestPayloadWithDocId = UploadImageValueRequestPayload & {
-  docId: number;
-};
-
 export type UploadImageValueRequestPayloadWithProjectId = UploadImageValueRequestPayload & {
   projectId: number;
 };
@@ -194,21 +146,9 @@ export type AppendVariableValueOperation = Omit<components['schemas']['AppendVal
   value: NewNonSectionValuePayloadUnion;
 };
 
-export type AppendVariableValueRequestWithDocId = AppendVariableValueOperation & {
-  docId: number;
-};
-
 export type NewSectionTextValuePayload = components['schemas']['NewSectionTextValuePayload'];
 
 export type NewSectionVariableValuePayload = components['schemas']['NewSectionVariableValuePayload'];
-
-export type ReplaceSectionValuesOperationPayloadWithDocId = Omit<
-  components['schemas']['ReplaceValuesOperationPayload'],
-  'values'
-> & {
-  docId: number;
-  values: (NewSectionTextValuePayload | NewSectionVariableValuePayload)[];
-};
 
 export type ReplaceSectionValuesOperationPayloadWithProjectId = Omit<
   components['schemas']['ReplaceValuesOperationPayload'],


### PR DESCRIPTION
Delete type declarations that aren't referenced anywhere.

This does not touch unused types in generated code; those types
will reappear every time the code generator is run.