### PR TITLE
Remove invalid type dependency

### DIFF
--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="react-scripts" />
-
 declare module 'playcanvas/scripts/esm/camera-controls.mjs';
 declare module 'playcanvas/scripts/esm/annotations.mjs';
 declare module 'playcanvas/scripts/esm/gsplat/shader-effect-crop.mjs';


### PR DESCRIPTION
We no longer install the react-scripts module, so the reference to
it in react-app-env.d.ts was a no-op. Remove it so it isn't flagged
as a missing dependency by Knip.