### PR TITLE
Remove outdated Craco command from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "test": "TZ=America/Los_Angeles rstest -w",
     "test:ci": "TZ=America/Los_Angeles rstest",
     "test-coverage": "TZ=America/Los_Angeles rstest --coverage",
-    "eject": "craco eject",
     "generate-collateral": "yarn build-version-file && yarn generate-strings",
     "generate-strings": "node scripts/generate-strings.js && node scripts/unused-strings.js",
     "alphabetize-strings": "node scripts/alphabetize-strings.js",


### PR DESCRIPTION
We no longer use Craco for module management, so our
`yarn eject` command wouldn't work any more. Remove it.