### PR TITLE
Move ModalValuesType to batch types file

### DIFF
--- a/src/scenes/InventoryRouter/view/BatchesCellRenderer.tsx
+++ b/src/scenes/InventoryRouter/view/BatchesCellRenderer.tsx
@@ -1,5 +1,0 @@
-export type ModalValuesType = {
-  type: string;
-  openChangeQuantityModal: boolean;
-  batch?: any;
-};

--- a/src/scenes/InventoryRouter/view/ChangeQuantityModal.tsx
+++ b/src/scenes/InventoryRouter/view/ChangeQuantityModal.tsx
@@ -8,11 +8,10 @@ import Button from 'src/components/common/button/Button';
 import { useTrackModalAbandonment } from 'src/hooks/useTrackModalAbandonment';
 import { ChangeBatchStatusRequestPayload, useChangeBatchStatusesMutation } from 'src/queries/generated/nurseryBatches';
 import strings from 'src/strings';
+import { ModalValuesType } from 'src/types/Batch';
 import useForm from 'src/utils/useForm';
 import { useNumberFormatter } from 'src/utils/useNumberFormatter';
 import useSnackbar from 'src/utils/useSnackbar';
-
-import { ModalValuesType } from './BatchesCellRenderer';
 
 export interface ChangeQuantityModalProps {
   modalValues: ModalValuesType;

--- a/src/scenes/InventoryRouter/view/QuantitiesMenu.tsx
+++ b/src/scenes/InventoryRouter/view/QuantitiesMenu.tsx
@@ -2,8 +2,7 @@ import React, { type JSX } from 'react';
 
 import TableRowPopupMenu from 'src/components/common/table/TableRowPopupMenu';
 import strings from 'src/strings';
-
-import { ModalValuesType } from './BatchesCellRenderer';
+import { ModalValuesType } from 'src/types/Batch';
 
 export type QuantitiesMenuProps = {
   setModalValues: React.Dispatch<React.SetStateAction<ModalValuesType>>;

--- a/src/types/Batch.ts
+++ b/src/types/Batch.ts
@@ -92,3 +92,9 @@ export const batchHistoryEventEnumToLocalized = (batchHistoryType: BatchHistoryP
     }
   }
 };
+
+export type ModalValuesType = {
+  type: string;
+  openChangeQuantityModal: boolean;
+  batch?: any;
+};


### PR DESCRIPTION
We deleted all the code from `BatchesCellRenderer.tsx` other than
`ModalValuesType`, which left that type in a file with a misleading
name. Move it to the types file for batches.
