### PR TITLE
Generate strings before running tests in deploy-docs

### DIFF
--- a/.buildkite/scripts/deploy-docs.sh
+++ b/.buildkite/scripts/deploy-docs.sh
@@ -13,6 +13,9 @@ rm -f docs/.gitignore
 echo "--- :yarn: Output license report"
 yarn license-report
 
+echo "--- :yarn: Generate strings"
+yarn generate-strings
+
 echo "--- :jest: Run unit tests to generate coverage"
 yarn test-coverage
 


### PR DESCRIPTION
The deploy-docs job runs the unit test suite for coverage but never
generated the string tables and broke the test that imports src/strings/strings-en directly 

Co-Authored-By: Claude Opus 5 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)