### PR TITLE
Upload screenshots after test failure

### DIFF
--- a/.buildkite/scripts/run-screenshot-check.sh
+++ b/.buildkite/scripts/run-screenshot-check.sh
@@ -32,8 +32,14 @@ DOCKER_BASE=(
 )
 
 echo "--- :camera_with_flash: Run screenshot regression tests"
-"${DOCKER_BASE[@]}" \
-  sh -c "node_modules/.bin/wait-on -t 60000 http://localhost:3001 \
+if "${DOCKER_BASE[@]}" sh -c "node_modules/.bin/wait-on -t 60000 http://localhost:3001 \
          && node_modules/.bin/playwright test playwright/e2e/suites/screenshots --project=prod"
+then
+    status=0
+else
+    status=1
+fi
 
 .buildkite/scripts/upload-playwright-results.sh
+
+exit $status


### PR DESCRIPTION
The weekly screenshot-comparison test script used to run Playwright
as its last step, so if the Playwright run failed, the script would
exit with an error code. That was fine when we were using Buildkite's
built-in artifact upload plugin; the plugin ran whether the test
succeeded or not. But when we switched to uploading using our own
script, the fact that the test script exited on Playwright failure
caused it to never reach our upload logic.

Capture the exit code of the Playwright command and run the upload
script unconditionally.