### PR TITLE
Remove unnecessary exports of symbols

### DIFF
--- a/playwright/e2e/utils/consoleDeliverable.ts
+++ b/playwright/e2e/utils/consoleDeliverable.ts
@@ -30,7 +30,7 @@ export async function addQuestionnaireComments(question: string, comments: strin
   await validateQuestionnaireComments(question, comments, page);
 }
 
-export async function validateQuestionnaireComments(question: string, comments: string, page: Page) {
+async function validateQuestionnaireComments(question: string, comments: string, page: Page) {
   await expect(page.getByText(question).locator('../../..').getByText(comments)).toBeVisible();
 }
 

--- a/playwright/e2e/utils/userUtils.ts
+++ b/playwright/e2e/utils/userUtils.ts
@@ -18,7 +18,7 @@ export const changeToFunderUser = async (context: BrowserContext, baseURL: strin
   ]);
 };
 
-export const changeToContributor = async (context: BrowserContext, baseURL: string | undefined) => {
+const changeToContributor = async (context: BrowserContext, baseURL: string | undefined) => {
   await context.clearCookies({ name: 'SESSION' });
   await context.addCookies([
     { name: 'SESSION', value: 'YmQ0Y2Y1MTktOGI0Ny00ODI2LTlmNjYtYjlmZGI5YzAyNWI4', url: baseURL },

--- a/src/components/Map/testdata.ts
+++ b/src/components/Map/testdata.ts
@@ -62,7 +62,7 @@ export const feature3: GeometryFeature = {
   id: 2,
 };
 
-export const feature4: GeometryFeature = {
+const feature4: GeometryFeature = {
   type: 'Feature',
   geometry: {
     type: 'MultiPolygon',
@@ -82,7 +82,7 @@ export const feature4: GeometryFeature = {
   id: 2,
 };
 
-export const feature5: GeometryFeature = {
+const feature5: GeometryFeature = {
   type: 'Feature',
   geometry: {
     type: 'MultiPolygon',

--- a/src/components/Map/utils.tsx
+++ b/src/components/Map/utils.tsx
@@ -62,7 +62,7 @@ export function toFeature(
   };
 }
 
-export const getFillColor = (source: MapSourceRenderProperties, type: 'highlight' | 'select' | 'hover' | 'default') => {
+const getFillColor = (source: MapSourceRenderProperties, type: 'highlight' | 'select' | 'hover' | 'default') => {
   switch (type) {
     case 'highlight':
       return source.highlightFillColor || source.fillColor;

--- a/src/components/common/FilterGroup/filters/FilterCountWeight.tsx
+++ b/src/components/common/FilterGroup/filters/FilterCountWeight.tsx
@@ -11,7 +11,7 @@ import { AndNodePayload, FieldNodePayload, OrNodePayload, SearchNodePayload } fr
 import { weightUnits } from 'src/units';
 
 export type WEIGHT_QUANTITY_FIELDS = 'remainingQuantity' | 'totalQuantity' | 'withdrawalQuantity';
-export const COUNT_WEIGHT_VALID_FIELDS: Record<WEIGHT_QUANTITY_FIELDS, string[]> = {
+const COUNT_WEIGHT_VALID_FIELDS: Record<WEIGHT_QUANTITY_FIELDS, string[]> = {
   remainingQuantity: ['remainingQuantity', 'remainingGrams', 'remainingUnits'],
   totalQuantity: ['totalQuantity', 'totalGrams', 'totalUnits'],
   withdrawalQuantity: ['withdrawalQuantity', 'withdrawalGrams', 'withdrawalUnits'],

--- a/src/components/common/table/index.tsx
+++ b/src/components/common/table/index.tsx
@@ -96,7 +96,7 @@ export type OrderPreserveableTableProps = {
   setColumns: (columns: TableColumnType[]) => void;
 };
 
-export function OrderPreserveableTable<T extends TableRowType>(
+function OrderPreserveableTable<T extends TableRowType>(
   props: TableProps<T> & OrderPreserveableTableProps
 ): JSX.Element {
   const [initialized, setInitialized] = useState<boolean>(false);

--- a/src/queries/acceleratorReports/photos.ts
+++ b/src/queries/acceleratorReports/photos.ts
@@ -144,6 +144,4 @@ const injectedRtkApi = api.injectEndpoints({
   }),
 });
 
-export { injectedRtkApi as api };
-
 export const { useBatchReportPhotosMutation } = injectedRtkApi;

--- a/src/queries/appVersion/appVersion.ts
+++ b/src/queries/appVersion/appVersion.ts
@@ -19,6 +19,4 @@ const injectedRtkApi = api.injectEndpoints({
   }),
 });
 
-export { injectedRtkApi as api };
-
-export const { useGetAppVersionQuery, useLazyGetAppVersionQuery } = injectedRtkApi;
+export const { useGetAppVersionQuery } = injectedRtkApi;

--- a/src/queries/exports/observations.ts
+++ b/src/queries/exports/observations.ts
@@ -217,17 +217,10 @@ export type ExportBiomassObservationsApiArg = {
   plantingSiteId?: number;
 };
 
-export { injectedRtkApi as api };
-
 export const {
-  useExportObservationGpxQuery,
   useLazyExportObservationGpxQuery,
-  useExportBiomassPlotsCsvQuery,
   useLazyExportBiomassPlotsCsvQuery,
-  useExportBiomassSpeciesCsvQuery,
   useLazyExportBiomassSpeciesCsvQuery,
-  useExportBiomassTreesShrubsCsvQuery,
   useLazyExportBiomassTreesShrubsCsvQuery,
-  useExportBiomassObservationsCsvQuery,
   useLazyExportBiomassObservationsCsvQuery,
 } = injectedRtkApi;

--- a/src/queries/observations/observations.ts
+++ b/src/queries/observations/observations.ts
@@ -44,6 +44,4 @@ const injectedRtkApi = api.injectEndpoints({
   }),
 });
 
-export { injectedRtkApi as api };
-
-export const { useListObservationEventsQuery, useLazyListObservationEventsQuery } = injectedRtkApi;
+export const { useLazyListObservationEventsQuery } = injectedRtkApi;

--- a/src/queries/plantingSeasons/events.ts
+++ b/src/queries/plantingSeasons/events.ts
@@ -80,11 +80,4 @@ const injectedRtkApi = api.injectEndpoints({
   }),
 });
 
-export { injectedRtkApi as api };
-
-export const {
-  useListPlantingSeasonEventsQuery,
-  useLazyListPlantingSeasonEventsQuery,
-  useListInventoryPlanningEventsQuery,
-  useLazyListInventoryPlanningEventsQuery,
-} = injectedRtkApi;
+export const { useLazyListPlantingSeasonEventsQuery, useLazyListInventoryPlanningEventsQuery } = injectedRtkApi;

--- a/src/queries/search/accessions.ts
+++ b/src/queries/search/accessions.ts
@@ -199,17 +199,10 @@ const injectedRtkApi = api.injectEndpoints({
   overrideExisting: false,
 });
 
-export { injectedRtkApi as api };
-
 export const {
-  useSearchAccessionsQuery,
   useLazySearchAccessionsQuery,
-  useGetPendingAccessionsQuery,
   useLazyGetPendingAccessionsQuery,
-  useGetCollectorsQuery,
   useLazyGetCollectorsQuery,
-  useGetCollectionSiteNamesQuery,
   useLazyGetCollectionSiteNamesQuery,
-  useGetAccessionForSpeciesQuery,
   useLazyGetAccessionForSpeciesQuery,
 } = injectedRtkApi;

--- a/src/queries/search/batches.ts
+++ b/src/queries/search/batches.ts
@@ -329,19 +329,11 @@ type BatchSearchResponse = {
   results: NurseryBatchesSearchResponseElement[];
 };
 
-export { injectedRtkApi as api };
-
 export const {
-  useCountAllBatchesQuery,
   useLazyCountAllBatchesQuery,
-  useListBatchesByIdsQuery,
   useLazyListBatchesByIdsQuery,
-  useListAllBatchesQuery,
   useLazyListAllBatchesQuery,
-  useListBatchIdsForSpeciesQuery,
   useLazyListBatchIdsForSpeciesQuery,
   useListBatchesForSpeciesQuery,
-  useLazyListBatchesForSpeciesQuery,
   useListBatchesForNurseryQuery,
-  useLazyListBatchesForNurseryQuery,
 } = injectedRtkApi;

--- a/src/queries/search/botanicalCountries.ts
+++ b/src/queries/search/botanicalCountries.ts
@@ -42,6 +42,4 @@ const injectedRtkApi = api.injectEndpoints({
   }),
 });
 
-export { injectedRtkApi as api };
-
-export const { useListBotanicalCountriesQuery, useLazyListBotanicalCountriesQuery } = injectedRtkApi;
+export const { useLazyListBotanicalCountriesQuery } = injectedRtkApi;

--- a/src/queries/search/countries.ts
+++ b/src/queries/search/countries.ts
@@ -41,6 +41,4 @@ const injectedRtkApi = api.injectEndpoints({
   }),
 });
 
-export { injectedRtkApi as api };
-
-export const { useListCountriesQuery, useLazyListCountriesQuery } = injectedRtkApi;
+export const { useListCountriesQuery } = injectedRtkApi;

--- a/src/queries/search/draftPlantingSites.ts
+++ b/src/queries/search/draftPlantingSites.ts
@@ -112,11 +112,4 @@ export type SearchDraftPlantingSiteSummariesApiArgs = {
   searchTerm?: string;
 };
 
-export { injectedRtkApi as api };
-
-export const {
-  useCountDraftPlantingSitesQuery,
-  useLazyCountDraftPlantingSitesQuery,
-  useSearchDraftPlantingSitesQuery,
-  useLazySearchDraftPlantingSitesQuery,
-} = injectedRtkApi;
+export const { useLazyCountDraftPlantingSitesQuery, useLazySearchDraftPlantingSitesQuery } = injectedRtkApi;

--- a/src/queries/search/inventoryPlanning.ts
+++ b/src/queries/search/inventoryPlanning.ts
@@ -283,9 +283,4 @@ export const aggregateInventoryPlanningRows = (
     .sort((a, b) => a.scientificName.localeCompare(b.scientificName));
 };
 
-export const {
-  useListInventoryPlanningSeasonsQuery,
-  useLazyListInventoryPlanningSeasonsQuery,
-  useListInventoryPlanningSpeciesAvailableQuery,
-  useLazyListInventoryPlanningSpeciesAvailableQuery,
-} = injectedRtkApi;
+export const { useListInventoryPlanningSeasonsQuery, useListInventoryPlanningSpeciesAvailableQuery } = injectedRtkApi;

--- a/src/queries/search/nurseries.ts
+++ b/src/queries/search/nurseries.ts
@@ -541,15 +541,10 @@ export type SearchNurseryWithdrawalPayload = {
   undoesWithdrawalDate?: string;
 };
 
-export { injectedRtkApi as api };
-
 export const {
-  useSearchNurseryWithdrawalsFilterOptionsQuery,
   useLazySearchNurseryWithdrawalsFilterOptionsQuery,
   useSearchNurseryWithdrawalsQuery,
   useLazySearchNurseryWithdrawalsQuery,
-  useCountNurseryWithdrawalsQuery,
   useLazyCountNurseryWithdrawalsQuery,
   useSearchNurseryWithdrawalPhotosQuery,
-  useLazySearchNurseryWithdrawalPhotosQuery,
 } = injectedRtkApi;

--- a/src/queries/search/nurseryInventory.ts
+++ b/src/queries/search/nurseryInventory.ts
@@ -192,11 +192,4 @@ const injectedRtkApi = api.injectEndpoints({
   }),
 });
 
-export { injectedRtkApi as api };
-
-export const {
-  useSearchSpeciesInventoryQuery,
-  useLazySearchSpeciesInventoryQuery,
-  useSearchInventoryByNurseryQuery,
-  useLazySearchInventoryByNurseryQuery,
-} = injectedRtkApi;
+export const { useLazySearchSpeciesInventoryQuery, useLazySearchInventoryByNurseryQuery } = injectedRtkApi;

--- a/src/queries/search/observations.ts
+++ b/src/queries/search/observations.ts
@@ -65,8 +65,6 @@ const injectedRtkApi = api.injectEndpoints({
   }),
 });
 
