### PR TITLE
SW-8829 Save expand/collapse state of nav items to preferences

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@rsbuild/plugin-svgr": "^2.0.5",
     "@rsbuild/plugin-type-check": "^1.6.0",
     "@rstest/core": "^0.11.0",
-    "@terraware/web-components": "^v5.0.0",
+    "@terraware/web-components": "^v5.0.8",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.0.0",
     "@turf/area": "^6.5.0",

--- a/playwright/e2e/suites/interaction/accession.spec.ts
+++ b/playwright/e2e/suites/interaction/accession.spec.ts
@@ -186,8 +186,8 @@ test.describe('AccessionTests', () => {
         ''
       );
       await page.locator(`#${accessionRow}-accessionNumber`).getByText(accessionId).click();
-      await page.getByRole('button', { name: 'Withdraw' }).waitFor({ state: 'visible' });
-      await page.getByRole('button', { name: 'Withdraw' }).click();
+      await page.getByRole('button', { name: 'Withdraw', ...exactOptions }).waitFor({ state: 'visible' });
+      await page.getByRole('button', { name: 'Withdraw', ...exactOptions }).click();
 
       await page.getByPlaceholder('Select...').first().click();
       await page.getByText('Planting', { exact: true }).click();

--- a/playwright/e2e/suites/interaction/accession.spec.ts
+++ b/playwright/e2e/suites/interaction/accession.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { changeToSuperAdmin } from '../../utils/userUtils';
-import { exactOptions, selectOrg, waitFor } from '../../utils/utils';
+import { exactOptions, openNavItem, selectOrg, waitFor } from '../../utils/utils';
 
 const yearId = new Date().getFullYear().toString().slice(-2);
 
@@ -18,8 +18,7 @@ test.describe('AccessionTests', () => {
   });
 
   test('Add An Accession', async ({ page }, testInfo) => {
-    await page.getByRole('button', { name: 'Seeds' }).click();
-    await page.getByRole('button', { name: 'Accessions' }).click();
+    await openNavItem(page, 'Seeds', 'Accessions');
     await page.getByRole('button', { name: 'Add Accession' }).click();
     await page.getByPlaceholder('Search or Select...').click();
     await page.locator('li').filter({ hasText: 'Coconut' }).locator('div').click();
@@ -139,8 +138,7 @@ test.describe('AccessionTests', () => {
   test.describe('Withdraw Tests', () => {
     test.describe.configure({ mode: 'default' });
     test('Withdraw to Nursery by seed count', async ({ page }, testInfo) => {
-      await page.getByRole('button', { name: 'Seeds' }).click();
-      await page.getByRole('button', { name: 'Accessions' }).click();
+      await openNavItem(page, 'Seeds', 'Accessions');
 
       const accessionRow = (await page.getByText(accessionId).evaluate((el) => el.closest('td')?.id ?? '')).replace(
         '-accessionNumber',
@@ -162,8 +160,7 @@ test.describe('AccessionTests', () => {
       await expect(page.getByLabel('History')).toContainText(
         'Super Admin withdrew 300 seeds for nurseryAdding some test notes here!'
       );
-      await page.getByRole('button', { name: 'Seedlings' }).click();
-      await page.getByRole('button', { name: 'Inventory', ...exactOptions }).click();
+      await openNavItem(page, 'Seedlings', 'Inventory');
       await page.getByLabel('By Species').getByText('By Species').waitFor({ state: 'visible' });
       await page.getByText('Coconut', exactOptions).locator('..').waitFor({ state: 'visible' });
       const coconutRowNum = (
@@ -182,8 +179,7 @@ test.describe('AccessionTests', () => {
     });
 
     test('Withdraw to Plant', async ({ page }, testInfo) => {
-      await page.getByRole('button', { name: 'Seeds' }).click();
-      await page.getByRole('button', { name: 'Accessions' }).click();
+      await openNavItem(page, 'Seeds', 'Accessions');
 
       const accessionRow = (await page.getByText(accessionId).evaluate((el) => el.closest('td')?.id ?? '')).replace(
         '-accessionNumber',
@@ -203,8 +199,7 @@ test.describe('AccessionTests', () => {
     });
 
     test('Withdraw to Viability Test', async ({ page }, testInfo) => {
-      await page.getByRole('button', { name: 'Seeds' }).click();
-      await page.getByRole('button', { name: 'Accessions' }).click();
+      await openNavItem(page, 'Seeds', 'Accessions');
 
       const accessionRow = (await page.getByText(accessionId).evaluate((el) => el.closest('td')?.id ?? '')).replace(
         '-accessionNumber',

--- a/playwright/e2e/suites/interaction/adHocObservationDataUpload.spec.ts
+++ b/playwright/e2e/suites/interaction/adHocObservationDataUpload.spec.ts
@@ -6,7 +6,7 @@ import {
   uploadAdHocObservationData,
 } from '../../utils/observationUtils';
 import { changeToSuperAdmin } from '../../utils/userUtils';
-import { selectOrg, waitFor } from '../../utils/utils';
+import { openNavItem, selectOrg, waitFor } from '../../utils/utils';
 
 test.describe('AdHocObservationDataUploadTests', () => {
   test.beforeEach(async ({ context, baseURL }) => {
@@ -31,8 +31,7 @@ test.describe('AdHocObservationDataUploadTests', () => {
     await page.goto('/');
     await waitFor(page, '#home');
     await selectOrg(page, 'Terraformation (staging)');
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Observations' }).click();
+    await openNavItem(page, 'Plantings', 'Observations');
     await page.getByRole('textbox').first().click();
     await page.locator('li.select-value', { hasText: 'All Planting Sites' }).click();
     await page.locator('#plot-selection-selector').click();

--- a/playwright/e2e/suites/interaction/inventory.spec.ts
+++ b/playwright/e2e/suites/interaction/inventory.spec.ts
@@ -2,7 +2,7 @@ import { Locator, expect, test } from '@playwright/test';
 import { Page } from 'playwright-core';
 
 import { changeToSuperAdmin } from '../../utils/userUtils';
-import { exactOptions, selectOrg, waitFor } from '../../utils/utils';
+import { exactOptions, openNavItem, selectOrg, waitFor } from '../../utils/utils';
 
 test.describe('InventoryTests', () => {
   test.beforeEach(async ({ page, context, baseURL }, testInfo) => {
@@ -13,8 +13,7 @@ test.describe('InventoryTests', () => {
   });
 
   test('Add A Batch (no accession)', async ({ page }, testInfo) => {
-    await page.getByRole('button', { name: 'Seedlings' }).click();
-    await page.getByRole('button', { name: 'Inventory', ...exactOptions }).click();
+    await openNavItem(page, 'Seedlings', 'Inventory');
     await page.locator('#new-inventory').click();
     await page.getByPlaceholder('Search or Select...').click();
     await page.locator('li').filter({ hasText: 'Banana' }).locator('div').click();
@@ -60,8 +59,7 @@ test.describe('InventoryTests', () => {
   });
 
   test('Add A Batch from an Accession', async ({ page }, testInfo) => {
-    await page.getByRole('button', { name: 'Seedlings' }).click();
-    await page.getByRole('button', { name: 'Inventory', ...exactOptions }).click();
+    await openNavItem(page, 'Seedlings', 'Inventory');
     await page.locator('#new-inventory').click();
     await page.getByPlaceholder('Search or Select...').click();
     await page.locator('li').filter({ hasText: 'Kousa Dogwood' }).locator('div').click();
@@ -100,8 +98,7 @@ test.describe('InventoryTests', () => {
   });
 
   test('Transition Status and Withdraw Dead', async ({ page }, testInfo) => {
-    await page.getByRole('button', { name: 'Seedlings' }).click();
-    await page.getByRole('button', { name: 'Inventory', ...exactOptions }).click();
+    await openNavItem(page, 'Seedlings', 'Inventory');
     await page.getByRole('tab', { name: 'By Batch' }).click();
     const batchNumber = await getBatchNumberBySpeciesAndNursery(page, 'Kousa Dogwood', 'Nursery');
     await page.getByRole('link', { name: batchNumber }).click();
@@ -152,8 +149,7 @@ test.describe('InventoryTests', () => {
   });
 
   test('Transfer Nurseries', async ({ page }, testInfo) => {
-    await page.getByRole('button', { name: 'Seedlings' }).click();
-    await page.getByRole('button', { name: 'Inventory', ...exactOptions }).click();
+    await openNavItem(page, 'Seedlings', 'Inventory');
     await page.getByRole('tab', { name: 'By Batch' }).click();
     const batchNumber = await getBatchNumberBySpeciesAndNursery(page, 'Banana', 'Nursery');
     await page.getByRole('link', { name: batchNumber }).click();
@@ -230,8 +226,7 @@ test.describe('InventoryTests', () => {
       console.log(message.text());
     });
 
-    await page.getByRole('button', { name: 'Seedlings' }).click();
-    await page.getByRole('button', { name: 'Inventory', ...exactOptions }).click();
+    await openNavItem(page, 'Seedlings', 'Inventory');
     await page.getByRole('tab', { name: 'By Batch' }).click();
 
     const batchNumber = await getBatchNumberBySpeciesAndNursery(page, 'Kousa Dogwood', 'Nursery');
@@ -258,8 +253,7 @@ test.describe('InventoryTests', () => {
     await page.locator('#acknowledge-button').click();
     await page.getByRole('tab', { name: 'History' }).click();
     await expect(page.getByRole('cell', { name: 'Withdrawal - Planting' }).nth(0)).toBeVisible();
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Planting Progress' }).click();
+    await openNavItem(page, 'Plantings', 'Planting Progress');
     await expect(page.getByRole('cell', { name: 'Planting Site' })).toBeVisible();
     await expect(page.getByRole('cell', { name: '60' })).toBeVisible();
     await page.getByRole('link', { name: '60' }).click();
@@ -276,8 +270,7 @@ test.describe('InventoryTests', () => {
   });
 
   test('Plants dashboard after outplanting', async ({ page }, testInfo) => {
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).click();
+    await openNavItem(page, 'Plantings', 'Dashboard');
     await page.getByPlaceholder('Select...').click();
     await page.getByText('Planting Site', { exact: true }).click();
     await expect(page.getByText('60')).toBeVisible();
@@ -287,8 +280,7 @@ test.describe('InventoryTests', () => {
   });
 
   test('Withdrawals after outplanting', async ({ page }, testInfo) => {
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Planting Progress' }).click();
+    await openNavItem(page, 'Plantings', 'Planting Progress');
     const mapTab = page.locator('p.MuiTypography-root').filter({ hasText: 'Map', hasNotText: 'show for this' });
     await mapTab.click();
 

--- a/playwright/e2e/suites/interaction/locations.spec.ts
+++ b/playwright/e2e/suites/interaction/locations.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { changeToSuperAdmin } from '../../utils/userUtils';
-import { selectOrg, waitFor } from '../../utils/utils';
+import { openNavItem, selectOrg, waitFor } from '../../utils/utils';
 
 test.describe('LocationTests', () => {
   test.beforeEach(async ({ page, context, baseURL }, testInfo) => {
@@ -14,8 +14,7 @@ test.describe('LocationTests', () => {
   test('Create a Seedbank', async ({ page }, testInfo) => {
     const newSeedBankName = `My New Seed Bank-${new Date().getTime()}`;
 
-    await page.getByRole('button', { name: 'Locations' }).click();
-    await page.getByRole('button', { name: 'Seed Banks' }).click();
+    await openNavItem(page, 'Locations', 'Seed Banks');
 
     await page.getByRole('button', { name: 'Add Seed Bank' }).click();
 
@@ -58,8 +57,7 @@ test.describe('LocationTests', () => {
   test('Create a Nursery', async ({ page }, testInfo) => {
     const newNurseryName = `My New Nursery-${new Date().getTime()}`;
 
-    await page.getByRole('button', { name: 'Locations' }).click();
-    await page.getByRole('button', { name: 'Nurseries' }).click();
+    await openNavItem(page, 'Locations', 'Nurseries');
     await page.getByRole('button', { name: 'Add Nursery' }).click();
     await page.locator('#name').getByRole('textbox').fill(newNurseryName);
     await page.locator('textarea').click();

--- a/playwright/e2e/suites/interaction/observationDataUpload.spec.ts
+++ b/playwright/e2e/suites/interaction/observationDataUpload.spec.ts
@@ -8,7 +8,7 @@ import {
   uploadObservationData,
 } from '../../utils/observationUtils';
 import { changeToSuperAdmin } from '../../utils/userUtils';
-import { selectOrg, waitFor } from '../../utils/utils';
+import { openNavItem, selectOrg, waitFor } from '../../utils/utils';
 
 test.describe('ObservationDataUploadTests', () => {
   test.beforeEach(async ({ context, baseURL }) => {
@@ -38,8 +38,7 @@ test.describe('ObservationDataUploadTests', () => {
     await page.goto('/');
     await waitFor(page, '#home');
     await selectOrg(page, 'Terraformation (staging)');
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Observations' }).click();
+    await openNavItem(page, 'Plantings', 'Observations');
     await page.getByRole('textbox').first().click();
     await page.locator('li.select-value', { hasText: 'All Planting Sites' }).click();
 

--- a/playwright/e2e/suites/interaction/observationDetails.spec.ts
+++ b/playwright/e2e/suites/interaction/observationDetails.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { changeToSuperAdmin } from '../../utils/userUtils';
-import { selectOrg, waitFor } from '../../utils/utils';
+import { openNavItem, selectOrg, waitFor } from '../../utils/utils';
 
 test.describe('ObservationDetailsTests', () => {
   test.beforeEach(async ({ page, context, baseURL }, testInfo) => {
@@ -9,8 +9,7 @@ test.describe('ObservationDetailsTests', () => {
     await page.goto('/');
     await waitFor(page, '#home');
     await selectOrg(page, 'Terraformation (staging)');
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Observations' }).click();
+    await openNavItem(page, 'Plantings', 'Observations');
 
     // wait for table rows to load
     await waitFor(page, '#row1');

--- a/playwright/e2e/suites/interaction/observations.spec.ts
+++ b/playwright/e2e/suites/interaction/observations.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { changeToSuperAdmin } from '../../utils/userUtils';
-import { selectOrg, waitFor } from '../../utils/utils';
+import { openNavItem, selectOrg, waitFor } from '../../utils/utils';
 
 test.describe('ObservationsTests', () => {
   test.beforeEach(async ({ page, context, baseURL }, testInfo) => {
@@ -12,8 +12,7 @@ test.describe('ObservationsTests', () => {
   });
 
   test('Schedule Observation', async ({ page }, testInfo) => {
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Observations' }).click();
+    await openNavItem(page, 'Plantings', 'Observations');
 
     await page.getByRole('button', { name: 'Schedule Observation' }).click();
     await expect(page.getByText('Schedule Observation')).toBeVisible();
@@ -42,8 +41,7 @@ test.describe('ObservationsTests', () => {
   });
 
   test('Reschedule Observation', async ({ page }, testInfo) => {
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Observations' }).click();
+    await openNavItem(page, 'Plantings', 'Observations');
 
     // wait for table rows to load
     await waitFor(page, '#row1');
@@ -81,8 +79,7 @@ test.describe('ObservationsTests', () => {
   });
 
   test('End Observation', async ({ page }, testInfo) => {
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Observations' }).click();
+    await openNavItem(page, 'Plantings', 'Observations');
 
     // wait for table rows to load
     await waitFor(page, '#row1');

--- a/playwright/e2e/suites/interaction/participantPlantsDashboard.spec.ts
+++ b/playwright/e2e/suites/interaction/participantPlantsDashboard.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { changeToSuperAdmin } from '../../utils/userUtils';
-import { exactOptions, selectOrg, waitFor } from '../../utils/utils';
+import { openNavItem, selectOrg, waitFor } from '../../utils/utils';
 
 test.describe('ParticipantPlantsDashboardTests', () => {
   test.beforeEach(async ({ page, context, baseURL }, testInfo) => {
@@ -13,8 +13,7 @@ test.describe('ParticipantPlantsDashboardTests', () => {
   test('Rolled-up dashboard for selected project', async ({ page }, testInfo) => {
     await selectOrg(page, 'Terraformation (staging)');
 
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).click();
+    await openNavItem(page, 'Plantings', 'Dashboard');
 
     await page.getByPlaceholder('No Project Selected').click();
     await page.getByText('Phase 1 Project', { exact: true }).click();
@@ -60,8 +59,7 @@ test.describe('ParticipantPlantsDashboardTests', () => {
   test('Planting site dashboard no observations', async ({ page }, testInfo) => {
     await selectOrg(page, 'Terraformation (staging)');
 
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).click();
+    await openNavItem(page, 'Plantings', 'Dashboard');
 
     await page.getByPlaceholder('Select...').click();
     await page.getByText('PS1', { exact: true }).click();
@@ -107,8 +105,7 @@ test.describe('ParticipantPlantsDashboardTests', () => {
   test('Planting site dashboard observations', async ({ page }, testInfo) => {
     await selectOrg(page, 'Terraformation (staging)');
 
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).click();
+    await openNavItem(page, 'Plantings', 'Dashboard');
 
     await page.getByPlaceholder('Select...').click();
     await page.getByText('PS2', { exact: true }).click();
@@ -203,8 +200,7 @@ test.describe('ParticipantPlantsDashboardTests', () => {
     await page.reload();
 
     await waitFor(page, '#home');
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).click();
+    await openNavItem(page, 'Plantings', 'Dashboard');
 
     await expect(page.getByText('To view data in this dashboard, add a planting site', { exact: true })).toBeVisible({
       timeout: 5000,

--- a/playwright/e2e/suites/interaction/survivalRateSettings.spec.ts
+++ b/playwright/e2e/suites/interaction/survivalRateSettings.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { changeToSuperAdmin } from '../../utils/userUtils';
-import { exactOptions, selectOrg, waitFor } from '../../utils/utils';
+import { openNavItem, selectOrg, waitFor } from '../../utils/utils';
 
 test.describe('SurvivalRateSettingsTests', () => {
   test.describe.configure({ timeout: 120000 });
@@ -16,10 +16,7 @@ test.describe('SurvivalRateSettingsTests', () => {
   test('Edit permanent plots T0 settings using observation data and verify survival rate on dashboard', async ({
     page,
   }) => {
-    if (!(await page.getByRole('button', { name: 'Observations' }).isVisible())) {
-      await page.getByRole('button', { name: 'Plantings' }).click();
-    }
-    await page.getByRole('button', { name: 'Observations' }).click();
+    await openNavItem(page, 'Plantings', 'Observations');
     await page.locator('.select').first().click();
     await page.getByRole('list').getByText('PS2', { exact: true }).click();
     await expect(page.getByRole('button', { name: 'Survival Rate Settings' })).toBeVisible({ timeout: 10000 });
@@ -39,10 +36,7 @@ test.describe('SurvivalRateSettingsTests', () => {
     await expect(page.getByText('t0 set for Permanent Plots')).toBeVisible({ timeout: 60000 });
 
     // Navigate to Dashboard
-    if (!(await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).isVisible())) {
-      await page.getByRole('button', { name: 'Plantings' }).click();
-    }
-    await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).click();
+    await openNavItem(page, 'Plantings', 'Dashboard');
     await page.getByPlaceholder('Select...').click();
     await page.getByText('PS2', { exact: true }).click();
 
@@ -50,10 +44,7 @@ test.describe('SurvivalRateSettingsTests', () => {
   });
 
   test('Edit one plot to manual density and verify new survival rate', async ({ page }) => {
-    if (!(await page.getByRole('button', { name: 'Observations' }).isVisible())) {
-      await page.getByRole('button', { name: 'Plantings' }).click();
-    }
-    await page.getByRole('button', { name: 'Observations' }).click();
+    await openNavItem(page, 'Plantings', 'Observations');
     await page.locator('.select').first().click();
     await page.getByRole('list').getByText('PS2', { exact: true }).click();
     await expect(page.getByRole('button', { name: 'Survival Rate Settings' })).toBeVisible({ timeout: 10000 });
@@ -82,10 +73,7 @@ test.describe('SurvivalRateSettingsTests', () => {
     await expect(page.getByText('t0 set for Permanent Plots')).toBeVisible({ timeout: 60000 });
 
     // Navigate to Dashboard
-    if (!(await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).isVisible())) {
-      await page.getByRole('button', { name: 'Plantings' }).click();
-    }
-    await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).click();
+    await openNavItem(page, 'Plantings', 'Dashboard');
     await page.getByPlaceholder('Select...').click();
     await page.getByText('PS2', { exact: true }).click();
 

--- a/playwright/e2e/suites/screenshots/observationDetailsScreenshots.spec.ts
+++ b/playwright/e2e/suites/screenshots/observationDetailsScreenshots.spec.ts
@@ -1,7 +1,7 @@
 import { Page, expect, test } from '@playwright/test';
 
 import { changeToSuperAdmin } from '../../utils/userUtils';
-import { selectOrg, waitFor } from '../../utils/utils';
+import { openNavItem, selectOrg, waitFor } from '../../utils/utils';
 
 // For element-level screenshots (tables, map containers) where content is uniform
 const SCREENSHOT_OPTIONS = {
@@ -53,8 +53,7 @@ test.describe('ObservationDetailsScreenshots', () => {
     await page.goto('/');
     await waitFor(page, '#home');
     await selectOrg(page, 'Terraformation (staging)');
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Observations' }).click();
+    await openNavItem(page, 'Plantings', 'Observations');
     await waitFor(page, '#row1');
   });
 

--- a/playwright/e2e/suites/screenshots/plantsDashboardScreenshots.spec.ts
+++ b/playwright/e2e/suites/screenshots/plantsDashboardScreenshots.spec.ts
@@ -1,7 +1,7 @@
 import { Page, expect, test } from '@playwright/test';
 
 import { changeToSuperAdmin } from '../../utils/userUtils';
-import { exactOptions, selectOrg, waitFor } from '../../utils/utils';
+import { openNavItem, selectOrg, waitFor } from '../../utils/utils';
 
 // For element-level screenshots (cards, tables) where content is uniform
 const SCREENSHOT_OPTIONS = {
@@ -60,8 +60,7 @@ test.describe('PlantsDashboardScreenshots', () => {
     await page.reload();
     await waitFor(page, '#home', 15000);
 
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).click();
+    await openNavItem(page, 'Plantings', 'Dashboard');
 
     await expect(page.getByText('To view data in this dashboard, add a planting site', { exact: true })).toBeVisible({
       timeout: 5000,
@@ -84,8 +83,7 @@ test.describe('PlantsDashboardScreenshots', () => {
   test('Plants Dashboard — project area totals with rolled-up view', async ({ page }) => {
     await selectOrg(page, 'Terraformation (staging)');
 
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).click();
+    await openNavItem(page, 'Plantings', 'Dashboard');
 
     await page.getByPlaceholder('No Project Selected').click();
     await page.getByText('Phase 1 Project', { exact: true }).click();
@@ -101,8 +99,7 @@ test.describe('PlantsDashboardScreenshots', () => {
   test('Plants Dashboard — planting site with no observations (plants and species card)', async ({ page }) => {
     await selectOrg(page, 'Terraformation (staging)');
 
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).click();
+    await openNavItem(page, 'Plantings', 'Dashboard');
 
     await page.getByPlaceholder('Select...').click();
     await page.getByText('PS1', { exact: true }).click();
@@ -116,8 +113,7 @@ test.describe('PlantsDashboardScreenshots', () => {
   test('Plants Dashboard — planting site with no observations (site map)', async ({ page }) => {
     await selectOrg(page, 'Terraformation (staging)');
 
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).click();
+    await openNavItem(page, 'Plantings', 'Dashboard');
 
     await page.getByPlaceholder('Select...').click();
     await page.getByText('PS1', { exact: true }).click();
@@ -134,8 +130,7 @@ test.describe('PlantsDashboardScreenshots', () => {
   test('Plants Dashboard — planting site with observations (full page)', async ({ page }) => {
     await selectOrg(page, 'Terraformation (staging)');
 
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).click();
+    await openNavItem(page, 'Plantings', 'Dashboard');
 
     await page.getByPlaceholder('Select...').click();
     await page.getByText('PS2', { exact: true }).click();
@@ -152,8 +147,7 @@ test.describe('PlantsDashboardScreenshots', () => {
   test('Plants Dashboard — planting site with observations (stratum trends card)', async ({ page }) => {
     await selectOrg(page, 'Terraformation (staging)');
 
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).click();
+    await openNavItem(page, 'Plantings', 'Dashboard');
 
     await page.getByPlaceholder('Select...').click();
     await page.getByText('PS2', { exact: true }).click();
@@ -168,8 +162,7 @@ test.describe('PlantsDashboardScreenshots', () => {
   test('Plants Dashboard — planting site with observations (plant density card)', async ({ page }) => {
     await selectOrg(page, 'Terraformation (staging)');
 
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).click();
+    await openNavItem(page, 'Plantings', 'Dashboard');
 
     await page.getByPlaceholder('Select...').click();
     await page.getByText('PS2', { exact: true }).click();
@@ -183,8 +176,7 @@ test.describe('PlantsDashboardScreenshots', () => {
   test('Plants Dashboard — planting site with observations (site map)', async ({ page }) => {
     await selectOrg(page, 'Terraformation (staging)');
 
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).click();
+    await openNavItem(page, 'Plantings', 'Dashboard');
 
     await page.getByPlaceholder('Select...').click();
     await page.getByText('PS2', { exact: true }).click();
@@ -201,8 +193,7 @@ test.describe('PlantsDashboardScreenshots', () => {
   test('Plants Dashboard — site map with observation events layer toggled on', async ({ page }) => {
     await selectOrg(page, 'Terraformation (staging)');
 
-    await page.getByRole('button', { name: 'Plantings' }).click();
-    await page.getByRole('button', { name: 'Dashboard', ...exactOptions }).click();
+    await openNavItem(page, 'Plantings', 'Dashboard');
 
     await page.getByPlaceholder('Select...').click();
     await page.getByText('PS2', { exact: true }).click();

--- a/playwright/e2e/utils/utils.ts
+++ b/playwright/e2e/utils/utils.ts
@@ -16,3 +16,12 @@ export const selectOrg = async (page: Page, orgName: string) => {
     await waitFor(page, '#home');
   }
 };
+
+export const openNavItem = async (page: Page, parentName: string, childName: string) => {
+  const child = page.getByRole('button', { name: childName, exact: true });
+  if (!(await child.isVisible().catch(() => false))) {
+    await page.getByRole('button', { name: parentName, exact: true }).click();
+    await child.waitFor({ state: 'visible' });
+  }
+  await child.click();
+};

--- a/playwright/e2e/utils/utils.ts
+++ b/playwright/e2e/utils/utils.ts
@@ -18,9 +18,13 @@ export const selectOrg = async (page: Page, orgName: string) => {
 };
 
 export const openNavItem = async (page: Page, parentName: string, childName: string) => {
-  const child = page.getByRole('button', { name: childName, exact: true });
+  const section = page
+    .locator('.nav-item--has-children')
+    .filter({ has: page.getByRole('button', { name: parentName, exact: true }) });
+  await section.getByRole('button', { name: parentName, exact: true }).waitFor({ state: 'visible' });
+  const child = section.getByRole('button', { name: childName, exact: true });
   if (!(await child.isVisible().catch(() => false))) {
-    await page.getByRole('button', { name: parentName, exact: true }).click();
+    await section.getByRole('button', { name: parentName, exact: true }).click();
     await child.waitFor({ state: 'visible' });
   }
   await child.click();

--- a/src/scenes/OrgRouter/NavBar.tsx
+++ b/src/scenes/OrgRouter/NavBar.tsx
@@ -1,4 +1,4 @@
-import React, { type JSX, useCallback, useEffect, useMemo } from 'react';
+import React, { type JSX, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useMatch } from 'react-router';
 
 import { Box, Typography, useTheme } from '@mui/material';
@@ -99,12 +99,21 @@ export default function NavBar({
     [userPreferences]
   );
 
+  const navSectionsRef = useRef<Record<string, boolean>>({});
+  useEffect(() => {
+    const persisted = (userPreferences?.navSectionsExpanded as Record<string, boolean> | undefined) ?? {};
+    navSectionsRef.current = { ...persisted, ...navSectionsRef.current };
+  }, [userPreferences]);
+
+  const navSectionsWriteRef = useRef<Promise<unknown>>(Promise.resolve());
   const persistNavSection = useCallback(
     (id: string, open: boolean) => {
-      const sections = (userPreferences?.navSectionsExpanded as Record<string, boolean> | undefined) ?? {};
-      void updateUserPreferences({ navSectionsExpanded: { ...sections, [id]: open } });
+      navSectionsRef.current = { ...navSectionsRef.current, [id]: open };
+      navSectionsWriteRef.current = navSectionsWriteRef.current
+        .catch(() => undefined)
+        .then(() => updateUserPreferences({ navSectionsExpanded: { ...navSectionsRef.current } }));
     },
-    [userPreferences, updateUserPreferences]
+    [updateUserPreferences]
   );
 
   const [countNurseryWithdrawals, countNurseryWithdrawalsResponse] = useLazyCountNurseryWithdrawalsQuery();

--- a/src/scenes/OrgRouter/NavBar.tsx
+++ b/src/scenes/OrgRouter/NavBar.tsx
@@ -37,7 +37,7 @@ export default function NavBar({
   hasSpecies,
   setShowNavBar,
 }: NavBarProps): JSX.Element | null {
-  const { isAllowed } = useUser();
+  const { isAllowed, userPreferences, updateUserPreferences } = useUser();
   const { selectedOrganization } = useOrganization();
   const theme = useTheme();
   const { isDesktop, isMobile } = useDeviceInfo();
@@ -89,6 +89,22 @@ export default function NavBar({
       }
     },
     [closeNavBar, navigate]
+  );
+
+  const navSectionExpanded = useCallback(
+    (id: string, defaultExpanded: boolean): boolean => {
+      const sections = userPreferences?.navSectionsExpanded as Record<string, boolean> | undefined;
+      return sections?.[id] ?? defaultExpanded;
+    },
+    [userPreferences]
+  );
+
+  const persistNavSection = useCallback(
+    (id: string, open: boolean) => {
+      const sections = (userPreferences?.navSectionsExpanded as Record<string, boolean> | undefined) ?? {};
+      void updateUserPreferences({ navSectionsExpanded: { ...sections, [id]: open } });
+    },
+    [userPreferences, updateUserPreferences]
   );
 
   const [countNurseryWithdrawals, countNurseryWithdrawalsResponse] = useLazyCountNurseryWithdrawalsQuery();
@@ -376,7 +392,13 @@ export default function NavBar({
         </>
       )}
       <NavSection />
-      <NavItem label={strings.SEEDS} icon='seeds' id='seeds'>
+      <NavItem
+        label={strings.SEEDS}
+        icon='seeds'
+        id='seeds'
+        defaultOpen={navSectionExpanded('seeds', true)}
+        onClick={(open) => persistNavSection('seeds', !!open)}
+      >
         <SubNavbar>
           <NavItem
             label={strings.DASHBOARD}
@@ -396,10 +418,22 @@ export default function NavBar({
           />
         </SubNavbar>
       </NavItem>
-      <NavItem label={strings.SEEDLINGS} icon='iconSeedling' id='seedlings'>
+      <NavItem
+        label={strings.SEEDLINGS}
+        icon='iconSeedling'
+        id='seedlings'
+        defaultOpen={navSectionExpanded('seedlings', true)}
+        onClick={(open) => persistNavSection('seedlings', !!open)}
+      >
         <SubNavbar>{getSeedlingsMenuItems()}</SubNavbar>
       </NavItem>
-      <NavItem label={strings.PLANTINGS} icon='iconRestorationSite' id='plants'>
+      <NavItem
+        label={strings.PLANTINGS}
+        icon='iconRestorationSite'
+        id='plants'
+        defaultOpen={navSectionExpanded('plants', true)}
+        onClick={(open) => persistNavSection('plants', !!open)}
+      >
         <SubNavbar>
           <>
             <NavItem
@@ -451,7 +485,13 @@ export default function NavBar({
       {isManagerOrHigher(selectedOrganization) && (
         <>
           <NavSection />
-          <NavItem label={strings.LOCATIONS} icon='iconMyLocation' id='locations'>
+          <NavItem
+            label={strings.LOCATIONS}
+            icon='iconMyLocation'
+            id='locations'
+            defaultOpen={navSectionExpanded('locations', false)}
+            onClick={(open) => persistNavSection('locations', !!open)}
+          >
             <SubNavbar>
               <NavItem
                 label={strings.SEED_BANKS}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6471,10 +6471,10 @@
   resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.11.2.tgz#00409e743ac4eea9afe5b7708594d5fcebb00212"
   integrity sha512-vTtpNt7mKCiZ1pwU9hfKPhpdVO2sVzFQsxoVBGtOSHxlrRRzYr8iQ2TlwbAcRYCcEiZ9ECAM8kBzH0v2+VzfKw==
 
-"@terraware/web-components@^v5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-5.0.0.tgz#73a3e0f1e6a1f497f7ec3ec37a4872085a94ad7a"
-  integrity sha512-5Loc+zzthUN8BYj/T2KXFCwYXyShWM3ku5NY4WcBtVb6lPKHwtOUcR9+hDTzVGXMScbI3fnR9sqCFQ2n0rlPCA==
+"@terraware/web-components@^v5.0.8":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@terraware/web-components/-/web-components-5.0.8.tgz#48d4f27a24e28f42e59e030f257b44e25cb0bb53"
+  integrity sha512-Hc8QhhqiSqsskByxufI6T244yOEjwfXujEIOI+92PFTKQ+rXb8fkhT5/B6ZIYzXziD+hUzzWKzNWaWG4CiNDPA==
   dependencies:
     "@dnd-kit/core" "^6.0.7"
     "@dnd-kit/sortable" "^10.0.0"


### PR DESCRIPTION
-  Seeds, Seedlings, and Plantings nav items are now expanded by default
- When collapsing/expanding save state to preferences
- Locations is collapsed by default and save to preferences if changed