### PR TITLE
Fix lifetime indicator progress bars in later report years

### DIFF
--- a/src/components/AcceleratorReports/IndicatorProgressRow.tsx
+++ b/src/components/AcceleratorReports/IndicatorProgressRow.tsx
@@ -47,8 +47,6 @@ const IndicatorProgressRow = ({
   const [resetModalOpened, setResetModalOpened] = useState(false);
   const [overwriting, setOverwriting] = useState(false);
 
-  // both cumulative classes accumulate the year's quarters; only the lifetime one reaches back past
-  // the start of the year
   const isLifetime = indicator.classId === 'Lifetime Cumulative';
   const isYearly = indicator.classId === 'Yearly Cumulative';
   const isCumulative = isLifetime || isYearly;
@@ -56,20 +54,14 @@ const IndicatorProgressRow = ({
   const precision = indicator.precision ?? 0;
   const baselineValue = indicator.baseline ?? 0;
 
-  // a yearly indicator restarts at zero each year, so it carries neither the baseline nor a prior total
   const startingTotal = isLifetime ? indicator.previousYearCumulativeTotal ?? baselineValue : 0;
-
-  // A lifetime bar starts at the total carried in from earlier years, so from the second year on the
-  // year's target can sit behind that origin — it was reached before this year began.
-  const targetBehindOrigin = indicator.target !== undefined && indicator.target <= startingTotal;
+  const targetBehindOrigin = isLifetime && indicator.target !== undefined && indicator.target <= startingTotal;
 
   const startingTotalLabel =
     indicator.previousYearCumulativeTotal !== undefined && year !== undefined ? String(year - 1) : strings.BASELINE;
 
   const enteredValue = isAutoCalculated ? indicator.overrideValue ?? indicator.systemValue : indicator.value;
 
-  // A cumulative total is the earlier quarters plus this one, so substitute the entered value for this
-  // quarter and re-sum; that keeps the year and lifetime bars in step while the value is being edited.
   const currentYearProgress = useMemo(() => {
     const progress = indicator.currentYearProgress ?? [];
 
@@ -102,9 +94,7 @@ const IndicatorProgressRow = ({
     const barMax = Math.max(total, target ?? 0, barMin);
     const range = barMax - barMin;
 
-    // A target behind the origin has no room to be drawn as a milestone still ahead, so it belongs at
-    // the origin with the whole bar counting as progress past it. Scaling it as though it were ahead
-    // is what used to squeeze the fill into an invisible sliver at the far right.
+    // Pin target at start if origin is ahead of target
     const anchorPercent =
       target === undefined
         ? undefined
@@ -138,8 +128,7 @@ const IndicatorProgressRow = ({
       return aboveTarget > 0 ? anchorPercent + ((value - target) / aboveTarget) * (100 - anchorPercent) : anchorPercent;
     };
 
-    // A target already behind the origin with nothing added this year leaves no span to scale, but the
-    // target is still met, so the bar reads as complete rather than empty.
+    // Show target met if origin is ahead of target
     if (targetBehindOrigin && range <= 0) {
       return { segments: [{ key: 'total', quarter: undefined, startPercent: 0, widthPercent: 100 }], targetPercent: 0 };
     }
@@ -186,7 +175,6 @@ const IndicatorProgressRow = ({
       return undefined;
     }
 
-    // a yearly target measures the year's progress alone, so the project baseline is not on its scale
     const origin = isYearly ? 0 : baselineValue;
     const denominator = target - origin;
 
@@ -194,9 +182,6 @@ const IndicatorProgressRow = ({
       return undefined;
     }
 
-    // A target already met before this year began divides a whole lifetime of progress by a target
-    // that stopped being the yardstick years ago, which reads as an absurd figure next to a full bar.
-    // The only honest thing left to say about it is that it is met.
     if (targetBehindOrigin) {
       return 100;
     }
@@ -330,11 +315,7 @@ const IndicatorProgressRow = ({
               color={theme.palette.TwClrTxtSecondary}
               fontSize='14px'
               position='absolute'
-              sx={
-                // the label is right-aligned on the mark, so at the origin it would sit entirely off
-                // the left edge; park it opposite instead, as it is when there is no mark to align to
-                targetPercent ? { left: `${targetPercent}%`, transform: 'translateX(-100%)' } : { right: 0 }
-              }
+              sx={targetPercent ? { left: `${targetPercent}%`, transform: 'translateX(-100%)' } : { right: 0 }}
               top={0}
               whiteSpace='nowrap'
             >

--- a/src/components/AcceleratorReports/IndicatorProgressRow.tsx
+++ b/src/components/AcceleratorReports/IndicatorProgressRow.tsx
@@ -315,9 +315,11 @@ const IndicatorProgressRow = ({
               color={theme.palette.TwClrTxtSecondary}
               fontSize='14px'
               position='absolute'
-
-              sx={targetPercent !== undefined ? { left: `${targetPercent}%`, transform: 'translateX(-100%)' } : { right: 0 }}
-
+              sx={
+                targetPercent !== undefined
+                  ? { left: `${targetPercent}%`, transform: 'translateX(-100%)' }
+                  : { right: 0 }
+              }
               top={0}
               whiteSpace='nowrap'
             >

--- a/src/components/AcceleratorReports/IndicatorProgressRow.tsx
+++ b/src/components/AcceleratorReports/IndicatorProgressRow.tsx
@@ -59,6 +59,10 @@ const IndicatorProgressRow = ({
   // a yearly indicator restarts at zero each year, so it carries neither the baseline nor a prior total
   const startingTotal = isLifetime ? indicator.previousYearCumulativeTotal ?? baselineValue : 0;
 
+  // A lifetime bar starts at the total carried in from earlier years, so from the second year on the
+  // year's target can sit behind that origin — it was reached before this year began.
+  const targetBehindOrigin = indicator.target !== undefined && indicator.target <= startingTotal;
+
   const startingTotalLabel =
     indicator.previousYearCumulativeTotal !== undefined && year !== undefined ? String(year - 1) : strings.BASELINE;
 
@@ -98,15 +102,30 @@ const IndicatorProgressRow = ({
     const barMax = Math.max(total, target ?? 0, barMin);
     const range = barMax - barMin;
 
+    // A target behind the origin has no room to be drawn as a milestone still ahead, so it belongs at
+    // the origin with the whole bar counting as progress past it. Scaling it as though it were ahead
+    // is what used to squeeze the fill into an invisible sliver at the far right.
     const anchorPercent =
-      target !== undefined && range > 0 ? Math.max(MIN_TARGET_PERCENT, ((target - barMin) / range) * 100) : undefined;
+      target === undefined
+        ? undefined
+        : targetBehindOrigin
+          ? 0
+          : range > 0
+            ? Math.max(MIN_TARGET_PERCENT, ((target - barMin) / range) * 100)
+            : undefined;
 
     const toPercent = (value: number) => {
-      if (range <= 0) {
+      // the origin is 0 by definition, whatever the scale does above it
+      if (value <= barMin) {
         return 0;
       }
 
-      if (anchorPercent === undefined || target === undefined) {
+      if (range <= 0) {
+        return 100;
+      }
+
+      // with the target at the origin there is no piecewise split left to make
+      if (target === undefined || anchorPercent === undefined || anchorPercent <= 0) {
         return ((value - barMin) / range) * 100;
       }
 
@@ -118,6 +137,12 @@ const IndicatorProgressRow = ({
       const aboveTarget = barMax - target;
       return aboveTarget > 0 ? anchorPercent + ((value - target) / aboveTarget) * (100 - anchorPercent) : anchorPercent;
     };
+
+    // A target already behind the origin with nothing added this year leaves no span to scale, but the
+    // target is still met, so the bar reads as complete rather than empty.
+    if (targetBehindOrigin && range <= 0) {
+      return { segments: [{ key: 'total', quarter: undefined, startPercent: 0, widthPercent: 100 }], targetPercent: 0 };
+    }
 
     let runningTotal = barMin;
     const barSegments =
@@ -136,7 +161,7 @@ const IndicatorProgressRow = ({
         : [{ key: 'total', quarter: undefined, startPercent: 0, widthPercent: toPercent(total) }];
 
     return { segments: barSegments, targetPercent: anchorPercent };
-  }, [cumulativeValue, currentYearProgress, indicator.target, isCumulative, startingTotal]);
+  }, [cumulativeValue, currentYearProgress, indicator.target, isCumulative, startingTotal, targetBehindOrigin]);
 
   const fillColor =
     indicator.status === 'Unlikely'
@@ -169,8 +194,15 @@ const IndicatorProgressRow = ({
       return undefined;
     }
 
+    // A target already met before this year began divides a whole lifetime of progress by a target
+    // that stopped being the yardstick years ago, which reads as an absurd figure next to a full bar.
+    // The only honest thing left to say about it is that it is met.
+    if (targetBehindOrigin) {
+      return 100;
+    }
+
     return Math.round((((cumulativeValue ?? 0) - origin) / denominator) * 100);
-  }, [baselineValue, cumulativeValue, indicator.target, isYearly]);
+  }, [baselineValue, cumulativeValue, indicator.target, isYearly, targetBehindOrigin]);
 
   const statusOptions = useMemo<DropdownItem[]>(
     () => [
@@ -299,9 +331,9 @@ const IndicatorProgressRow = ({
               fontSize='14px'
               position='absolute'
               sx={
-                targetPercent !== undefined
-                  ? { left: `${targetPercent}%`, transform: 'translateX(-100%)' }
-                  : { right: 0 }
+                // the label is right-aligned on the mark, so at the origin it would sit entirely off
+                // the left edge; park it opposite instead, as it is when there is no mark to align to
+                targetPercent ? { left: `${targetPercent}%`, transform: 'translateX(-100%)' } : { right: 0 }
               }
               top={0}
               whiteSpace='nowrap'

--- a/src/components/AcceleratorReports/IndicatorProgressRow.tsx
+++ b/src/components/AcceleratorReports/IndicatorProgressRow.tsx
@@ -315,7 +315,9 @@ const IndicatorProgressRow = ({
               color={theme.palette.TwClrTxtSecondary}
               fontSize='14px'
               position='absolute'
-              sx={targetPercent ? { left: `${targetPercent}%`, transform: 'translateX(-100%)' } : { right: 0 }}
+
+              sx={targetPercent !== undefined ? { left: `${targetPercent}%`, transform: 'translateX(-100%)' } : { right: 0 }}
+
               top={0}
               whiteSpace='nowrap'
             >

--- a/src/components/AcceleratorReports/LifetimeProgressBar.tsx
+++ b/src/components/AcceleratorReports/LifetimeProgressBar.tsx
@@ -44,25 +44,54 @@ const LifetimeProgressBar = ({
       return [];
     }
 
-    return [
-      previousYearCumulativeTotal !== undefined
-        ? { key: 'previousYear', label: String(year - 1), percent: toBarPercent(previousYearCumulativeTotal) }
-        : undefined,
-      yearTarget !== undefined
+    // Once the year's target is behind us it is no longer the thing to aim at, and marking it reads as
+    // a step backwards whenever the previous year's total is already past it. Mark where the year has
+    // actually reached instead.
+    const yearTargetMet = yearTarget !== undefined && currentProgress >= yearTarget;
+
+    const yearMark = yearTargetMet
+      ? { key: 'yearToDate', label: String(year), percent: toBarPercent(currentProgress) }
+      : yearTarget !== undefined
         ? {
             key: 'yearTarget',
             label: strings.formatString(strings.X_TARGET, String(year)).toString(),
             percent: toBarPercent(yearTarget),
           }
+        : undefined;
+
+    const marks = [
+      previousYearCumulativeTotal !== undefined
+        ? { key: 'previousYear', label: String(year - 1), percent: toBarPercent(previousYearCumulativeTotal) }
         : undefined,
+      yearMark,
     ].filter((tick): tick is { key: string; label: string; percent: number } => tick !== undefined);
-  }, [lifetimeSpan, previousYearCumulativeTotal, strings, toBarPercent, year, yearTarget]);
+
+    // Marks that land on the same spot — both clamped to the end of the project, say — would stack
+    // their labels on top of one another. The later year is the one worth reading.
+    const taken = new Set<number>();
+
+    return marks
+      .reverse()
+      .filter((tick) => {
+        const position = Math.round(tick.percent);
+
+        if (taken.has(position)) {
+          return false;
+        }
+
+        taken.add(position);
+        return true;
+      })
+      .reverse();
+  }, [currentProgress, lifetimeSpan, previousYearCumulativeTotal, strings, toBarPercent, year, yearTarget]);
 
   if (lifetimeSpan <= 0) {
     return null;
   }
 
-  const percentComplete = Math.round(toPercent(currentProgress));
+  // clamped like the fill it describes: an end-of-project target that progress has run past says
+  // complete, not 535083%
+  const percentComplete = Math.round(toBarPercent(currentProgress));
 
   return (
     // the tick labels hang below the bar so they do not pull the row's centre off the bar itself


### PR DESCRIPTION
A lifetime indicator's bars are scaled around the cumulative total carried in from earlier years, but its target is the target for the _current_ year. From the second year on those diverge, and the rendering breaks in two separate places once the target falls behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)