### PR TITLE
Suppress Knip reports on generated query files

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -10,6 +10,7 @@ const config: KnipConfig = {
     'public/js/table-of-contents.js',
   ],
   project: ['**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,mdx,sass,scss}!'],
+  ignore: ['src/queries/generated/**'],
 };
 
 export default config;


### PR DESCRIPTION
The generated code for RTK Query exports a lot of symbols that aren't
used anywhere, but that's expected and not a sign of something we need
to look into. Tell Knip to not report problems in those files.