-export { injectedRtkApi as api };
-
 export type CountObservationsApiArgs = {
   organizationId: number;
   plantingSiteId?: number;
@@ -75,4 +73,4 @@ export type CountObservationsApiArgs = {
   state?: ('Upcoming' | 'InProgress' | 'Completed' | 'Overdue' | 'Abandoned')[];
 };
 
-export const { useCountObservationsQuery, useLazyCountObservationsQuery } = injectedRtkApi;
+export const { useLazyCountObservationsQuery } = injectedRtkApi;

--- a/src/queries/search/plantingDateRequests.ts
+++ b/src/queries/search/plantingDateRequests.ts
@@ -302,8 +302,5 @@ type PlantingDateRequestsApiResponse = {
   results: PlantingDateRequestApiResult[];
 };
 
-export const {
-  useListPlantingDateRequestsQuery,
-  useLazyListPlantingDateRequestsQuery,
-  useLazyGetScheduledPlantingDateWithdrawnTotalQuery,
-} = injectedRtkApi;
+export const { useLazyListPlantingDateRequestsQuery, useLazyGetScheduledPlantingDateWithdrawnTotalQuery } =
+  injectedRtkApi;

--- a/src/queries/search/plantingSites.ts
+++ b/src/queries/search/plantingSites.ts
@@ -277,17 +277,11 @@ export type ObservationDatesSearchResult = {
   endDate: string;
 };
 
-export { injectedRtkApi as api };
-
 export const {
-  useCountPlantingSitesQuery,
   useLazyCountPlantingSitesQuery,
-  useSearchPlantingSitesQuery,
   useLazySearchPlantingSitesQuery,
-  useSearchPlantingSiteProjectsQuery,
   useLazySearchPlantingSiteProjectsQuery,
   useSearchMonitoringPlotsQuery,
   useLazySearchMonitoringPlotsQuery,
   useSearchObservationDatesQuery,
-  useLazySearchObservationDatesQuery,
 } = injectedRtkApi;

--- a/src/queries/search/plantings.ts
+++ b/src/queries/search/plantings.ts
@@ -94,6 +94,4 @@ export type Plantings = {
   withdrawalId: number;
 };
 
-export { injectedRtkApi as api };
-
-export const { useSearchPlantingsForSiteQuery, useLazySearchPlantingsForSiteQuery } = injectedRtkApi;
+export const { useSearchPlantingsForSiteQuery } = injectedRtkApi;

--- a/src/queries/search/projectModules.ts
+++ b/src/queries/search/projectModules.ts
@@ -63,6 +63,4 @@ export type GetModuleProjectsApiArg = {
   locale?: string;
 };
 
-export { injectedRtkApi as api };
-
-export const { useGetModuleProjectsQuery, useLazyGetModuleProjectsQuery } = injectedRtkApi;
+export const { useLazyGetModuleProjectsQuery } = injectedRtkApi;

--- a/src/queries/search/speciesProjects.ts
+++ b/src/queries/search/speciesProjects.ts
@@ -52,6 +52,4 @@ const injectedRtkApi = api.injectEndpoints({
   }),
 });
 
-export { injectedRtkApi as api };
-
-export const { useListSpeciesProjectNamesQuery, useLazyListSpeciesProjectNamesQuery } = injectedRtkApi;
+export const { useLazyListSpeciesProjectNamesQuery } = injectedRtkApi;

