### PR TITLE
SW-8874 Accessions: Allow withdrawals to specify weight units

### DIFF
--- a/src/components/WeightUnitsSelector.tsx
+++ b/src/components/WeightUnitsSelector.tsx
@@ -1,0 +1,33 @@
+import React, { type JSX } from 'react';
+
+import { Dropdown } from '@terraware/web-components';
+import { SelectStyles } from '@terraware/web-components/components/Select/SelectT';
+
+import strings from 'src/strings';
+import { usePreferredWeightUnits } from 'src/units';
+
+export type WeightUnitsSelectorProps = {
+  onChange: (newValue: string) => void;
+  selectedValue: any;
+  id?: string;
+  label?: string;
+  selectStyles?: SelectStyles;
+};
+
+export default function WeightUnitsSelector(props: WeightUnitsSelectorProps): JSX.Element {
+  const { onChange, selectedValue, id, label, selectStyles } = props;
+  const preferredUnits = usePreferredWeightUnits();
+
+  return (
+    <Dropdown
+      id={id}
+      label={label}
+      options={preferredUnits}
+      placeholder={strings.SELECT}
+      onChange={onChange}
+      selectedValue={selectedValue}
+      fullWidth={true}
+      selectStyles={selectStyles}
+    />
+  );
+}

--- a/src/scenes/AccessionsRouter/edit/QuantityModal.tsx
+++ b/src/scenes/AccessionsRouter/edit/QuantityModal.tsx
@@ -2,11 +2,11 @@ import React, { type JSX, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 
 import { Box, FormControlLabel, Grid, Radio, RadioGroup, Typography, useTheme } from '@mui/material';
-import { Dropdown, Icon, Textfield } from '@terraware/web-components';
-import { SelectStyles } from '@terraware/web-components/components/Select/SelectT';
+import { Icon, Textfield } from '@terraware/web-components';
 import _ from 'lodash';
 
 import ConvertedValue from 'src/components/ConvertedValue';
+import WeightUnitsSelector from 'src/components/WeightUnitsSelector';
 import DialogBox from 'src/components/common/DialogBox/DialogBox';
 import Link from 'src/components/common/Link';
 import Button from 'src/components/common/button/Button';
@@ -16,7 +16,7 @@ import { useUser } from 'src/providers';
 import { useUpdateAccessionMutation } from 'src/queries/generated/accessionsV2';
 import strings from 'src/strings';
 import { Accession } from 'src/types/Accession';
-import { Unit, isUnitInPreferredSystem, usePreferredWeightUnits } from 'src/units';
+import { Unit, isUnitInPreferredSystem } from 'src/units';
 import useDeviceInfo from 'src/utils/useDeviceInfo';
 import useForm from 'src/utils/useForm';
 import useSnackbar from 'src/utils/useSnackbar';
@@ -28,27 +28,6 @@ export interface QuantityModalProps {
   onClose: () => void;
   statusEdit?: boolean;
   title: string;
-}
-
-interface UnitsSelectorProps {
-  onChange: (newValue: string) => void;
-  selectedValue: any;
-  selectStyles?: SelectStyles;
-}
-
-function UnitsSelector(props: UnitsSelectorProps): JSX.Element {
-  const preferredUnits = usePreferredWeightUnits();
-
-  return (
-    <Dropdown
-      options={preferredUnits}
-      placeholder={strings.SELECT}
-      onChange={props.onChange}
-      selectedValue={props.selectedValue}
-      fullWidth={true}
-      selectStyles={props.selectStyles}
-    />
-  );
 }
 
 export default function QuantityModal({ open, onClose, statusEdit, title }: QuantityModalProps): JSX.Element | null {
@@ -357,7 +336,7 @@ function QuantityModalForm(props: QuantityModalFormProps): JSX.Element {
                   errorText={totalWeightError}
                 />
                 <Box height={totalWeightError ? '85px' : 'auto'}>
-                  <UnitsSelector
+                  <WeightUnitsSelector
                     onChange={onChangeRemainingQuantityUnit}
                     selectedValue={
                       record.remainingQuantity?.units === 'Seeds'
@@ -439,7 +418,7 @@ function QuantityModalForm(props: QuantityModalFormProps): JSX.Element {
                     </Grid>
                     <Grid item xs={4}>
                       <Box height={subsetWeightError ? '85px' : subsetError ? '65px' : 'auto'} paddingTop='24px'>
-                        <UnitsSelector onChange={onChangeSubsetUnit} selectedValue={record.subsetWeight?.units} />
+                        <WeightUnitsSelector onChange={onChangeSubsetUnit} selectedValue={record.subsetWeight?.units} />
                       </Box>
                     </Grid>
                   </Grid>

--- a/src/scenes/AccessionsRouter/withdraw/WeightWithdrawal.tsx
+++ b/src/scenes/AccessionsRouter/withdraw/WeightWithdrawal.tsx
@@ -144,20 +144,26 @@ export default function WeightWithdrawal(props: WeightWithdrawalProps): JSX.Elem
     [onChangeAmount, onUnitsUpdate, withdrawnQuantity]
   );
 
+  const withdrawAllWeight = useMemo(
+    () => (remainingWeight?.quantity && remainingWeight.units !== 'Seeds' ? remainingWeight : undefined),
+    [remainingWeight]
+  );
+
   const onSelectAll = useCallback(
     (withdrawAll: boolean) => {
       if (withdrawAll) {
-        if (remainingWeight?.quantity && remainingWeight.units !== 'Seeds') {
-          onUnitsUpdate(remainingWeight.units);
-          onChangeAmount(remainingWeight.quantity, remainingWeight.units);
+        if (!withdrawAllWeight) {
+          return;
         }
+        onUnitsUpdate(withdrawAllWeight.units);
+        onChangeAmount(withdrawAllWeight.quantity, withdrawAllWeight.units);
       } else {
         onChangeAmount(undefined, units);
       }
 
       setWithdrawAllSelected(withdrawAll);
     },
-    [onChangeAmount, onUnitsUpdate, remainingWeight, units]
+    [onChangeAmount, onUnitsUpdate, units, withdrawAllWeight]
   );
 
   const remainingLabel = useMemo(
@@ -233,6 +239,7 @@ export default function WeightWithdrawal(props: WeightWithdrawalProps): JSX.Elem
             label={strings.WITHDRAW_ALL}
             onChange={onSelectAll}
             value={withdrawAllSelected}
+            disabled={!withdrawAllWeight}
           />
         </Grid>
         {accession.subsetWeight?.quantity && accession.subsetCount ? (

--- a/src/scenes/AccessionsRouter/withdraw/WeightWithdrawal.tsx
+++ b/src/scenes/AccessionsRouter/withdraw/WeightWithdrawal.tsx
@@ -1,29 +1,49 @@
-import React, { type JSX, useCallback, useEffect, useState } from 'react';
+import React, { type JSX, useCallback, useEffect, useMemo, useState } from 'react';
 
-import { Box, Grid, useTheme } from '@mui/material';
+import { Box, Grid, Typography, useTheme } from '@mui/material';
 import { Checkbox, Textfield } from '@terraware/web-components';
 
+import WeightUnitsSelector from 'src/components/WeightUnitsSelector';
 import strings from 'src/strings';
-import { Accession, Withdrawal } from 'src/types/Accession';
-import { convertUnits, unitAbbv } from 'src/units';
+import { Accession } from 'src/types/Accession';
+import { UnitType, convertUnits, convertWeightToSeedCount, unitAbbv } from 'src/units';
 
 export interface WeightWithdrawalProps {
   accession: Accession;
   purpose: string | undefined;
+  units: UnitType;
+  onUnitsUpdate: (units: UnitType) => void;
   onWithdrawCtUpdate: (withdrawnQuantity: number, valid: boolean) => void;
 }
 
 export default function WeightWithdrawal(props: WeightWithdrawalProps): JSX.Element {
-  const { accession, purpose, onWithdrawCtUpdate } = props;
+  const { accession, purpose, units, onUnitsUpdate, onWithdrawCtUpdate } = props;
 
   const [withdrawAllSelected, setWithdrawAllSelected] = useState(false);
   const theme = useTheme();
   const [estimatedWithdrawnCt, setEstimatedWithdrawnCt] = useState<number>(0);
-  const [withdrawnQuantity, setWithdrawnQuantity] = useState<Withdrawal['withdrawnQuantity']>({
-    quantity: 0,
-    units: accession.remainingQuantity?.units || 'Grams',
-  });
+  const [withdrawnQuantity, setWithdrawnQuantity] = useState<number | undefined>(0);
   const [withdrawnQtyError, setWithdrawnQtyError] = useState<string>('');
+
+  const remainingWeight = useMemo(
+    () => (accession.remainingQuantity?.units === 'Seeds' ? accession.estimatedWeight : accession.remainingQuantity),
+    [accession.estimatedWeight, accession.remainingQuantity]
+  );
+
+  const remainingCount = useMemo(() => {
+    if (accession.remainingQuantity?.units === 'Seeds') {
+      return accession.remainingQuantity.quantity;
+    }
+    if (!remainingWeight || !accession.subsetCount || !accession.subsetWeight?.quantity) {
+      return undefined;
+    }
+    return convertWeightToSeedCount(
+      remainingWeight.quantity,
+      remainingWeight.units,
+      accession.subsetWeight,
+      accession.subsetCount
+    );
+  }, [accession.remainingQuantity, accession.subsetCount, accession.subsetWeight, remainingWeight]);
 
   useEffect(() => {
     setWithdrawnQtyError('');
@@ -38,55 +58,8 @@ export default function WeightWithdrawal(props: WeightWithdrawalProps): JSX.Elem
     }
   }, [purpose, accession.subsetCount, accession.subsetWeight?.quantity]);
 
-  const onSelectAll = (id: string, withdrawAll: boolean) => {
-    if (withdrawAll) {
-      if (
-        accession.remainingQuantity?.units &&
-        accession.remainingQuantity?.units === 'Seeds' &&
-        accession.estimatedWeight?.quantity
-      ) {
-        onChangeWithdrawnQuantity(accession.estimatedWeight?.quantity);
-      } else if (accession.remainingQuantity?.units && accession.remainingQuantity?.units !== 'Seeds') {
-        onChangeWithdrawnQuantity(accession.remainingQuantity?.quantity);
-      }
-    } else {
-      setWithdrawnQuantity(undefined);
-    }
-
-    setWithdrawAllSelected(withdrawAll);
-  };
-
   const validateAmount = useCallback(
-    (estimated: number, withdrawnQty: number, withdrawnUnits: string) => {
-      if (!estimated) {
-        setWithdrawnQtyError(strings.WITHDRAWAL_COUNT_GREATER_THAN_ZERO_ERROR);
-        return false;
-      }
-      if (!withdrawnQty) {
-        setWithdrawnQtyError(strings.REQUIRED_FIELD);
-        return false;
-      }
-      if (isNaN(withdrawnQty) || Number(withdrawnQty) <= 0) {
-        setWithdrawnQtyError(strings.INVALID_VALUE);
-        return false;
-      }
-      if (
-        accession.remainingQuantity?.units === withdrawnUnits &&
-        accession.remainingQuantity.units === 'Seeds' &&
-        Number(estimated) > accession.remainingQuantity?.quantity
-      ) {
-        setWithdrawnQtyError(strings.WITHDRAWN_QUANTITY_ERROR);
-        return false;
-      }
-      if (
-        accession.remainingQuantity?.units === withdrawnUnits &&
-        accession.remainingQuantity.units !== 'Seeds' &&
-        accession.remainingQuantity?.quantity &&
-        withdrawnQty > accession.remainingQuantity?.quantity
-      ) {
-        setWithdrawnQtyError(strings.WITHDRAWN_QUANTITY_ERROR);
-        return false;
-      }
+    (estimated: number, withdrawnQty: number | undefined, withdrawnUnits: UnitType) => {
       if (
         purpose === 'Nursery' &&
         (!accession.estimatedCount || !accession.subsetWeight?.quantity || !accession.subsetCount)
@@ -101,73 +74,103 @@ export default function WeightWithdrawal(props: WeightWithdrawalProps): JSX.Elem
         setWithdrawnQtyError(strings.MISSING_SUBSET_WEIGHT_ERROR_VIABILITY_TEST);
         return false;
       }
-
+      if (!estimated) {
+        setWithdrawnQtyError(strings.WITHDRAWAL_COUNT_GREATER_THAN_ZERO_ERROR);
+        return false;
+      }
+      if (!withdrawnQty) {
+        setWithdrawnQtyError(strings.REQUIRED_FIELD);
+        return false;
+      }
+      if (isNaN(withdrawnQty) || Number(withdrawnQty) <= 0) {
+        setWithdrawnQtyError(strings.INVALID_VALUE);
+        return false;
+      }
+      if (remainingCount !== undefined && estimated > remainingCount) {
+        setWithdrawnQtyError(strings.WITHDRAWN_QUANTITY_ERROR);
+        return false;
+      }
+      if (remainingWeight && remainingWeight.units !== 'Seeds') {
+        const withdrawnWeight = convertUnits(withdrawnQty, withdrawnUnits, remainingWeight.units);
+        if (withdrawnWeight > remainingWeight.quantity * (1 + 1e-6)) {
+          setWithdrawnQtyError(strings.WITHDRAWN_QUANTITY_ERROR);
+          return false;
+        }
+      }
       setWithdrawnQtyError('');
       return true;
     },
-    [accession, purpose]
+    [accession, purpose, remainingCount, remainingWeight]
+  );
+
+  const onChangeAmount = useCallback(
+    (value: number | undefined, withdrawnUnits: UnitType) => {
+      const estimated = convertWeightToSeedCount(
+        value || 0,
+        withdrawnUnits,
+        accession.subsetWeight,
+        accession.subsetCount
+      );
+      setEstimatedWithdrawnCt(estimated);
+
+      setWithdrawAllSelected(
+        !!remainingWeight &&
+          remainingWeight.units === withdrawnUnits &&
+          value?.toString() === remainingWeight.quantity.toString()
+      );
+
+      setWithdrawnQuantity(value);
+
+      const valid = validateAmount(estimated, value, withdrawnUnits);
+      onWithdrawCtUpdate(value || 0, valid);
+    },
+    [accession.subsetCount, accession.subsetWeight, onWithdrawCtUpdate, remainingWeight, validateAmount]
   );
 
   const onChangeWithdrawnQuantity = useCallback(
-    (value: number) => {
-      let estimated = 0;
-      let valid = false;
-
-      if (
-        value.toString() === accession.remainingQuantity?.quantity.toString() &&
-        withdrawnQuantity?.units === accession.remainingQuantity?.units
-      ) {
-        setWithdrawAllSelected(true);
-      } else {
-        setWithdrawAllSelected(false);
-      }
-
-      if (accession.subsetCount && accession.subsetWeight) {
-        if (
-          accession.remainingQuantity?.units &&
-          accession.remainingQuantity?.units === 'Seeds' &&
-          accession.estimatedWeight?.units
-        ) {
-          estimated = Math.round(
-            convertUnits(value, accession.estimatedWeight?.units, accession.subsetWeight.units) *
-              (accession.subsetCount / accession.subsetWeight.quantity)
-          );
-        } else if (accession.remainingQuantity?.units) {
-          estimated = Math.round(
-            convertUnits(value, accession.remainingQuantity?.units, accession.subsetWeight.units) *
-              (accession.subsetCount / accession.subsetWeight.quantity)
-          );
-        }
-        setEstimatedWithdrawnCt(estimated);
-      }
-
-      setWithdrawnQuantity(
-        value.toString().trim() === ''
-          ? undefined
-          : {
-              quantity: value || 0,
-              units: withdrawnQuantity?.units || accession.remainingQuantity?.units || 'Grams',
-            }
-      );
-
-      setWithdrawnQtyError('');
-      if (purpose === 'Nursery' || purpose === 'Viability Testing') {
-        if (!accession.estimatedCount || !accession.subsetWeight?.quantity || !accession.subsetCount) {
-          setWithdrawnQtyError(
-            purpose === 'Nursery'
-              ? strings.MISSING_SUBSET_WEIGHT_ERROR_NURSERY
-              : strings.MISSING_SUBSET_WEIGHT_ERROR_VIABILITY_TEST
-          );
-        }
-      }
-      valid = validateAmount(
-        estimated,
-        value,
-        withdrawnQuantity?.units || accession.remainingQuantity?.units || 'Grams'
-      );
-      onWithdrawCtUpdate(value || 0, valid);
+    (value: unknown) => {
+      const stringValue = value?.toString().trim();
+      onChangeAmount(stringValue ? Number(stringValue) : undefined, units);
     },
-    [accession, onWithdrawCtUpdate, purpose, validateAmount, withdrawnQuantity?.units]
+    [onChangeAmount, units]
+  );
+
+  const onChangeUnits = useCallback(
+    (newValue: string) => {
+      const newUnits = newValue as UnitType;
+      onUnitsUpdate(newUnits);
+      onChangeAmount(withdrawnQuantity, newUnits);
+    },
+    [onChangeAmount, onUnitsUpdate, withdrawnQuantity]
+  );
+
+  const onSelectAll = useCallback(
+    (withdrawAll: boolean) => {
+      if (withdrawAll) {
+        if (remainingWeight?.quantity && remainingWeight.units !== 'Seeds') {
+          onUnitsUpdate(remainingWeight.units);
+          onChangeAmount(remainingWeight.quantity, remainingWeight.units);
+        }
+      } else {
+        onChangeAmount(undefined, units);
+      }
+
+      setWithdrawAllSelected(withdrawAll);
+    },
+    [onChangeAmount, onUnitsUpdate, remainingWeight, units]
+  );
+
+  const remainingLabel = useMemo(
+    () =>
+      strings
+        .formatString(
+          strings.AMOUNT_REMAINING,
+          remainingWeight?.quantity !== undefined
+            ? `${remainingWeight.quantity}${unitAbbv()[remainingWeight.units]}`
+            : strings.UNKNOWN
+        )
+        .toString(),
+    [remainingWeight]
   );
 
   return (
@@ -197,44 +200,38 @@ export default function WeightWithdrawal(props: WeightWithdrawalProps): JSX.Elem
       ) : null}
       <Grid container direction='row' justifyContent='space-between'>
         <Grid item xs={accession.subsetWeight?.quantity && accession.subsetCount ? 6 : 12} paddingBottom={2}>
-          <Box display='flex' alignItems={withdrawnQtyError ? 'center' : 'end'}>
-            <Textfield
-              label={strings
-                .formatString(
-                  strings.AMOUNT_REMAINING,
-                  `${
-                    accession.remainingQuantity?.units !== 'Seeds'
-                      ? accession.remainingQuantity?.quantity
-                      : accession.estimatedWeight?.quantity
-                        ? accession.estimatedWeight?.quantity
-                        : 'Unknown '
-                  }${accession.estimatedWeight?.units ? unitAbbv()[accession.estimatedWeight?.units] : ''}`
-                )
-                .toString()}
-              id='withdrawnQuantity'
-              onChange={(value) => onChangeWithdrawnQuantity(Number(value))}
-              type='number'
-              value={withdrawnQuantity?.quantity.toString()}
-              errorText={withdrawnQtyError}
-              required={true}
-            />
-            <Box paddingLeft={1}>
-              <Box>
-                {accession.remainingQuantity?.units === 'Seeds'
-                  ? accession.estimatedWeight?.units
-                    ? unitAbbv()[accession.estimatedWeight?.units]
-                    : ''
-                  : accession.remainingQuantity?.units
-                    ? unitAbbv()[accession.remainingQuantity?.units]
-                    : ''}
-              </Box>
+          <Typography
+            component='label'
+            htmlFor='withdrawnQuantity'
+            color={theme.palette.TwClrTxtSecondary}
+            display='block'
+            fontSize='14px'
+            lineHeight='20px'
+            marginBottom='4px'
+          >
+            {`${remainingLabel} *`}
+          </Typography>
+          <Box display='flex' alignItems='flex-start'>
+            <Box flexGrow={1}>
+              <Textfield
+                label=''
+                id='withdrawnQuantity'
+                onChange={onChangeWithdrawnQuantity}
+                type='number'
+                value={withdrawnQuantity?.toString()}
+                errorText={withdrawnQtyError}
+                required={true}
+              />
+            </Box>
+            <Box flexShrink={0} paddingLeft={1} paddingTop='4px' width='88px'>
+              <WeightUnitsSelector id='withdrawnQuantityUnits' onChange={onChangeUnits} selectedValue={units} />
             </Box>
           </Box>
           <Checkbox
             id='withdrawAll'
             name=''
             label={strings.WITHDRAW_ALL}
-            onChange={(value) => onSelectAll('withdrawAll', value)}
+            onChange={onSelectAll}
             value={withdrawAllSelected}
           />
         </Grid>

--- a/src/scenes/AccessionsRouter/withdraw/WithdrawModal.tsx
+++ b/src/scenes/AccessionsRouter/withdraw/WithdrawModal.tsx
@@ -31,7 +31,7 @@ import { NurseryTransfer } from 'src/types/Batch';
 import { Facility } from 'src/types/Facility';
 import { SearchNodePayload } from 'src/types/Search';
 import { OrganizationUser, User } from 'src/types/User';
-import { UnitType, convertUnits } from 'src/units';
+import { UnitType, convertWeightToSeedCount } from 'src/units';
 import { getAllNurseries, getSeedBank, isContributor } from 'src/utils/organization';
 import { renderUser } from 'src/utils/renderUser';
 import useForm from 'src/utils/useForm';
@@ -89,6 +89,13 @@ function WithdrawDialogForm(props: WithdrawDialogFormProps): JSX.Element {
   const [timeZone, setTimeZone] = useState(tz.id);
   const [isByWeight, setIsByWeight] = useState(accession.remainingQuantity?.units !== 'Seeds');
   const [withdrawalQty, setWithdrawalQty] = useState<number>(0);
+  const [withdrawalUnits, setWithdrawalUnits] = useState<UnitType>(() => {
+    const accessionUnits =
+      accession.remainingQuantity?.units === 'Seeds'
+        ? accession.estimatedWeight?.units
+        : accession.remainingQuantity?.units;
+    return accessionUnits && accessionUnits !== 'Seeds' ? accessionUnits : 'Grams';
+  });
   const [withdrawalValid, setWithdrawalValid] = useState<boolean>(false);
   const [withdrawalButtonEnabled, setWithdrawalButtonEnabled] = useState<boolean>(true);
   const [showDateWarning, setShowDateWarning] = useState<boolean>(false);
@@ -251,28 +258,11 @@ function WithdrawDialogForm(props: WithdrawDialogFormProps): JSX.Element {
   }, [record.purpose, isNurseryTransfer, isByWeight, setRecord]);
 
   const estimatedWithdrawalQty = useMemo(() => {
-    let estimated = 0;
-    if (isByWeight && accession.subsetCount && accession.subsetWeight) {
-      if (
-        accession.remainingQuantity?.units &&
-        accession.remainingQuantity?.units === 'Seeds' &&
-        accession.estimatedWeight?.units
-      ) {
-        estimated = Math.round(
-          convertUnits(withdrawalQty, accession.estimatedWeight?.units, accession.subsetWeight.units) *
-            (accession.subsetCount / accession.subsetWeight.quantity)
-        );
-      } else if (accession.remainingQuantity?.units) {
-        estimated = Math.round(
-          convertUnits(withdrawalQty, accession.remainingQuantity?.units, accession.subsetWeight.units) *
-            (accession.subsetCount / accession.subsetWeight.quantity)
-        );
-      }
-    } else if (!isByWeight) {
+    if (!isByWeight) {
       return withdrawalQty;
     }
-    return estimated;
-  }, [accession, isByWeight, withdrawalQty]);
+    return convertWeightToSeedCount(withdrawalQty, withdrawalUnits, accession.subsetWeight, accession.subsetCount);
+  }, [accession.subsetCount, accession.subsetWeight, isByWeight, withdrawalQty, withdrawalUnits]);
 
   const onChangeUser = useCallback(
     (newValue: OrganizationUser) => {
@@ -404,17 +394,7 @@ function WithdrawDialogForm(props: WithdrawDialogFormProps): JSX.Element {
               createViabilityTestRequestPayload: viabilityTesting,
             }).unwrap();
           } else {
-            let units: UnitType;
-            if (isByWeight) {
-              if (accession.remainingQuantity?.units === 'Seeds') {
-                units = 'Grams';
-              } else {
-                units = accession.remainingQuantity?.units || 'Grams';
-              }
-            } else {
-              units = 'Seeds';
-            }
-            record.withdrawnQuantity = { quantity: withdrawalQty, units };
+            record.withdrawnQuantity = { quantity: withdrawalQty, units: isByWeight ? withdrawalUnits : 'Seeds' };
             await createWithdrawal({
               accessionId: accession.id,
               createWithdrawalRequestPayload: record,
@@ -437,7 +417,6 @@ function WithdrawDialogForm(props: WithdrawDialogFormProps): JSX.Element {
     }
   }, [
     accession.id,
-    accession.remainingQuantity?.units,
     createNurseryTransferWithdrawal,
     createViabilityTest,
     createWithdrawal,
@@ -457,6 +436,7 @@ function WithdrawDialogForm(props: WithdrawDialogFormProps): JSX.Element {
     validateInventoryBatch,
     viabilityTesting,
     withdrawalQty,
+    withdrawalUnits,
   ]);
 
   const handleSaveWithdrawal = useCallback(() => {
@@ -690,6 +670,8 @@ function WithdrawDialogForm(props: WithdrawDialogFormProps): JSX.Element {
               <WeightWithdrawal
                 accession={accession}
                 purpose={isNurseryTransfer ? 'Nursery' : record.purpose}
+                units={withdrawalUnits}
+                onUnitsUpdate={setWithdrawalUnits}
                 onWithdrawCtUpdate={onWithdrawCtUpdate}
               />
             ) : (

--- a/src/units.test.ts
+++ b/src/units.test.ts
@@ -1,0 +1,38 @@
+import { convertWeightToSeedCount } from './units';
+
+describe('convertWeightToSeedCount', () => {
+  it('returns 0 without a subset count', () => {
+    expect(convertWeightToSeedCount(100, 'Grams', { quantity: 1, units: 'Grams' }, undefined)).toBe(0);
+    expect(convertWeightToSeedCount(100, 'Grams', { quantity: 1, units: 'Grams' }, 0)).toBe(0);
+  });
+
+  it('returns 0 without a subset weight', () => {
+    expect(convertWeightToSeedCount(100, 'Grams', undefined, 10)).toBe(0);
+    expect(convertWeightToSeedCount(100, 'Grams', { quantity: 0, units: 'Grams' }, 10)).toBe(0);
+  });
+
+  it('applies the subset ratio when the units already match', () => {
+    // 5g at 1g per 10 seeds is 50 seeds.
+    expect(convertWeightToSeedCount(5, 'Grams', { quantity: 1, units: 'Grams' }, 10)).toBe(50);
+  });
+
+  it('converts to the subset weight units before applying the subset ratio', () => {
+    // 5000mg is 5g, so still 50 seeds against a 1g per 10 seed subset.
+    expect(convertWeightToSeedCount(5000, 'Milligrams', { quantity: 1, units: 'Grams' }, 10)).toBe(50);
+    // 1kg is 1000g, at 100g per 25 seeds that is 250 seeds.
+    expect(convertWeightToSeedCount(1, 'Kilograms', { quantity: 100, units: 'Grams' }, 25)).toBe(250);
+  });
+
+  it('converts milligrams to ounces without the grams factor', () => {
+    // 1000mg against a 1oz per 10 seed subset is ~0.035oz, which rounds to no whole seeds.
+    // The regressed factor would have made this ~35oz and produced hundreds of seeds.
+    expect(convertWeightToSeedCount(1000, 'Milligrams', { quantity: 1, units: 'Ounces' }, 10)).toBe(0);
+  });
+
+  it('rounds to the nearest whole seed', () => {
+    // 1g at 3g per 10 seeds is 3.33 seeds.
+    expect(convertWeightToSeedCount(1, 'Grams', { quantity: 3, units: 'Grams' }, 10)).toBe(3);
+    // 2g at 3g per 10 seeds is 6.67 seeds.
+    expect(convertWeightToSeedCount(2, 'Grams', { quantity: 3, units: 'Grams' }, 10)).toBe(7);
+  });
+});

--- a/src/units.ts
+++ b/src/units.ts
@@ -110,7 +110,7 @@ export function convertUnits(value: number, unit: string, outputUnit: string) {
           return value * 0.035274;
         }
         case 'Pounds': {
-          return value * 0.002204;
+          return value * 0.00220462;
         }
         case 'Milligrams': {
           return value * 1000;
@@ -145,7 +145,7 @@ export function convertUnits(value: number, unit: string, outputUnit: string) {
     case 'Milligrams': {
       switch (outputUnit) {
         case 'Ounces': {
-          return value * 0.035274;
+          return value * 0.000035274;
         }
         case 'Pounds': {
           return value * 2.20462e-6;

--- a/src/units.ts
+++ b/src/units.ts
@@ -205,6 +205,18 @@ export function convertUnits(value: number, unit: string, outputUnit: string) {
   }
 }
 
+export function convertWeightToSeedCount(
+  quantity: number,
+  units: string,
+  subsetWeight?: { quantity: number; units: string },
+  subsetCount?: number
+) {
+  if (!subsetCount || !subsetWeight?.quantity) {
+    return 0;
+  }
+  return Math.round(convertUnits(quantity, units, subsetWeight.units) * (subsetCount / subsetWeight.quantity));
+}
+
 export function isUnitInPreferredSystem(unit: string, system: string) {
   const units = getUnitsForSystem(system);
   const found = units.find((iUnit) => iUnit.value === unit);


### PR DESCRIPTION
- Move the dropdown for selecting unit to a shared component 
- Since Nursery and Viability Testing withdrawals are done with quantity values, allow selecting different weight units in the FE, and then converting to seeds quantity
- Move the convertWeightToSeedCount to a shared file (it was repeated code)