### PR TITLE
Don't flag SharedStringKeys as unused

### DIFF
--- a/src/strings/index.tsx
+++ b/src/strings/index.tsx
@@ -18,7 +18,8 @@ type AppStrings = typeof english;
  * worth reporting. `yarn generate-strings` fails on the same collision with a plainer message.
  */
 type NoStringsSharedWithComponents<T extends { alreadyDefinedByWebComponents: never }> = T;
-export type SharedStringKeys = NoStringsSharedWithComponents<{
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type SharedStringKeys = NoStringsSharedWithComponents<{
   alreadyDefinedByWebComponents: Extract<keyof ComponentStrings, keyof AppStrings>;
 }>;
 


### PR DESCRIPTION
The `SharedStringKeys` type is a compile-time validation check that
bombs out if web-components and terraware-web define strings with
the same keys. It's not intended to be used as the type of any
actual values. Exclude it from eslint's "unused vars" check.