--- a/src/queries/search/speciesTargetsForSubstratum.ts
+++ b/src/queries/search/speciesTargetsForSubstratum.ts
@@ -139,4 +139,4 @@ type WithdrawalsApiResponse = {
   results: WithdrawalsApiResult[];
 };
 
-export const { useListSpeciesTargetsForSubstratumQuery, useLazyListSpeciesTargetsForSubstratumQuery } = injectedRtkApi;
+export const { useLazyListSpeciesTargetsForSubstratumQuery } = injectedRtkApi;

--- a/src/queries/search/strata.ts
+++ b/src/queries/search/strata.ts
@@ -176,10 +176,7 @@ export type StratumSurvivalRate = {
 };
 
 export const {
-  useListStrataQuery,
   useLazyListStrataQuery,
-  useGetStratumPlantDensityTrendQuery,
   useLazyGetStratumPlantDensityTrendQuery,
-  useGetStratumSurvivalRateTrendQuery,
   useLazyGetStratumSurvivalRateTrendQuery,
 } = injectedRtkApi;

--- a/src/queries/search/substrata.ts
+++ b/src/queries/search/substrata.ts
@@ -54,4 +54,4 @@ export type SubstratumPayload = {
   stratumName: string;
 };
 
-export const { useListSubstrataQuery, useLazyListSubstrataQuery } = injectedRtkApi;
+export const { useLazyListSubstrataQuery } = injectedRtkApi;

--- a/src/queries/search/t0.ts
+++ b/src/queries/search/t0.ts
@@ -97,6 +97,4 @@ export type PlotsWithObservations = {
   permanentIndex?: string;
 };
 
-export { injectedRtkApi as api };
-
 export const { useGetPlotsWithObservationsQuery, useLazyGetPlotsWithObservationsQuery } = injectedRtkApi;

--- a/src/queries/search/virtualWalkthroughs.ts
+++ b/src/queries/search/virtualWalkthroughs.ts
@@ -105,6 +105,4 @@ export type OrganizationVirtualWalkthrough = {
   monitoringPlotName?: string;
 };
 
-export { injectedRtkApi as api };
-
-export const { useSearchVirtualWalkthroughsQuery, useLazySearchVirtualWalkthroughsQuery } = injectedRtkApi;
+export const { useSearchVirtualWalkthroughsQuery } = injectedRtkApi;

--- a/src/queries/seedFundReports/files.ts
+++ b/src/queries/seedFundReports/files.ts
@@ -81,6 +81,4 @@ const injectedRtkApi = api.injectEndpoints({
   }),
 });
 
-export { injectedRtkApi as api };
-
 export const { useBatchSeedFundReportFilesMutation } = injectedRtkApi;

--- a/src/queries/seedFundReports/photos.ts
+++ b/src/queries/seedFundReports/photos.ts
@@ -81,6 +81,4 @@ const injectedRtkApi = api.injectEndpoints({
   }),
 });
 
-export { injectedRtkApi as api };
-
 export const { useBatchSeedFundReportPhotosMutation } = injectedRtkApi;

--- a/src/redux/features/accelerator/acceleratorSlice.ts
+++ b/src/redux/features/accelerator/acceleratorSlice.ts
@@ -10,7 +10,7 @@ import { requestAcceleratorOrgs, requestAssignTerraformationContact } from './ac
  */
 const initialStateAcceleratorOrgs: Record<string, StatusT<AcceleratorOrg[]>> = {};
 
