### PR TITLE
SW-8760 Share accelerator report mutation state per report

### DIFF
--- a/src/components/AcceleratorReports/PhotosBox.tsx
+++ b/src/components/AcceleratorReports/PhotosBox.tsx
@@ -5,8 +5,8 @@ import { Textfield } from '@terraware/web-components';
 import { useDeviceInfo } from '@terraware/web-components/utils';
 
 import { API_PATHS } from 'src/constants';
+import useAcceleratorReportActions from 'src/hooks/useAcceleratorReportActions';
 import useBoolean from 'src/hooks/useBoolean';
-import { useBatchReportPhotosMutation } from 'src/queries/acceleratorReports/photos';
 import strings from 'src/strings';
 import { AcceleratorReportPhoto, NewAcceleratorReportPhoto, isAcceleratorReport } from 'src/types/AcceleratorReport';
 import useSnackbar from 'src/utils/useSnackbar';
@@ -122,7 +122,9 @@ const PhotosBox = (props: ReportBoxProps) => {
     setNewPhotos([]);
   }
 
-  const [batchReportPhotos, { isLoading }] = useBatchReportPhotosMutation();
+  const acceleratorReportId = report && isAcceleratorReport(report) ? report.id : undefined;
+  const { batchPhotos, batchPhotosResponse } = useAcceleratorReportActions(acceleratorReportId);
+  const isLoading = batchPhotosResponse.isLoading;
   const snackbar = useSnackbar();
 
   const files = useMemo(() => {
@@ -183,13 +185,12 @@ const PhotosBox = (props: ReportBoxProps) => {
       }
 
       try {
-        await batchReportPhotos({
+        await batchPhotos({
           projectId,
-          reportId: report.id,
           photosToUpdate: toUpdate,
           photosToUpload: newPhotos,
           fileIdsToDelete: toDelete.map((photo) => photo.fileId),
-        }).unwrap();
+        })?.unwrap();
 
         snackbar.toastSuccess(strings.CHANGES_SAVED);
         setInternalEditing(false);
@@ -198,7 +199,7 @@ const PhotosBox = (props: ReportBoxProps) => {
         snackbar.toastError();
       }
     }
-  }, [report, toDelete, toUpdate, newPhotos, batchReportPhotos, projectId, setInternalEditing, snackbar]);
+  }, [report, toDelete, toUpdate, newPhotos, batchPhotos, projectId, setInternalEditing, snackbar]);
 
   const onCancel = useCallback(() => {
     setInternalEditing(false);

--- a/src/components/AcceleratorReports/PhotosBox.tsx
+++ b/src/components/AcceleratorReports/PhotosBox.tsx
@@ -123,8 +123,8 @@ const PhotosBox = (props: ReportBoxProps) => {
   }
 
   const acceleratorReportId = report && isAcceleratorReport(report) ? report.id : undefined;
-  const { batchPhotos, batchPhotosResponse } = useAcceleratorReportActions(acceleratorReportId);
-  const isLoading = batchPhotosResponse.isLoading;
+  const { upsertReportPhotos, upsertReportPhotosResponse } = useAcceleratorReportActions(acceleratorReportId);
+  const isLoading = upsertReportPhotosResponse.isLoading;
   const snackbar = useSnackbar();
 
   const files = useMemo(() => {
@@ -185,7 +185,7 @@ const PhotosBox = (props: ReportBoxProps) => {
       }
 
       try {
-        await batchPhotos({
+        await upsertReportPhotos({
           projectId,
           photosToUpdate: toUpdate,
           photosToUpload: newPhotos,
@@ -199,7 +199,7 @@ const PhotosBox = (props: ReportBoxProps) => {
         snackbar.toastError();
       }
     }
-  }, [report, toDelete, toUpdate, newPhotos, batchPhotos, projectId, setInternalEditing, snackbar]);
+  }, [report, toDelete, toUpdate, newPhotos, upsertReportPhotos, projectId, setInternalEditing, snackbar]);
 
   const onCancel = useCallback(() => {
     setInternalEditing(false);

--- a/src/components/AcceleratorReports/ReportMessages.tsx
+++ b/src/components/AcceleratorReports/ReportMessages.tsx
@@ -6,9 +6,9 @@ import { Message } from '@terraware/web-components';
 import ApprovedReportMessage from 'src/components/AcceleratorReports/ApprovedReportMessage';
 import RejectedReportMessage from 'src/components/AcceleratorReports/RejectedReportMessage';
 import { toReportReviewPayload } from 'src/components/AcceleratorReports/utils';
+import useAcceleratorReportActions from 'src/hooks/useAcceleratorReportActions';
 import useOneAcceleratorReport from 'src/hooks/useOneAcceleratorReport';
 import { useLocalization, useUser } from 'src/providers';
-import { useReviewOneAcceleratorReportMutation } from 'src/queries/generated/acceleratorReports';
 import RejectDialog from 'src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/RejectDialog';
 import useSnackbar from 'src/utils/useSnackbar';
 
@@ -27,17 +27,19 @@ const ReportMessages = ({ isConsoleView, reportId }: ReportMessagesProps): JSX.E
 
   const { report } = useOneAcceleratorReport(reportId);
 
-  const [reviewReport, reviewReportResponse] = useReviewOneAcceleratorReportMutation();
+  const { reviewFeedback, reviewFeedbackResponse } = useAcceleratorReportActions(reportId);
 
   useEffect(() => {
-    if (reviewReportResponse.isError) {
+    if (reviewFeedbackResponse.isError) {
       snackbar.toastError();
+      reviewFeedbackResponse.reset();
       return;
     }
-    if (reviewReportResponse.isSuccess) {
+    if (reviewFeedbackResponse.isSuccess) {
       setShowRejectDialog(false);
+      reviewFeedbackResponse.reset();
     }
-  }, [reviewReportResponse.isError, reviewReportResponse.isSuccess, snackbar]);
+  }, [reviewFeedbackResponse, snackbar]);
 
   const unpublishedChanges = useMemo(() => {
     if (!isConsoleView || !report?.unpublishedProperties?.length) {
@@ -80,13 +82,10 @@ const ReportMessages = ({ isConsoleView, reportId }: ReportMessagesProps): JSX.E
   const editFeedback = useCallback(
     (feedback: string) => {
       if (report) {
-        void reviewReport({
-          reportId,
-          reviewAcceleratorReportRequestPayload: { review: { ...toReportReviewPayload(report), feedback } },
-        });
+        void reviewFeedback({ review: { ...toReportReviewPayload(report), feedback } });
       }
     },
-    [report, reportId, reviewReport]
+    [report, reviewFeedback]
   );
 
   if (!report) {

--- a/src/hooks/useAcceleratorReportActions.ts
+++ b/src/hooks/useAcceleratorReportActions.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 
-import { useBatchReportPhotosMutation } from 'src/queries/acceleratorReports/photos';
+import { useUpsertReportPhotosMutation } from 'src/queries/acceleratorReports/photos';
 import {
   ReviewAcceleratorReportIndicatorsRequestPayload,
   ReviewAcceleratorReportRequestPayload,
@@ -13,7 +13,7 @@ import {
 } from 'src/queries/generated/acceleratorReports';
 import { AcceleratorReportPhoto, NewAcceleratorReportPhoto } from 'src/types/AcceleratorReport';
 
-type BatchReportPhotosArgs = {
+type UpsertReportPhotosArgs = {
   fileIdsToDelete?: number[];
   photosToUpdate?: AcceleratorReportPhoto[];
   photosToUpload?: NewAcceleratorReportPhoto[];
@@ -42,7 +42,7 @@ const useAcceleratorReportActions = (reportId?: number) => {
   const [updateValues, updateReportValuesResponse] = useUpdateOneAcceleratorReportValuesMutation({
     fixedCacheKey: cacheKey(reportId, 'update-values'),
   });
-  const [batchPhotoChanges, batchPhotosResponse] = useBatchReportPhotosMutation({
+  const [upsertPhotos, upsertReportPhotosResponse] = useUpsertReportPhotosMutation({
     fixedCacheKey: cacheKey(reportId, 'photos'),
   });
 
@@ -79,9 +79,9 @@ const useAcceleratorReportActions = (reportId?: number) => {
     [reportId, updateValues]
   );
 
-  const batchPhotos = useCallback(
-    (args: BatchReportPhotosArgs) => (reportId === undefined ? undefined : batchPhotoChanges({ ...args, reportId })),
-    [batchPhotoChanges, reportId]
+  const upsertReportPhotos = useCallback(
+    (args: UpsertReportPhotosArgs) => (reportId === undefined ? undefined : upsertPhotos({ ...args, reportId })),
+    [upsertPhotos, reportId]
   );
 
   const responses = useMemo(
@@ -92,16 +92,16 @@ const useAcceleratorReportActions = (reportId?: number) => {
       reviewFeedbackResponse,
       reviewIndicatorsResponse,
       updateReportValuesResponse,
-      batchPhotosResponse,
+      upsertReportPhotosResponse,
     ],
     [
-      batchPhotosResponse,
       publishReportResponse,
       reviewFeedbackResponse,
       reviewIndicatorsResponse,
       reviewReportResponse,
       submitReportResponse,
       updateReportValuesResponse,
+      upsertReportPhotosResponse,
     ]
   );
 
@@ -128,8 +128,6 @@ const useAcceleratorReportActions = (reportId?: number) => {
   const isLoading = responses.some((response) => response.isLoading);
 
   return {
-    batchPhotos,
-    batchPhotosResponse,
     isLoading,
     publishReport,
     publishReportResponse,
@@ -143,6 +141,8 @@ const useAcceleratorReportActions = (reportId?: number) => {
     submitReportResponse,
     updateReportValues,
     updateReportValuesResponse,
+    upsertReportPhotos,
+    upsertReportPhotosResponse,
   };
 };
 

--- a/src/hooks/useAcceleratorReportActions.ts
+++ b/src/hooks/useAcceleratorReportActions.ts
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+import { useBatchReportPhotosMutation } from 'src/queries/acceleratorReports/photos';
+import {
+  ReviewAcceleratorReportIndicatorsRequestPayload,
+  ReviewAcceleratorReportRequestPayload,
+  UpdateAcceleratorReportValuesRequestPayload,
+  usePublishOneAcceleratorReportMutation,
+  useReviewOneAcceleratorReportIndicatorsMutation,
+  useReviewOneAcceleratorReportMutation,
+  useSubmitOneAcceleratorReportMutation,
+  useUpdateOneAcceleratorReportValuesMutation,
+} from 'src/queries/generated/acceleratorReports';
+import { AcceleratorReportPhoto, NewAcceleratorReportPhoto } from 'src/types/AcceleratorReport';
+
+type BatchReportPhotosArgs = {
+  fileIdsToDelete?: number[];
+  photosToUpdate?: AcceleratorReportPhoto[];
+  photosToUpload?: NewAcceleratorReportPhoto[];
+  projectId: number;
+};
+
+const cacheKey = (reportId: number | undefined, action: string) =>
+  reportId === undefined ? undefined : `report-${reportId}-${action}`;
+
+/**
+ * Write actions for a single accelerator report. Each mutation is registered under a `fixedCacheKey`
+ * derived from `reportId`, so every component that calls this hook for the same report shares one
+ * in-flight state: a submit started by one component is visible to all the others, even after the
+ * component that started it unmounts. `isLoading` is true while any of the actions is in flight.
+ *
+ * Each action resolves to `undefined` without making a request when `reportId` is undefined.
+ */
+const useAcceleratorReportActions = (reportId?: number) => {
+  const [submit, submitReportResponse] = useSubmitOneAcceleratorReportMutation({
+    fixedCacheKey: cacheKey(reportId, 'submit'),
+  });
+  const [publish, publishReportResponse] = usePublishOneAcceleratorReportMutation({
+    fixedCacheKey: cacheKey(reportId, 'publish'),
+  });
+  const [review, reviewReportResponse] = useReviewOneAcceleratorReportMutation({
+    fixedCacheKey: cacheKey(reportId, 'review'),
+  });
+  // the feedback edit is a separate affordance that happens to reuse the review endpoint, and it is
+  // rendered alongside the review buttons, so it gets its own key to keep the two results apart
+  const [reviewFeedbackOnly, reviewFeedbackResponse] = useReviewOneAcceleratorReportMutation({
+    fixedCacheKey: cacheKey(reportId, 'review-feedback'),
+  });
+  const [reviewIndicatorEntries, reviewIndicatorsResponse] = useReviewOneAcceleratorReportIndicatorsMutation({
+    fixedCacheKey: cacheKey(reportId, 'review-indicators'),
+  });
+  const [updateValues, updateReportValuesResponse] = useUpdateOneAcceleratorReportValuesMutation({
+    fixedCacheKey: cacheKey(reportId, 'update-values'),
+  });
+  const [batchPhotoChanges, batchPhotosResponse] = useBatchReportPhotosMutation({
+    fixedCacheKey: cacheKey(reportId, 'photos'),
+  });
+
+  const submitReport = useCallback(() => (reportId === undefined ? undefined : submit(reportId)), [reportId, submit]);
+
+  const publishReport = useCallback(
+    () => (reportId === undefined ? undefined : publish(reportId)),
+    [publish, reportId]
+  );
+
+  const reviewReport = useCallback(
+    (reviewAcceleratorReportRequestPayload: ReviewAcceleratorReportRequestPayload) =>
+      reportId === undefined ? undefined : review({ reportId, reviewAcceleratorReportRequestPayload }),
+    [reportId, review]
+  );
+
+  const reviewFeedback = useCallback(
+    (reviewAcceleratorReportRequestPayload: ReviewAcceleratorReportRequestPayload) =>
+      reportId === undefined ? undefined : reviewFeedbackOnly({ reportId, reviewAcceleratorReportRequestPayload }),
+    [reportId, reviewFeedbackOnly]
+  );
+
+  const reviewIndicators = useCallback(
+    (reviewAcceleratorReportIndicatorsRequestPayload: ReviewAcceleratorReportIndicatorsRequestPayload) =>
+      reportId === undefined
+        ? undefined
+        : reviewIndicatorEntries({ reportId, reviewAcceleratorReportIndicatorsRequestPayload }),
+    [reportId, reviewIndicatorEntries]
+  );
+
+  const updateReportValues = useCallback(
+    (updateAcceleratorReportValuesRequestPayload: UpdateAcceleratorReportValuesRequestPayload) =>
+      reportId === undefined ? undefined : updateValues({ reportId, updateAcceleratorReportValuesRequestPayload }),
+    [reportId, updateValues]
+  );
+
+  const batchPhotos = useCallback(
+    (args: BatchReportPhotosArgs) => (reportId === undefined ? undefined : batchPhotoChanges({ ...args, reportId })),
+    [batchPhotoChanges, reportId]
+  );
+
+  const responses = useMemo(
+    () => [
+      submitReportResponse,
+      publishReportResponse,
+      reviewReportResponse,
+      reviewFeedbackResponse,
+      reviewIndicatorsResponse,
+      updateReportValuesResponse,
+      batchPhotosResponse,
+    ],
+    [
+      batchPhotosResponse,
+      publishReportResponse,
+      reviewFeedbackResponse,
+      reviewIndicatorsResponse,
+      reviewReportResponse,
+      submitReportResponse,
+      updateReportValuesResponse,
+    ]
+  );
+
+  // Results held under a fixedCacheKey outlive the components that created them, so a component
+  // mounting for a report that was already acted on would re-run its isSuccess/isError effects on a
+  // result someone else has handled. Discard settled results once per report, leaving anything still
+  // in flight alone so a component mounting mid-request still sees it.
+  const clearedReportId = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (clearedReportId.current === reportId) {
+      return;
+    }
+
+    clearedReportId.current = reportId;
+
+    responses.forEach((response) => {
+      if (response.isSuccess || response.isError) {
+        response.reset();
+      }
+    });
+  }, [reportId, responses]);
+
+  const isLoading = responses.some((response) => response.isLoading);
+
+  return {
+    batchPhotos,
+    batchPhotosResponse,
+    isLoading,
+    publishReport,
+    publishReportResponse,
+    reviewFeedback,
+    reviewFeedbackResponse,
+    reviewIndicators,
+    reviewIndicatorsResponse,
+    reviewReport,
+    reviewReportResponse,
+    submitReport,
+    submitReportResponse,
+    updateReportValues,
+    updateReportValuesResponse,
+  };
+};
+
+export default useAcceleratorReportActions;

--- a/src/hooks/useAcceleratorReportActions.ts
+++ b/src/hooks/useAcceleratorReportActions.ts
@@ -23,14 +23,6 @@ type BatchReportPhotosArgs = {
 const cacheKey = (reportId: number | undefined, action: string) =>
   reportId === undefined ? undefined : `report-${reportId}-${action}`;
 
-/**
- * Write actions for a single accelerator report. Each mutation is registered under a `fixedCacheKey`
- * derived from `reportId`, so every component that calls this hook for the same report shares one
- * in-flight state: a submit started by one component is visible to all the others, even after the
- * component that started it unmounts. `isLoading` is true while any of the actions is in flight.
- *
- * Each action resolves to `undefined` without making a request when `reportId` is undefined.
- */
 const useAcceleratorReportActions = (reportId?: number) => {
   const [submit, submitReportResponse] = useSubmitOneAcceleratorReportMutation({
     fixedCacheKey: cacheKey(reportId, 'submit'),
@@ -41,8 +33,6 @@ const useAcceleratorReportActions = (reportId?: number) => {
   const [review, reviewReportResponse] = useReviewOneAcceleratorReportMutation({
     fixedCacheKey: cacheKey(reportId, 'review'),
   });
-  // the feedback edit is a separate affordance that happens to reuse the review endpoint, and it is
-  // rendered alongside the review buttons, so it gets its own key to keep the two results apart
   const [reviewFeedbackOnly, reviewFeedbackResponse] = useReviewOneAcceleratorReportMutation({
     fixedCacheKey: cacheKey(reportId, 'review-feedback'),
   });

--- a/src/queries/acceleratorReports/photos.ts
+++ b/src/queries/acceleratorReports/photos.ts
@@ -3,7 +3,7 @@ import { AcceleratorReportPhoto, NewAcceleratorReportPhoto } from 'src/types/Acc
 import { baseApi as api } from '../baseApi';
 import { acceleratorReportMediaTag, acceleratorReportTag } from '../tags';
 
-type BatchPhotosRequest = {
+type UpsertPhotosRequest = {
   projectId: number;
   reportId: number;
   photosToUpdate?: AcceleratorReportPhoto[];
@@ -11,13 +11,13 @@ type BatchPhotosRequest = {
   fileIdsToDelete?: number[];
 };
 
-type BatchPhotosResponse = {
+type UpsertPhotosResponse = {
   uploadedFileIds?: number[];
 };
 
 const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({
-    batchReportPhotos: build.mutation<BatchPhotosResponse, BatchPhotosRequest>({
+    upsertReportPhotos: build.mutation<UpsertPhotosResponse, UpsertPhotosRequest>({
       queryFn: async (args, _api, _extraOptions, baseQuery) => {
         const { projectId, reportId, photosToUpdate = [], photosToUpload = [], fileIdsToDelete = [] } = args;
 
@@ -144,4 +144,4 @@ const injectedRtkApi = api.injectEndpoints({
   }),
 });
 
-export const { useBatchReportPhotosMutation } = injectedRtkApi;
+export const { useUpsertReportPhotosMutation } = injectedRtkApi;

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportEditV2.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportEditV2.tsx
@@ -15,14 +15,11 @@ import {
 import Page from 'src/components/Page';
 import Card from 'src/components/common/Card';
 import { APP_PATHS } from 'src/constants';
+import useAcceleratorReportActions from 'src/hooks/useAcceleratorReportActions';
 import useOneAcceleratorReport from 'src/hooks/useOneAcceleratorReport';
 import { useSyncNavigate } from 'src/hooks/useSyncNavigate';
 import { useLocalization } from 'src/providers';
-import {
-  AcceleratorReportPayload,
-  useReviewOneAcceleratorReportIndicatorsMutation,
-  useReviewOneAcceleratorReportMutation,
-} from 'src/queries/generated/acceleratorReports';
+import { AcceleratorReportPayload } from 'src/queries/generated/acceleratorReports';
 import useSnackbar from 'src/utils/useSnackbar';
 
 import { useAcceleratorProjectData } from '../AcceleratorProjectContext';
@@ -41,9 +38,7 @@ const ReportEditV2 = (): JSX.Element => {
 
   const navigate = useSyncNavigate();
   const snackbar = useSnackbar();
-  const [reviewReport, reviewReportResponse] = useReviewOneAcceleratorReportMutation();
-  const [reviewIndicators, reviewIndicatorsResponse] = useReviewOneAcceleratorReportIndicatorsMutation();
-  const saving = reviewReportResponse.isLoading || reviewIndicatorsResponse.isLoading;
+  const { isLoading: saving, reviewIndicators, reviewReport } = useAcceleratorReportActions(reportId);
 
   const goToReport = useCallback(
     () =>
@@ -85,14 +80,8 @@ const ReportEditV2 = (): JSX.Element => {
 
     try {
       await Promise.all([
-        reviewReport({
-          reportId,
-          reviewAcceleratorReportRequestPayload: { review: toReportReviewPayload(record) },
-        }).unwrap(),
-        reviewIndicators({
-          reportId,
-          reviewAcceleratorReportIndicatorsRequestPayload: toIndicatorEntriesPayload(record),
-        }).unwrap(),
+        reviewReport({ review: toReportReviewPayload(record) })?.unwrap(),
+        reviewIndicators(toIndicatorEntriesPayload(record))?.unwrap(),
       ]);
 
       snackbar.toastSuccess(strings.CHANGES_SAVED);
@@ -100,7 +89,7 @@ const ReportEditV2 = (): JSX.Element => {
     } catch {
       snackbar.toastError();
     }
-  }, [goToReport, record, reportId, reviewIndicators, reviewReport, snackbar, strings.CHANGES_SAVED]);
+  }, [goToReport, record, reviewIndicators, reviewReport, snackbar, strings.CHANGES_SAVED]);
 
   const pageCrumbs = useMemo(
     () => [

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportOptionsMenu.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportOptionsMenu.tsx
@@ -3,9 +3,9 @@ import React, { type JSX, useCallback, useEffect, useMemo, useState } from 'reac
 import { DropdownItem } from '@terraware/web-components';
 
 import OptionsMenu from 'src/components/common/OptionsMenu';
+import useAcceleratorReportActions from 'src/hooks/useAcceleratorReportActions';
 import useOneAcceleratorReport from 'src/hooks/useOneAcceleratorReport';
 import { useLocalization, useUser } from 'src/providers';
-import { usePublishOneAcceleratorReportMutation } from 'src/queries/generated/acceleratorReports';
 import useSnackbar from 'src/utils/useSnackbar';
 
 import PublishModal from './PublishModal';
@@ -23,18 +23,20 @@ const ReportOptionsMenu = ({ reportId }: ReportOptionsMenuProps): JSX.Element | 
 
   const { report } = useOneAcceleratorReport(reportId);
 
-  const [publishReport, publishReportResponse] = usePublishOneAcceleratorReportMutation();
+  const { publishReport, publishReportResponse } = useAcceleratorReportActions(reportId);
 
   useEffect(() => {
     if (publishReportResponse.isError) {
       snackbar.toastError();
+      publishReportResponse.reset();
       return;
     }
     if (publishReportResponse.isSuccess) {
       snackbar.toastSuccess(strings.REPORT_PUBLISHED);
       setShowPublishModal(false);
+      publishReportResponse.reset();
     }
-  }, [publishReportResponse.isError, publishReportResponse.isSuccess, snackbar, strings]);
+  }, [publishReportResponse, snackbar, strings]);
 
   const optionItems = useMemo(
     (): DropdownItem[] => [
@@ -55,7 +57,7 @@ const ReportOptionsMenu = ({ reportId }: ReportOptionsMenuProps): JSX.Element | 
 
   const closePublishModal = useCallback(() => setShowPublishModal(false), []);
 
-  const publish = useCallback(() => void publishReport(reportId), [publishReport, reportId]);
+  const publish = useCallback(() => void publishReport(), [publishReport]);
 
   if (!isAllowed('PUBLISH_REPORTS')) {
     return null;

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportReviewButtons.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportReviewButtons.tsx
@@ -3,9 +3,10 @@ import React, { type JSX, useCallback, useEffect, useState } from 'react';
 import { Button } from '@terraware/web-components';
 
 import { toReportReviewPayload } from 'src/components/AcceleratorReports/utils';
+import useAcceleratorReportActions from 'src/hooks/useAcceleratorReportActions';
 import useOneAcceleratorReport from 'src/hooks/useOneAcceleratorReport';
 import { useLocalization, useUser } from 'src/providers';
-import { ReportReviewPayload, useReviewOneAcceleratorReportMutation } from 'src/queries/generated/acceleratorReports';
+import { ReportReviewPayload } from 'src/queries/generated/acceleratorReports';
 import useSnackbar from 'src/utils/useSnackbar';
 
 import ApproveReportDialog from './ApproveReportDialog';
@@ -30,31 +31,28 @@ const ReportReviewButtons = ({ reportId }: ReportReviewButtonsProps): JSX.Elemen
   // a report can only be reviewed once it has been submitted
   const notReviewable = report?.status === undefined || report.status === 'Not Submitted';
 
-  const [reviewReport, reviewReportResponse] = useReviewOneAcceleratorReportMutation();
+  const { reviewReport, reviewReportResponse } = useAcceleratorReportActions(reportId);
 
   useEffect(() => {
     if (reviewReportResponse.isError) {
       snackbar.toastError();
+      reviewReportResponse.reset();
       return;
     }
     if (reviewReportResponse.isSuccess) {
       setShowApproveDialog(false);
       setShowRejectDialog(false);
+      reviewReportResponse.reset();
     }
-  }, [reviewReportResponse.isError, reviewReportResponse.isSuccess, snackbar]);
+  }, [reviewReportResponse, snackbar]);
 
   const review = useCallback(
     (status: ReportReviewPayload['status'], feedback?: string) => {
       if (report) {
-        void reviewReport({
-          reportId,
-          reviewAcceleratorReportRequestPayload: {
-            review: { ...toReportReviewPayload(report), feedback, status },
-          },
-        });
+        void reviewReport({ review: { ...toReportReviewPayload(report), feedback, status } });
       }
     },
-    [report, reportId, reviewReport]
+    [report, reviewReport]
   );
 
   const approveReport = useCallback(() => review('Approved'), [review]);

--- a/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportReviewButtons.tsx
+++ b/src/scenes/AcceleratorRouter/AcceleratorProjects/Reports/ReportReviewButtons.tsx
@@ -28,10 +28,10 @@ const ReportReviewButtons = ({ reportId }: ReportReviewButtonsProps): JSX.Elemen
 
   const { report } = useOneAcceleratorReport(reportId);
 
-  // a report can only be reviewed once it has been submitted
-  const notReviewable = report?.status === undefined || report.status === 'Not Submitted';
+  const { reviewReport, reviewReportResponse, isLoading } = useAcceleratorReportActions(reportId);
 
-  const { reviewReport, reviewReportResponse } = useAcceleratorReportActions(reportId);
+  // a report can only be reviewed once it has been submitted
+  const notReviewable = report?.status === undefined || report.status === 'Not Submitted' || isLoading;
 
   useEffect(() => {
     if (reviewReportResponse.isError) {

--- a/src/scenes/Reports/AcceleratorReportEditForm.tsx
+++ b/src/scenes/Reports/AcceleratorReportEditForm.tsx
@@ -15,7 +15,7 @@ import Card from 'src/components/common/Card';
 import WrappedPageForm from 'src/components/common/PageForm';
 import useNavigateTo from 'src/hooks/useNavigateTo';
 import { useLocalization } from 'src/providers';
-import { useBatchReportPhotosMutation } from 'src/queries/acceleratorReports/photos';
+import { useUpsertReportPhotosMutation } from 'src/queries/acceleratorReports/photos';
 import {
   AcceleratorReportPayload,
   ReportAutoCalculatedIndicatorPayload,
@@ -52,7 +52,7 @@ const AcceleratorReportEditForm = ({ report }: AcceleratorReportEditFormProps) =
   const [record, , onChange, onChangeCallback] = useForm<AcceleratorReportPayload>(report);
   const [validate, setValidate] = useState(false);
   const [updateReport, updateReportResponse] = useUpdateAcceleratorReportValuesMutation();
-  const [batchReportPhotos, { isLoading: isBatchReportPhotosLoading }] = useBatchReportPhotosMutation();
+  const [upsertReportPhotos, { isLoading: isUpsertReportPhotosLoading }] = useUpsertReportPhotosMutation();
   const [photos, setPhotos] = useState<AcceleratorReportPhotoActions>({ toAdd: [], toDelete: [], toUpdate: [] });
   const snackbar = useSnackbar();
 
@@ -85,7 +85,7 @@ const AcceleratorReportEditForm = ({ report }: AcceleratorReportEditFormProps) =
     }
 
     try {
-      await batchReportPhotos({
+      await upsertReportPhotos({
         projectId,
         reportId: report.id,
         photosToUpdate: photos.toUpdate,
@@ -97,7 +97,7 @@ const AcceleratorReportEditForm = ({ report }: AcceleratorReportEditFormProps) =
     } catch (error) {
       snackbar.toastError();
     }
-  }, [photos.toDelete, photos.toUpdate, photos.toAdd, batchReportPhotos, projectId, report.id, goToReport, snackbar]);
+  }, [photos.toDelete, photos.toUpdate, photos.toAdd, upsertReportPhotos, projectId, report.id, goToReport, snackbar]);
 
   useEffect(() => {
     if (updateReportResponse.isError) {
@@ -246,7 +246,7 @@ const AcceleratorReportEditForm = ({ report }: AcceleratorReportEditFormProps) =
             onChange={onChangeCallback('additionalComments')}
           />
           <PhotosBox report={report} projectId={projectId} editing={true} onChange={onChangePhotosCallback} />
-          {isBatchReportPhotosLoading && <BusySpinner />}
+          {isUpsertReportPhotosLoading && <BusySpinner />}
         </Card>
       </Box>
     </WrappedPageForm>

--- a/src/scenes/Reports/AcceleratorReportEditV2.tsx
+++ b/src/scenes/Reports/AcceleratorReportEditV2.tsx
@@ -10,13 +10,11 @@ import ReportEditFields from 'src/components/AcceleratorReports/ReportEditFields
 import { getReportName, toUpdateReportValuesPayload } from 'src/components/AcceleratorReports/utils';
 import Page from 'src/components/Page';
 import Card from 'src/components/common/Card';
+import useAcceleratorReportActions from 'src/hooks/useAcceleratorReportActions';
 import useNavigateTo from 'src/hooks/useNavigateTo';
 import useOneAcceleratorReport from 'src/hooks/useOneAcceleratorReport';
 import { useLocalization } from 'src/providers';
-import {
-  AcceleratorReportPayload,
-  useUpdateOneAcceleratorReportValuesMutation,
-} from 'src/queries/generated/acceleratorReports';
+import { AcceleratorReportPayload } from 'src/queries/generated/acceleratorReports';
 import useSnackbar from 'src/utils/useSnackbar';
 
 const AcceleratorReportEditV2 = (): JSX.Element => {
@@ -29,7 +27,7 @@ const AcceleratorReportEditV2 = (): JSX.Element => {
 
   const { goToAcceleratorReport } = useNavigateTo();
   const snackbar = useSnackbar();
-  const [updateReport, updateReportResponse] = useUpdateOneAcceleratorReportValuesMutation();
+  const { isLoading, updateReportValues, updateReportValuesResponse } = useAcceleratorReportActions(reportId);
 
   const goToReport = useCallback(() => goToAcceleratorReport(reportId), [goToAcceleratorReport, reportId]);
 
@@ -67,23 +65,25 @@ const AcceleratorReportEditV2 = (): JSX.Element => {
       return;
     }
 
-    void updateReport({ reportId, updateAcceleratorReportValuesRequestPayload: toUpdateReportValuesPayload(record) });
-  }, [record, reportId, updateReport]);
+    void updateReportValues(toUpdateReportValuesPayload(record));
+  }, [record, updateReportValues]);
 
   useEffect(() => {
-    if (updateReportResponse.isError) {
+    if (updateReportValuesResponse.isError) {
       snackbar.toastError();
-    } else if (updateReportResponse.isSuccess) {
+      updateReportValuesResponse.reset();
+    } else if (updateReportValuesResponse.isSuccess) {
       snackbar.toastSuccess(strings.CHANGES_SAVED);
       goToReport();
+      updateReportValuesResponse.reset();
     }
-  }, [goToReport, snackbar, strings.CHANGES_SAVED, updateReportResponse.isError, updateReportResponse.isSuccess]);
+  }, [goToReport, snackbar, strings.CHANGES_SAVED, updateReportValuesResponse]);
 
   const rightComponent = useMemo(
     () => (
       <Box display='flex' gap={theme.spacing(1)} justifyContent='flex-end'>
         <Button
-          disabled={updateReportResponse.isLoading}
+          disabled={isLoading}
           id='cancelEditAcceleratorReport'
           label={strings.CANCEL}
           onClick={goToReport}
@@ -93,7 +93,7 @@ const AcceleratorReportEditV2 = (): JSX.Element => {
         />
 
         <Button
-          disabled={updateReportResponse.isLoading}
+          disabled={isLoading}
           id='saveEditAcceleratorReport'
           label={strings.SAVE}
           onClick={onSave}
@@ -101,7 +101,7 @@ const AcceleratorReportEditV2 = (): JSX.Element => {
         />
       </Box>
     ),
-    [goToReport, onSave, strings, theme, updateReportResponse.isLoading]
+    [goToReport, isLoading, onSave, strings, theme]
   );
 
   return (

--- a/src/scenes/Reports/ReportSubmitButton.tsx
+++ b/src/scenes/Reports/ReportSubmitButton.tsx
@@ -2,9 +2,9 @@ import React, { type JSX, useCallback, useEffect, useState } from 'react';
 
 import { Button } from '@terraware/web-components';
 
+import useAcceleratorReportActions from 'src/hooks/useAcceleratorReportActions';
 import useOneAcceleratorReport from 'src/hooks/useOneAcceleratorReport';
 import { useLocalization } from 'src/providers';
-import { useSubmitOneAcceleratorReportMutation } from 'src/queries/generated/acceleratorReports';
 import useSnackbar from 'src/utils/useSnackbar';
 
 import SubmitReportDialog from './SubmitReportDialog';
@@ -21,30 +21,31 @@ const ReportSubmitButton = ({ reportId }: ReportSubmitButtonProps): JSX.Element 
 
   const { isFetching, report } = useOneAcceleratorReport(reportId);
 
-  const [submit, submitResponse] = useSubmitOneAcceleratorReportMutation();
+  const { isLoading, submitReport, submitReportResponse } = useAcceleratorReportActions(reportId);
 
   useEffect(() => {
-    if (submitResponse.isError) {
+    if (submitReportResponse.isError) {
       snackbar.toastError();
+      submitReportResponse.reset();
     }
-  }, [snackbar, submitResponse.isError]);
+  }, [snackbar, submitReportResponse]);
 
   const status = report?.status;
 
-  const disabled = (status !== 'Not Submitted' && status !== 'Needs Update') || isFetching || submitResponse.isLoading;
+  const disabled = (status !== 'Not Submitted' && status !== 'Needs Update') || isFetching || isLoading;
 
   const openSubmitDialog = useCallback(() => setShowSubmitDialog(true), []);
 
   const closeSubmitDialog = useCallback(() => setShowSubmitDialog(false), []);
 
-  const submitReport = useCallback(() => {
-    void submit(reportId);
+  const onSubmit = useCallback(() => {
+    void submitReport();
     setShowSubmitDialog(false);
-  }, [reportId, submit]);
+  }, [submitReport]);
 
   return (
     <>
-      {showSubmitDialog && <SubmitReportDialog onClose={closeSubmitDialog} onSubmit={submitReport} />}
+      {showSubmitDialog && <SubmitReportDialog onClose={closeSubmitDialog} onSubmit={onSubmit} />}
 
       <Button
         disabled={disabled}


### PR DESCRIPTION
Add useAcceleratorReportActions, which registers each of the report mutations
under a fixedCacheKey derived from the report id. Components that call it for
the same report now share one in-flight state, and the aggregate isLoading
covers every write action on that report.

Co-Authored-By: Claude Opus 5 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)