### PR TITLE
Planting Goals Tab: Show spinner only on first load

### DIFF
--- a/src/hooks/usePlantingSite.ts
+++ b/src/hooks/usePlantingSite.ts
@@ -23,7 +23,8 @@ const usePlantingSite = (plantingSiteId: number | undefined) => {
 
   return {
     plantingSite,
-    isLoading: getPlantingSiteResponse.isFetching,
+    isLoading: getPlantingSiteResponse.isLoading,
+    isFetching: getPlantingSiteResponse.isFetching,
     isSuccess: getPlantingSiteResponse.isSuccess,
   };
 };

--- a/src/scenes/PlantingPlansRouter/PlantingPlanDetailsView.tsx
+++ b/src/scenes/PlantingPlansRouter/PlantingPlanDetailsView.tsx
@@ -32,7 +32,7 @@ const PlantingPlanDetailsView = (): JSX.Element => {
 
   const params = useParams<{ plantingSiteId: string }>();
   const plantingSiteId = Number(params.plantingSiteId);
-  const { plantingSite, isLoading } = usePlantingSite(plantingSiteId);
+  const { plantingSite } = usePlantingSite(plantingSiteId);
 
   const [segment, setSegment] = useState<PlantingPlanSegment>(readStoredSegment);
   const [addSeasonModalOpen, , openAddSeasonModal, closeAddSeasonModal] = useBoolean(false);
@@ -93,7 +93,7 @@ const PlantingPlanDetailsView = (): JSX.Element => {
     [description, plantingSite, segment, segments, selectSegment, strings, theme]
   );
 
-  if (isLoading || !plantingSite) {
+  if (!plantingSite) {
     return <BusySpinner withSkrim={true} />;
   }
 

--- a/src/scenes/PlantingPlansRouter/PlantingPlanDetailsView.tsx
+++ b/src/scenes/PlantingPlansRouter/PlantingPlanDetailsView.tsx
@@ -32,7 +32,7 @@ const PlantingPlanDetailsView = (): JSX.Element => {
 
   const params = useParams<{ plantingSiteId: string }>();
   const plantingSiteId = Number(params.plantingSiteId);
-  const { plantingSite } = usePlantingSite(plantingSiteId);
+  const { plantingSite, isLoading } = usePlantingSite(plantingSiteId);
 
   const [segment, setSegment] = useState<PlantingPlanSegment>(readStoredSegment);
   const [addSeasonModalOpen, , openAddSeasonModal, closeAddSeasonModal] = useBoolean(false);
@@ -93,7 +93,7 @@ const PlantingPlanDetailsView = (): JSX.Element => {
     [description, plantingSite, segment, segments, selectSegment, strings, theme]
   );
 
-  if (!plantingSite) {
+  if (isLoading || !plantingSite) {
     return <BusySpinner withSkrim={true} />;
   }
 


### PR DESCRIPTION
This is to avoid showing the spinner in every density edit