-export const acceleratorOrgsSlice = createSlice({
+const acceleratorOrgsSlice = createSlice({
   name: 'acceleratorOrgsSlice',
   initialState: initialStateAcceleratorOrgs,
   reducers: {},
@@ -24,7 +24,7 @@ export const acceleratorOrgsSlice = createSlice({
  */
 const initialStateAssignTerraformationContact: Record<string, StatusT<Response>> = {};
 
-export const assignTerraformationContactSlice = createSlice({
+const assignTerraformationContactSlice = createSlice({
   name: 'assignTerraformationContactSlice',
   initialState: initialStateAssignTerraformationContact,
   reducers: {},

--- a/src/redux/features/acceleratorProjectSpecies/acceleratorProjectSpeciesSlice.ts
+++ b/src/redux/features/acceleratorProjectSpecies/acceleratorProjectSpeciesSlice.ts
@@ -22,7 +22,7 @@ import {
  */
 const initialStateAcceleratorProjectSpeciesCreate: { [key: string]: StatusT<AcceleratorProjectSpecies> } = {};
 
-export const acceleratorProjectSpeciesCreateSlice = createSlice({
+const acceleratorProjectSpeciesCreateSlice = createSlice({
   name: 'acceleratorProjectSpeciesCreateSlice',
   initialState: initialStateAcceleratorProjectSpeciesCreate,
   reducers: {},
@@ -36,7 +36,7 @@ export const acceleratorProjectSpeciesCreateSlice = createSlice({
  */
 const initialStateAcceleratorProjectDeleteMany: { [key: string]: StatusT<boolean> } = {};
 
-export const acceleratorProjectSpeciesDeleteManySlice = createSlice({
+const acceleratorProjectSpeciesDeleteManySlice = createSlice({
   name: 'acceleratorProjectSpeciesDeleteManySlice',
   initialState: initialStateAcceleratorProjectDeleteMany,
   reducers: {},
@@ -50,7 +50,7 @@ export const acceleratorProjectSpeciesDeleteManySlice = createSlice({
  */
 const initialStateAcceleratorProjectAddMany: { [key: string]: StatusT<boolean> } = {};
 
-export const acceleratorProjectSpeciesAddManySlice = createSlice({
+const acceleratorProjectSpeciesAddManySlice = createSlice({
   name: 'acceleratorProjectSpeciesAddManySlice',
   initialState: initialStateAcceleratorProjectAddMany,
   reducers: {},
@@ -64,7 +64,7 @@ export const acceleratorProjectSpeciesAddManySlice = createSlice({
  */
 const initialStateAcceleratorProjectGet: { [key: string]: StatusT<AcceleratorProjectSpecies> } = {};
 
-export const acceleratorProjectSpeciesGetSlice = createSlice({
+const acceleratorProjectSpeciesGetSlice = createSlice({
   name: 'acceleratorProjectSpeciesGetSlice',
   initialState: initialStateAcceleratorProjectGet,
   reducers: {},
@@ -78,7 +78,7 @@ export const acceleratorProjectSpeciesGetSlice = createSlice({
  */
 const initialStateAcceleratorProjectsForSpeciesGet: { [key: string]: StatusT<AcceleratorProjectForSpecies[]> } = {};
 
-export const acceleratorProjectsForSpeciesGetSlice = createSlice({
+const acceleratorProjectsForSpeciesGetSlice = createSlice({
   name: 'acceleratorProjectsForSpeciesGetSlice',
   initialState: initialStateAcceleratorProjectsForSpeciesGet,
   reducers: {},
@@ -92,7 +92,7 @@ export const acceleratorProjectsForSpeciesGetSlice = createSlice({
  */
 const initialStateAcceleratorProjectsList: { [key: string]: StatusT<SpeciesForAcceleratorProject[]> } = {};
 
-export const acceleratorProjectSpeciesListSlice = createSlice({
+const acceleratorProjectSpeciesListSlice = createSlice({
   name: 'acceleratorProjectSpeciesListSlice',
   initialState: initialStateAcceleratorProjectsList,
   reducers: {},
@@ -107,7 +107,7 @@ export const acceleratorProjectSpeciesListSlice = createSlice({
  */
 const initialStateAcceleratorProjectUpdate: { [key: string]: StatusT<boolean> } = {};
 
-export const acceleratorProjectSpeciesUpdateSlice = createSlice({
+const acceleratorProjectSpeciesUpdateSlice = createSlice({
   name: 'acceleratorProjectSpeciesUpdateSlice',
   initialState: initialStateAcceleratorProjectUpdate,
   reducers: {},

--- a/src/redux/features/application/applicationSlice.ts
+++ b/src/redux/features/application/applicationSlice.ts
@@ -22,7 +22,7 @@ import {
  */
 const initialStateApplicationCreate: Record<string, StatusT<number>> = {};
 
-export const applicationCreateSlice = createSlice({
+const applicationCreateSlice = createSlice({
   name: 'applicationCreateSlice',
   initialState: initialStateApplicationCreate,
   reducers: {},
@@ -36,7 +36,7 @@ export const applicationCreateSlice = createSlice({
  */
 const initialStateApplicationProjectCreate: Record<string, StatusT<number>> = {};
 
-export const applicationProjectCreateSlice = createSlice({
+const applicationProjectCreateSlice = createSlice({
   name: 'applicationProjectCreateSlice',
   initialState: initialStateApplicationProjectCreate,
   reducers: {},
@@ -50,7 +50,7 @@ export const applicationProjectCreateSlice = createSlice({
  */
 const initialStateApplications: Record<string, StatusT<Application[]>> = {};
 
-export const applicationListSlice = createSlice({
+const applicationListSlice = createSlice({
   name: 'applicationListSlice',
   initialState: initialStateApplications,
   reducers: {},
@@ -64,7 +64,7 @@ export const applicationListSlice = createSlice({
  */
 const initialStateApplicationDeliverables: Record<string, StatusT<ApplicationDeliverable[]>> = {};
 
-export const applicationDeliverablesListSlice = createSlice({
+const applicationDeliverablesListSlice = createSlice({
   name: 'applicationDeliverablesListSlice',
   initialState: initialStateApplicationDeliverables,
   reducers: {},
@@ -78,7 +78,7 @@ export const applicationDeliverablesListSlice = createSlice({
  */
 const initialStateApplicationHistory: Record<string, StatusT<ApplicationHistory[]>> = {};
 
-export const applicationHistoryListSlice = createSlice({
+const applicationHistoryListSlice = createSlice({
   name: 'applicationHistoryListSlice',
   initialState: initialStateApplicationHistory,
   reducers: {},
@@ -92,7 +92,7 @@ export const applicationHistoryListSlice = createSlice({
  */
 const initialStateApplicationModules: Record<string, StatusT<ApplicationModule[]>> = {};
 
-export const applicationModuleListSlice = createSlice({
+const applicationModuleListSlice = createSlice({
   name: 'applicationModuleListSlice',
   initialState: initialStateApplicationModules,
   reducers: {},
@@ -106,7 +106,7 @@ export const applicationModuleListSlice = createSlice({
  */
 const initialStateApplicationRestart: Record<string, StatusT<Response>> = {};
 
-export const applicationRestartSlice = createSlice({
+const applicationRestartSlice = createSlice({
   name: 'applicationRestartSlice',
   initialState: initialStateApplicationRestart,
   reducers: {},
@@ -120,7 +120,7 @@ export const applicationRestartSlice = createSlice({
  */
 const initialStateApplicationSubmit: Record<string, StatusT<string[]>> = {};
 
-export const applicationSubmitSlice = createSlice({
+const applicationSubmitSlice = createSlice({
   name: 'applicationSubmitSlice',
   initialState: initialStateApplicationSubmit,
   reducers: {},
@@ -134,7 +134,7 @@ export const applicationSubmitSlice = createSlice({
  */
 const initialStateApplicationReview: Record<string, StatusT<Response>> = {};
 
-export const applicationReviewSlice = createSlice({
+const applicationReviewSlice = createSlice({
   name: 'applicationReviewSlice',
   initialState: initialStateApplicationReview,
   reducers: {},
@@ -148,7 +148,7 @@ export const applicationReviewSlice = createSlice({
  */
 const initialStateApplicationUpdateBoundary: Record<string, StatusT<Response>> = {};
 
-export const applicationUpdateBoundarySlice = createSlice({
+const applicationUpdateBoundarySlice = createSlice({
   name: 'applicationUpdateBoundarySlice',
   initialState: initialStateApplicationUpdateBoundary,
   reducers: {},
@@ -162,7 +162,7 @@ export const applicationUpdateBoundarySlice = createSlice({
  */
 const initialStateApplicationUploadBoundary: Record<string, StatusT<Response>> = {};
 
-export const applicationUploadBoundarySlice = createSlice({
+const applicationUploadBoundarySlice = createSlice({
   name: 'applicationUploadBoundarySlice',
   initialState: initialStateApplicationUploadBoundary,
   reducers: {},

--- a/src/redux/features/deliverables/deliverablesSlice.ts
+++ b/src/redux/features/deliverables/deliverablesSlice.ts
@@ -17,7 +17,7 @@ import { DeliverableWithOverdue, ListDeliverablesElementWithOverdue } from 'src/
  */
 const initialStateDeliverablesList: { [key: string]: StatusT<ListDeliverablesElementWithOverdue[]> } = {};
 
-export const deliverablesListSlice = createSlice({
+const deliverablesListSlice = createSlice({
   name: 'deliverablesListSlice',
   initialState: initialStateDeliverablesList,
   reducers: {},
@@ -42,7 +42,7 @@ export const deliverableCompositeKeyFn = (arg: unknown): string => {
   return `d${castArg.deliverableId}-p${castArg.projectId}`;
 };
 
-export const deliverablesSlice = createSlice({
+const deliverablesSlice = createSlice({
   name: 'deliverablesSlice',
   initialState: initialStateDeliverable,
   reducers: {},
@@ -57,7 +57,7 @@ export const deliverablesSlice = createSlice({
  */
 const initialStateEditDeliverable: { [key: number | string]: StatusT<number | string> } = {};
 
-export const deliverablesEditSlice = createSlice({
+const deliverablesEditSlice = createSlice({
   name: 'deliverablesEditSlice',
   initialState: initialStateEditDeliverable,
   reducers: {},

--- a/src/redux/features/documentProducer/documents/documentsSelector.ts
+++ b/src/redux/features/documentProducer/documents/documentsSelector.ts
@@ -12,15 +12,14 @@ import { Document as DocumentType } from 'src/types/documentProducer/Document';
 
 import { AsyncRequest, AsyncRequestT } from '../../asyncUtils';
 
-export const selectDocuments = (requestId: string) => (state: RootState) =>
-  state.documentProducerDocumentList[requestId];
+const selectDocuments = (requestId: string) => (state: RootState) => state.documentProducerDocumentList[requestId];
 
 export const selectGetDocument =
   (docId: number) =>
   (state: RootState): AsyncRequestT<DocumentType> | undefined =>
     state.documentProducerDocument[docId];
 
-export const selectListHistory = createCachedSelector(
+const selectListHistory = createCachedSelector(
   (state: RootState, id: number) => state.documentProducerDocumentListHistory[id],
   (response) => {
     if (response) {

--- a/src/redux/features/documentProducer/values/valuesSelector.ts
+++ b/src/redux/features/documentProducer/values/valuesSelector.ts
@@ -6,10 +6,10 @@ import { VariableValue } from 'src/types/documentProducer/VariableValue';
 
 import { variableListCompositeKeyFn } from './valuesSlice';
 
-export const selectVariablesValues = (state: RootState, docId: number | string, maxValueId?: number) =>
+const selectVariablesValues = (state: RootState, docId: number | string, maxValueId?: number) =>
   state.documentProducerVariableValuesList[docId];
 
-export const selectGetVariableValues = createCachedSelector(
+const selectGetVariableValues = createCachedSelector(
   (state: RootState, projectId: number | string, variableId: number, maxValueId?: number) =>
     state.documentProducerVariableValuesList[variableListCompositeKeyFn({ projectId, maxValueId })],
   (state: RootState, projectId: number | string, variableId: number, maxValueId?: number) => projectId,

--- a/src/redux/features/documentProducer/variables/variablesSelector.ts
+++ b/src/redux/features/documentProducer/variables/variablesSelector.ts
@@ -17,7 +17,7 @@ import { deliverableCompositeKeyFn } from '../../deliverables/deliverablesSlice'
 import { variableListCompositeKeyFn } from '../values/valuesSlice';
 import { specificVariablesCompositeKeyFn, variableHistoryCompositeKeyFn } from './variablesSlice';
 
-export const selectDocumentVariables = (state: RootState, documentId: number | undefined) =>
+const selectDocumentVariables = (state: RootState, documentId: number | undefined) =>
   documentId ? state.documentProducerDocumentVariables[documentId] : undefined;
 
 export const selectAllVariables = (requestId: string) => (state: RootState) =>

--- a/src/redux/features/events/eventsSlice.ts
+++ b/src/redux/features/events/eventsSlice.ts
@@ -17,7 +17,7 @@ import {
  */
 const initialStateEvent: { [key: string]: StatusT<ModuleEvent> } = {};
 
-export const eventSlice = createSlice({
+const eventSlice = createSlice({
   name: 'eventSlice',
   initialState: initialStateEvent,
   reducers: {},
@@ -31,7 +31,7 @@ export const eventSlice = createSlice({
  */
 const initialStateEventsList: { [key: string]: StatusT<ModuleEvent[]> } = {};
 
-export const eventListSlice = createSlice({
+const eventListSlice = createSlice({
   name: 'eventListSlice',
   initialState: initialStateEventsList,
   reducers: {},
@@ -98,7 +98,7 @@ const eventProjectsUpdateSlice = createSlice({
  */
 const initialStateEventDeleteMany: { [key: string]: StatusT<boolean> } = {};
 
-export const eventDeleteManySlice = createSlice({
+const eventDeleteManySlice = createSlice({
   name: 'eventDeleteManySlice',
   initialState: initialStateEventDeleteMany,
   reducers: {},

--- a/src/redux/features/funder/entities/fundingEntitiesSlice.ts
+++ b/src/redux/features/funder/entities/fundingEntitiesSlice.ts
@@ -28,7 +28,7 @@ const initialStateFundingEntityCreate: { [requestId: string]: StatusT<{ fundingE
 
 const initialStateFundingEntityInvite: { [requestId: string]: StatusT<string | InviteFunderResponse> } = {};
 
-export const fundingEntitySlice = createSlice({
+const fundingEntitySlice = createSlice({
   name: 'fundingEntitySlice',
   initialState: initialStateFundingEntity,
   reducers: {},
@@ -37,7 +37,7 @@ export const fundingEntitySlice = createSlice({
   },
 });
 
-export const fundingEntitiesSlice = createSlice({
+const fundingEntitiesSlice = createSlice({
   name: 'fundingEntitiesSlice',
   initialState: initialStateFundingEntities,
   reducers: {},
@@ -46,7 +46,7 @@ export const fundingEntitiesSlice = createSlice({
   },
 });
 
-export const userFundingEntitySlice = createSlice({
+const userFundingEntitySlice = createSlice({
   name: 'userFundingEntitySlice',
   initialState: initialStateUserFundingEntity,
   reducers: {},
@@ -55,7 +55,7 @@ export const userFundingEntitySlice = createSlice({
   },
 });
 
-export const fundingEntityUpdateSlice = createSlice({
+const fundingEntityUpdateSlice = createSlice({
   name: 'fundingEntityUpdateSlice',
   initialState: initialStateFundingEntityUpdate,
   reducers: {},
@@ -64,7 +64,7 @@ export const fundingEntityUpdateSlice = createSlice({
   },
 });
 
-export const fundingEntityCreateSlice = createSlice({
+const fundingEntityCreateSlice = createSlice({
   name: 'fundingEntityCreateSlice',
   initialState: initialStateFundingEntityCreate,
   reducers: {},
@@ -73,7 +73,7 @@ export const fundingEntityCreateSlice = createSlice({
   },
 });
 
-export const fundingEntityInviteSlice = createSlice({
+const fundingEntityInviteSlice = createSlice({
   name: 'fundingEntityInviteSlice',
   initialState: initialStateFundingEntityInvite,
   reducers: {},
@@ -84,7 +84,7 @@ export const fundingEntityInviteSlice = createSlice({
 
 const initialStateFunderList: { [requestId: string]: StatusT<Funder[]> } = {};
 
-export const funderListSlice = createSlice({
+const funderListSlice = createSlice({
   name: 'funderListSlice',
   initialState: initialStateFunderList,
   reducers: {},
@@ -95,7 +95,7 @@ export const funderListSlice = createSlice({
 
 const initialStateDeleteFunder: { [requestId: string]: StatusT<Response> } = {};
 
-export const deleteFundersSlice = createSlice({
+const deleteFundersSlice = createSlice({
   name: 'deleteFundersSlice',
   initialState: initialStateDeleteFunder,
   reducers: {},
@@ -106,7 +106,7 @@ export const deleteFundersSlice = createSlice({
 
 const initialStateProjectFundingEntities: { [requestId: string]: StatusT<FundingEntity[]> } = {};
 
-export const projectFundingEntitiesSlice = createSlice({
+const projectFundingEntitiesSlice = createSlice({
   name: 'projectFundingEntitiesSlice',
   initialState: initialStateProjectFundingEntities,
   reducers: {},

--- a/src/redux/features/funder/projects/funderProjectsSlice.ts
+++ b/src/redux/features/funder/projects/funderProjectsSlice.ts
@@ -10,7 +10,7 @@ import {
 } from './funderProjectsAsyncThunks';
 
 const initialPublishedProjects: { [key: string]: StatusT<PublishedProject[]> } = {};
-export const publishedProjectsSlice = createSlice({
+const publishedProjectsSlice = createSlice({
   name: 'publishedProjectsSlice',
   initialState: initialPublishedProjects,
   reducers: {},
@@ -20,7 +20,7 @@ export const publishedProjectsSlice = createSlice({
 });
 
 const initialStateFunderProject: { [key: string]: FunderProjectDetails } = {};
-export const funderProjectsSlice = createSlice({
+const funderProjectsSlice = createSlice({
   name: 'funderProjectSlice',
   initialState: initialStateFunderProject,
   reducers: {},
@@ -39,7 +39,7 @@ export const funderProjectsSlice = createSlice({
 });
 
 const initialPublishFunderProject: { [key: string]: StatusT<number> } = {};
-export const publishFunderProjectSlice = createSlice({
+const publishFunderProjectSlice = createSlice({
   name: 'publishFunderProjectSlice',
   initialState: initialPublishFunderProject,
   reducers: {},

--- a/src/redux/features/gis/gisSlice.ts
+++ b/src/redux/features/gis/gisSlice.ts
@@ -7,7 +7,7 @@ import { requestGetGis } from './gisAsyncThunks';
 
 const initialGisState: { [key: string]: StatusT<GisResponse> } = {};
 
-export const gisSlice = createSlice({
+const gisSlice = createSlice({
   name: 'gisSlice',
   initialState: initialGisState,
   reducers: {},

--- a/src/redux/features/matrixView/matrixViewSlice.ts
+++ b/src/redux/features/matrixView/matrixViewSlice.ts
@@ -6,7 +6,7 @@ import { ProjectsWithVariablesSearchResult, requestGetProjectsWithVariables } fr
 
 const initialProjectsWithVariablesState: { [key: string]: StatusT<ProjectsWithVariablesSearchResult[]> } = {};
 
-export const projectsWithVariablesSlice = createSlice({
+const projectsWithVariablesSlice = createSlice({
   name: 'projectsWithVariablesSlice',
   initialState: initialProjectsWithVariablesState,
   reducers: {},

--- a/src/redux/features/message/messageSlice.ts
+++ b/src/redux/features/message/messageSlice.ts
@@ -13,7 +13,7 @@ const initialState: MessageState = {
   messages: {},
 };
 
-export const messageSlice = createSlice({
+const messageSlice = createSlice({
   name: 'message',
   initialState,
   reducers: {

--- a/src/redux/features/modules/modulesSlice.ts
+++ b/src/redux/features/modules/modulesSlice.ts
@@ -16,7 +16,7 @@ import {
  */
 const initialStateModule: { [key: string]: StatusT<Module> } = {};
 
-export const moduleSlice = createSlice({
+const moduleSlice = createSlice({
   name: 'moduleSlice',
   initialState: initialStateModule,
   reducers: {},
@@ -30,7 +30,7 @@ export const moduleSlice = createSlice({
  */
 const initialStateModuleList: { [key: string]: StatusT<Module[]> } = {};
 
-export const moduleListSlice = createSlice({
+const moduleListSlice = createSlice({
   name: 'moduleListSlice',
   initialState: initialStateModuleList,
   reducers: {},
@@ -44,7 +44,7 @@ export const moduleListSlice = createSlice({
  */
 const initialStateModuleOrgProjects: { [key: string]: StatusT<number[]> } = {};
 
-export const moduleOrgProjectsSlice = createSlice({
+const moduleOrgProjectsSlice = createSlice({
   name: 'moduleOrgProjectsSlice',
   initialState: initialStateModuleOrgProjects,
   reducers: {},
@@ -58,7 +58,7 @@ export const moduleOrgProjectsSlice = createSlice({
  */
 const initialStateModuleProjects: { [key: string]: StatusT<ModuleProjectsSearchResult> } = {};
 
-export const moduleProjectsSlice = createSlice({
+const moduleProjectsSlice = createSlice({
   name: 'moduleProjectsSlice',
   initialState: initialStateModuleProjects,
   reducers: {},
@@ -72,7 +72,7 @@ export const moduleProjectsSlice = createSlice({
  */
 const initialStateSearchModules: { [key: string]: StatusT<ModuleSearchResult[]> } = {};
 
-export const searchModulesSlice = createSlice({
+const searchModulesSlice = createSlice({
   name: 'searchModulesSlice',
   initialState: initialStateSearchModules,
   reducers: {},

--- a/src/redux/features/organizationUser/organizationUsersSlice.ts
+++ b/src/redux/features/organizationUser/organizationUsersSlice.ts
@@ -11,7 +11,7 @@ export type OrganizationUsersData = {
 
 const initialStateOrganizationUsers: { [key: string]: StatusT<OrganizationUsersData> } = {};
 
-export const organizationUsersListSlice = createSlice({
+const organizationUsersListSlice = createSlice({
   name: 'organizationUsersListSlice',
   initialState: initialStateOrganizationUsers,
   reducers: {},

--- a/src/redux/features/projectSpecies/projectSpeciesSlice.ts
+++ b/src/redux/features/projectSpecies/projectSpeciesSlice.ts
@@ -10,7 +10,7 @@ import { requestSpeciesDeliverables } from './projectSpeciesAsyncThunks';
  */
 const initialStateSpeciesDeliverables: { [key: string]: StatusT<SpeciesDeliverable[]> } = {};
 
-export const speciesDeliverablesSlice = createSlice({
+const speciesDeliverablesSlice = createSlice({
   name: 'speciesDeliverablesSlice',
   initialState: initialStateSpeciesDeliverables,
   reducers: {},

--- a/src/redux/features/projectToDo/projectToDoSlice.ts
+++ b/src/redux/features/projectToDo/projectToDoSlice.ts
@@ -11,7 +11,7 @@ import { requestProjectToDoDeliverables, requestProjectToDoEvents } from './proj
  */
 const initialStateProjectToDoDeliverables: { [key: string]: StatusT<DeliverableToDoItem[]> } = {};
 
-export const deliverablesToDoListSlice = createSlice({
+const deliverablesToDoListSlice = createSlice({
   name: 'projectToDoDeliverablesSlice',
   initialState: initialStateProjectToDoDeliverables,
   reducers: {},
@@ -25,7 +25,7 @@ export const deliverablesToDoListSlice = createSlice({
  */
 const initialStateProjectToDoEvents: { [key: string]: StatusT<EventToDoItem[]> } = {};
 
-export const eventsToDoListSlice = createSlice({
+const eventsToDoListSlice = createSlice({
   name: 'projectToDoEventsSlice',
   initialState: initialStateProjectToDoEvents,
   reducers: {},

--- a/src/redux/features/snackbar/snackbarSelectors.ts
+++ b/src/redux/features/snackbar/snackbarSelectors.ts
@@ -3,6 +3,6 @@ import { createSelector } from '@reduxjs/toolkit';
 import { RootState } from 'src/redux/rootReducer';
 import { Type } from 'src/types/Snackbar';
 
-export const selectSnackbars = (state: RootState) => state.snackbar.snackbars;
+const selectSnackbars = (state: RootState) => state.snackbar.snackbars;
 
 export const selectSnackbar = (type: Type) => createSelector(selectSnackbars, (snackbars) => snackbars[type]);

--- a/src/redux/features/snackbar/snackbarSlice.ts
+++ b/src/redux/features/snackbar/snackbarSlice.ts
@@ -17,7 +17,7 @@ const initialState: SnackbarState = {
   },
 };
 
-export const snackbarSlice = createSlice({
+const snackbarSlice = createSlice({
   name: 'snackbar',
   initialState,
   reducers: {

--- a/src/redux/features/species/speciesSlice.ts
+++ b/src/redux/features/species/speciesSlice.ts
@@ -8,7 +8,7 @@ import { MergeOtherSpeciesRequestData, requestMergeOtherSpecies } from './specie
  */
 const initialStateMergeOtherSpecies: { [key: string]: StatusT<MergeOtherSpeciesRequestData[]> } = {};
 
-export const mergeOtherSpeciesSlice = createSlice({
+const mergeOtherSpeciesSlice = createSlice({
   name: 'mergeOtherSpeciesSlice',
   initialState: initialStateMergeOtherSpecies,
   reducers: {},

--- a/src/redux/features/subLocations/subLocationsSlice.ts
+++ b/src/redux/features/subLocations/subLocationsSlice.ts
@@ -11,7 +11,7 @@ type Data = {
 // Define the initial state
 const initialState: Data = {};
 
-export const subLocationsSlice = createSlice({
+const subLocationsSlice = createSlice({
   name: 'subLocationsSlice',
   initialState,
   reducers: {

--- a/src/redux/features/tracking/trackingSlice.ts
+++ b/src/redux/features/tracking/trackingSlice.ts
@@ -23,7 +23,7 @@ type SiteData = {
 // Define the initial state
 const initialState: { [organizationId: string]: StatusT<SitesData> } & SitesData = {};
 
-export const trackingSlice = createSlice({
+const trackingSlice = createSlice({
   name: 'trackingSlice',
   initialState,
   reducers: {
@@ -64,7 +64,7 @@ type SearchData = {
 // Define the initial state for search
 const initialSearchState: SearchData = {};
 
-export const plantingSitesSearchResultsSlice = createSlice({
+const plantingSitesSearchResultsSlice = createSlice({
   name: 'plantingSitesResultsSlice',
   initialState: initialSearchState,
   reducers: {
@@ -90,7 +90,7 @@ type SiteReportedPlantsPayload = {
 
 const initialSiteReportedPlantsState: Record<number, SiteReportedPlantsData> = {};
 
-export const siteReportedPlantsSlice = createSlice({
+const siteReportedPlantsSlice = createSlice({
   name: 'siteReportedPlantsSlice',
   initialState: initialSiteReportedPlantsState,
   reducers: {
@@ -115,7 +115,7 @@ const monitoringPlotsSlice = createSlice({
 });
 
 const initialStatePlantingSiteList: { [key: string]: StatusT<PlantingSite[]> } = {};
-export const plantingSiteListSlice = createSlice({
+const plantingSiteListSlice = createSlice({
   name: 'plantingSiteListSlice',
   initialState: initialStatePlantingSiteList,
   reducers: {},
@@ -124,7 +124,7 @@ export const plantingSiteListSlice = createSlice({
   },
 });
 
-export const projectPlantingSiteListSlice = createSlice({
+const projectPlantingSiteListSlice = createSlice({
   name: 'projectPlantingSiteListSlice',
   initialState: initialStatePlantingSiteList,
   reducers: {},
@@ -134,7 +134,7 @@ export const projectPlantingSiteListSlice = createSlice({
 });
 
 const initialStatePlantingSite: { [key: string]: StatusT<PlantingSite> } = {};
-export const plantingSiteSlice = createSlice({
+const plantingSiteSlice = createSlice({
   name: 'plantingSiteSlice',
   initialState: initialStatePlantingSite,
   reducers: {},

--- a/src/redux/features/tracking/trackingThunks.ts
+++ b/src/redux/features/tracking/trackingThunks.ts
@@ -26,7 +26,7 @@ export type PlotsWithObservationsSearchResult = {
   permanentIndex?: string;
 };
 
-export const requestPlantingSite = (plantingSiteId: number, locale?: string | null) => {
+const requestPlantingSite = (plantingSiteId: number, locale?: string | null) => {
   return async (dispatch: Dispatch, _getState: () => RootState) => {
     try {
       const response = await TrackingService.getPlantingSite(plantingSiteId);
@@ -83,7 +83,7 @@ export const requestPlantingSites = createAsyncThunk(
   }
 );
 
-export const requestPlantingSitesSearchResults = (organizationId: number) => {
+const requestPlantingSitesSearchResults = (organizationId: number) => {
   return async (dispatch: Dispatch, _getState: () => RootState) => {
     try {
       const response: PlantingSiteSearchResult[] | null = await TrackingService.searchPlantingSites(organizationId);

--- a/src/redux/features/user/userAnalyticsSlice.ts
+++ b/src/redux/features/user/userAnalyticsSlice.ts
@@ -8,7 +8,7 @@ const initialState: UserAnalyticsState = {
   gtmInstrumented: false,
 };
 
-export const userAnalyticsSlice = createSlice({
+const userAnalyticsSlice = createSlice({
   name: 'userAnalytics',
   initialState,
   reducers: {

--- a/src/redux/hooks/useSelectorProcessor.ts
+++ b/src/redux/hooks/useSelectorProcessor.ts
@@ -20,7 +20,7 @@ export type OnSelectorData = React.Dispatch<React.SetStateAction<any>>;
 /**
  * Hook that handles callbacks with selectors
  */
-export const useProcessorCallbacks = (
+const useProcessorCallbacks = (
   selector: any,
   onData: OnSelectorData,
   { handleError = true, dispatched = true, onSuccess, onError, onPending, onPartialSuccess }: ProcessorCallbacksProps

--- a/src/redux/rootReducer.ts
+++ b/src/redux/rootReducer.ts
@@ -27,7 +27,7 @@ import trackingReducers from './features/tracking/trackingSlice';
 import userAnalyticsReducers from './features/user/userAnalyticsSlice';
 
 // assembly of app reducers
-export const reducers = {
+const reducers = {
   ...acceleratorReducers,
   ...applicationReducers,
   ...deliverablesReducers,

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/MetricRow.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/MetricRow.tsx
@@ -627,5 +627,4 @@ const MetricRow = ({
   );
 };
 
-export { isAutoCalculatedIndicator };
 export default MetricRow;

--- a/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
+++ b/src/scenes/Home/TerrawareHomeView/PlantingSiteStats.tsx
@@ -21,7 +21,7 @@ import { useNumberFormatter } from 'src/utils/useNumberFormatter';
 
 import StatsCardItem from './StatsCardItem';
 
-export const PlantingSiteStats = () => {
+const PlantingSiteStats = () => {
   const { strings } = useLocalization();
   const numberFormatter = useNumberFormatter();
   const { isDesktop } = useDeviceInfo();

--- a/src/scenes/Home/TerrawareHomeView/StatsCardItem.tsx
+++ b/src/scenes/Home/TerrawareHomeView/StatsCardItem.tsx
@@ -17,7 +17,7 @@ export type StatsCardItemProps = {
   value?: string;
 };
 
-export const StatsCardItem = ({
+const StatsCardItem = ({
   label,
   linkOnClick,
   linkText,

--- a/src/scenes/PlantingSitesRouter/index.tsx
+++ b/src/scenes/PlantingSitesRouter/index.tsx
@@ -22,7 +22,7 @@ export default function PlantingSites(): JSX.Element {
   );
 }
 
-export function PlantingSitesRouter(): JSX.Element {
+function PlantingSitesRouter(): JSX.Element {
   const { plantingSiteId } = useParams<{ plantingSiteId: string }>();
 
   return (
@@ -33,7 +33,7 @@ export function PlantingSitesRouter(): JSX.Element {
   );
 }
 
-export function PlantingSitesDraftRouter(): JSX.Element {
+function PlantingSitesDraftRouter(): JSX.Element {
   return (
     <Routes>
       <Route path={'/:plantingSiteId/stratum/:stratumId'} element={<PlantingSiteDraftStratumView />} />

--- a/src/scenes/PlantsDashboardRouter/components/htmlLegendPlugin.ts
+++ b/src/scenes/PlantsDashboardRouter/components/htmlLegendPlugin.ts
@@ -2,7 +2,7 @@ import { Chart } from 'chart.js';
 
 import strings from 'src/strings';
 
-export const getOrCreateLegendList = (chart: any, id: string) => {
+const getOrCreateLegendList = (chart: any, id: string) => {
   const legendContainer = document.getElementById(id);
   let listContainer = legendContainer?.querySelector('ul');
 

--- a/src/scenes/Settings/settingsTabs.ts
+++ b/src/scenes/Settings/settingsTabs.ts
@@ -4,7 +4,7 @@ import { isAdmin, isManagerOrHigher } from 'src/utils/organization';
 
 export type SettingsSection = 'organization' | 'people' | 'projects';
 
-export const SETTINGS_TAB_SESSION_KEY = 'tab-org-settings';
+const SETTINGS_TAB_SESSION_KEY = 'tab-org-settings';
 
 export const SECTION_PATHS: Record<SettingsSection, string> = {
   organization: APP_PATHS.ORGANIZATION,
@@ -24,7 +24,7 @@ export const getAllowedSections = (organization?: Organization): SettingsSection
   return sections;
 };
 
-export const readStoredSection = (): SettingsSection | undefined => {
+const readStoredSection = (): SettingsSection | undefined => {
   try {
     const stored = sessionStorage.getItem(SETTINGS_TAB_SESSION_KEY);
     return stored && stored in SECTION_PATHS ? (stored as SettingsSection) : undefined;
@@ -41,7 +41,7 @@ export const writeStoredSection = (section: SettingsSection): void => {
   }
 };
 
-export const getSettingsLandingSection = (organization?: Organization): SettingsSection => {
+const getSettingsLandingSection = (organization?: Organization): SettingsSection => {
   const allowed = getAllowedSections(organization);
   const stored = readStoredSection();
   return (stored && allowed.includes(stored) ? stored : allowed[0]) ?? 'people';

--- a/src/types/AcceleratorProject.ts
+++ b/src/types/AcceleratorProject.ts
@@ -50,7 +50,7 @@ export type RegionLabel = {
   label: string;
 };
 
-export const REGIONS = (): RegionLabel[] => [
+const REGIONS = (): RegionLabel[] => [
   { region: 'Antarctica', label: strings.REGION_ANTARCTICA },
   { region: 'East Asia & Pacific', label: strings.REGION_EAST_ASIA_PACIFIC },
   { region: 'Europe & Central Asia', label: strings.REGION_EUROPE_CENTRAL_ASIA },

--- a/src/types/AcceleratorProjectSpecies.ts
+++ b/src/types/AcceleratorProjectSpecies.ts
@@ -9,7 +9,7 @@ export type SpeciesNativeCategory = AcceleratorProjectSpecies['speciesNativeCate
 export type AcceleratorProjectForSpecies = components['schemas']['ParticipantProjectForSpeciesPayload'];
 export type SpeciesForAcceleratorProject = components['schemas']['SpeciesForParticipantProjectPayload'];
 
-export const getSpeciesNativeCategoryLabel = (value: SpeciesNativeCategory): string => {
+const getSpeciesNativeCategoryLabel = (value: SpeciesNativeCategory): string => {
   switch (value) {
     case 'Native':
       return strings.NATIVE;

--- a/src/types/Species.ts
+++ b/src/types/Species.ts
@@ -326,7 +326,7 @@ export function getSuccessionalGroupsString(species?: Species): string {
     .join(', ');
 }
 
-export const getWoodDensityLevel = (value: WoodDensityLevel): string => {
+const getWoodDensityLevel = (value: WoodDensityLevel): string => {
   switch (value) {
     case 'Family':
       return strings.FAMILY;

--- a/src/units.ts
+++ b/src/units.ts
@@ -19,7 +19,7 @@ export function weightUnits() {
   ];
 }
 
-export function weightUnitsV2(unit?: string) {
+function weightUnitsV2(unit?: string) {
   if (unit === 'imperial') {
     return [
       { label: strings.OZ, value: 'Ounces' },
@@ -63,7 +63,7 @@ export type InitializedUnits = {
   updated?: boolean;
 };
 
-export function getUnitsForSystem(system: string) {
+function getUnitsForSystem(system: string) {
   if (system === 'imperial') {
     return [
       { label: strings.LB_POUNDS, value: 'Pounds' },

--- a/src/utils/acl.ts
+++ b/src/utils/acl.ts
@@ -99,7 +99,7 @@ const isReadOnlyOrHigher = (user: User): boolean => ReadOnlyPlus.some((role) => 
 /**
  * Functions related to authorization around global roles
  */
-export const globalRolesAvailableToSet = (user: User): UserGlobalRole[] => {
+const globalRolesAvailableToSet = (user: User): UserGlobalRole[] => {
   if (isSuperAdmin(user)) {
     // Super admin can assign all roles
     return USER_GLOBAL_ROLES;

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -9,7 +9,7 @@ export const makeCsv = (columns: ColumnHeader[], data: CsvData[], quoteStrings =
   return asBlob(csvConfig)(csv);
 };
 
-export const downloadFile = (filename: string, mimeType: string, fileContent: string) => {
+const downloadFile = (filename: string, mimeType: string, fileContent: string) => {
   const encodedUri = `data:${mimeType};charset=utf-8,${encodeURIComponent(fileContent)}`;
   const link = document.createElement('a');
   link.setAttribute('href', encodedUri);

--- a/src/utils/documentProducer/variables.ts
+++ b/src/utils/documentProducer/variables.ts
@@ -88,7 +88,7 @@ export const variableDependencyMet = (variable: VariableWithValues, allVariables
   }
 };
 
-export const getRawValue = (variable: VariableWithValues): number | number[] | string | undefined => {
+const getRawValue = (variable: VariableWithValues): number | number[] | string | undefined => {
   const firstValue = variable.values[0];
 
   if (!firstValue) {

--- a/src/utils/filterHooks/index.ts
+++ b/src/utils/filterHooks/index.ts
@@ -7,7 +7,7 @@ export type FiltersType = Record<string, FilterValue>;
 
 // Convert an array to a comma separated string and other values to a string
 // Array values are sorted, so we can detect equality easier elsewhere
-export const normalizeValue = (value: FilterValue): string => {
+const normalizeValue = (value: FilterValue): string => {
   if (isArray(value)) {
     return value
       .sort((valueA, valueB) => `${valueA}`.localeCompare(`${valueB}`))
@@ -52,9 +52,9 @@ export const filtersEqual = (a: FiltersType, b: FiltersType) =>
   Object.keys(a).every((key) => (isEmptyArray(a[key]) && !b[key]) || filterValueEqual(a[key], b[key])) &&
   Object.keys(b).every((key) => (isEmptyArray(b[key]) && !a[key]) || filterValueEqual(a[key], b[key]));
 
-export const isFilterKey = (viewIdentifier: string, key: string) => key.includes(`${viewIdentifier}_filter_`);
-export const scrubFilterKey = (key: string) => key.replace(/.*_filter_(.+)/, '$1');
-export const makeFiltersSessionKey = (viewIdentifier: string) => `${viewIdentifier}_filters`;
+const isFilterKey = (viewIdentifier: string, key: string) => key.includes(`${viewIdentifier}_filter_`);
+const scrubFilterKey = (key: string) => key.replace(/.*_filter_(.+)/, '$1');
+const makeFiltersSessionKey = (viewIdentifier: string) => `${viewIdentifier}_filters`;
 
 export const getFiltersFromSession = (viewIdentifier: string): FiltersType => {
   try {

--- a/src/utils/generateRandomColor.tsx
+++ b/src/utils/generateRandomColor.tsx
@@ -53,4 +53,4 @@ const generateTerrawareRandomColors = (theme: Theme, numberOfColors: number) => 
   return colors;
 };
 
-export { generateRandomColor, generateTerrawareRandomColors };
+export { generateTerrawareRandomColors };

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -78,4 +78,4 @@ const shouldShowHeicPlaceholder = async (file: File): Promise<boolean> => {
   return !isSupported;
 };
 
-export { getImagePath, isHeicFile, isHeicSupportedByBrowser, shouldShowHeicPlaceholder };
+export { getImagePath, shouldShowHeicPlaceholder };

--- a/src/utils/organization.tsx
+++ b/src/utils/organization.tsx
@@ -3,7 +3,7 @@ import { Facility, FacilityType } from 'src/types/Facility';
 import { HighOrganizationRolesValues, Organization, OrganizationRole } from 'src/types/Organization';
 import { OrganizationUser } from 'src/types/User';
 
-export const getFacilitiesByType = (organization: Organization, type: FacilityType, locale?: string) => {
+const getFacilitiesByType = (organization: Organization, type: FacilityType, locale?: string) => {
   let facilitiesByType: Facility[] = [];
   if (organization && organization.facilities) {
     facilitiesByType = organization?.facilities

--- a/src/utils/requestsId.tsx
+++ b/src/utils/requestsId.tsx
@@ -2,7 +2,7 @@ export type RequestIds = {
   [endpoint: string]: string;
 };
 
-export const requestIds: RequestIds = {};
+const requestIds: RequestIds = {};
 
 export const setRequestId = (key: string, id?: string): string => {
   requestIds[key] = id || Math.random().toString();

--- a/src/utils/searchAndSort.ts
+++ b/src/utils/searchAndSort.ts
@@ -221,7 +221,7 @@ const getRawField = <T extends Record<string, unknown>>(result: T, field: string
   }
 };
 
-export const sortResults = <T extends Record<string, unknown>>(
+const sortResults = <T extends Record<string, unknown>>(
   results: T[],
   locale: string | null,
   sortOrder: SearchSortOrder,


### PR DESCRIPTION
For any symbols that are only referenced in the same source file,
make them local instead of exporting them. This will make it
slightly easier to do additional dead code detection.

This is the result of

    yarn knip --fix --fix-type exports
    yarn format:changed

followed by a small amount of manual editing to remove blank lines
left behind by Knip.