### PR TITLE
Remove unnecessary type exports

### DIFF
--- a/src/components/AcceleratorReports/AcceleratorReportTargetsTable.tsx
+++ b/src/components/AcceleratorReports/AcceleratorReportTargetsTable.tsx
@@ -30,7 +30,7 @@ import {
 import { formatPrecision } from 'src/utils/numbers';
 import useSnackbar from 'src/utils/useSnackbar';
 
-export type RowMetric = {
+type RowMetric = {
   name: string;
   description?: string;
   type: string;

--- a/src/components/AcceleratorReports/EditableReportBox.tsx
+++ b/src/components/AcceleratorReports/EditableReportBox.tsx
@@ -5,7 +5,7 @@ import { Box, Grid, Typography, useTheme } from '@mui/material';
 import Button from 'src/components/common/button/Button';
 import strings from 'src/strings';
 
-export type EditableReportBoxProps = {
+type EditableReportBoxProps = {
   name: string;
   description?: string;
   canEdit: boolean;

--- a/src/components/AcceleratorReports/EmptyFieldPlaceholder.tsx
+++ b/src/components/AcceleratorReports/EmptyFieldPlaceholder.tsx
@@ -2,7 +2,7 @@ import React, { type JSX } from 'react';
 
 import { Typography, useTheme } from '@mui/material';
 
-export type EmptyFieldPlaceholderProps = {
+type EmptyFieldPlaceholderProps = {
   text: string;
 };
 

--- a/src/components/AcceleratorReports/IndicatorProgressRow.tsx
+++ b/src/components/AcceleratorReports/IndicatorProgressRow.tsx
@@ -43,7 +43,7 @@ export type ProgressIndicator = {
   value?: number;
 };
 
-export type IndicatorProgressRowProps = {
+type IndicatorProgressRowProps = {
   editing?: boolean;
   indicator: ProgressIndicator;
   onChange?: (id: string, value: unknown) => void;

--- a/src/components/AcceleratorReports/IndicatorProgressSection.tsx
+++ b/src/components/AcceleratorReports/IndicatorProgressSection.tsx
@@ -102,7 +102,7 @@ export const IndicatorProgressSectionContent = ({
   );
 };
 
-export type IndicatorProgressSectionProps = {
+type IndicatorProgressSectionProps = {
   isConsoleView?: boolean;
   reportId?: number;
 };

--- a/src/components/AcceleratorReports/LifetimeProgressBar.tsx
+++ b/src/components/AcceleratorReports/LifetimeProgressBar.tsx
@@ -8,7 +8,7 @@ const BAR_HEIGHT = 8;
 const TICK_OVERHANG = 3;
 const TICK_LABEL_HEIGHT = '16px';
 
-export type LifetimeProgressBarProps = {
+type LifetimeProgressBarProps = {
   baseline?: number;
   currentProgress: number;
   endOfProjectTarget?: number;

--- a/src/components/AcceleratorReports/ProjectHealthBar.tsx
+++ b/src/components/AcceleratorReports/ProjectHealthBar.tsx
@@ -6,7 +6,7 @@ import useOneAcceleratorReport from 'src/hooks/useOneAcceleratorReport';
 import { useLocalization } from 'src/providers';
 import { MetricStatus } from 'src/types/AcceleratorReport';
 
-export type ProjectHealthIndicator = {
+type ProjectHealthIndicator = {
   status?: MetricStatus;
 };
 
@@ -100,7 +100,7 @@ export const ProjectHealthBarContent = ({ indicators }: ProjectHealthBarContentP
   );
 };
 
-export type ProjectHealthBarProps = {
+type ProjectHealthBarProps = {
   reportId?: number;
 };
 

--- a/src/components/AcceleratorReports/ReportDropdown.tsx
+++ b/src/components/AcceleratorReports/ReportDropdown.tsx
@@ -8,7 +8,7 @@ export type ReportOption = {
   title: string;
 };
 
-export type ReportDropdownProps = {
+type ReportDropdownProps = {
   reports: ReportOption[];
   selectedReportId?: number;
   onChange: (reportId: number) => void;

--- a/src/components/AcceleratorReports/ReportEditFields.tsx
+++ b/src/components/AcceleratorReports/ReportEditFields.tsx
@@ -15,7 +15,7 @@ const INDICATOR_FIELDS: Record<string, keyof AcceleratorReportPayload> = {
   project: 'projectIndicators',
 };
 
-export type ReportEditFieldsProps = {
+type ReportEditFieldsProps = {
   onChangeCallback: (id: string) => (value: unknown) => void;
   record: AcceleratorReportPayload;
   isConsoleView?: boolean;

--- a/src/components/AcceleratorReports/ReportMessages.tsx
+++ b/src/components/AcceleratorReports/ReportMessages.tsx
@@ -12,7 +12,7 @@ import { useReviewOneAcceleratorReportMutation } from 'src/queries/generated/acc
 import RejectDialog from 'src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/RejectDialog';
 import useSnackbar from 'src/utils/useSnackbar';
 
-export type ReportMessagesProps = {
+type ReportMessagesProps = {
   isConsoleView?: boolean;
   reportId: number;
 };

--- a/src/components/AcceleratorReports/ResetIndicatorModal.tsx
+++ b/src/components/AcceleratorReports/ResetIndicatorModal.tsx
@@ -5,7 +5,7 @@ import { Confirm } from '@terraware/web-components';
 
 import { useLocalization } from 'src/providers';
 
-export type ResetIndicatorModalProps = {
+type ResetIndicatorModalProps = {
   onClose: () => void;
   onSubmit: () => void;
 };

--- a/src/components/ActivityLog/useSyncActivityMedia.ts
+++ b/src/components/ActivityLog/useSyncActivityMedia.ts
@@ -11,14 +11,14 @@ import { useDeletePlotPhotoMutation, useUploadOtherPlotMediaMutation } from 'src
 import { QueryTagTypes } from 'src/queries/tags';
 import { useAppDispatch } from 'src/redux/store';
 
-export type SyncActivityMediaResult = {
+type SyncActivityMediaResult = {
   error?: string;
   fileId?: number;
   operation: 'delete' | 'update' | 'upload';
   success: boolean;
 };
 
-export type SyncActivityMediaResponse = {
+type SyncActivityMediaResponse = {
   allSuccessful: boolean;
   deletedCount: number;
   results: SyncActivityMediaResult[];
@@ -26,7 +26,7 @@ export type SyncActivityMediaResponse = {
   uploadedCount: number;
 };
 
-export type SyncActivityMediaRequest = {
+type SyncActivityMediaRequest = {
   activityId: number;
   mediaItems: ActivityMediaItem[];
   observationId?: number;

--- a/src/components/Application/ConfirmModal.tsx
+++ b/src/components/Application/ConfirmModal.tsx
@@ -6,7 +6,7 @@ import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Button from 'src/components/common/button/Button';
 import strings from 'src/strings';
 
-export type NewApplicationModalProps = {
+type NewApplicationModalProps = {
   open: boolean;
   title: string;
   body: string;

--- a/src/components/DocumentProducer/DeliverableEditImages/index.tsx
+++ b/src/components/DocumentProducer/DeliverableEditImages/index.tsx
@@ -10,7 +10,7 @@ import { getImagePath } from 'src/utils/images';
 
 import PhotoSelector, { PhotoWithAttributes } from '../EditImagesModal/PhotoSelector';
 
-export type DeliverableEditImagesProps = {
+type DeliverableEditImagesProps = {
   projectId: number;
   setDeletedImages: (values: VariableValueImageValue[]) => void;
   setImages: (values: VariableValueImageValue[]) => void;

--- a/src/components/DocumentProducer/DeliverableVariableDetailsInput/index.tsx
+++ b/src/components/DocumentProducer/DeliverableVariableDetailsInput/index.tsx
@@ -29,7 +29,7 @@ import DeliverableEditTable from '../DeliverableEditTable';
 import { PhotoWithAttributes } from '../EditImagesModal/PhotoSelector';
 import { VariableTableCell } from '../EditableTableModal/helpers';
 
-export type DeliverableVariableDetailsInputProps = {
+type DeliverableVariableDetailsInputProps = {
   hideDescription?: boolean;
   values: VariableValueValue[];
   setCellValues?: (values: VariableTableCell[][]) => void;

--- a/src/components/DocumentProducer/DocumentMetadataEdit/index.tsx
+++ b/src/components/DocumentProducer/DocumentMetadataEdit/index.tsx
@@ -16,7 +16,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 
 import { getDocumentOwnerOptions, getDocumentTemplateName, getDocumentTemplateOptions } from './helpers';
 
-export type DocumentMetadataEditProps = {
+type DocumentMetadataEditProps = {
   documentName?: string;
   setDocumentName: (name: string) => void;
   documentOwner?: string;

--- a/src/components/DocumentProducer/EditImagesModal/PhotoSelector.tsx
+++ b/src/components/DocumentProducer/EditImagesModal/PhotoSelector.tsx
@@ -8,7 +8,7 @@ import PhotoDragDrop, { PhotoDragDropProps } from 'src/components/Photo/PhotoDra
 import PhotoPreview from 'src/components/Photo/PhotoPreview';
 import strings from 'src/strings';
 
-export type PhotoChooserErrorType = {
+type PhotoChooserErrorType = {
   title: string;
   text: string;
 };
@@ -29,7 +29,7 @@ export type PhotoWithAttributes = {
   citation: string;
 };
 
-export type PhotoWithAttributesAndUrl = PhotoWithAttributes & {
+type PhotoWithAttributesAndUrl = PhotoWithAttributes & {
   url: string;
 };
 

--- a/src/components/DocumentProducer/EditImagesModal/index.tsx
+++ b/src/components/DocumentProducer/EditImagesModal/index.tsx
@@ -31,7 +31,7 @@ import { getImagePath } from 'src/utils/images';
 
 import PhotoSelector, { PhotoWithAttributes } from './PhotoSelector';
 
-export type EditImagesModalProps = {
+type EditImagesModalProps = {
   display?: boolean;
   variable: ImageVariableWithValues;
   onFinish: (edited: boolean) => void;

--- a/src/components/DocumentProducer/EditVariable/index.tsx
+++ b/src/components/DocumentProducer/EditVariable/index.tsx
@@ -32,7 +32,7 @@ import {
   VariableValueValue,
 } from 'src/types/documentProducer/VariableValue';
 
-export type EditVariableProps = {
+type EditVariableProps = {
   display?: boolean;
   onFinish: (edited: boolean) => void;
   projectId: number;

--- a/src/components/DocumentProducer/EditableSection/Display.tsx
+++ b/src/components/DocumentProducer/EditableSection/Display.tsx
@@ -7,7 +7,7 @@ import { VariableValueValue } from 'src/types/documentProducer/VariableValue';
 
 import DisplayVariableValue from './DisplayVariableValue';
 
-export type EditableSectionDisplayProps = {
+type EditableSectionDisplayProps = {
   allVariables: VariableWithValues[];
   projectId: number;
   onEditVariableValue: (variable?: VariableWithValues) => void;

--- a/src/components/DocumentProducer/ErrorMessage/index.tsx
+++ b/src/components/DocumentProducer/ErrorMessage/index.tsx
@@ -2,7 +2,7 @@ import React, { type JSX } from 'react';
 
 import { Typography, useTheme } from '@mui/material';
 
-export type ErrorMessageProps = {
+type ErrorMessageProps = {
   error?: string;
   fontSize?: number;
 };

--- a/src/components/DocumentProducer/PageContent/index.tsx
+++ b/src/components/DocumentProducer/PageContent/index.tsx
@@ -3,13 +3,13 @@ import React, { type JSX } from 'react';
 import { Box, CircularProgress, Typography, useTheme } from '@mui/material';
 import { Button, IconName } from '@terraware/web-components';
 
-export type SecondaryButtonProps = {
+type SecondaryButtonProps = {
   title?: string;
   icon?: IconName;
   onClick: () => void;
 };
 
-export type PageContentProps = {
+type PageContentProps = {
   title?: string;
   secondaryButton?: SecondaryButtonProps;
   children?: React.ReactNode;

--- a/src/components/DocumentProducer/PageDialog/index.tsx
+++ b/src/components/DocumentProducer/PageDialog/index.tsx
@@ -5,7 +5,7 @@ import DialogBox, { Props as DialogBoxProps } from '@terraware/web-components/co
 import PageWorkflow from 'src/components/DocumentProducer/PageWorkflow';
 import { WorkflowSuccessProps } from 'src/redux/hooks/useWorkflowSuccess';
 
-export type PageDialogProps = DialogBoxProps & WorkflowSuccessProps;
+type PageDialogProps = DialogBoxProps & WorkflowSuccessProps;
 
 const PageDialog = (props: PageDialogProps): JSX.Element => {
   const { ...dialogProps }: DialogBoxProps = props;

--- a/src/components/DocumentProducer/PageForm/index.tsx
+++ b/src/components/DocumentProducer/PageForm/index.tsx
@@ -5,7 +5,7 @@ import Form, { PageFormProps as FormProps } from '@terraware/web-components/comp
 import PageWorkflow from 'src/components/DocumentProducer/PageWorkflow';
 import { WorkflowSuccessProps } from 'src/redux/hooks/useWorkflowSuccess';
 
-export type PageFormProps = FormProps & WorkflowSuccessProps;
+type PageFormProps = FormProps & WorkflowSuccessProps;
 
 const PageForm = (props: PageFormProps): JSX.Element => {
   const { ...formProps }: FormProps = props;

--- a/src/components/DocumentProducer/PageWorkflow/PartialErrorsDialog.tsx
+++ b/src/components/DocumentProducer/PageWorkflow/PartialErrorsDialog.tsx
@@ -6,7 +6,7 @@ import { Button, DialogBox } from '@terraware/web-components';
 import ErrorMessage from 'src/components/DocumentProducer/ErrorMessage';
 import strings from 'src/strings';
 
-export type PartialErrorsDialogProps = {
+type PartialErrorsDialogProps = {
   onClose: () => void;
   partialError: string;
 };

--- a/src/components/DocumentProducer/PageWorkflow/index.tsx
+++ b/src/components/DocumentProducer/PageWorkflow/index.tsx
@@ -7,7 +7,7 @@ import strings from 'src/strings';
 
 import PartialErrorsDialog from './PartialErrorsDialog';
 
-export type PageWorkflowProps = WorkflowSuccessProps & {
+type PageWorkflowProps = WorkflowSuccessProps & {
   children: React.ReactNode;
 };
 

--- a/src/components/DocumentProducer/Search/index.tsx
+++ b/src/components/DocumentProducer/Search/index.tsx
@@ -9,7 +9,7 @@ import FilterGroup, { FilterField } from 'src/components/common/FilterGroup';
 import strings from 'src/strings';
 import { FieldOptionsMap } from 'src/types/Search';
 
-export type SearchFiltersProp = {
+type SearchFiltersProp = {
   filterColumns: FilterField[];
   filterOptions: FieldOptionsMap;
   filters: Record<string, any>;

--- a/src/components/DocumentProducer/TableContent/index.tsx
+++ b/src/components/DocumentProducer/TableContent/index.tsx
@@ -9,7 +9,7 @@ import Search, { SearchProps } from 'src/components/DocumentProducer/Search';
 import Table from 'src/components/common/table';
 import CellRenderer from 'src/components/common/table/TableCellRenderer';
 
-export type TableProps<T> = {
+type TableProps<T> = {
   tableOrderBy: string;
   tableOrder?: SortOrder;
   tableColumns: TableColumnType[];
@@ -24,7 +24,7 @@ export type TableProps<T> = {
   sortComparator?: (a: T, b: T, orderBy: keyof T) => number;
 };
 
-export type TableContentProps<T> = {
+type TableContentProps<T> = {
   // Search
   searchProps?: SearchProps;
 

--- a/src/components/DocumentProducer/TableDisplay/index.tsx
+++ b/src/components/DocumentProducer/TableDisplay/index.tsx
@@ -21,7 +21,7 @@ import {
 } from 'src/types/documentProducer/Variable';
 import { VariableValueValue } from 'src/types/documentProducer/VariableValue';
 
-export type TableDisplayProps = {
+type TableDisplayProps = {
   variable: TableVariableWithValues;
 };
 

--- a/src/components/DocumentProducer/VariableDetailsInput/index.tsx
+++ b/src/components/DocumentProducer/VariableDetailsInput/index.tsx
@@ -22,7 +22,7 @@ import {
   VariableValueValue,
 } from 'src/types/documentProducer/VariableValue';
 
-export type VariableDetailsInputProps = {
+type VariableDetailsInputProps = {
   display?: boolean;
   values: VariableValueValue[];
   setValues: (values: VariableValueValue[]) => void;

--- a/src/components/Map/EditableMapV2.tsx
+++ b/src/components/Map/EditableMapV2.tsx
@@ -39,7 +39,7 @@ import { boundariesToViewState, getMapErrorLayer, readOnlyBoundariesToMapLayers 
 
 // Callback to select one feature from among list of features on the map that overlap the click target.
 export type LayerFeature = MapGeoJSONFeature;
-export type FeatureSelectorOnClick = (features: LayerFeature[]) => LayerFeature | undefined;
+type FeatureSelectorOnClick = (features: LayerFeature[]) => LayerFeature | undefined;
 
 export type EditableMapProps = {
   activeContext?: MapEntityOptions;

--- a/src/components/Map/MapIcon.tsx
+++ b/src/components/Map/MapIcon.tsx
@@ -3,7 +3,7 @@ import React, { CSSProperties, type JSX } from 'react';
 import { useTheme } from '@mui/material';
 import { Icon } from '@terraware/web-components';
 
-export type MapIconType = 'polygon' | 'slice' | 'trash';
+type MapIconType = 'polygon' | 'slice' | 'trash';
 
 export type MapIconProps = {
   centerAligned?: boolean;

--- a/src/components/Map/MapRenderUtils.tsx
+++ b/src/components/Map/MapRenderUtils.tsx
@@ -112,7 +112,7 @@ export function MapTooltip({ title, properties, subtitle, subtitleColor }: MapTo
   );
 }
 
-export type ButtonType = {
+type ButtonType = {
   title: string;
   onClick: () => void;
 };

--- a/src/components/Map/MapSearchBox.tsx
+++ b/src/components/Map/MapSearchBox.tsx
@@ -10,7 +10,7 @@ import strings from 'src/strings';
 import useDebounce from 'src/utils/useDebounce';
 import useMapboxSearch from 'src/utils/useMapboxSearch';
 
-export type MapSearchBoxProp = {
+type MapSearchBoxProp = {
   onSelect?: (features: AddressAutofillFeatureSuggestion[] | null) => void;
   style?: CSSProperties;
 };

--- a/src/components/Map/MapViewStyleControl.tsx
+++ b/src/components/Map/MapViewStyleControl.tsx
@@ -28,7 +28,7 @@ export const useMapViewStyle = (initialMapViewStyle?: MapViewStyle): [MapViewSty
   );
 };
 
-export type MapViewStyleControlProps = {
+type MapViewStyleControlProps = {
   mapViewStyle?: MapViewStyle;
   onChangeMapViewStyle: (style: MapViewStyle) => void;
 };

--- a/src/components/Map/MapViewStyleSwitch.tsx
+++ b/src/components/Map/MapViewStyleSwitch.tsx
@@ -6,7 +6,7 @@ import strings from 'src/strings';
 import { MapViewStyle } from 'src/types/Map';
 import { getRgbaFromHex } from 'src/utils/color';
 
-export type MapViewStyleSwitchProps = {
+type MapViewStyleSwitchProps = {
   mapViewStyle?: MapViewStyle;
   onChangeMapViewStyle: (style: MapViewStyle) => void;
 };

--- a/src/components/Map/UndoRedoControl.tsx
+++ b/src/components/Map/UndoRedoControl.tsx
@@ -3,7 +3,7 @@ import React, { type JSX } from 'react';
 import { Box, useTheme } from '@mui/material';
 import { Button } from '@terraware/web-components';
 
-export type UndoRedoBoundaryControlProps = {
+type UndoRedoBoundaryControlProps = {
   onRedo?: () => void;
   onUndo?: () => void;
 };

--- a/src/components/NewMap/MapBox.tsx
+++ b/src/components/NewMap/MapBox.tsx
@@ -34,7 +34,7 @@ import {
 import { useMaintainLayerOrder } from './useMaintainLayerOrder';
 import { getBoundingBoxFromPoints, isBoundsValid } from './utils';
 
-export type MapBoxProps = {
+type MapBoxProps = {
   additionalComponent?: React.ReactNode;
   clusterMaxZoom?: number;
   clusterRadius?: number;

--- a/src/components/NewMap/MapContainer.tsx
+++ b/src/components/NewMap/MapContainer.tsx
@@ -4,7 +4,7 @@ import { useDeviceInfo } from '@terraware/web-components/utils';
 
 import './styles.scss';
 
-export type MapContainerProps = {
+type MapContainerProps = {
   containerId?: string;
   drawer?: ReactNode;
   drawerOpen?: boolean;

--- a/src/components/NewMap/MapDrawer.tsx
+++ b/src/components/NewMap/MapDrawer.tsx
@@ -9,7 +9,7 @@ import './styles.scss';
 
 export type MapDrawerSize = 'small' | 'medium' | 'large';
 
-export type MapDrawerProp = {
+type MapDrawerProp = {
   children?: ReactNode;
   drawerRef?: MutableRefObject<HTMLDivElement | null>;
   headerComponent?: ReactNode;

--- a/src/components/NewMap/MapLegend.tsx
+++ b/src/components/NewMap/MapLegend.tsx
@@ -25,7 +25,7 @@ export type MapDropdownLegendGroup = {
   setSelectedValue: (value: string | undefined) => void;
 } & BaseMapLegendGroup;
 
-export type MapSingleSelectLegendItem = {
+type MapSingleSelectLegendItem = {
   disabled?: boolean;
   id: string;
   label: string;
@@ -53,7 +53,7 @@ export type MapMultiSelectLegendGroup = {
   type: 'multi-select';
 } & BaseMapLegendGroup;
 
-export type MapGroupToggleLegendItem = {
+type MapGroupToggleLegendItem = {
   label: string;
   style: MapIconComponentStyle | MapFillComponentStyle;
 };
@@ -71,13 +71,13 @@ export type MapLegendGroup =
   | MapGroupToggleLegendGroup
   | MapDropdownLegendGroup;
 
-export type MapLegendItem =
+type MapLegendItem =
   | MapMultiSelectLegendItem
   | MapSingleSelectLegendItem
   | MapGroupToggleLegendItem
   | MapDropdownLegendItem;
 
-export type MapLegendProps = {
+type MapLegendProps = {
   legends: MapLegendGroup[];
 };
 

--- a/src/components/NewMap/index.tsx
+++ b/src/components/NewMap/index.tsx
@@ -11,7 +11,7 @@ import { MapCursor, MapHighlightGroup, MapLayer, MapMarkerGroup, MapNameTag, Map
 import useStickyMapViewStyle from './useStickyMapViewStyle';
 import { getBoundingBoxFromMultiPolygons, getBoundsZoomLevel } from './utils';
 
-export type MapComponentProps = {
+type MapComponentProps = {
   additionalComponent?: React.ReactNode;
   clusterMaxZoom?: number;
   clusterRadius?: number;

--- a/src/components/NewMap/types.tsx
+++ b/src/components/NewMap/types.tsx
@@ -59,7 +59,7 @@ export type MapLayer = {
   visible: boolean;
 };
 
-export type MapHighlight = {
+type MapHighlight = {
   featureIds: MapLayerFeatureId[];
   style: MapFillComponentStyle;
 };

--- a/src/components/NewMap/useMapPhotoDrawer.tsx
+++ b/src/components/NewMap/useMapPhotoDrawer.tsx
@@ -23,7 +23,7 @@ export type PlotSplat = {
   splat: ObservationSplatPayload;
 };
 
-export type WithdrawalPhoto = {
+type WithdrawalPhoto = {
   kind: 'withdrawal-photo';
   capturedLocalTime?: string;
   withdrawalId: number;
@@ -32,7 +32,7 @@ export type WithdrawalPhoto = {
   gpsCoordinates: Point;
 };
 
-export type MapDrawerPhotoItem = PlotPhoto | PlotSplat | WithdrawalPhoto;
+type MapDrawerPhotoItem = PlotPhoto | PlotSplat | WithdrawalPhoto;
 
 const useMapPhotoDrawer = () => {
   const [selectedPhotos, setSelectedPhotos] = useState<MapDrawerPhotoItem[]>([]);

--- a/src/components/NewMap/usePlantingSiteMapLegend.ts
+++ b/src/components/NewMap/usePlantingSiteMapLegend.ts
@@ -5,7 +5,7 @@ import { useLocalization } from 'src/providers';
 import { MapSingleSelectLegendGroup } from './MapLegend';
 import useMapFeatureStyles from './useMapFeatureStyles';
 
-export type PlantingSiteMapLayer = 'sites' | 'strata' | 'substrata';
+type PlantingSiteMapLayer = 'sites' | 'strata' | 'substrata';
 
 const usePlantingSiteMapLegend = (defaultLayer?: PlantingSiteMapLayer, disabled?: boolean) => {
   const { strings } = useLocalization();

--- a/src/components/NewMap/useWithdrawalPhotosForPlantingSite.ts
+++ b/src/components/NewMap/useWithdrawalPhotosForPlantingSite.ts
@@ -1,6 +1,6 @@
 import { WithdrawalPhotoSearchEntry, useSearchNurseryWithdrawalPhotosQuery } from 'src/queries/search/nurseries';
 
-export type WithdrawalPhotoEntry = WithdrawalPhotoSearchEntry;
+type WithdrawalPhotoEntry = WithdrawalPhotoSearchEntry;
 
 type UseWithdrawalPhotosForPlantingSiteArgs = {
   enabled?: boolean;

--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -9,7 +9,7 @@ import PageSnackbar from 'src/components/PageSnackbar';
 import PageHeaderWrapper from 'src/components/common/PageHeaderWrapper';
 import TfMain from 'src/components/common/TfMain';
 
-export type ButtonType = {
+type ButtonType = {
   title: string;
   onClick: () => void;
 };

--- a/src/components/Photo/PhotoSelectorWithPreview.tsx
+++ b/src/components/Photo/PhotoSelectorWithPreview.tsx
@@ -7,7 +7,7 @@ import PhotoDragDrop, { PhotoDragDropProps } from 'src/components/Photo/PhotoDra
 
 import PhotoPreview from './PhotoPreview';
 
-export type PhotoSelectorWithPreviewErrorType = {
+type PhotoSelectorWithPreviewErrorType = {
   title: string;
   text: string;
 };

--- a/src/components/ProjectField/CountrySelect.tsx
+++ b/src/components/ProjectField/CountrySelect.tsx
@@ -8,7 +8,7 @@ import { Region, getRegionValue } from 'src/types/AcceleratorProject';
 import { ProjectFieldEditProps } from '.';
 import ProjectFieldSelect from './Select';
 
-export type Props = Omit<ProjectFieldEditProps, 'onChange'> & {
+type Props = Omit<ProjectFieldEditProps, 'onChange'> & {
   onChange: (countryCode?: string, region?: string) => void;
   region?: Region;
 };

--- a/src/components/ProjectField/FluidEntryWrapper.tsx
+++ b/src/components/ProjectField/FluidEntryWrapper.tsx
@@ -2,7 +2,7 @@ import React, { type JSX } from 'react';
 
 import { Grid, useTheme } from '@mui/material';
 
-export interface FluidWrapperProps {
+interface FluidWrapperProps {
   height?: string;
   children: JSX.Element;
 }

--- a/src/components/ProjectField/GridEntryWrapper.tsx
+++ b/src/components/ProjectField/GridEntryWrapper.tsx
@@ -2,7 +2,7 @@ import React, { type JSX } from 'react';
 
 import { Grid, SxProps, useTheme } from '@mui/material';
 
-export interface GridEntryWrapperProps {
+interface GridEntryWrapperProps {
   children: JSX.Element;
   height?: string;
   md?: number;

--- a/src/components/Tables/ClientSideFilterTable.tsx
+++ b/src/components/Tables/ClientSideFilterTable.tsx
@@ -19,8 +19,7 @@ import { parseSearchTerm } from 'src/utils/search';
 import { SearchAndSortFn, SearchOrderConfig, searchAndSort as genericSearchAndSort } from 'src/utils/searchAndSort';
 import useDebounce from 'src/utils/useDebounce';
 
-export interface ClientSideFilterTableProps
-  extends Omit<OrderPreservedTablePropsFull<TableRowType>, 'columns' | 'orderBy'> {
+interface ClientSideFilterTableProps extends Omit<OrderPreservedTablePropsFull<TableRowType>, 'columns' | 'orderBy'> {
   busy?: boolean;
   clientSortedFields?: string[];
   columns: TableColumnType[] | ((activeLocale: string | null) => TableColumnType[]);

--- a/src/components/Variables/VariableHistoryTable.tsx
+++ b/src/components/Variables/VariableHistoryTable.tsx
@@ -22,7 +22,7 @@ import {
 
 import VariableHistoryCellRenderer from './VariableHistoryCellRenderer';
 
-export type VariableChange = {
+type VariableChange = {
   field: 'feedback' | 'internalComment' | 'status' | 'value' | 'table' | 'image';
   previous: string;
   current: string;

--- a/src/components/common/Chart/ProgressChart.tsx
+++ b/src/components/common/Chart/ProgressChart.tsx
@@ -4,7 +4,7 @@ import { Box, LinearProgress, Typography, useTheme } from '@mui/material';
 
 import { MetricStatus } from 'src/types/AcceleratorReport';
 
-export type QuarterlyProgressItem = {
+type QuarterlyProgressItem = {
   quarter: string;
   value: number;
 };

--- a/src/components/common/FilterGroup/filters/FilterCountWeight.tsx
+++ b/src/components/common/FilterGroup/filters/FilterCountWeight.tsx
@@ -10,7 +10,7 @@ import strings from 'src/strings';
 import { AndNodePayload, FieldNodePayload, OrNodePayload, SearchNodePayload } from 'src/types/Search';
 import { weightUnits } from 'src/units';
 
-export type WEIGHT_QUANTITY_FIELDS = 'remainingQuantity' | 'totalQuantity' | 'withdrawalQuantity';
+type WEIGHT_QUANTITY_FIELDS = 'remainingQuantity' | 'totalQuantity' | 'withdrawalQuantity';
 const COUNT_WEIGHT_VALID_FIELDS: Record<WEIGHT_QUANTITY_FIELDS, string[]> = {
   remainingQuantity: ['remainingQuantity', 'remainingGrams', 'remainingUnits'],
   totalQuantity: ['totalQuantity', 'totalGrams', 'totalUnits'],

--- a/src/components/common/ImportModal.tsx
+++ b/src/components/common/ImportModal.tsx
@@ -17,12 +17,12 @@ import ProgressCircle from './ProgressCircle/ProgressCircle';
 import Button from './button/Button';
 import Icon from './icon/Icon';
 
-export type ImportProblemElement = {
+type ImportProblemElement = {
   problem: string;
   row: number;
 };
 
-export type ImportResponsePayload = Omit<ImportModuleResponsePayload, 'problems'> & {
+type ImportResponsePayload = Omit<ImportModuleResponsePayload, 'problems'> & {
   problems: ImportProblemElement[];
 };
 

--- a/src/components/common/MapLegend/index.tsx
+++ b/src/components/common/MapLegend/index.tsx
@@ -19,7 +19,7 @@ type MapLegendItem = {
   isDisabled?: boolean;
 };
 
-export type MapLegendGroup = {
+type MapLegendGroup = {
   title: string;
   items: MapLegendItem[];
   tooltip?: string;

--- a/src/components/common/MediaItem.tsx
+++ b/src/components/common/MediaItem.tsx
@@ -18,7 +18,7 @@ export type MediaFile = {
   isQuadrat: boolean;
 };
 
-export type MediaItemProps = {
+type MediaItemProps = {
   mediaFile: MediaFile;
   imageSrc: string;
   onDownload?: (fileId: number) => void;

--- a/src/components/common/PageCard.tsx
+++ b/src/components/common/PageCard.tsx
@@ -11,7 +11,7 @@ import Link from './Link';
 import Icon from './icon/Icon';
 import { IconName } from './icon/icons';
 
-export type LinkStyle = 'plain' | 'button-primary' | 'button-secondary';
+type LinkStyle = 'plain' | 'button-primary' | 'button-secondary';
 
 export interface PageCardProps {
   cardIsClickable?: boolean;

--- a/src/components/common/PlantingSiteMapLegend.tsx
+++ b/src/components/common/PlantingSiteMapLegend.tsx
@@ -6,13 +6,7 @@ import MapLegend from 'src/components/common/MapLegend';
 import strings from 'src/strings';
 import { getRgbaFromHex } from 'src/utils/color';
 
-export type PlantingSiteMapLegendOption =
-  | 'site'
-  | 'stratum'
-  | 'substratum'
-  | 'permanentPlot'
-  | 'temporaryPlot'
-  | 'adHocPlot';
+type PlantingSiteMapLegendOption = 'site' | 'stratum' | 'substratum' | 'permanentPlot' | 'temporaryPlot' | 'adHocPlot';
 
 export type PlantingSiteMapLegendProps = {
   options: PlantingSiteMapLegendOption[];

--- a/src/components/common/SDG/SdgIcon.tsx
+++ b/src/components/common/SDG/SdgIcon.tsx
@@ -2,7 +2,7 @@ import React, { type JSX } from 'react';
 
 import { SustainableDevelopmentGoal } from 'src/types/SeedFundReport';
 
-export type SdgIconProps = {
+type SdgIconProps = {
   goal: SustainableDevelopmentGoal;
   size?: number; // dimensions are width x height (where width = height = size)
 };

--- a/src/components/common/SearchFiltersWrapper/index.tsx
+++ b/src/components/common/SearchFiltersWrapper/index.tsx
@@ -14,7 +14,7 @@ import ExportTableComponent, { ExportTableProps } from './ExportTableComponent';
 import FeaturedFilters from './FeaturedFilters';
 import IconFilters from './IconFilters';
 
-export type SearchInputProps = {
+type SearchInputProps = {
   search: string;
   onSearch: (search: string) => void;
 };

--- a/src/components/common/SearchFiltersWrapperV2/index.tsx
+++ b/src/components/common/SearchFiltersWrapperV2/index.tsx
@@ -12,7 +12,7 @@ import useDeviceInfo from 'src/utils/useDeviceInfo';
 import FeaturedFilters from './FeaturedFilters';
 import IconFilters from './IconFilters';
 
-export type SearchInputProps = {
+type SearchInputProps = {
   search: string;
   searchPlaceholder?: string;
   onSearch: (search: string) => void;

--- a/src/components/common/SegmentControl/index.tsx
+++ b/src/components/common/SegmentControl/index.tsx
@@ -11,7 +11,7 @@ export type SegmentOption<T extends string> = {
   disabled?: boolean;
 };
 
-export type SegmentControlProps<T extends string> = {
+type SegmentControlProps<T extends string> = {
   segments: SegmentOption<T>[];
   selected: T;
   onChange: (id: T) => void;

--- a/src/components/common/SubLocations/index.tsx
+++ b/src/components/common/SubLocations/index.tsx
@@ -17,7 +17,7 @@ import { useNumberFormatter } from 'src/utils/useNumberFormatter';
 import AddEditSubLocationModal from './AddEditSubLocationModal';
 import SubLocationsCellRenderer from './SubLocationsCellRenderer';
 
-export type FacilityType = 'seedbank' | 'nursery';
+type FacilityType = 'seedbank' | 'nursery';
 
 export type SublocationsProps = {
   facilityType: FacilityType;

--- a/src/components/common/button/TooltipButton.tsx
+++ b/src/components/common/button/TooltipButton.tsx
@@ -5,7 +5,7 @@ import Tooltip from '@terraware/web-components/components/Tooltip/Tooltip';
 
 import Button from './Button';
 
-export type TooltipButtonProps = {
+type TooltipButtonProps = {
   tooltip?: string; // if not undefined, hovering over the button will show a tooltip
 };
 

--- a/src/components/common/table/index.tsx
+++ b/src/components/common/table/index.tsx
@@ -89,7 +89,7 @@ export function BaseTable<T extends TableRowType>(props: TableProps<T>): JSX.Ele
  * Also saves new columns order upon reordering, into user preferences (for the org scope).
  */
 
-export type OrderPreserveableTableProps = {
+type OrderPreserveableTableProps = {
   // user preference name to store the columns order
   columnsPreferenceName?: string;
   id: string;
@@ -161,7 +161,7 @@ function OrderPreserveableTable<T extends TableRowType>(
  * where client does not need extra semantics to filter columns.
  * Species table is an example where this won't work, uses its own setColumns implementation.
  */
-export type OrderPreservedTableProps = {
+type OrderPreservedTableProps = {
   id: string;
   columns: TableColumnType[] | (() => TableColumnType[]);
 };

--- a/src/components/common/table/useTableDensity.ts
+++ b/src/components/common/table/useTableDensity.ts
@@ -4,7 +4,7 @@ import { TableDensityType } from '@terraware/web-components/components/table/typ
 
 import { useUser } from 'src/providers';
 
-export type Response = {
+type Response = {
   tableDensity: TableDensityType;
   setTableDensity: (density: TableDensityType) => void;
 };

--- a/src/components/seeds/database/AccessionsBySpeciesTable.tsx
+++ b/src/components/seeds/database/AccessionsBySpeciesTable.tsx
@@ -25,7 +25,7 @@ import { SearchResponseElementWithId } from 'src/types/Search';
 import { makeCsv } from 'src/utils/csv';
 import { useNumberFormatter } from 'src/utils/useNumberFormatter';
 
-export type SpeciesRow = {
+type SpeciesRow = {
   id: string;
   speciesId: number | undefined;
   speciesName: string;

--- a/src/hooks/batches/useSaveBatch.ts
+++ b/src/hooks/batches/useSaveBatch.ts
@@ -14,7 +14,7 @@ import {
 import { useLazyGetAccessionForSpeciesQuery } from 'src/queries/search/accessions';
 import { Batch } from 'src/types/Batch';
 
-export type UpdateBatchRequestPayloadWithId = UpdateBatchRequestPayload & { id: number };
+type UpdateBatchRequestPayloadWithId = UpdateBatchRequestPayload & { id: number };
 
 export type SavableBatch = (CreateBatchRequestPayload | UpdateBatchRequestPayloadWithId) & Batch;
 

--- a/src/hooks/observations/index.ts
+++ b/src/hooks/observations/index.ts
@@ -1,6 +1,4 @@
 export { default as useListObservationResults } from './useListObservationResults';
 export { default as useGetOneObservationResults } from './useOneObservationResults';
-export type { ObservationDepth } from './types';
 export { default as useLatestSiteObservationResult } from './useLatestSiteObservationResult';
 export { default as useProjectSiteObservationResults } from './useProjectSiteObservationResults';
-export type { ProjectSiteObservationResult } from './useProjectSiteObservationResults';

--- a/src/hooks/observations/useProjectSiteObservationResults.ts
+++ b/src/hooks/observations/useProjectSiteObservationResults.ts
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { ObservationResultsPayload, useLazyGetObservationResultsQuery } from 'src/queries/generated/observations';
 import { PlantingSitePayload, useLazyListPlantingSitesQuery } from 'src/queries/generated/plantingSites';
 
-export type ProjectSiteObservationResult = {
+type ProjectSiteObservationResult = {
   site: PlantingSitePayload;
   result?: ObservationResultsPayload;
 };

--- a/src/hooks/useUpdateCurrentUser.ts
+++ b/src/hooks/useUpdateCurrentUser.ts
@@ -8,7 +8,7 @@ import { User } from 'src/types/User';
 
 import useUpdateUserPreferences from './useUpdateUserPreferences';
 
-export type UpdateCurrentUserOptions = {
+type UpdateCurrentUserOptions = {
   skipAcknowledgeTimeZone?: boolean;
 };
 

--- a/src/knowledgeBaseLinks.ts
+++ b/src/knowledgeBaseLinks.ts
@@ -1,7 +1,7 @@
 import { useLocalization } from 'src/providers';
 import { SupportedLocaleId } from 'src/strings/locales';
 
-export type TerrawarePath =
+type TerrawarePath =
   | '/home'
   | '/myaccount'
   | '/myaccount/edit'

--- a/src/providers/AcceleratorProject/AcceleratorProjectSpeciesProvider.tsx
+++ b/src/providers/AcceleratorProject/AcceleratorProjectSpeciesProvider.tsx
@@ -23,7 +23,7 @@ import { useDeliverableData } from '../Deliverable/DeliverableContext';
 import { useProjectData } from '../Project/ProjectContext';
 import { AcceleratorProjectSpeciesContext, AcceleratorProjectSpeciesData } from './AcceleratorProjectSpeciesContext';
 
-export type Props = {
+type Props = {
   children: React.ReactNode;
 };
 

--- a/src/providers/Application/index.tsx
+++ b/src/providers/Application/index.tsx
@@ -18,7 +18,7 @@ import { isAllowed } from 'src/utils/acl';
 
 import { ApplicationContext, ApplicationData } from './Context';
 
-export type Props = {
+type Props = {
   children?: ReactNode;
 };
 

--- a/src/providers/Deliverable/DeliverableProvider.tsx
+++ b/src/providers/Deliverable/DeliverableProvider.tsx
@@ -5,7 +5,7 @@ import useFetchDeliverable from 'src/components/DeliverableView/useFetchDelivera
 
 import { DeliverableContext, DeliverableData } from './DeliverableContext';
 
-export type Props = {
+type Props = {
   children: React.ReactNode;
 };
 

--- a/src/providers/DocumentProducer/Provider.tsx
+++ b/src/providers/DocumentProducer/Provider.tsx
@@ -33,7 +33,7 @@ import {
 import { DocumentProducerContext, DocumentProducerData } from './Context';
 import { getContainingSections } from './util';
 
-export type Props = {
+type Props = {
   children: React.ReactNode;
 };
 

--- a/src/providers/Participant/ParticipantProvider.tsx
+++ b/src/providers/Participant/ParticipantProvider.tsx
@@ -10,7 +10,7 @@ import { Project } from 'src/types/Project';
 
 import { ParticipantContext, ParticipantData } from './ParticipantContext';
 
-export type Props = {
+type Props = {
   children: React.ReactNode;
 };
 

--- a/src/providers/Project/ProjectProvider.tsx
+++ b/src/providers/Project/ProjectProvider.tsx
@@ -8,7 +8,7 @@ import { useGetProjectQuery } from 'src/queries/generated/projects';
 
 import { ProjectContext, ProjectData } from './ProjectContext';
 
-export type Props = {
+type Props = {
   children: React.ReactNode;
 };
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,7 +4,7 @@ import UserFundingEntityProvider from './UserFundingEntityProvider';
 import UserProvider from './UserProvider';
 import { useLocalization, useOrganization, useTimeZones, useUser, useUserFundingEntity } from './hooks';
 
-export type { ProvidedOrganizationData, ProvidedLocalizationData, ProvidedUserData } from './DataTypes';
+export type { ProvidedLocalizationData } from './DataTypes';
 
 export {
   useUserFundingEntity,

--- a/src/queries/acceleratorReports/photos.ts
+++ b/src/queries/acceleratorReports/photos.ts
@@ -3,7 +3,7 @@ import { AcceleratorReportPhoto, NewAcceleratorReportPhoto } from 'src/types/Acc
 import { baseApi as api } from '../baseApi';
 import { acceleratorReportMediaTag, acceleratorReportTag } from '../tags';
 
-export type BatchPhotosRequest = {
+type BatchPhotosRequest = {
   projectId: number;
   reportId: number;
   photosToUpdate?: AcceleratorReportPhoto[];
@@ -11,7 +11,7 @@ export type BatchPhotosRequest = {
   fileIdsToDelete?: number[];
 };
 
-export type BatchPhotosResponse = {
+type BatchPhotosResponse = {
   uploadedFileIds?: number[];
 };
 

--- a/src/queries/appVersion/appVersion.ts
+++ b/src/queries/appVersion/appVersion.ts
@@ -1,7 +1,7 @@
 import { baseApi as api } from '../baseApi';
 
-export type GetAppVersionApiResponse = string;
-export type GetAppVersionApiArg = void;
+type GetAppVersionApiResponse = string;
+type GetAppVersionApiArg = void;
 
 const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({

--- a/src/queries/exports/observations.ts
+++ b/src/queries/exports/observations.ts
@@ -212,7 +212,7 @@ const injectedRtkApi = api.injectEndpoints({
   }),
 });
 
-export type ExportBiomassObservationsApiArg = {
+type ExportBiomassObservationsApiArg = {
   organizationId: number;
   plantingSiteId?: number;
 };

--- a/src/queries/plantingSeasons/events.ts
+++ b/src/queries/plantingSeasons/events.ts
@@ -6,14 +6,14 @@ import {
 } from '../generated/events';
 import { QueryTagTypes } from '../tags';
 
-export type EventSubject = NonNullable<ListEventLogEntriesRequestPayload['subjects']>[number];
+type EventSubject = NonNullable<ListEventLogEntriesRequestPayload['subjects']>[number];
 
-export type ListPlantingSeasonEventsArgs = {
+type ListPlantingSeasonEventsArgs = {
   organizationId: number;
   plantingSeasonId: number;
 };
 
-export type ListInventoryPlanningEventsArgs = {
+type ListInventoryPlanningEventsArgs = {
   organizationId: number;
   plantingSeasonId?: number;
   plantingSiteId?: number;

--- a/src/queries/search/accessions.ts
+++ b/src/queries/search/accessions.ts
@@ -23,20 +23,20 @@ export type SearchResponseAccession = {
   state: AccessionState;
 };
 
-export type SearchAccessionsApiArg = {
+type SearchAccessionsApiArg = {
   organizationId: number;
   fields: string[];
   searchCriteria?: SearchCriteria;
   sortOrder?: SearchSortOrder;
 };
 
-export type GetCollectorsApiArg = number;
-export type GetCollectionSiteNamesApiArg = number;
-export type GetAccessionForSpeciesApiArg = {
+type GetCollectorsApiArg = number;
+type GetCollectionSiteNamesApiArg = number;
+type GetAccessionForSpeciesApiArg = {
   organizationId: number;
   speciesId: number;
 };
-export type GetPendingAccessionsApiArg = number;
+type GetPendingAccessionsApiArg = number;
 
 type SearchResponse<T> = {
   results: T[];

--- a/src/queries/search/batches.ts
+++ b/src/queries/search/batches.ts
@@ -70,7 +70,7 @@ export type NurseryBatchesSearchResponseElement = SearchResponseElement & {
   project_name?: string;
 };
 
-export type ListBatchesByIdsApiArg = {
+type ListBatchesByIdsApiArg = {
   organizationId: number;
   batchIds: number[];
 };
@@ -85,19 +85,19 @@ export type ListAllBatchesApiArg = {
   query?: string;
 };
 
-export type ListBatchIdsForSpeciesApiArg = {
+type ListBatchIdsForSpeciesApiArg = {
   organizationId: number;
   speciesIds: number[];
 };
 
-export type ListBatchesForSpeciesApiArg = {
+type ListBatchesForSpeciesApiArg = {
   organizationId: number;
   speciesId: number;
   searchFields?: SearchNodePayload[];
   sortOrder?: SearchSortOrder;
 };
 
-export type ListBatchesForNurseryApiArg = {
+type ListBatchesForNurseryApiArg = {
   organizationId: number;
   nurseryId: number;
   searchFields?: SearchNodePayload[];

--- a/src/queries/search/batchesForWithdraw.ts
+++ b/src/queries/search/batchesForWithdraw.ts
@@ -14,7 +14,7 @@ export type BatchForWithdraw = {
   projectName?: string;
 };
 
-export type ListBatchesForWithdrawArgs = {
+type ListBatchesForWithdrawArgs = {
   organizationId: number;
   facilityId?: number;
   speciesIds: number[];

--- a/src/queries/search/draftPlantingSites.ts
+++ b/src/queries/search/draftPlantingSites.ts
@@ -105,7 +105,7 @@ type ListDraftPlantingSiteSummariesApiResponse = {
   results: DraftPlantingSiteSummaryApiResult[];
 };
 
-export type SearchDraftPlantingSiteSummariesApiArgs = {
+type SearchDraftPlantingSiteSummariesApiArgs = {
   organizationId: number;
   projectIds?: number[];
   searchOrder?: SearchSortOrderElement[];

--- a/src/queries/search/inventoryPlanning.ts
+++ b/src/queries/search/inventoryPlanning.ts
@@ -1,7 +1,7 @@
 import { baseApi as api } from '../baseApi';
 import { QueryTagTypes } from '../tags';
 
-export type InventoryPlanningArgs = {
+type InventoryPlanningArgs = {
   organizationId: number;
   plantingSiteId?: number;
   plantingSeasonId?: number;

--- a/src/queries/search/nurseries.ts
+++ b/src/queries/search/nurseries.ts
@@ -443,7 +443,7 @@ type SearchNurseryWithdrawalFilterOptionsApiResponse = {
   };
 };
 
-export type NurseryWithdrawalFilterOptions = {
+type NurseryWithdrawalFilterOptions = {
   nurseryNames: string[];
   destinationNames: string[];
   stratumNames: string[];
@@ -451,7 +451,7 @@ export type NurseryWithdrawalFilterOptions = {
   speciesNames: string[];
 };
 
-export type SearchNurseryWithdrawalPhotosApiArgs = {
+type SearchNurseryWithdrawalPhotosApiArgs = {
   plantingSiteId: number;
 };
 

--- a/src/queries/search/observations.ts
+++ b/src/queries/search/observations.ts
@@ -65,7 +65,7 @@ const injectedRtkApi = api.injectEndpoints({
   }),
 });
 
-export type CountObservationsApiArgs = {
+type CountObservationsApiArgs = {
   organizationId: number;
   plantingSiteId?: number;
   observationType?: 'Monitoring' | 'Biomass Measurements';

--- a/src/queries/search/plantingDateRequests.ts
+++ b/src/queries/search/plantingDateRequests.ts
@@ -17,7 +17,7 @@ export type PlantingDateRequestSubstratumSpecies = {
   withdrawnQuantity: number;
 };
 
-export type PlantingDateRequestSubstratum = {
+type PlantingDateRequestSubstratum = {
   substratumId: number;
   substratumName: string;
   stratumId: number;
@@ -41,14 +41,14 @@ export type PlantingDateRequestRow = {
   substrata: PlantingDateRequestSubstratum[];
 };
 
-export type ListPlantingDateRequestsArgs = {
+type ListPlantingDateRequestsArgs = {
   organizationId: number;
   plantingSiteId?: number;
   plantingSeasonId?: number;
   speciesId?: number;
 };
 
-export type ScheduledPlantingDateWithdrawalsArgs = {
+type ScheduledPlantingDateWithdrawalsArgs = {
   plantingSeasonId: number;
   date: string;
 };

--- a/src/queries/search/plantingSeasons.ts
+++ b/src/queries/search/plantingSeasons.ts
@@ -123,7 +123,7 @@ type PlantingSeasonSummaryApiResponse = {
   results: PlantingSeasonSummaryApiResult[];
 };
 
-export type PlantingSeasonSpeciesSummaryRow = {
+type PlantingSeasonSpeciesSummaryRow = {
   speciesId: number;
   scientificName?: string;
   commonName?: string;

--- a/src/queries/search/plantingSites.ts
+++ b/src/queries/search/plantingSites.ts
@@ -220,7 +220,7 @@ type ListPlantingSiteProjectsApiResult = {
   };
 };
 
-export type SearchPlantingSiteSummariesApiArgs = {
+type SearchPlantingSiteSummariesApiArgs = {
   organizationId: number;
   projectIds?: number[];
   searchOrder?: SearchSortOrderElement[];
@@ -254,7 +254,7 @@ export type MonitoringPlotSearchResult = {
   plotNumber: string;
 };
 
-export type SearchObservationDatesApiArgs = {
+type SearchObservationDatesApiArgs = {
   plantingSiteId: number;
   state?: ('Upcoming' | 'InProgress' | 'Completed' | 'Overdue' | 'Abandoned')[];
 };
@@ -270,7 +270,7 @@ type SearchObservationDatesApiResult = {
   endDate: string;
 };
 
-export type ObservationDatesSearchResult = {
+type ObservationDatesSearchResult = {
   id: number;
   completedTime: string;
   startDate: string;

--- a/src/queries/search/plantings.ts
+++ b/src/queries/search/plantings.ts
@@ -75,14 +75,14 @@ type SearchPlantingsApiResponse = {
   results: PlantingsApiResult[];
 };
 
-export type PlantingSpecies = {
+type PlantingSpecies = {
   conservationCategory: string;
   rare: boolean;
   scientificName: string;
   speciesId: number;
 };
 
-export type Plantings = {
+type Plantings = {
   id: number;
   createdTime: string;
   deliveryId: number;

--- a/src/queries/search/projectModules.ts
+++ b/src/queries/search/projectModules.ts
@@ -51,14 +51,14 @@ type GetModuleProjectsApiResponse = {
   results: ModulesProjectApiResult[];
 };
 
-export type ModuleProject = {
+type ModuleProject = {
   projectId: number;
   projectName: string;
   startDate: string;
   endDate: string;
 };
 
-export type GetModuleProjectsApiArg = {
+type GetModuleProjectsApiArg = {
   moduleId: number | string;
   locale?: string;
 };

--- a/src/queries/search/speciesProjects.ts
+++ b/src/queries/search/speciesProjects.ts
@@ -1,7 +1,7 @@
 import { baseApi as api } from '../baseApi';
 import { QueryTagTypes } from '../tags';
 
-export type ListSpeciesProjectNamesApiArg = {
+type ListSpeciesProjectNamesApiArg = {
   organizationId: number;
   speciesId: number;
 };

--- a/src/queries/search/speciesTargetsForSubstratum.ts
+++ b/src/queries/search/speciesTargetsForSubstratum.ts
@@ -10,7 +10,7 @@ export type SpeciesTargetForSubstratum = {
   notYetWithdrawn: number;
 };
 
-export type SpeciesTargetsForSubstratumArgs = {
+type SpeciesTargetsForSubstratumArgs = {
   plantingSeasonId: number;
   substratumId: number;
 };

--- a/src/queries/search/strata.ts
+++ b/src/queries/search/strata.ts
@@ -118,7 +118,7 @@ const injectedRtkApi = api.injectEndpoints({
   }),
 });
 
-export type ListStrataArgs = {
+type ListStrataArgs = {
   organizationId: number;
   plantingSiteId?: number;
 };
@@ -133,7 +133,7 @@ type ListStrataApiResponse = {
   results: ListStrataApiResult[];
 };
 
-export type StratumPayload = {
+type StratumPayload = {
   id: number;
   name: string;
   plantingSiteId: number;
@@ -150,7 +150,7 @@ type GetStratumPlantDensityTrendApiResponse = {
   results: StratumPlantDensityTrendApiResult[];
 };
 
-export type StratumPlantDensity = {
+type StratumPlantDensity = {
   observationId: number;
   completedTime: string;
   plantDensity: number;
@@ -168,7 +168,7 @@ type GetStratumSurvivalRateTrendApiResponse = {
   results: StratumSurvivalRateTrendApiResult[];
 };
 
-export type StratumSurvivalRate = {
+type StratumSurvivalRate = {
   observationId: number;
   completedTime: string;
   survivalRate: number;

--- a/src/queries/search/t0.ts
+++ b/src/queries/search/t0.ts
@@ -80,14 +80,14 @@ type GetPlotsWithObservationsApiResponse = {
   results: PlotsWithObservationsApiResult[];
 };
 
-export type PlotT0Observation = {
+type PlotT0Observation = {
   observation_startDate: string;
   observation_completedTime: string;
   observation_id: string;
   isPermanent: string;
 };
 
-export type PlotsWithObservations = {
+type PlotsWithObservations = {
   id: number;
   name: string;
   substratum_name: string;

--- a/src/queries/search/virtualWalkthroughs.ts
+++ b/src/queries/search/virtualWalkthroughs.ts
@@ -71,7 +71,7 @@ const injectedRtkApi = api.injectEndpoints({
   }),
 });
 
-export type SplatStatus = 'Preparing' | 'Ready' | 'Errored';
+type SplatStatus = 'Preparing' | 'Ready' | 'Errored';
 
 type SearchVirtualWalkthroughApiResult = {
   fileId: string;

--- a/src/queries/seedFundReports/files.ts
+++ b/src/queries/seedFundReports/files.ts
@@ -1,13 +1,13 @@
 import { baseApi as api } from '../baseApi';
 import { QueryTagTypes } from '../tags';
 
-export type BatchSeedFundReportFilesRequest = {
+type BatchSeedFundReportFilesRequest = {
   reportId: number;
   filesToUpload?: File[];
   fileIdsToDelete?: number[];
 };
 
-export type BatchSeedFundReportFilesResponse = {
+type BatchSeedFundReportFilesResponse = {
   uploadedFileIds?: number[];
 };
 

--- a/src/queries/seedFundReports/photos.ts
+++ b/src/queries/seedFundReports/photos.ts
@@ -1,13 +1,13 @@
 import { baseApi as api } from '../baseApi';
 import { QueryTagTypes } from '../tags';
 
-export type BatchSeedFundReportPhotosRequest = {
+type BatchSeedFundReportPhotosRequest = {
   reportId: number;
   photosToUpload?: File[];
   photoIdsToDelete?: number[];
 };
 
-export type BatchSeedFundReportPhotosResponse = {
+type BatchSeedFundReportPhotosResponse = {
   uploadedFileIds?: number[];
 };
 

--- a/src/redux/features/documentProducer/documentTemplates/documentTemplatesSlice.ts
+++ b/src/redux/features/documentProducer/documentTemplates/documentTemplatesSlice.ts
@@ -9,7 +9,7 @@ export type DocumentTemplatesData = {
 };
 
 // Define the initial state
-export type DocumentTemplatesState = {
+type DocumentTemplatesState = {
   listDocumentTemplates: DocumentTemplatesData;
 };
 

--- a/src/redux/features/message/messageSlice.ts
+++ b/src/redux/features/message/messageSlice.ts
@@ -1,6 +1,6 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-export type Message = {
+type Message = {
   key: string;
   data: any;
 };

--- a/src/redux/features/organizationUser/organizationUsersSlice.ts
+++ b/src/redux/features/organizationUser/organizationUsersSlice.ts
@@ -5,7 +5,7 @@ import { OrganizationUser } from 'src/types/User';
 
 import { requestListOrganizationUsers } from './organizationUsersAsyncThunks';
 
-export type OrganizationUsersData = {
+type OrganizationUsersData = {
   users: OrganizationUser[];
 };
 

--- a/src/redux/features/tracking/trackingThunks.ts
+++ b/src/redux/features/tracking/trackingThunks.ts
@@ -9,7 +9,7 @@ import { PlantingSiteSearchResult } from 'src/types/Tracking';
 
 import { setPlantingSiteAction, setPlantingSitesAction, setPlantingSitesSearchResultsAction } from './trackingSlice';
 
-export type PlotT0Observation = {
+type PlotT0Observation = {
   observation_startDate: string;
   observation_completedTime: string;
   observation_id: string;

--- a/src/redux/hooks/useMultiSelectorProcessor/index.ts
+++ b/src/redux/hooks/useMultiSelectorProcessor/index.ts
@@ -10,7 +10,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 import { createCombinedSelector, getCombinedStatus } from './util';
 
 // selector processor callbacks for easier use
-export type ProcessorCallbacksProps = {
+type ProcessorCallbacksProps = {
   handleError?: boolean; // whether to pop up a toast error if the selector has an error
   dispatched?: boolean; // whether an action has been dispatched for this selector, defaults to true
   onData?: React.Dispatch<React.SetStateAction<any>>;
@@ -20,7 +20,7 @@ export type ProcessorCallbacksProps = {
   onSuccess?: (data?: any) => void;
 };
 
-export type AsyncRequestSelector = (state: RootState) => AsyncRequest | undefined;
+type AsyncRequestSelector = (state: RootState) => AsyncRequest | undefined;
 
 export type SelectorIdentifier = string;
 

--- a/src/redux/hooks/useWorkflowSuccess.ts
+++ b/src/redux/hooks/useWorkflowSuccess.ts
@@ -5,7 +5,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 
 import { Statuses } from '../features/asyncUtils';
 
-export type SelectedState = {
+type SelectedState = {
   status: Statuses;
   error?: string;
   updatedAt?: number;

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/AcceleratorProjectProvider.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/AcceleratorProjectProvider.tsx
@@ -15,7 +15,7 @@ import { getUserDisplayName } from 'src/utils/user';
 
 import { AcceleratorProjectContext, AcceleratorProjectData } from './AcceleratorProjectContext';
 
-export type Props = {
+type Props = {
   children: React.ReactNode;
 };
 

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/Metadata.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/Metadata.tsx
@@ -10,7 +10,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 
 import InternalComment from './InternalComment';
 
-export type MetadataProps = {
+type MetadataProps = {
   report: AcceleratorReportPayload;
   projectId: number;
 };

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportInternalComment.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportInternalComment.tsx
@@ -9,7 +9,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 
 import InternalComment from './InternalComment';
 
-export type ReportInternalCommentProps = {
+type ReportInternalCommentProps = {
   projectId: number;
   report: AcceleratorReportPayload;
 };

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportOptionsMenu.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportOptionsMenu.tsx
@@ -10,7 +10,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 
 import PublishModal from './PublishModal';
 
-export type ReportOptionsMenuProps = {
+type ReportOptionsMenuProps = {
   reportId: number;
 };
 

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportReviewButtons.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportReviewButtons.tsx
@@ -13,7 +13,7 @@ import RejectDialog from './RejectDialog';
 
 const NO_WRAP = { '&.button': { minWidth: 'auto', whiteSpace: 'nowrap' } };
 
-export type ReportReviewButtonsProps = {
+type ReportReviewButtonsProps = {
   reportId: number;
 };
 

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportTabV2.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportTabV2.tsx
@@ -25,7 +25,7 @@ import { useListPublishedReportsQuery } from 'src/queries/generated/publishedRep
 
 import ReportInternalComment from './ReportInternalComment';
 
-export type ReportTabV2Props = {
+type ReportTabV2Props = {
   active?: boolean;
 };
 

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportsView.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportsView.tsx
@@ -21,7 +21,7 @@ import ReportReviewButtons from './ReportReviewButtons';
 import ReportTabV2 from './ReportTabV2';
 import ReportsSettings from './ReportsSettings';
 
-export type ReportsViewProps = {
+type ReportsViewProps = {
   tab?: string;
 };
 

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/Scoring/ScoringWrapper.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/Scoring/ScoringWrapper.tsx
@@ -13,7 +13,7 @@ import strings from 'src/strings';
 
 import { useAcceleratorProjectData } from '../AcceleratorProjectContext';
 
-export type Props = {
+type Props = {
   children: React.ReactNode;
   isForm?: boolean;
   isLoading?: boolean;

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/Voting/VoteBadge.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/Voting/VoteBadge.tsx
@@ -8,7 +8,7 @@ import { useLocalization } from 'src/providers';
 import strings from 'src/strings';
 import { VoteOption } from 'src/types/ProjectVotes';
 
-export type VoteBadgeProps = {
+type VoteBadgeProps = {
   vote?: VoteOption;
 };
 

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/Voting/VoteRowGrid.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/Voting/VoteRowGrid.tsx
@@ -4,7 +4,7 @@ import { Grid, useTheme } from '@mui/material';
 
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 
-export type Props = {
+type Props = {
   leftChild?: React.ReactNode;
   rightChild?: React.ReactNode;
   style?: Record<string, string | number>;

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/Voting/VotingWrapper.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/Voting/VotingWrapper.tsx
@@ -18,7 +18,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 import VoteBadge from './VoteBadge';
 import VoteRowGrid from './VoteRowGrid';
 
-export type Props = {
+type Props = {
   children: React.ReactNode;
   isForm?: boolean;
   rightComponent?: React.ReactNode;

--- a/src/scenes/AcceleratorRouter/Applications/ApplicationListTab.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationListTab.tsx
@@ -17,7 +17,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 
 import ApplicationCellRenderer from './ApplicationCellRenderer';
 
-export type ApplicationRow = {
+type ApplicationRow = {
   countryCode?: string;
   countryName?: string;
   id: number;

--- a/src/scenes/AcceleratorRouter/Applications/ApplicationReviewModal.tsx
+++ b/src/scenes/AcceleratorRouter/Applications/ApplicationReviewModal.tsx
@@ -21,7 +21,7 @@ import {
 } from 'src/types/Application';
 import useForm from 'src/utils/useForm';
 
-export type ApplicationReviewModalProps = {
+type ApplicationReviewModalProps = {
   open: boolean;
   onClose: () => void;
   onSuccess: () => void;

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentActions.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentActions.tsx
@@ -12,7 +12,7 @@ import Preview from '../PreviewView';
 import SaveVersion from './SaveVersion';
 import UpdateMetadata from './UpdateMetadata';
 
-export type DocumentActionsProps = {
+type DocumentActionsProps = {
   document: Document;
   onDocumentUpdate: () => void;
 };

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentMetadata.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentMetadata.tsx
@@ -10,7 +10,7 @@ import { DocumentTemplate } from 'src/types/documentProducer/DocumentTemplate';
 import { getDateTimeDisplayValue } from 'src/utils/dateFormatter';
 import { getUserDisplayName } from 'src/utils/user';
 
-export type DocumentMetadataProps = {
+type DocumentMetadataProps = {
   document: Document;
   documentTemplate: DocumentTemplate;
 };

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/DocumentVariablesTab.tsx
@@ -93,7 +93,7 @@ const tableCellRenderer = (props: RendererProps<any>): JSX.Element => {
   return <CellRenderer {...props} />;
 };
 
-export type DocumentVariablesProps = {
+type DocumentVariablesProps = {
   projectId?: number;
 };
 

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/SaveVersion.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/SaveVersion.tsx
@@ -9,7 +9,7 @@ import { requestSaveVersion } from 'src/redux/features/documentProducer/document
 import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 
-export type SaveVersionProps = {
+type SaveVersionProps = {
   docId: number;
   onFinish: (saved: boolean) => void;
 };

--- a/src/scenes/AcceleratorRouter/Documents/DocumentView/UpdateMetadata.tsx
+++ b/src/scenes/AcceleratorRouter/Documents/DocumentView/UpdateMetadata.tsx
@@ -10,7 +10,7 @@ import { useAppDispatch, useAppSelector } from 'src/redux/store';
 import strings from 'src/strings';
 import { Document } from 'src/types/documentProducer/Document';
 
-export type UpdateMetadataProps = {
+type UpdateMetadataProps = {
   doc: Document;
   onFinish: (saved: boolean) => void;
 };

--- a/src/scenes/AcceleratorRouter/FundingEntities/DeleteFundingEntityModal.tsx
+++ b/src/scenes/AcceleratorRouter/FundingEntities/DeleteFundingEntityModal.tsx
@@ -11,7 +11,7 @@ import strings from 'src/strings';
 import { FundingEntity } from 'src/types/FundingEntity';
 import useSnackbar from 'src/utils/useSnackbar';
 
-export interface DeleteFundingEntityModalProps {
+interface DeleteFundingEntityModalProps {
   open: boolean;
   fundingEntity: FundingEntity;
   onClose: () => void;

--- a/src/scenes/ApplicationRouter/NewApplicationModal.tsx
+++ b/src/scenes/ApplicationRouter/NewApplicationModal.tsx
@@ -31,7 +31,7 @@ type NewApplication = {
   projectName?: string;
 };
 
-export type NewApplicationModalProps = {
+type NewApplicationModalProps = {
   open: boolean;
   onClose: () => void;
 };

--- a/src/scenes/FunderReport/FunderReportTabV2.tsx
+++ b/src/scenes/FunderReport/FunderReportTabV2.tsx
@@ -16,7 +16,7 @@ import Card from 'src/components/common/Card';
 import { useListPublishedReportsQuery } from 'src/queries/generated/publishedReports';
 import useQuery from 'src/utils/useQuery';
 
-export type FunderReportTabV2Props = {
+type FunderReportTabV2Props = {
   selectedProjectId: number;
 };
 

--- a/src/scenes/Home/ParticipantHomeView/ToDoProvider/index.tsx
+++ b/src/scenes/Home/ParticipantHomeView/ToDoProvider/index.tsx
@@ -16,7 +16,7 @@ import { ToDoItem, compareToDoItems } from 'src/types/ProjectToDo';
 
 import { ToDoContext, ToDoData } from './Context';
 
-export type Props = {
+type Props = {
   children?: React.ReactNode;
 };
 

--- a/src/scenes/InventoryRouter/BatchWithdrawModal/AddPhotosStep.tsx
+++ b/src/scenes/InventoryRouter/BatchWithdrawModal/AddPhotosStep.tsx
@@ -4,7 +4,7 @@ import { Box } from '@mui/material';
 
 import SelectPhotos from 'src/components/common/Photos/SelectPhotos';
 
-export type AddPhotosStepProps = {
+type AddPhotosStepProps = {
   photos: File[];
   onPhotosChanged: (files: File[]) => void;
 };

--- a/src/scenes/InventoryRouter/BatchWithdrawModal/QuantitiesStep.tsx
+++ b/src/scenes/InventoryRouter/BatchWithdrawModal/QuantitiesStep.tsx
@@ -9,7 +9,7 @@ import SeedlingBatchBox from './SeedlingBatchBox';
 import SpeciesTargetsTable from './SpeciesTargetsTable';
 import { BatchInfo, BatchWithdrawDraft, BatchWithdrawQuantities } from './types';
 
-export type QuantitiesStepProps = {
+type QuantitiesStepProps = {
   batches: BatchInfo[];
   draft: BatchWithdrawDraft;
   speciesTargets?: SpeciesTargetForSubstratum[];

--- a/src/scenes/InventoryRouter/BatchWithdrawModal/SeedlingBatchBox.tsx
+++ b/src/scenes/InventoryRouter/BatchWithdrawModal/SeedlingBatchBox.tsx
@@ -9,7 +9,7 @@ import { useLocalization } from 'src/providers';
 
 import { BatchInfo, BatchWithdrawQuantities } from './types';
 
-export type SeedlingBatchBoxProps = {
+type SeedlingBatchBoxProps = {
   speciesName: string;
   batches: BatchInfo[];
   isPlanting: boolean;

--- a/src/scenes/InventoryRouter/BatchWithdrawModal/SpeciesTargetsTable.tsx
+++ b/src/scenes/InventoryRouter/BatchWithdrawModal/SpeciesTargetsTable.tsx
@@ -5,7 +5,7 @@ import { Box, Typography, useTheme } from '@mui/material';
 import { useLocalization } from 'src/providers';
 import { SpeciesTargetForSubstratum } from 'src/queries/search/speciesTargetsForSubstratum';
 
-export type SpeciesTargetsTableProps = {
+type SpeciesTargetsTableProps = {
   rows: SpeciesTargetForSubstratum[];
 };
 

--- a/src/scenes/InventoryRouter/InventoryV2View.tsx
+++ b/src/scenes/InventoryRouter/InventoryV2View.tsx
@@ -32,11 +32,11 @@ export const InventoryListTypes: Record<string, string> = {
 type InventoryListTypeKeys = keyof typeof InventoryListTypes;
 export type InventoryListType = (typeof InventoryListTypes)[InventoryListTypeKeys];
 
-export type FacilityName = {
+type FacilityName = {
   facility_name: string;
 };
 
-export type InventoryResult = {
+type InventoryResult = {
   facility_id: string;
   species_id: string;
   species_scientificName: string;

--- a/src/scenes/ModulesRouter/CurrentTimeline.tsx
+++ b/src/scenes/ModulesRouter/CurrentTimeline.tsx
@@ -5,7 +5,7 @@ import { useDeviceInfo } from '@terraware/web-components/utils';
 
 import strings from 'src/strings';
 
-export type TimelineStep = {
+type TimelineStep = {
   name: string;
   description: string;
 };

--- a/src/scenes/MyAccountRouter/index.tsx
+++ b/src/scenes/MyAccountRouter/index.tsx
@@ -4,7 +4,7 @@ import { Route, Routes } from 'react-router';
 import { useOrganization } from 'src/providers';
 import MyAccountPage from 'src/scenes/MyAccountRouter/MyAccountPage';
 
-export interface Props {
+interface Props {
   className?: string;
   hasNav?: boolean;
 }

--- a/src/scenes/NurseryRouter/NurserySummaryRow.tsx
+++ b/src/scenes/NurseryRouter/NurserySummaryRow.tsx
@@ -5,7 +5,7 @@ import { Box, Typography, useTheme } from '@mui/material';
 import { useLocalization } from 'src/providers';
 import { PlantingDateRequestSpeciesDetail } from 'src/queries/search/plantingDateRequests';
 
-export type NurserySummaryRowProps = {
+type NurserySummaryRowProps = {
   species: PlantingDateRequestSpeciesDetail;
   ready: number;
   index: number;

--- a/src/scenes/NurseryRouter/ReassignmentRenderer.tsx
+++ b/src/scenes/NurseryRouter/ReassignmentRenderer.tsx
@@ -10,12 +10,12 @@ import { StratumResponsePayload, SubstratumResponsePayload } from 'src/queries/g
 import strings from 'src/strings';
 import { NumberFormatter } from 'src/types/Number';
 
-export type SubstratumInfo = {
+type SubstratumInfo = {
   id: number;
   name: string;
 };
 
-export type StratumInfo = {
+type StratumInfo = {
   id: number;
   name: string;
   substrata: SubstratumInfo[];

--- a/src/scenes/NurseryRouter/RequestSpeciesBox.tsx
+++ b/src/scenes/NurseryRouter/RequestSpeciesBox.tsx
@@ -11,7 +11,7 @@ const batchGridTemplateColumns = '2fr 1fr 1fr 1fr';
 const withdrawColumnSx = { gridColumn: 4 };
 const withdrawInputSx = { gridColumn: 4, justifySelf: 'end', width: '100px' };
 
-export type RequestSpeciesBoxProps = {
+type RequestSpeciesBoxProps = {
   species: PlantingDateRequestSubstratumSpecies;
   substratumId: number;
   batches: BatchForWithdraw[];

--- a/src/scenes/ObservationsRouterV2/ListView/PlantMonitoringList.tsx
+++ b/src/scenes/ObservationsRouterV2/ListView/PlantMonitoringList.tsx
@@ -117,7 +117,7 @@ const PlantMonitoringActionsMenuContent = ({ row }: { row: PlantMonitoringRow })
   );
 };
 
-export type PlantMonitoringListProps = {
+type PlantMonitoringListProps = {
   plantingSiteId?: PlantingSiteId;
 };
 

--- a/src/scenes/ObservationsRouterV2/SingleView/MatchSpeciesModal.tsx
+++ b/src/scenes/ObservationsRouterV2/SingleView/MatchSpeciesModal.tsx
@@ -82,7 +82,7 @@ export default function MatchSpeciesModal(props: MatchSpeciesModalProps): JSX.El
   );
 }
 
-export interface MatchSpeciesRowProps {
+interface MatchSpeciesRowProps {
   matchSpeciesPayload: MergeOtherSpeciesPayloadPartial;
   setRecords: React.Dispatch<
     React.SetStateAction<

--- a/src/scenes/PlantingPlansRouter/PlantingPlanDensitySection.tsx
+++ b/src/scenes/PlantingPlansRouter/PlantingPlanDensitySection.tsx
@@ -24,7 +24,7 @@ const parseDensity = (value: string | undefined): number | undefined => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 };
 
-export type PlantingPlanDensitySectionProps = {
+type PlantingPlanDensitySectionProps = {
   plantingSite: PlantingSitePayload;
   densityByStratum: Record<number, string>;
   onDensityChange: (stratumId: number, value: string) => void;

--- a/src/scenes/PlantingPlansRouter/PlantingPlanMapThumbnail.tsx
+++ b/src/scenes/PlantingPlansRouter/PlantingPlanMapThumbnail.tsx
@@ -6,7 +6,7 @@ import usePlantingSite from 'src/hooks/usePlantingSite';
 import { simplifyToBudget } from 'src/utils/geometry';
 import useMapboxToken from 'src/utils/useMapboxToken';
 
-export type PlantingPlanMapThumbnailProps = {
+type PlantingPlanMapThumbnailProps = {
   plantingSiteId: number;
   width?: number;
   height?: number;

--- a/src/scenes/PlantingPlansRouter/PlantingPlanOverview.tsx
+++ b/src/scenes/PlantingPlansRouter/PlantingPlanOverview.tsx
@@ -12,7 +12,7 @@ import PlantingPlanStats from './PlantingPlanStats';
 
 const PLACEHOLDER = '-';
 
-export type PlantingPlanOverviewProps = {
+type PlantingPlanOverviewProps = {
   plantingSite: PlantingSitePayload;
 };
 

--- a/src/scenes/PlantingPlansRouter/PlantingPlanPlantsChip.tsx
+++ b/src/scenes/PlantingPlansRouter/PlantingPlanPlantsChip.tsx
@@ -5,7 +5,7 @@ import { Box, Typography, useTheme } from '@mui/material';
 import strings from 'src/strings';
 import { useNumberFormatter } from 'src/utils/useNumberFormatter';
 
-export type PlantingPlanPlantsChipProps = {
+type PlantingPlanPlantsChipProps = {
   plants: number;
 };
 

--- a/src/scenes/PlantingPlansRouter/PlantingPlanSeasons.tsx
+++ b/src/scenes/PlantingPlansRouter/PlantingPlanSeasons.tsx
@@ -12,7 +12,7 @@ import { useNumberFormatter } from 'src/utils/useNumberFormatter';
 
 const PLACEHOLDER = '-';
 
-export type PlantingPlanSeasonsProps = {
+type PlantingPlanSeasonsProps = {
   plantingSite: PlantingSitePayload;
 };
 

--- a/src/scenes/PlantingPlansRouter/PlantingPlanSiteGoals.tsx
+++ b/src/scenes/PlantingPlansRouter/PlantingPlanSiteGoals.tsx
@@ -21,7 +21,7 @@ const parseDensity = (value: string | undefined): number | undefined => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 };
 
-export type PlantingPlanSiteGoalsProps = {
+type PlantingPlanSiteGoalsProps = {
   plantingSite: PlantingSitePayload;
 };
 

--- a/src/scenes/PlantingPlansRouter/PlantingPlanSpeciesSection.tsx
+++ b/src/scenes/PlantingPlansRouter/PlantingPlanSpeciesSection.tsx
@@ -14,7 +14,7 @@ export type SpeciesTarget = {
   target: string;
 };
 
-export type PlantingPlanSpeciesSectionProps = {
+type PlantingPlanSpeciesSectionProps = {
   speciesTargets: SpeciesTarget[];
   onAdd: (speciesId: number, target: string) => void;
   onUpdate: (speciesId: number, target: string) => void;

--- a/src/scenes/PlantingPlansRouter/PlantingPlanStatTile.tsx
+++ b/src/scenes/PlantingPlansRouter/PlantingPlanStatTile.tsx
@@ -2,7 +2,7 @@ import React, { type JSX } from 'react';
 
 import { Box, Divider, Typography, useTheme } from '@mui/material';
 
-export type PlantingPlanStatTileProps = {
+type PlantingPlanStatTileProps = {
   label: string;
   value: string;
   showDivider?: boolean;

--- a/src/scenes/PlantingPlansRouter/PlantingPlanStats.tsx
+++ b/src/scenes/PlantingPlansRouter/PlantingPlanStats.tsx
@@ -6,7 +6,7 @@ import strings from 'src/strings';
 
 import PlantingPlanStatTile from './PlantingPlanStatTile';
 
-export type PlantingPlanStatsProps = {
+type PlantingPlanStatsProps = {
   targetPlants: string;
   area: string;
   initialPlantingDensity: string;

--- a/src/scenes/PlantingSitesRouter/edit/editor/Form.tsx
+++ b/src/scenes/PlantingSitesRouter/edit/editor/Form.tsx
@@ -6,7 +6,7 @@ import { FormButton, PageForm } from '@terraware/web-components';
 import strings from 'src/strings';
 import { SiteEditStep } from 'src/types/PlantingSite';
 
-export type OptionalStep = {
+type OptionalStep = {
   completed: boolean;
 };
 

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteCreate.ts
@@ -18,7 +18,7 @@ import useSnackbar from 'src/utils/useSnackbar';
  * @param nextStep
  * Next step to use in the flow if create was successful.
  */
-export type Data = {
+type Data = {
   draft: DraftPlantingSite;
   nextStep: SiteEditStep;
 };

--- a/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
+++ b/src/scenes/PlantingSitesRouter/hooks/useDraftPlantingSiteUpdate.ts
@@ -23,7 +23,7 @@ import usePlantingSiteValidate from './usePlantingSiteValidate';
  * @param optionalSteps
  * Dictionary of optional steps that were completed if update was successful.
  */
-export type Data = {
+type Data = {
   draft: DraftPlantingSite;
   nextStep: SiteEditStep;
   optionalSteps?: Record<OptionalSiteEditStep, boolean>;

--- a/src/scenes/PlantingSitesRouter/view/PlantingSiteMapV2.tsx
+++ b/src/scenes/PlantingSitesRouter/view/PlantingSiteMapV2.tsx
@@ -26,7 +26,7 @@ import useMapboxToken from 'src/utils/useMapboxToken';
 
 import PlantingSiteMapDrawer from './PlantingSiteMapDrawer';
 
-export type PlantingSiteMapV2Props = {
+type PlantingSiteMapV2Props = {
   plantingSiteId: number;
 };
 

--- a/src/scenes/Reports/AcceleratorReportTabV2.tsx
+++ b/src/scenes/Reports/AcceleratorReportTabV2.tsx
@@ -22,7 +22,7 @@ import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useParticipantData } from 'src/providers/Participant/ParticipantContext';
 import { useLazyListAcceleratorReportsQuery } from 'src/queries/generated/acceleratorReports';
 
-export type AcceleratorReportTabV2Props = {
+type AcceleratorReportTabV2Props = {
   active?: boolean;
 };
 

--- a/src/scenes/Reports/AcceleratorReportsView.tsx
+++ b/src/scenes/Reports/AcceleratorReportsView.tsx
@@ -21,7 +21,7 @@ import useStickyTabs from 'src/utils/useStickyTabs';
 import AcceleratorReportTabV2 from './AcceleratorReportTabV2';
 import ReportSubmitButton from './ReportSubmitButton';
 
-export type AcceleratorReportsViewProps = {
+type AcceleratorReportsViewProps = {
   tab?: string;
 };
 

--- a/src/scenes/Reports/ReportSubmitButton.tsx
+++ b/src/scenes/Reports/ReportSubmitButton.tsx
@@ -9,7 +9,7 @@ import useSnackbar from 'src/utils/useSnackbar';
 
 import SubmitReportDialog from './SubmitReportDialog';
 
-export type ReportSubmitButtonProps = {
+type ReportSubmitButtonProps = {
   reportId: number;
 };
 

--- a/src/scenes/Species/SpeciesCheck/CancelSpeciesCheckModal.tsx
+++ b/src/scenes/Species/SpeciesCheck/CancelSpeciesCheckModal.tsx
@@ -4,7 +4,7 @@ import { Button, DialogBox } from '@terraware/web-components';
 
 import strings from 'src/strings';
 
-export type CancelSpeciesCheckModalProps = {
+type CancelSpeciesCheckModalProps = {
   onClose: () => void;
   onConfirm: () => void;
 };

--- a/src/scenes/Species/SpeciesCheck/NameCheckStep.tsx
+++ b/src/scenes/Species/SpeciesCheck/NameCheckStep.tsx
@@ -18,7 +18,7 @@ const issueLabel = (problem: SpeciesProblemElement): string => {
   }
 };
 
-export type NameCheckStepProps = {
+type NameCheckStepProps = {
   summaries: ProjectCheckSummaryProps[];
   speciesWithProblems: Species[];
   selectedSpeciesIds: Set<number>;

--- a/src/scenes/Species/SpeciesCheck/NativeCheckStep.tsx
+++ b/src/scenes/Species/SpeciesCheck/NativeCheckStep.tsx
@@ -11,7 +11,7 @@ import SpeciesNativityBadge from '../SpeciesNativityBadge';
 import ProjectCheckSummary, { ProjectCheckSummaryProps } from './ProjectCheckSummary';
 import { NATIVITY_VALUES, Nativity, OverrideEdit, getNativityLabel, projectSpeciesKey } from './types';
 
-export type PendingRow = {
+type PendingRow = {
   species: Species;
   nativity: Nativity;
 };
@@ -23,7 +23,7 @@ export type NativeCheckProjectSection = {
   pending: PendingRow[];
 };
 
-export type NativeCheckStepProps = {
+type NativeCheckStepProps = {
   mode: 'list' | 'override';
   sections: NativeCheckProjectSection[];
   selectedKeys: Set<string>;

--- a/src/scenes/Species/SpeciesCheck/SetLocationStep.tsx
+++ b/src/scenes/Species/SpeciesCheck/SetLocationStep.tsx
@@ -9,7 +9,7 @@ import { Country } from 'src/types/Country';
 
 import { LocationEdit, LocationTarget } from './types';
 
-export type SetLocationStepProps = {
+type SetLocationStepProps = {
   targets: LocationTarget[];
   edits: Record<number, LocationEdit>;
   countries: Country[];

--- a/src/scenes/Species/SpeciesCheck/SpeciesCheckModal.tsx
+++ b/src/scenes/Species/SpeciesCheck/SpeciesCheckModal.tsx
@@ -28,7 +28,7 @@ import { LocationEdit, LocationTarget, Nativity, ORG_TARGET_KEY, OverrideEdit, p
 
 export type SpeciesCheckEntry = 'first-time' | 'menu' | 'added';
 
-export type SpeciesCheckModalProps = {
+type SpeciesCheckModalProps = {
   open: boolean;
   onClose: () => void;
   species: Species[];

--- a/src/scenes/Species/SpeciesCheck/SpeciesCheckStepper.tsx
+++ b/src/scenes/Species/SpeciesCheck/SpeciesCheckStepper.tsx
@@ -2,7 +2,7 @@ import React, { type JSX } from 'react';
 
 import { Step, StepLabel, Stepper, useTheme } from '@mui/material';
 
-export type SpeciesCheckStepperProps = {
+type SpeciesCheckStepperProps = {
   steps: string[];
   activeStep: number;
 };

--- a/src/services/AcceleratorProjectSpeciesService.ts
+++ b/src/services/AcceleratorProjectSpeciesService.ts
@@ -34,7 +34,7 @@ type GetSpeciesForProjectResponse =
 type GetSubmissionSnapshotResponse =
   paths[typeof ENDPOINT_ACCELERATOR_PROJECT_SPECIES_SUBMISSION_SNAPSHOT]['get']['responses'][200]['content']['*/*'];
 
-export type UpdateRequestPayload =
+type UpdateRequestPayload =
   paths[typeof ENDPOINT_ACCELERATOR_PROJECT_SPECIES_SINGULAR]['put']['requestBody']['content']['application/json'];
 type UpdateResponse =
   paths[typeof ENDPOINT_ACCELERATOR_PROJECT_SPECIES_SINGULAR]['put']['responses'][200]['content']['application/json'];

--- a/src/services/DeliverablesService.ts
+++ b/src/services/DeliverablesService.ts
@@ -33,14 +33,14 @@ export const ENDPOINT_DELIVERABLE_DOCUMENT = '/api/v1/accelerator/deliverables/{
 const DELIVERABLES_IMPORT_ENDPOINT = '/api/v1/accelerator/deliverables/import';
 
 export type ListDeliverablesRequestParams = paths[typeof ENDPOINT_DELIVERABLES]['get']['parameters']['query'];
-export type GetDeliverableResponsePayload =
+type GetDeliverableResponsePayload =
   paths[typeof ENDPOINT_DELIVERABLE_SUBMISSION]['get']['responses'][200]['content']['application/json'];
 
-export type UpdateSubmissionRequestPayload =
+type UpdateSubmissionRequestPayload =
   paths[typeof ENDPOINT_DELIVERABLE_SUBMISSION]['put']['requestBody']['content']['application/json'];
-export type UpdateSubmissionResponsePayload =
+type UpdateSubmissionResponsePayload =
   paths[typeof ENDPOINT_DELIVERABLE_SUBMISSION]['put']['responses'][200]['content']['application/json'];
-export type ImportDeliverablesResponsePayload =
+type ImportDeliverablesResponsePayload =
   paths[typeof DELIVERABLES_IMPORT_ENDPOINT]['post']['responses'][200]['content']['application/json'];
 
 const httpDeliverables = HttpService.root(ENDPOINT_DELIVERABLES);

--- a/src/services/DraftPlantingSiteService.ts
+++ b/src/services/DraftPlantingSiteService.ts
@@ -22,7 +22,7 @@ export type CreateDraftPlantingSiteResponse = Response & {
   draftId: number | null;
 };
 
-export type DraftPlantingSiteData = {
+type DraftPlantingSiteData = {
   site?: DraftPlantingSite;
 };
 

--- a/src/services/EventService.ts
+++ b/src/services/EventService.ts
@@ -4,11 +4,11 @@ import { ModuleEvent } from 'src/types/Module';
 
 import HttpService, { Response, Response2 } from './HttpService';
 
-export type EventsData = {
+type EventsData = {
   events: ModuleEvent[] | undefined;
 };
 
-export type EventData = {
+type EventData = {
   event: ModuleEvent | undefined;
 };
 
@@ -16,10 +16,8 @@ const EVENTS_ENDPOINT = '/api/v1/accelerator/events';
 const EVENT_ENDPONT = '/api/v1/accelerator/events/{eventId}';
 const EVENT_PROJECTS_ENDPOINT = '/api/v1/accelerator/events/{eventId}/projects';
 
-export type ListEventsResponsePayload =
-  paths[typeof EVENTS_ENDPOINT]['get']['responses'][200]['content']['application/json'];
-export type GetEventResponsePayload =
-  paths[typeof EVENT_ENDPONT]['get']['responses'][200]['content']['application/json'];
+type ListEventsResponsePayload = paths[typeof EVENTS_ENDPOINT]['get']['responses'][200]['content']['application/json'];
+type GetEventResponsePayload = paths[typeof EVENT_ENDPONT]['get']['responses'][200]['content']['application/json'];
 export type CreateModuleEventResponsePayload =
   paths[typeof EVENTS_ENDPOINT]['post']['responses'][200]['content']['application/json'];
 export type DeleteEventResponsePayload =

--- a/src/services/FacilityService.ts
+++ b/src/services/FacilityService.ts
@@ -15,15 +15,15 @@ import SearchService from './SearchService';
 /**
  * Types exported from service
  */
-export type Facilities = Facility[];
+type Facilities = Facility[];
 
-export type FacilitySearchParams = {
+type FacilitySearchParams = {
   type: FacilityType;
   organizationId: number | string;
   query?: string;
 };
 
-export type GetFacilityRequest = {
+type GetFacilityRequest = {
   organization: Organization;
   facilityId: number | string;
   type: FacilityType;

--- a/src/services/HttpService.ts
+++ b/src/services/HttpService.ts
@@ -7,7 +7,7 @@ import axios, { AxiosResponse } from './axios';
 /**
  * Url replacements
  */
-export type Replacements = Record<string, string>;
+type Replacements = Record<string, string>;
 
 /**
  * Request types
@@ -17,22 +17,22 @@ export type ServerData = { status?: 'ok' | 'error' };
 
 export type Params = Record<string, string>;
 
-export type Request = {
+type Request = {
   url?: string; // override url to use
   urlReplacements?: Replacements;
   headers?: Record<string, any>;
   params?: Params; // query params
 };
 
-export type GetRequest = Request;
+type GetRequest = Request;
 
-export type PostRequest = Request & {
+type PostRequest = Request & {
   entity?: Record<string, any>;
 };
 
-export type PutRequest = PostRequest;
+type PutRequest = PostRequest;
 
-export type DeleteRequest = PostRequest;
+type DeleteRequest = PostRequest;
 
 /**
  * Response type

--- a/src/services/ModuleService.ts
+++ b/src/services/ModuleService.ts
@@ -9,10 +9,8 @@ const MODULES_ENDOINT = '/api/v1/accelerator/modules';
 const MODULE_ENDOINT = '/api/v1/accelerator/modules/{moduleId}';
 const MODULES_IMPORT_ENDPOINT = '/api/v1/accelerator/modules/import';
 
-export type ListModulesResponsePayload =
-  paths[typeof MODULES_ENDOINT]['get']['responses'][200]['content']['application/json'];
-export type GetModuleResponsePayload =
-  paths[typeof MODULE_ENDOINT]['get']['responses'][200]['content']['application/json'];
+type ListModulesResponsePayload = paths[typeof MODULES_ENDOINT]['get']['responses'][200]['content']['application/json'];
+type GetModuleResponsePayload = paths[typeof MODULE_ENDOINT]['get']['responses'][200]['content']['application/json'];
 export type ImportModuleResponsePayload =
   paths[typeof MODULES_IMPORT_ENDPOINT]['post']['responses'][200]['content']['application/json'];
 

--- a/src/services/OrganizationService.ts
+++ b/src/services/OrganizationService.ts
@@ -19,34 +19,34 @@ import HttpService, { Response } from './HttpService';
 /**
  * Types exported from service
  */
-export type OrganizationsData = {
+type OrganizationsData = {
   organizations: Organization[];
 };
 
-export type OrganizationsResponse = Response & OrganizationsData;
+type OrganizationsResponse = Response & OrganizationsData;
 
-export type OrganizationRoles = {
+type OrganizationRoles = {
   roles: OrganizationRoleInfo[];
 };
-export type OrganizationRolesResponse = Response & OrganizationRoles;
+type OrganizationRolesResponse = Response & OrganizationRoles;
 
-export type OrganizationData = {
+type OrganizationData = {
   organization?: Organization;
 };
 
-export type OrganizationResponse = Response & OrganizationData;
+type OrganizationResponse = Response & OrganizationData;
 
-export type OrganizationInternalTags = {
+type OrganizationInternalTags = {
   internalTags: number[];
 };
 
-export type OrganizationInternalTagsResponse = Response & OrganizationInternalTags;
+type OrganizationInternalTagsResponse = Response & OrganizationInternalTags;
 
-export type OrganizationsInternalTags = {
+type OrganizationsInternalTags = {
   organizations: OrganizationWithInternalTags[];
 };
 
-export type OrganizationsInternalTagsResponse = Response & OrganizationsInternalTags;
+type OrganizationsInternalTagsResponse = Response & OrganizationsInternalTags;
 
 // endpoint
 const ORGANIZATIONS_ENDPOINT = '/api/v1/organizations';

--- a/src/services/OrganizationUserService.ts
+++ b/src/services/OrganizationUserService.ts
@@ -11,15 +11,15 @@ import HttpService, { Response } from './HttpService';
 /**
  * Types exported from service
  */
-export type OrganizationUsers = {
+type OrganizationUsers = {
   users: OrganizationUser[];
 };
 
-export type OrganizationUsersResponse = Response & OrganizationUsers;
+type OrganizationUsersResponse = Response & OrganizationUsers;
 
-export type CreateOrganizationUserError = 'PRE_EXISTING_USER' | 'INVALID_EMAIL';
+type CreateOrganizationUserError = 'PRE_EXISTING_USER' | 'INVALID_EMAIL';
 
-export type CreateOrganizationUserResponse = Response & {
+type CreateOrganizationUserResponse = Response & {
   userId: number;
   errorDetails?: CreateOrganizationUserError;
 };

--- a/src/services/SearchService.ts
+++ b/src/services/SearchService.ts
@@ -31,22 +31,20 @@ const SEARCH_VALUES_ENDPOINT = '/api/v1/search/values';
  *
  * You will generally want SearchRequestPayload instead of this.
  */
-export type RawSearchRequestPayload =
-  paths[typeof SEARCH_ENDPOINT]['post']['requestBody']['content']['application/json'];
+type RawSearchRequestPayload = paths[typeof SEARCH_ENDPOINT]['post']['requestBody']['content']['application/json'];
 
-export type SearchResponsePayload =
-  paths[typeof SEARCH_ENDPOINT]['post']['responses'][200]['content']['application/json'];
+type SearchResponsePayload = paths[typeof SEARCH_ENDPOINT]['post']['responses'][200]['content']['application/json'];
 
-export type RawSearchCountRequestPayload =
+type RawSearchCountRequestPayload =
   paths[typeof SEARCH_COUNT_ENDPOINT]['post']['requestBody']['content']['application/json'];
 
-export type SearchCountResponsePayload =
+type SearchCountResponsePayload =
   paths[typeof SEARCH_COUNT_ENDPOINT]['post']['responses'][200]['content']['application/json'];
 
-export type RawSearchValuesRequestPayload =
+type RawSearchValuesRequestPayload =
   paths[typeof SEARCH_VALUES_ENDPOINT]['post']['requestBody']['content']['application/json'];
 
-export type SearchValuesResponsePayload =
+type SearchValuesResponsePayload =
   paths[typeof SEARCH_VALUES_ENDPOINT]['post']['responses'][200]['content']['application/json'];
 
 const httpSearch = HttpService.root(SEARCH_ENDPOINT);

--- a/src/services/SpeciesService.ts
+++ b/src/services/SpeciesService.ts
@@ -14,10 +14,10 @@ import SearchService from './SearchService';
  * Types exported from service
  */
 
-export type SpeciesUploadTemplate = {
+type SpeciesUploadTemplate = {
   template?: string;
 };
-export type SpeciesUploadStatusDetails = {
+type SpeciesUploadStatusDetails = {
   uploadStatus?: GetUploadStatusResponsePayload;
 };
 

--- a/src/services/SubLocationService.ts
+++ b/src/services/SubLocationService.ts
@@ -24,17 +24,17 @@ type SubLocationResponsePayload =
  * exported types
  */
 
-export type SubLocationsData = {
+type SubLocationsData = {
   subLocations: SubLocation[];
 };
 export type SubLocationsResponse = Response & SubLocationsData;
 
-export type SubLocationData = {
+type SubLocationData = {
   subLocation?: SubLocation;
 };
-export type SubLocationResponse = Response & SubLocationData;
+type SubLocationResponse = Response & SubLocationData;
 
-export type SubLocationUpdateRequestBody =
+type SubLocationUpdateRequestBody =
   paths[typeof SUB_LOCATION_ENDPOINT]['put']['requestBody']['content']['application/json'];
 
 const httpSubLocations = HttpService.root(SUB_LOCATIONS_ENDPOINT);

--- a/src/services/TrackingService.ts
+++ b/src/services/TrackingService.ts
@@ -35,11 +35,11 @@ type CreatePlantingSiteResponse =
 /**
  * exported type
  */
-export type PlantingSitesData = {
+type PlantingSitesData = {
   sites?: PlantingSite[];
 };
 
-export type PlantingSiteData = {
+type PlantingSiteData = {
   site?: PlantingSite;
 };
 

--- a/src/services/funder/FundingEntityService.ts
+++ b/src/services/funder/FundingEntityService.ts
@@ -8,23 +8,23 @@ import HttpService, { Response, Response2 } from '../HttpService';
  */
 
 // types
-export type FundingEntitiesData = {
+type FundingEntitiesData = {
   fundingEntities?: FundingEntity[];
 };
 
-export type FundingEntityData = {
+type FundingEntityData = {
   fundingEntity: FundingEntity | undefined;
 };
 
-export type UserFundingEntityData = {
+type UserFundingEntityData = {
   userFundingEntity: FundingEntity | undefined;
 };
 
-export type FundingEntitiesResponse = Response & FundingEntitiesData;
-export type UserFundingEntityResponse = Response & UserFundingEntityData;
-export type FundingEntityResponse = Response & FundingEntityData;
+type FundingEntitiesResponse = Response & FundingEntitiesData;
+type UserFundingEntityResponse = Response & UserFundingEntityData;
+type FundingEntityResponse = Response & FundingEntityData;
 
-export type InviteFunderError = 'PRE_EXISTING_USER' | 'INVALID_EMAIL';
+type InviteFunderError = 'PRE_EXISTING_USER' | 'INVALID_EMAIL';
 
 export type InviteFunderResponse = Response & {
   email: string;
@@ -53,14 +53,14 @@ type ListFundersServerResponse =
   paths[typeof FUNDING_ENTITY_USERS_ENDPOINT]['get']['responses'][200]['content']['application/json'];
 type ListFunderReportsServerResponse =
   paths[typeof FUNDER_REPORTS_ENDPOINT]['get']['responses'][200]['content']['application/json'];
-export type UpdateFundingEntityRequest =
+type UpdateFundingEntityRequest =
   paths[typeof FUNDING_ENTITY_ENDPOINT]['put']['requestBody']['content']['application/json'];
-export type CreateFundingEntityRequest =
+type CreateFundingEntityRequest =
   paths[typeof FUNDING_ENTITIES_LIST_ENDPOINT]['post']['requestBody']['content']['application/json'];
 
-export type InviteFunderServerResponse =
+type InviteFunderServerResponse =
   paths[typeof FUNDING_ENTITY_USERS_ENDPOINT]['post']['responses'][200]['content']['application/json'];
-export type DeleteFundersServerRequest =
+type DeleteFundersServerRequest =
   paths[typeof FUNDING_ENTITY_USERS_ENDPOINT]['delete']['requestBody']['content']['application/json'];
 
 const httpUserFundingEntity = HttpService.root(USER_FUNDING_ENTITY_ENDPOINT);

--- a/src/services/test/HttpServiceMocks.ts
+++ b/src/services/test/HttpServiceMocks.ts
@@ -5,16 +5,16 @@ import { Mocked, rstest } from '@rstest/core';
 
 import HttpService from '../HttpService';
 
-export type Get = Mocked<typeof HttpService.get>;
-export type Get2 = Mocked<typeof HttpService.get2>;
-export type Put = Mocked<typeof HttpService.put>;
-export type Put2 = Mocked<typeof HttpService.put2>;
-export type Post = Mocked<typeof HttpService.post>;
-export type Post2 = Mocked<typeof HttpService.post2>;
-export type Delete = Mocked<typeof HttpService.delete>;
-export type Delete2 = Mocked<typeof HttpService.delete2>;
+type Get = Mocked<typeof HttpService.get>;
+type Get2 = Mocked<typeof HttpService.get2>;
+type Put = Mocked<typeof HttpService.put>;
+type Put2 = Mocked<typeof HttpService.put2>;
+type Post = Mocked<typeof HttpService.post>;
+type Post2 = Mocked<typeof HttpService.post2>;
+type Delete = Mocked<typeof HttpService.delete>;
+type Delete2 = Mocked<typeof HttpService.delete2>;
 
-export type MockedImpls = {
+type MockedImpls = {
   get?: Get;
   get2?: Get2;
   put?: Put;

--- a/src/types/Facility.ts
+++ b/src/types/Facility.ts
@@ -7,7 +7,7 @@ export type PartialSubLocation = Partial<SubLocation>;
 
 export type FacilityType = components['schemas']['FacilityPayload']['type'];
 
-export type FacilityLocation = components['schemas']['Point'];
+type FacilityLocation = components['schemas']['Point'];
 
 export interface Facility {
   id: number;

--- a/src/types/Map.ts
+++ b/src/types/Map.ts
@@ -56,13 +56,13 @@ export type MapGeometry = number[][][][];
 
 export type MapSourceProperties = { [key: string]: any };
 
-export type MapAnnotation = {
+type MapAnnotation = {
   textField: string; // property field whose value to render as annotation
   textSize: number;
   textColor: string;
 };
 
-export type MapPatternFill = Expression | string;
+type MapPatternFill = Expression | string;
 
 /**
  * A renderable map entity
@@ -138,7 +138,7 @@ export type MapEntityOptions = {
 /**
  * Types of objects that can be added to MapData
  */
-export type MapObject = 'site' | 'stratum' | 'substratum' | 'permanentPlot' | 'temporaryPlot' | 'adHocPlot';
+type MapObject = 'site' | 'stratum' | 'substratum' | 'permanentPlot' | 'temporaryPlot' | 'adHocPlot';
 
 /**
  * Sources for a map

--- a/src/types/Observations.ts
+++ b/src/types/Observations.ts
@@ -12,13 +12,13 @@ import defaultStrings from 'src/strings';
 import { MultiPolygon } from './Tracking';
 
 // basic information on a single observation (excluding observation results)
-export type Observation = components['schemas']['ObservationPayload'];
+type Observation = components['schemas']['ObservationPayload'];
 
 // "Upcoming" | "InProgress" | "Completed" | "Overdue"
 export type ObservationState = Observation['state'];
 
 // plot replacement
-export type ReplaceObservationPlotRequestPayload = components['schemas']['ReplaceObservationPlotRequestPayload'];
+type ReplaceObservationPlotRequestPayload = components['schemas']['ReplaceObservationPlotRequestPayload'];
 // "Temporary" | "LongTerm"
 export type ReplaceObservationPlotDuration = ReplaceObservationPlotRequestPayload['duration'];
 
@@ -28,7 +28,7 @@ type Boundary = {
 
 // expanded information on an observation including observed results down to monitoring plot level detail
 // requires navigating a tree of stratum results -> substratum results -> ( species results | monitoring plot results )
-export type ObservationResultsPayload = RtkObservationResultsPayload;
+type ObservationResultsPayload = RtkObservationResultsPayload;
 
 export type AdHocObservationResults = Omit<RtkObservationResultsPayload, 'strata' | 'adHocPlot'> &
   Boundary & {
@@ -57,7 +57,7 @@ export type ObservationResultsWithLastObv = Omit<
 > & { strata: ObservationStratumResultsWithLastObv[] };
 
 // stratum level results -> contains a list of substratum level results
-export type ObservationStratumResultsPayload = RtkObservationStratumResultsPayload;
+type ObservationStratumResultsPayload = RtkObservationStratumResultsPayload;
 export type ObservationStratumResults = ObservationStratumResultsPayload & {
   completedDate?: string;
   stratumName: string;
@@ -68,18 +68,18 @@ export type ObservationStratumResults = ObservationStratumResultsPayload & {
   hasObservedTemporaryPlots: boolean;
 };
 
-export type ObservationStratumResultsWithLastObv = Omit<ObservationStratumResults, 'substrata'> & {
+type ObservationStratumResultsWithLastObv = Omit<ObservationStratumResults, 'substrata'> & {
   lastObv?: string;
   substrata: ObservationSubstratumResultsWithLastObv[];
 };
 
 // substratum level results -> contains lists of both species level results and monitoring plot level results
-export type ObservationSubstratumResultsPayload = RtkObservationSubstratumResultsPayload;
+type ObservationSubstratumResultsPayload = RtkObservationSubstratumResultsPayload;
 export type ObservationSubstratumResults = ObservationSubstratumResultsPayload & {
   substratumName: string;
   monitoringPlots: ObservationMonitoringPlotResults[];
 };
-export type ObservationSubstratumResultsWithLastObv = ObservationSubstratumResults & {
+type ObservationSubstratumResultsWithLastObv = ObservationSubstratumResults & {
   lastObv?: string;
 };
 // monitoring plot level results
@@ -142,19 +142,19 @@ export type PlotCondition = components['schemas']['CompleteAdHocObservationReque
 
 export type BiomassMeasurement = components['schemas']['ExistingBiomassMeasurementPayload'];
 
-export type MonitoringPlotFile = ObservationMonitoringPlotMediaPayload;
+type MonitoringPlotFile = ObservationMonitoringPlotMediaPayload;
 
-export type NewMonitoringPlotFile = Omit<MonitoringPlotFile, 'fileId' | 'type'> & {
+type NewMonitoringPlotFile = Omit<MonitoringPlotFile, 'fileId' | 'type'> & {
   file: File;
   type?: 'Plot' | 'Quadrat' | 'Soil';
 };
 
-export type NewMonitoringPlotMediaItem = {
+type NewMonitoringPlotMediaItem = {
   type: 'new';
   data: NewMonitoringPlotFile;
 };
 
-export type ExistingMonitoringPlotMediaItem = {
+type ExistingMonitoringPlotMediaItem = {
   type: 'existing';
   data: MonitoringPlotFile;
   isModified?: boolean;

--- a/src/types/Organization.ts
+++ b/src/types/Organization.ts
@@ -36,7 +36,7 @@ export type Organization = {
   website?: string;
 };
 
-export type HighOrganizationRoles = 'Admin' | 'Owner' | 'Terraformation Contact';
+type HighOrganizationRoles = 'Admin' | 'Owner' | 'Terraformation Contact';
 
 export const HighOrganizationRolesValues = ['Admin', 'Owner', 'Terraformation Contact'];
 

--- a/src/types/PlantingSite.ts
+++ b/src/types/PlantingSite.ts
@@ -23,7 +23,7 @@ export type PlantingSitesFilters = {
  * Expectation is for the client to parse the `data` JSON into first class properties on read,
  * and put them back into `data` as JSON upon write/update.
  */
-export type DraftPlantingSitePayloadRaw = components['schemas']['DraftPlantingSitePayload'];
+type DraftPlantingSitePayloadRaw = components['schemas']['DraftPlantingSitePayload'];
 export type DraftPlantingSitePayload = Omit<DraftPlantingSitePayloadRaw, 'createdTime' | 'modifiedTime'>;
 export type CreateDraftPlantingSiteRequestPayload = components['schemas']['CreateDraftPlantingSiteRequestPayload'];
 export type UpdateDraftPlantingSiteRequestPayload = components['schemas']['UpdateDraftPlantingSiteRequestPayload'];

--- a/src/types/Tracking.ts
+++ b/src/types/Tracking.ts
@@ -3,7 +3,7 @@ import { components } from 'src/api/types/generated-schema';
 // planting site, stratum, substratum
 export type PlantingSite = components['schemas']['PlantingSitePayload'];
 export type Stratum = components['schemas']['StratumResponsePayload'];
-export type Substratum = components['schemas']['SubstratumResponsePayload'];
+type Substratum = components['schemas']['SubstratumResponsePayload'];
 
 // geometry and types of geometries
 export type Polygon = components['schemas']['Polygon'];

--- a/src/types/documentProducer/Variable.ts
+++ b/src/types/documentProducer/Variable.ts
@@ -10,13 +10,13 @@ export type Variable = VariableListResponse['variables'][0];
 
 export type VariableType = components['schemas']['ExistingValuePayload']['type'];
 
-export type LinkVariable = components['schemas']['LinkVariablePayload'];
+type LinkVariable = components['schemas']['LinkVariablePayload'];
 
-export type SectionVariable = components['schemas']['SectionVariablePayload'];
+type SectionVariable = components['schemas']['SectionVariablePayload'];
 
-export type DateVariable = components['schemas']['DateVariablePayload'];
+type DateVariable = components['schemas']['DateVariablePayload'];
 
-export type EmailVariable = components['schemas']['EmailVariablePayload'];
+type EmailVariable = components['schemas']['EmailVariablePayload'];
 
 export type TextVariable = components['schemas']['TextVariablePayload'];
 export const isTextVariable = (input: unknown): input is TableVariable => (input as TextVariable).type === 'Text';
@@ -29,7 +29,7 @@ export const isTableVariable = (input: unknown): input is TableVariable => (inpu
 
 export type TableColumn = components['schemas']['TableVariablePayload']['columns'][0];
 
-export type NumberVariable = components['schemas']['NumberVariablePayload'];
+type NumberVariable = components['schemas']['NumberVariablePayload'];
 
 export type SelectVariable = components['schemas']['SelectVariablePayload'];
 export const isSelectVariable = (input: unknown): input is SelectVariable =>

--- a/src/types/documentProducer/VariableValue.ts
+++ b/src/types/documentProducer/VariableValue.ts
@@ -12,7 +12,7 @@ export const isDateVariableValue = (input: unknown): input is DateVariableValue 
 
 export type DeletedVariableValue = components['schemas']['ExistingDeletedValuePayload'];
 
-export type EmailVariableValue = components['schemas']['ExistingEmailValuePayload'];
+type EmailVariableValue = components['schemas']['ExistingEmailValuePayload'];
 
 export type ImageVariableValue = components['schemas']['ExistingImageValuePayload'];
 
@@ -129,12 +129,12 @@ export type Operation =
   | components['schemas']['ReplaceValuesOperationPayload']
   | components['schemas']['UpdateValueOperationPayload'];
 
-export type OriginalUploadImageValue = Required<
+type OriginalUploadImageValue = Required<
   operations['uploadProjectImageValue']
 >['requestBody']['content']['application/json'];
 
 // Change type for file attribute from string to File, because that is how we process it in the frontend
-export type UploadImageValueRequestPayload = Omit<OriginalUploadImageValue, 'file'> & { file: File };
+type UploadImageValueRequestPayload = Omit<OriginalUploadImageValue, 'file'> & { file: File };
 
 export type UploadImageValueRequestPayloadWithProjectId = UploadImageValueRequestPayload & {
   projectId: number;

--- a/src/utils/geometry.ts
+++ b/src/utils/geometry.ts
@@ -5,7 +5,7 @@
 
 export type Position = number[]; // [longitude, latitude]
 export type Ring = Position[];
-export type Polygon = Ring[]; // [outerRing, ...holes]
+type Polygon = Ring[]; // [outerRing, ...holes]
 export type MultiPolygonCoordinates = Polygon[];
 
 // Coordinate precision (~1m at 5 decimals) — plenty for a small thumbnail.

--- a/src/utils/requestsId.tsx
+++ b/src/utils/requestsId.tsx
@@ -1,4 +1,4 @@
-export type RequestIds = {
+type RequestIds = {
   [endpoint: string]: string;
 };
 

--- a/src/utils/useMapboxSearch.ts
+++ b/src/utils/useMapboxSearch.ts
@@ -10,7 +10,7 @@ import {
 
 import useMapboxToken from './useMapboxToken';
 
-export type MapboxSearch = {
+type MapboxSearch = {
   clear: () => void;
   retrieve: (suggestion: AddressAutofillSuggestion) => Promise<AddressAutofillFeatureSuggestion[]>;
   suggest: (suggestText: string) => Promise<AddressAutofillSuggestion[]>;


### PR DESCRIPTION
Remove the `export`s from types that are only referenced in the same
source file, aside from types in `src/queries/generated`.

No manual code edits here; this is the result of

    yarn knip --fix --fix-type types
    yarn format:changed
    git checkout -- src/queries/generated