### PR TITLE
SW-8788 New species added reminder doesn't show up until after a refresh

### DIFF
--- a/src/scenes/Species/SpeciesListView.tsx
+++ b/src/scenes/Species/SpeciesListView.tsx
@@ -152,6 +152,10 @@ export default function SpeciesListView({ reloadData, species }: SpeciesListProp
     setSpeciesCheckOpen(true);
   }, []);
 
+  useEffect(() => {
+    reloadData();
+  }, [reloadData]);
+
   const noLocationSet = hasMultipleProjects
     ? (availableProjects ?? []).every((p) => !p.botanicalCountryCode)
     : !selectedOrganization?.botanicalCountryCode;

--- a/src/scenes/Species/SpeciesListView.tsx
+++ b/src/scenes/Species/SpeciesListView.tsx
@@ -152,10 +152,6 @@ export default function SpeciesListView({ reloadData, species }: SpeciesListProp
     setSpeciesCheckOpen(true);
   }, []);
 
-  useEffect(() => {
-    reloadData();
-  }, [reloadData]);
-
   const noLocationSet = hasMultipleProjects
     ? (availableProjects ?? []).every((p) => !p.botanicalCountryCode)
     : !selectedOrganization?.botanicalCountryCode;

--- a/src/scenes/Species/index.tsx
+++ b/src/scenes/Species/index.tsx
@@ -1,9 +1,10 @@
-import React, { type JSX, useCallback } from 'react';
-import { Route, Routes } from 'react-router';
+import React, { type JSX, useCallback, useEffect, useRef } from 'react';
+import { Route, Routes, useLocation } from 'react-router';
 
 import { Box, CircularProgress } from '@mui/material';
 
 import EmptyStatePage from 'src/components/emptyStatePages/EmptyStatePage';
+import { APP_PATHS } from 'src/constants';
 import { useOrganizationSpecies } from 'src/hooks/useOrganizationSpecies';
 import SpeciesAddView from 'src/scenes/Species/SpeciesAddView';
 import SpeciesDetailView from 'src/scenes/Species/SpeciesDetailView';
@@ -12,6 +13,15 @@ import SpeciesListView from 'src/scenes/Species/SpeciesListView';
 
 const SpeciesRouter = () => {
   const { species, isLoading, refetch } = useOrganizationSpecies();
+  const location = useLocation();
+  const isListRoute = location.pathname === (APP_PATHS.SPECIES as string);
+  const wasListRoute = useRef(isListRoute);
+  useEffect(() => {
+    if (isListRoute && !wasListRoute.current) {
+      refetch();
+    }
+    wasListRoute.current = isListRoute;
+  }, [isListRoute, refetch]);
 
   const getSpeciesView = useCallback((): JSX.Element => {
     if (species.length > 0) {


### PR DESCRIPTION
The banner is driven by the species prop (uncheckedSpecies) and species comes from useOrganizationSpecies at the SpeciesRouter level, whose lazy listSpecies fetch is triggered once and only refetched by tag invalidation. If the post-add invalidation-refetch didn't land after going back to species page, stale data appears until a full reload.

The fix is to refetch the list whenever landing on species list page, instead of depending on invalidation reaching a lazy subscription