### PR TITLE
Remove Babel configuration

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "plugins": ["istanbul"],
-  "presets": ["@babel/preset-typescript", ["@babel/preset-env", { "targets": { "node": "current" } }]]
-}


### PR DESCRIPTION
We no longer directly use Babel to build our code, so there's no need
for its config file any more. The config file wasn't even valid, as
it referred to a plugin that was already removed from our dependencies.